### PR TITLE
Additional block factorization preconditioners

### DIFF
--- a/include/ibamr/StaggeredStokesBlockFactorizationPreconditioner.h
+++ b/include/ibamr/StaggeredStokesBlockFactorizationPreconditioner.h
@@ -69,6 +69,13 @@ namespace IBAMR
 class StaggeredStokesBlockFactorizationPreconditioner : public StaggeredStokesBlockPreconditioner
 {
 public:
+    enum FactorizationType
+    {
+        LOWER_TRIANGULAR,
+        UPPER_TRIANGULAR,
+        SYMMETRIC
+    };
+
     /*!
      * \brief Class constructor
      */
@@ -92,6 +99,11 @@ public:
     {
         return new StaggeredStokesBlockFactorizationPreconditioner(object_name, input_db, default_options_prefix);
     } // allocate_solver
+
+    /*!
+     * Set the factorization type.
+     */
+    void setFactorizationType(FactorizationType factorization_type);
 
     /*!
      * \name Linear solver functionality.
@@ -184,6 +196,23 @@ private:
     StaggeredStokesBlockFactorizationPreconditioner&
     operator=(const StaggeredStokesBlockFactorizationPreconditioner& that);
 
+    /*!
+     * \brief Solve the pressure subsystem.
+     */
+    void solvePressureSubsystem(SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x,
+                                SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& b,
+                                bool initial_guess_nonzero);
+
+    /*!
+     * \brief Solve the velocity subsystem.
+     */
+    void solveVelocitySubsystem(SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x,
+                                SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& b,
+                                bool initial_guess_nonzero);
+
+    // Solver configuration
+    FactorizationType d_factorization_type;
+
     // Boundary condition objects.
     SAMRAI::tbox::Pointer<IBTK::HierarchyGhostCellInterpolation> d_P_bdry_fill_op, d_no_fill_op;
 
@@ -191,7 +220,7 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double> > d_U_var;
     int d_F_U_mod_idx;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_P_var;
-    int d_P_scratch_idx;
+    int d_P_scratch_idx, d_F_P_mod_idx;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/StaggeredStokesBlockFactorizationPreconditioner.h
+++ b/include/ibamr/StaggeredStokesBlockFactorizationPreconditioner.h
@@ -73,7 +73,8 @@ public:
     {
         LOWER_TRIANGULAR,
         UPPER_TRIANGULAR,
-        SYMMETRIC
+        SYMMETRIC,
+        DIAGONAL
     };
 
     /*!

--- a/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
@@ -101,11 +101,12 @@ static Timer* t_deallocate_solver_state;
 
 StaggeredStokesBlockFactorizationPreconditioner::StaggeredStokesBlockFactorizationPreconditioner(
     const std::string& object_name,
-    Pointer<Database> /*input_db*/,
+    Pointer<Database> input_db,
     const std::string& /*default_options_prefix*/)
     : StaggeredStokesBlockPreconditioner(/*needs_velocity_solver*/ true,
                                          /*needs_pressure_solver*/ true),
-      d_P_bdry_fill_op(NULL), d_no_fill_op(NULL), d_U_var(NULL), d_F_U_mod_idx(-1), d_P_var(NULL), d_P_scratch_idx(-1)
+      d_factorization_type(LOWER_TRIANGULAR), d_P_bdry_fill_op(NULL), d_no_fill_op(NULL), d_U_var(NULL),
+      d_F_U_mod_idx(-1), d_P_var(NULL), d_P_scratch_idx(-1), d_F_P_mod_idx(-1)
 {
     GeneralSolver::init(object_name, /*homogeneous_bc*/ true);
 
@@ -113,6 +114,28 @@ StaggeredStokesBlockFactorizationPreconditioner::StaggeredStokesBlockFactorizati
     // one iteration.
     d_initial_guess_nonzero = false;
     d_max_iterations = 1;
+
+    // Read in the factorization type.
+    if (input_db->keyExists("factorization_type"))
+    {
+        std::string factorization_type_string = input_db->getString("factorization_type");
+        if (factorization_type_string == "LOWER_TRIANGULAR")
+        {
+            d_factorization_type = LOWER_TRIANGULAR;
+        }
+        else if (factorization_type_string == "UPPER_TRIANGULAR")
+        {
+            d_factorization_type = UPPER_TRIANGULAR;
+        }
+        else if (factorization_type_string == "SYMMETRIC")
+        {
+            d_factorization_type = SYMMETRIC;
+        }
+        else
+        {
+            TBOX_ERROR("unsupported factorization type: " << factorization_type_string << "\n");
+        }
+    }
 
     // Setup variables.
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -142,9 +165,11 @@ StaggeredStokesBlockFactorizationPreconditioner::StaggeredStokesBlockFactorizati
     {
         d_P_var = new CellVariable<NDIM, double>(P_var_name);
         d_P_scratch_idx = var_db->registerVariableAndContext(d_P_var, context, IntVector<NDIM>(CELLG));
+        d_F_P_mod_idx = var_db->registerClonedPatchDataIndex(d_P_var, d_P_scratch_idx);
     }
 #if !defined(NDEBUG)
     TBOX_ASSERT(d_P_scratch_idx >= 0);
+    TBOX_ASSERT(d_F_P_mod_idx >= 0);
 #endif
 
     // Setup Timers.
@@ -164,6 +189,12 @@ StaggeredStokesBlockFactorizationPreconditioner::~StaggeredStokesBlockFactorizat
     return;
 } // ~StaggeredStokesBlockFactorizationPreconditioner
 
+void StaggeredStokesBlockFactorizationPreconditioner::setFactorizationType(FactorizationType factorization_type)
+{
+    d_factorization_type = factorization_type;
+    return;
+}
+
 bool StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, double>& x,
                                                                   SAMRAIVectorReal<NDIM, double>& b)
 {
@@ -172,11 +203,6 @@ bool StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorRe
     // Initialize the solver (if necessary).
     const bool deallocate_at_completion = !d_is_initialized;
     if (!d_is_initialized) initializeSolverState(x, b);
-
-    // Determine whether we are solving a steady-state problem.
-    const bool steady_state =
-        d_U_problem_coefs.cIsZero() ||
-        (d_U_problem_coefs.cIsConstant() && MathUtilities<double>::equalEps(d_U_problem_coefs.getCConstant(), 0.0));
 
     // Get the vector components.
     const int F_U_idx = b.getComponentDescriptorIndex(0);
@@ -198,6 +224,10 @@ bool StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorRe
     Pointer<CellVariable<NDIM, double> > P_cc_var = P_var;
 
     // Setup the component solver vectors.
+    Pointer<SAMRAIVectorReal<NDIM, double> > F_U_vec;
+    F_U_vec = new SAMRAIVectorReal<NDIM, double>(d_object_name + "::F_U", d_hierarchy, d_coarsest_ln, d_finest_ln);
+    F_U_vec->addComponent(F_U_sc_var, F_U_idx, d_velocity_wgt_idx, d_velocity_data_ops);
+
     Pointer<SAMRAIVectorReal<NDIM, double> > F_U_mod_vec;
     F_U_mod_vec =
         new SAMRAIVectorReal<NDIM, double>(d_object_name + "::F_U_mod", d_hierarchy, d_coarsest_ln, d_finest_ln);
@@ -207,14 +237,14 @@ bool StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorRe
     U_vec = new SAMRAIVectorReal<NDIM, double>(d_object_name + "::U", d_hierarchy, d_coarsest_ln, d_finest_ln);
     U_vec->addComponent(U_sc_var, U_idx, d_velocity_wgt_idx, d_velocity_data_ops);
 
-    Pointer<SAMRAIVectorReal<NDIM, double> > P_scratch_vec;
-    P_scratch_vec =
-        new SAMRAIVectorReal<NDIM, double>(d_object_name + "::P_scratch", d_hierarchy, d_coarsest_ln, d_finest_ln);
-    P_scratch_vec->addComponent(d_P_var, d_P_scratch_idx, d_pressure_wgt_idx, d_pressure_data_ops);
-
     Pointer<SAMRAIVectorReal<NDIM, double> > F_P_vec;
     F_P_vec = new SAMRAIVectorReal<NDIM, double>(d_object_name + "::F_P", d_hierarchy, d_coarsest_ln, d_finest_ln);
     F_P_vec->addComponent(F_P_cc_var, F_P_idx, d_pressure_wgt_idx, d_pressure_data_ops);
+
+    Pointer<SAMRAIVectorReal<NDIM, double> > F_P_mod_vec;
+    F_P_mod_vec =
+        new SAMRAIVectorReal<NDIM, double>(d_object_name + "::F_P_mod", d_hierarchy, d_coarsest_ln, d_finest_ln);
+    F_P_mod_vec->addComponent(d_P_var, d_F_P_mod_idx, d_pressure_wgt_idx, d_pressure_data_ops);
 
     Pointer<SAMRAIVectorReal<NDIM, double> > P_vec;
     P_vec = new SAMRAIVectorReal<NDIM, double>(d_object_name + "::P", d_hierarchy, d_coarsest_ln, d_finest_ln);
@@ -223,24 +253,164 @@ bool StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorRe
     // Setup the interpolation transaction information.
     Pointer<VariableFillPattern<NDIM> > fill_pattern = new CellNoCornersFillPattern(CELLG, false, false, true);
     typedef HierarchyGhostCellInterpolation::InterpolationTransactionComponent InterpolationTransactionComponent;
-    InterpolationTransactionComponent P_transaction_comp(P_idx,
-                                                         DATA_REFINE_TYPE,
-                                                         USE_CF_INTERPOLATION,
-                                                         DATA_COARSEN_TYPE,
-                                                         BDRY_EXTRAP_TYPE,
-                                                         CONSISTENT_TYPE_2_BDRY,
-                                                         d_P_bc_coef,
-                                                         fill_pattern);
-    InterpolationTransactionComponent P_scratch_transaction_comp(d_P_scratch_idx,
-                                                                 DATA_REFINE_TYPE,
-                                                                 USE_CF_INTERPOLATION,
-                                                                 DATA_COARSEN_TYPE,
-                                                                 BDRY_EXTRAP_TYPE,
-                                                                 CONSISTENT_TYPE_2_BDRY,
-                                                                 d_P_bc_coef,
-                                                                 fill_pattern);
+    InterpolationTransactionComponent P_transaction_comp(P_idx, DATA_REFINE_TYPE, USE_CF_INTERPOLATION,
+                                                         DATA_COARSEN_TYPE, BDRY_EXTRAP_TYPE, CONSISTENT_TYPE_2_BDRY,
+                                                         d_P_bc_coef, fill_pattern);
+    InterpolationTransactionComponent P_scratch_transaction_comp(
+        d_P_scratch_idx, DATA_REFINE_TYPE, USE_CF_INTERPOLATION, DATA_COARSEN_TYPE, BDRY_EXTRAP_TYPE,
+        CONSISTENT_TYPE_2_BDRY, d_P_bc_coef, fill_pattern);
 
-    // (1) Solve the pressure sub-problem by applying inv(S^) to F_P, in which
+    switch (d_factorization_type)
+    {
+    case LOWER_TRIANGULAR:
+        solvePressureSubsystem(*P_vec, *F_P_vec, /*initial_guess_nonzero*/ false);
+        d_P_bdry_fill_op->resetTransactionComponent(P_transaction_comp);
+        d_hier_math_ops->grad(d_F_U_mod_idx, F_U_sc_var, /*cf_bdry_synch*/ true, -1.0, P_idx, P_cc_var,
+                              d_P_bdry_fill_op, d_pressure_solver->getSolutionTime(), 1.0, F_U_idx, F_U_sc_var);
+        d_P_bdry_fill_op->resetTransactionComponent(P_scratch_transaction_comp);
+        solveVelocitySubsystem(*U_vec, *F_U_mod_vec, /*initial_guess_nonzero*/ false);
+        break;
+
+    case UPPER_TRIANGULAR:
+        solveVelocitySubsystem(*U_vec, *F_U_vec, /*initial_guess_nonzero*/ false);
+        d_hier_math_ops->div(d_F_P_mod_idx, F_P_cc_var, 1.0, U_idx, U_sc_var, d_no_fill_op,
+                             d_velocity_solver->getSolutionTime(), /*cf_bdry_synch*/ true, 1.0, F_P_idx, F_P_cc_var);
+        solvePressureSubsystem(*P_vec, *F_P_mod_vec, /*initial_guess_nonzero*/ false);
+        break;
+
+    case SYMMETRIC:
+        solveVelocitySubsystem(*U_vec, *F_U_vec, /*initial_guess_nonzero*/ false);
+        d_hier_math_ops->div(d_F_P_mod_idx, F_P_cc_var, 1.0, U_idx, U_sc_var, d_no_fill_op,
+                             d_velocity_solver->getSolutionTime(), /*cf_bdry_synch*/ true, 1.0, F_P_idx, F_P_cc_var);
+        solvePressureSubsystem(*P_vec, *F_P_mod_vec, /*initial_guess_nonzero*/ false);
+        d_P_bdry_fill_op->resetTransactionComponent(P_transaction_comp);
+        d_hier_math_ops->grad(d_F_U_mod_idx, F_U_sc_var, /*cf_bdry_synch*/ true, -1.0, P_idx, P_cc_var,
+                              d_P_bdry_fill_op, d_pressure_solver->getSolutionTime(), 1.0, F_U_idx, F_U_sc_var);
+        d_P_bdry_fill_op->resetTransactionComponent(P_scratch_transaction_comp);
+        solveVelocitySubsystem(*U_vec, *F_U_mod_vec, /*initial_guess_nonzero*/ true);
+        break;
+
+    default:
+        TBOX_ERROR("unsupported block factorization type\n");
+    }
+
+    // Account for nullspace vectors.
+    correctNullspace(U_vec, P_vec);
+
+    // Deallocate the solver (if necessary).
+    if (deallocate_at_completion) deallocateSolverState();
+
+    IBAMR_TIMER_STOP(t_solve_system);
+    return true;
+}
+
+void StaggeredStokesBlockFactorizationPreconditioner::initializeSolverState(const SAMRAIVectorReal<NDIM, double>& x,
+                                                                            const SAMRAIVectorReal<NDIM, double>& b)
+{
+    IBAMR_TIMER_START(t_initialize_solver_state);
+
+    if (d_is_initialized) deallocateSolverState();
+
+    // Parent class initialization.
+    StaggeredStokesBlockPreconditioner::initializeSolverState(x, b);
+
+    // Setup hierarchy operators.
+    Pointer<VariableFillPattern<NDIM> > fill_pattern = new CellNoCornersFillPattern(CELLG, false, false, true);
+    typedef HierarchyGhostCellInterpolation::InterpolationTransactionComponent InterpolationTransactionComponent;
+    InterpolationTransactionComponent P_scratch_component(d_P_scratch_idx, DATA_REFINE_TYPE, USE_CF_INTERPOLATION,
+                                                          DATA_COARSEN_TYPE, BDRY_EXTRAP_TYPE, CONSISTENT_TYPE_2_BDRY,
+                                                          d_P_bc_coef, fill_pattern);
+    d_P_bdry_fill_op = new HierarchyGhostCellInterpolation();
+    d_P_bdry_fill_op->setHomogeneousBc(true);
+    d_P_bdry_fill_op->initializeOperatorState(P_scratch_component, d_hierarchy);
+
+    // Allocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_F_U_mod_idx)) level->allocatePatchData(d_F_U_mod_idx);
+        if (!level->checkAllocated(d_P_scratch_idx)) level->allocatePatchData(d_P_scratch_idx);
+        if (!level->checkAllocated(d_F_P_mod_idx)) level->allocatePatchData(d_F_P_mod_idx);
+    }
+
+    d_is_initialized = true;
+
+    IBAMR_TIMER_STOP(t_initialize_solver_state);
+    return;
+} // initializeSolverState
+
+void StaggeredStokesBlockFactorizationPreconditioner::deallocateSolverState()
+{
+    if (!d_is_initialized) return;
+
+    IBAMR_TIMER_START(t_deallocate_solver_state);
+
+    // Parent class deallocation.
+    StaggeredStokesBlockPreconditioner::deallocateSolverState();
+
+    // Deallocate hierarchy operators.
+    d_P_bdry_fill_op.setNull();
+
+    // Deallocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (level->checkAllocated(d_F_U_mod_idx)) level->deallocatePatchData(d_F_U_mod_idx);
+        if (level->checkAllocated(d_P_scratch_idx)) level->deallocatePatchData(d_P_scratch_idx);
+        if (level->checkAllocated(d_F_P_mod_idx)) level->deallocatePatchData(d_F_P_mod_idx);
+    }
+
+    d_is_initialized = false;
+
+    IBAMR_TIMER_STOP(t_deallocate_solver_state);
+    return;
+} // deallocateSolverState
+
+void StaggeredStokesBlockFactorizationPreconditioner::setInitialGuessNonzero(bool initial_guess_nonzero)
+{
+    if (initial_guess_nonzero)
+    {
+        TBOX_ERROR(d_object_name + "::setInitialGuessNonzero()\n"
+                   << "  class IBAMR::StaggeredStokesBlockFactorizationPreconditioner requires a "
+                      "zero initial guess" << std::endl);
+    }
+    return;
+} // setInitialGuessNonzero
+
+void StaggeredStokesBlockFactorizationPreconditioner::setMaxIterations(int max_iterations)
+{
+    if (max_iterations != 1)
+    {
+        TBOX_ERROR(d_object_name + "::setMaxIterations()\n"
+                   << "  class IBAMR::StaggeredStokesBlockFactorizationPreconditioner only "
+                      "performs a single iteration" << std::endl);
+    }
+    return;
+} // setMaxIterations
+
+/////////////////////////////// PROTECTED ////////////////////////////////////
+
+/////////////////////////////// PRIVATE //////////////////////////////////////
+
+void StaggeredStokesBlockFactorizationPreconditioner::solvePressureSubsystem(SAMRAIVectorReal<NDIM, double>& P_vec,
+                                                                             SAMRAIVectorReal<NDIM, double>& F_P_vec,
+                                                                             const bool initial_guess_nonzero)
+{
+    // Get the vector components.
+    const int P_idx = P_vec.getComponentDescriptorIndex(0);
+    const Pointer<Variable<NDIM> >& P_var = P_vec.getComponentVariable(0);
+    Pointer<CellVariable<NDIM, double> > P_cc_var = P_var;
+
+    const int F_P_idx = F_P_vec.getComponentDescriptorIndex(0);
+    const Pointer<Variable<NDIM> >& F_P_var = F_P_vec.getComponentVariable(0);
+    Pointer<CellVariable<NDIM, double> > F_P_cc_var = F_P_var;
+
+    Pointer<SAMRAIVectorReal<NDIM, double> > P_scratch_vec;
+    P_scratch_vec =
+        new SAMRAIVectorReal<NDIM, double>(d_object_name + "::P_scratch", d_hierarchy, d_coarsest_ln, d_finest_ln);
+    P_scratch_vec->addComponent(d_P_var, d_P_scratch_idx, d_pressure_wgt_idx, d_pressure_data_ops);
+
+    // Solve the pressure sub-problem by applying inv(S^) to F_P, in which
     // S^ is the approximate Schur complement.
     //
     // The Schur complement S is
@@ -283,6 +453,9 @@ bool StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorRe
     //       d_U_problem_coefs.getDConstant() == -K*mu
     //
     // in which K depends on the form of the time stepping scheme.
+    const bool steady_state =
+        d_U_problem_coefs.cIsZero() ||
+        (d_U_problem_coefs.cIsConstant() && MathUtilities<double>::equalEps(d_U_problem_coefs.getCConstant(), 0.0));
     if (steady_state)
     {
         d_pressure_data_ops->scale(P_idx, d_U_problem_coefs.getDConstant(), F_P_idx);
@@ -291,135 +464,29 @@ bool StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorRe
     {
         d_pressure_solver->setHomogeneousBc(true);
         LinearSolver* p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
-        if (p_pressure_solver) p_pressure_solver->setInitialGuessNonzero(false);
-        d_pressure_solver->solveSystem(*P_scratch_vec, *F_P_vec); // P_scratch_idx := -inv(L_rho)*F_P
-        d_pressure_data_ops->linearSum(
-            P_idx, -1.0 / getDt(), d_P_scratch_idx, d_U_problem_coefs.getDConstant(), F_P_idx);
+        if (p_pressure_solver) p_pressure_solver->setInitialGuessNonzero(initial_guess_nonzero);
+        d_pressure_solver->solveSystem(*P_scratch_vec, F_P_vec); // P_scratch_idx := -inv(L_rho)*F_P
+        d_pressure_data_ops->linearSum(P_idx, -1.0 / getDt(), d_P_scratch_idx, d_U_problem_coefs.getDConstant(),
+                                       F_P_idx);
     }
-    d_P_bdry_fill_op->resetTransactionComponent(P_transaction_comp);
-    d_P_bdry_fill_op->fillData(d_pressure_solver->getSolutionTime());
-    d_P_bdry_fill_op->resetTransactionComponent(P_scratch_transaction_comp);
+    return;
+}
 
-    // (2) Solve the velocity sub-problem.
+void StaggeredStokesBlockFactorizationPreconditioner::solveVelocitySubsystem(SAMRAIVectorReal<NDIM, double>& U_vec,
+                                                                             SAMRAIVectorReal<NDIM, double>& F_U_vec,
+                                                                             const bool initial_guess_nonzero)
+{
+    // Solve the velocity sub-problem.
     //
-    // U := inv(rho/dt - K*mu*L) * [F_U - G P]
-    static const bool cf_bdry_synch = true;
-    d_hier_math_ops->grad(d_F_U_mod_idx,
-                          d_U_var,
-                          cf_bdry_synch,
-                          -1.0,
-                          P_idx,
-                          P_cc_var,
-                          d_no_fill_op,
-                          d_pressure_solver->getSolutionTime(),
-                          1.0,
-                          F_U_idx,
-                          F_U_sc_var);
+    //    U := inv(rho/dt - K*mu*L) * F_U
+    //
+    // No special treatment is needed for the steady-state case.
     d_velocity_solver->setHomogeneousBc(true);
     LinearSolver* p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
-    if (p_velocity_solver) p_velocity_solver->setInitialGuessNonzero(false);
-    d_velocity_solver->solveSystem(*U_vec, *F_U_mod_vec);
-
-    // Account for nullspace vectors.
-    correctNullspace(U_vec, P_vec);
-
-    // Deallocate the solver (if necessary).
-    if (deallocate_at_completion) deallocateSolverState();
-
-    IBAMR_TIMER_STOP(t_solve_system);
-    return true;
-} // solveSystem
-
-void StaggeredStokesBlockFactorizationPreconditioner::initializeSolverState(const SAMRAIVectorReal<NDIM, double>& x,
-                                                                            const SAMRAIVectorReal<NDIM, double>& b)
-{
-    IBAMR_TIMER_START(t_initialize_solver_state);
-
-    if (d_is_initialized) deallocateSolverState();
-
-    // Parent class initialization.
-    StaggeredStokesBlockPreconditioner::initializeSolverState(x, b);
-
-    // Setup hierarchy operators.
-    Pointer<VariableFillPattern<NDIM> > fill_pattern = new CellNoCornersFillPattern(CELLG, false, false, true);
-    typedef HierarchyGhostCellInterpolation::InterpolationTransactionComponent InterpolationTransactionComponent;
-    InterpolationTransactionComponent P_scratch_component(d_P_scratch_idx,
-                                                          DATA_REFINE_TYPE,
-                                                          USE_CF_INTERPOLATION,
-                                                          DATA_COARSEN_TYPE,
-                                                          BDRY_EXTRAP_TYPE,
-                                                          CONSISTENT_TYPE_2_BDRY,
-                                                          d_P_bc_coef,
-                                                          fill_pattern);
-    d_P_bdry_fill_op = new HierarchyGhostCellInterpolation();
-    d_P_bdry_fill_op->setHomogeneousBc(true);
-    d_P_bdry_fill_op->initializeOperatorState(P_scratch_component, d_hierarchy);
-
-    // Allocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_F_U_mod_idx)) level->allocatePatchData(d_F_U_mod_idx);
-        if (!level->checkAllocated(d_P_scratch_idx)) level->allocatePatchData(d_P_scratch_idx);
-    }
-
-    d_is_initialized = true;
-
-    IBAMR_TIMER_STOP(t_initialize_solver_state);
+    if (p_velocity_solver) p_velocity_solver->setInitialGuessNonzero(initial_guess_nonzero);
+    d_velocity_solver->solveSystem(U_vec, F_U_vec);
     return;
-} // initializeSolverState
-
-void StaggeredStokesBlockFactorizationPreconditioner::deallocateSolverState()
-{
-    if (!d_is_initialized) return;
-
-    IBAMR_TIMER_START(t_deallocate_solver_state);
-
-    // Parent class deallocation.
-    StaggeredStokesBlockPreconditioner::deallocateSolverState();
-
-    // Deallocate hierarchy operators.
-    d_P_bdry_fill_op.setNull();
-
-    // Deallocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_F_U_mod_idx)) level->deallocatePatchData(d_F_U_mod_idx);
-        if (level->checkAllocated(d_P_scratch_idx)) level->deallocatePatchData(d_P_scratch_idx);
-    }
-
-    d_is_initialized = false;
-
-    IBAMR_TIMER_STOP(t_deallocate_solver_state);
-    return;
-} // deallocateSolverState
-
-void StaggeredStokesBlockFactorizationPreconditioner::setInitialGuessNonzero(bool initial_guess_nonzero)
-{
-    if (initial_guess_nonzero)
-    {
-        TBOX_ERROR(d_object_name + "::setInitialGuessNonzero()\n"
-                   << "  class IBAMR::StaggeredStokesBlockFactorizationPreconditioner requires a "
-                      "zero initial guess" << std::endl);
-    }
-    return;
-} // setInitialGuessNonzero
-
-void StaggeredStokesBlockFactorizationPreconditioner::setMaxIterations(int max_iterations)
-{
-    if (max_iterations != 1)
-    {
-        TBOX_ERROR(d_object_name + "::setMaxIterations()\n"
-                   << "  class IBAMR::StaggeredStokesBlockFactorizationPreconditioner only "
-                      "performs a single iteration" << std::endl);
-    }
-    return;
-} // setMaxIterations
-
-/////////////////////////////// PROTECTED ////////////////////////////////////
-
-/////////////////////////////// PRIVATE //////////////////////////////////////
+}
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
@@ -131,6 +131,10 @@ StaggeredStokesBlockFactorizationPreconditioner::StaggeredStokesBlockFactorizati
         {
             d_factorization_type = SYMMETRIC;
         }
+        else if (factorization_type_string == "DIAGONAL")
+        {
+            d_factorization_type = DIAGONAL;
+        }
         else
         {
             TBOX_ERROR("unsupported factorization type: " << factorization_type_string << "\n");
@@ -288,6 +292,11 @@ bool StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorRe
                               d_P_bdry_fill_op, d_pressure_solver->getSolutionTime(), 1.0, F_U_idx, F_U_sc_var);
         d_P_bdry_fill_op->resetTransactionComponent(P_scratch_transaction_comp);
         solveVelocitySubsystem(*U_vec, *F_U_mod_vec, /*initial_guess_nonzero*/ true);
+        break;
+
+    case DIAGONAL:
+        solveVelocitySubsystem(*U_vec, *F_U_vec, /*initial_guess_nonzero*/ false);
+        solvePressureSubsystem(*P_vec, *F_P_vec, /*initial_guess_nonzero*/ false);
         break;
 
     default:

--- a/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
@@ -266,7 +266,7 @@ bool StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorRe
 
     switch (d_factorization_type)
     {
-    case LOWER_TRIANGULAR:
+    case UPPER_TRIANGULAR:
         solvePressureSubsystem(*P_vec, *F_P_vec, /*initial_guess_nonzero*/ false);
         d_P_bdry_fill_op->resetTransactionComponent(P_transaction_comp);
         d_hier_math_ops->grad(d_F_U_mod_idx, F_U_sc_var, /*cf_bdry_synch*/ true, -1.0, P_idx, P_cc_var,
@@ -275,7 +275,7 @@ bool StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorRe
         solveVelocitySubsystem(*U_vec, *F_U_mod_vec, /*initial_guess_nonzero*/ false);
         break;
 
-    case UPPER_TRIANGULAR:
+    case LOWER_TRIANGULAR:
         solveVelocitySubsystem(*U_vec, *F_U_vec, /*initial_guess_nonzero*/ false);
         d_hier_math_ops->div(d_F_P_mod_idx, F_P_cc_var, 1.0, U_idx, U_sc_var, d_no_fill_op,
                              d_velocity_solver->getSolutionTime(), /*cf_bdry_synch*/ true, 1.0, F_P_idx, F_P_cc_var);


### PR DESCRIPTION
The original implementation of the "block factorization" Stokes preconditioner implemented the lower-triangular preconditioner described in [this paper](http://cims.nyu.edu/~donev/CFD/StokesPreconditioners.pdf).

As requested by @adonev  and @fbusabiaga, this PR adds support for the upper-triangular and diagonal preconditioners also described in that paper, along with a symmetric non-diagonal preconditioner.