### PR TITLE
Fixed IB examples ran in debugging mode

### DIFF
--- a/examples/IB/implicit/ex2/input3d.cylinder
+++ b/examples/IB/implicit/ex2/input3d.cylinder
@@ -186,9 +186,9 @@ Main {
 }
 
 CartesianGeometry {
-   domain_boxes = [ (0,0,0),(2*N - 1,N - 1,N/4 - 1) ]
-   x_lo = -0.5*L,-0.5*L,-0.125*L
-   x_up =  1.5*L, 0.5*L, 0.125*L
+   domain_boxes = [ (0,0,0),(2*N - 1,N - 1,N - 1) ]
+   x_lo = -0.5*L,-0.5*L,-0.5*L
+   x_up =  1.5*L, 0.5*L, 0.5*L
    periodic_dimension = 0,0,1
 }
 

--- a/src/IB/IBStandardForceGen.cpp
+++ b/src/IB/IBStandardForceGen.cpp
@@ -783,6 +783,8 @@ void IBStandardForceGen::computeLagrangianSpringForce(Pointer<LData> F_data,
                                                       LDataManager* const /*l_data_manager*/)
 {
     const int num_springs = static_cast<int>(d_spring_data[level_number].lag_mastr_node_idxs.size());
+    if (num_springs == 0)
+      return;
     const int* const lag_mastr_node_idxs = &d_spring_data[level_number].lag_mastr_node_idxs[0];
     const int* const lag_slave_node_idxs = &d_spring_data[level_number].lag_slave_node_idxs[0];
     const int* const petsc_mastr_node_idxs = &d_spring_data[level_number].petsc_mastr_node_idxs[0];
@@ -994,6 +996,8 @@ void IBStandardForceGen::computeLagrangianBeamForce(Pointer<LData> F_data,
                                                     LDataManager* const /*l_data_manager*/)
 {
     const int num_beams = static_cast<int>(d_beam_data[level_number].petsc_mastr_node_idxs.size());
+    if (num_beams == 0)
+      return;
     const int* const petsc_mastr_node_idxs = &d_beam_data[level_number].petsc_mastr_node_idxs[0];
     const int* const petsc_next_node_idxs = &d_beam_data[level_number].petsc_next_node_idxs[0];
     const int* const petsc_prev_node_idxs = &d_beam_data[level_number].petsc_prev_node_idxs[0];
@@ -1154,6 +1158,8 @@ void IBStandardForceGen::computeLagrangianTargetPointForce(Pointer<LData> F_data
                                                            LDataManager* const /*l_data_manager*/)
 {
     const int num_target_points = static_cast<int>(d_target_point_data[level_number].petsc_node_idxs.size());
+    if (num_target_points == 0)
+      return;
     const int* const petsc_node_idxs = &d_target_point_data[level_number].petsc_node_idxs[0];
     const double** const kappa = &d_target_point_data[level_number].kappa[0];
     const double** const eta = &d_target_point_data[level_number].eta[0];

--- a/src/IB/IBStandardForceGen.cpp
+++ b/src/IB/IBStandardForceGen.cpp
@@ -783,8 +783,7 @@ void IBStandardForceGen::computeLagrangianSpringForce(Pointer<LData> F_data,
                                                       LDataManager* const /*l_data_manager*/)
 {
     const int num_springs = static_cast<int>(d_spring_data[level_number].lag_mastr_node_idxs.size());
-    if (num_springs == 0)
-      return;
+    if (num_springs == 0) return;
     const int* const lag_mastr_node_idxs = &d_spring_data[level_number].lag_mastr_node_idxs[0];
     const int* const lag_slave_node_idxs = &d_spring_data[level_number].lag_slave_node_idxs[0];
     const int* const petsc_mastr_node_idxs = &d_spring_data[level_number].petsc_mastr_node_idxs[0];
@@ -996,8 +995,7 @@ void IBStandardForceGen::computeLagrangianBeamForce(Pointer<LData> F_data,
                                                     LDataManager* const /*l_data_manager*/)
 {
     const int num_beams = static_cast<int>(d_beam_data[level_number].petsc_mastr_node_idxs.size());
-    if (num_beams == 0)
-      return;
+    if (num_beams == 0) return;
     const int* const petsc_mastr_node_idxs = &d_beam_data[level_number].petsc_mastr_node_idxs[0];
     const int* const petsc_next_node_idxs = &d_beam_data[level_number].petsc_next_node_idxs[0];
     const int* const petsc_prev_node_idxs = &d_beam_data[level_number].petsc_prev_node_idxs[0];
@@ -1158,8 +1156,7 @@ void IBStandardForceGen::computeLagrangianTargetPointForce(Pointer<LData> F_data
                                                            LDataManager* const /*l_data_manager*/)
 {
     const int num_target_points = static_cast<int>(d_target_point_data[level_number].petsc_node_idxs.size());
-    if (num_target_points == 0)
-      return;
+    if (num_target_points == 0) return;
     const int* const petsc_node_idxs = &d_target_point_data[level_number].petsc_node_idxs[0];
     const double** const kappa = &d_target_point_data[level_number].kappa[0];
     const double** const eta = &d_target_point_data[level_number].eta[0];


### PR DESCRIPTION
IB examples explicit/ex0, explicit/ex1, explicit/ex2, explicit/ex5, implicit/ex0, implicit/ex1, and implicit/ex2 quit with error:
"attempt to subscript container with out-of-bounds index 0, but container only holds 0 elements."
I added an additional return statement if the number of springs/beams/target points were zero when forces were calculated in IBStandardForceGen

Additionally, IB examples implicit/ex2 failed when ran with input file input3d.cylinder with error:

P=00000:ERROR MESSAGE: 
P=00000:CartSideRobinPhysBdryOp::setPhysicalBoundaryConditions():
P=00000:  patch data index 6 does not correspond to a side-centered double precision variable.

The example did run with input file input3d.sphere. I changed options in the Cartesian Geometry to fix this. I am not sure if the example still functions as was originally intended.