### PR TITLE
Simplify Cartesian grid boundary condition handling

### DIFF
--- a/ibtk/include/ibtk/GeneralOperator.h
+++ b/ibtk/include/ibtk/GeneralOperator.h
@@ -241,9 +241,9 @@ public:
     virtual void deallocateOperatorState();
 
     /*!
-     * \brief Modify u to account for boundary conditions.
+     * \brief Modify u and f to account for boundary conditions.
      *
-     * Before calling this function, the form of the vector u should be set
+     * Before calling this function, the form of the vectors u and f should be set
      * properly by the user on all patch interiors on the range of levels
      * covered by the operator.  All data in this vector should be allocated.
      * The user is responsible for managing the storage for the vectors.
@@ -253,10 +253,12 @@ public:
      * \see initializeOperatorState
      *
      * \param u output: u modified to account for any physical boundary conditions
+     * \param f output: f modified to account for any physical boundary conditions
      *
-     * \note A default implementation is provided that does not modify the vector u.
+     * \note A default implementation is provided that does not modify u or f.
      */
-    virtual void imposeSolBc(SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& u);
+    virtual void modifySolverVecsForBcs(SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& u,
+                                        SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& f);
 
     //\}
 

--- a/ibtk/include/ibtk/GeneralOperator.h
+++ b/ibtk/include/ibtk/GeneralOperator.h
@@ -240,6 +240,24 @@ public:
      */
     virtual void deallocateOperatorState();
 
+    /*!
+     * \brief Modify u to account for boundary conditions.
+     *
+     * Before calling this function, the form of the vector u should be set
+     * properly by the user on all patch interiors on the range of levels
+     * covered by the operator.  All data in this vector should be allocated.
+     * The user is responsible for managing the storage for the vectors.
+     *
+     * \note The operator MUST be initialized prior to calling imposeSolBc.
+     *
+     * \see initializeOperatorState
+     *
+     * \param u output: u modified to account for any physical boundary conditions
+     *
+     * \note A default implementation is provided that does not modify the vector u.
+     */
+    virtual void imposeSolBc(SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& u);
+
     //\}
 
     /*!

--- a/ibtk/include/ibtk/LinearOperator.h
+++ b/ibtk/include/ibtk/LinearOperator.h
@@ -88,10 +88,7 @@ public:
      *
      * \see initializeOperatorState
      *
-     * \param y output: y=Ax
-     *
-     * \note A default implementation is provided which does nothing but warns
-     * that inhomogeneous boundary conditions are not properly supported.
+     * \param y output: y:=y-A*0
      */
     virtual void modifyRhsForInhomogeneousBc(SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& y);
 

--- a/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
@@ -223,6 +223,7 @@ bool PETScKrylovLinearSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAM
     if (d_b) d_b->allocateVectorData();
 
     // Solve the system using a PETSc KSP object.
+    d_A->imposeSolBc(x);
     PETScSAMRAIVectorReal::replaceSAMRAIVector(d_petsc_x, Pointer<SAMRAIVectorReal<NDIM, double> >(&x, false));
     d_A->setHomogeneousBc(d_homogeneous_bc);
     if (d_homogeneous_bc)
@@ -613,12 +614,12 @@ void PETScKrylovLinearSolver::resetKSPOperators()
     }
     if (!d_petsc_mat)
     {
-        ierr = MatCreateShell(
-            d_petsc_comm, 1, 1, PETSC_DETERMINE, PETSC_DETERMINE, static_cast<void*>(this), &d_petsc_mat);
+        ierr = MatCreateShell(d_petsc_comm, 1, 1, PETSC_DETERMINE, PETSC_DETERMINE, static_cast<void*>(this),
+                              &d_petsc_mat);
         IBTK_CHKERRQ(ierr);
     }
-    ierr = MatShellSetOperation(
-        d_petsc_mat, MATOP_MULT, reinterpret_cast<void (*)(void)>(PETScKrylovLinearSolver::MatVecMult_SAMRAI));
+    ierr = MatShellSetOperation(d_petsc_mat, MATOP_MULT,
+                                reinterpret_cast<void (*)(void)>(PETScKrylovLinearSolver::MatVecMult_SAMRAI));
     IBTK_CHKERRQ(ierr);
 
     // Reset the configuration of the PETSc KSP object.
@@ -724,8 +725,8 @@ void PETScKrylovLinearSolver::resetKSPNullspace()
         }
 
         static const PetscBool has_cnst = PETSC_FALSE;
-        ierr = MatNullSpaceCreate(
-            d_petsc_comm, has_cnst, static_cast<int>(nullspace_vecs.size()), &nullspace_vecs[0], &d_petsc_nullsp);
+        ierr = MatNullSpaceCreate(d_petsc_comm, has_cnst, static_cast<int>(nullspace_vecs.size()), &nullspace_vecs[0],
+                                  &d_petsc_nullsp);
         IBTK_CHKERRQ(ierr);
         ierr = KSPSetNullSpace(d_petsc_ksp, d_petsc_nullsp);
         IBTK_CHKERRQ(ierr);
@@ -758,9 +759,8 @@ void PETScKrylovLinearSolver::deallocateNullspaceData()
         PETScSAMRAIVectorReal::destroyPETScVector(d_petsc_nullspace_constant_vec);
         d_petsc_nullspace_constant_vec = NULL;
         d_nullspace_constant_vec->resetLevels(
-            0,
-            std::min(d_nullspace_constant_vec->getFinestLevelNumber(),
-                     d_nullspace_constant_vec->getPatchHierarchy()->getFinestLevelNumber()));
+            0, std::min(d_nullspace_constant_vec->getFinestLevelNumber(),
+                        d_nullspace_constant_vec->getPatchHierarchy()->getFinestLevelNumber()));
         d_nullspace_constant_vec->deallocateVectorData();
         d_nullspace_constant_vec->freeVectorComponents();
         d_nullspace_constant_vec.setNull();

--- a/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
@@ -223,20 +223,14 @@ bool PETScKrylovLinearSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAM
     if (d_b) d_b->allocateVectorData();
 
     // Solve the system using a PETSc KSP object.
-    d_A->imposeSolBc(x);
     PETScSAMRAIVectorReal::replaceSAMRAIVector(d_petsc_x, Pointer<SAMRAIVectorReal<NDIM, double> >(&x, false));
     d_A->setHomogeneousBc(d_homogeneous_bc);
-    if (d_homogeneous_bc)
-    {
-        PETScSAMRAIVectorReal::replaceSAMRAIVector(d_petsc_b, Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false));
-    }
-    else
-    {
-        d_b->copyVector(Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false));
-        d_A->modifyRhsForInhomogeneousBc(*d_b);
-        PETScSAMRAIVectorReal::replaceSAMRAIVector(d_petsc_b, d_b);
-        d_A->setHomogeneousBc(true);
-    }
+    d_b->copyVector(Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false));
+    d_A->modifyRhsForInhomogeneousBc(*d_b);
+    PETScSAMRAIVectorReal::replaceSAMRAIVector(d_petsc_b, d_b);
+    d_A->modifySolverVecsForBcs(x, *d_b);
+    d_A->setHomogeneousBc(true);
+
     ierr = PetscObjectStateIncrease(reinterpret_cast<PetscObject>(d_petsc_x));
     IBTK_CHKERRQ(ierr);
     ierr = PetscObjectStateIncrease(reinterpret_cast<PetscObject>(d_petsc_b));

--- a/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
@@ -214,22 +214,17 @@ bool PETScNewtonKrylovSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAM
     if (d_r) d_r->allocateVectorData();
 
     // Solve the system using a PETSc SNES object.
-    d_F->imposeSolBc(x);
     PETScSAMRAIVectorReal::replaceSAMRAIVector(d_petsc_x, Pointer<SAMRAIVectorReal<NDIM, double> >(&x, false));
+    d_b->copyVector(Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false));
     Pointer<LinearOperator> A = d_F;
     if (A)
     {
-        d_b->copyVector(Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false));
         A->modifyRhsForInhomogeneousBc(*d_b);
-        ierr = PetscObjectStateIncrease(reinterpret_cast<PetscObject>(d_petsc_b));
-        IBTK_CHKERRQ(ierr);
-        PETScSAMRAIVectorReal::replaceSAMRAIVector(d_petsc_b, d_b);
     }
-    else
-    {
-        PETScSAMRAIVectorReal::replaceSAMRAIVector(d_petsc_b, Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false));
-    }
-    Vec residual;
+    ierr = PetscObjectStateIncrease(reinterpret_cast<PetscObject>(d_petsc_b));
+    IBTK_CHKERRQ(ierr);
+    PETScSAMRAIVectorReal::replaceSAMRAIVector(d_petsc_b, d_b);
+    d_F->modifySolverVecsForBcs(x, *d_b);
 
     ierr = SNESSolve(d_petsc_snes, d_petsc_b, d_petsc_x);
     IBTK_CHKERRQ(ierr);
@@ -237,6 +232,7 @@ bool PETScNewtonKrylovSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAM
     IBTK_CHKERRQ(ierr);
     ierr = SNESGetLinearSolveIterations(d_petsc_snes, &d_current_linear_iterations);
     IBTK_CHKERRQ(ierr);
+    Vec residual;
     ierr = SNESGetFunction(d_petsc_snes, &residual, NULL, NULL);
     IBTK_CHKERRQ(ierr);
     ierr = VecNorm(residual, NORM_2, &d_current_residual_norm);

--- a/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
@@ -214,6 +214,7 @@ bool PETScNewtonKrylovSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAM
     if (d_r) d_r->allocateVectorData();
 
     // Solve the system using a PETSc SNES object.
+    d_F->imposeSolBc(x);
     PETScSAMRAIVectorReal::replaceSAMRAIVector(d_petsc_x, Pointer<SAMRAIVectorReal<NDIM, double> >(&x, false));
     Pointer<LinearOperator> A = d_F;
     if (A)
@@ -364,8 +365,8 @@ void PETScNewtonKrylovSolver::initializeSolverState(const SAMRAIVectorReal<NDIM,
 
     // Reset the member state variables to correspond to the values used by the
     // SNES object.  (Command-line options always take precedence.)
-    ierr = SNESGetTolerances(
-        d_petsc_snes, &d_abs_residual_tol, &d_rel_residual_tol, &d_solution_tol, &d_max_iterations, &d_max_evaluations);
+    ierr = SNESGetTolerances(d_petsc_snes, &d_abs_residual_tol, &d_rel_residual_tol, &d_solution_tol, &d_max_iterations,
+                             &d_max_evaluations);
     IBTK_CHKERRQ(ierr);
 
     // Setup the KrylovLinearSolver wrapper to correspond to the KSP employed by
@@ -538,8 +539,8 @@ void PETScNewtonKrylovSolver::resetWrappedSNES(SNES& petsc_snes)
         void* petsc_snes_func_ctx;
         ierr = SNESGetFunction(d_petsc_snes, NULL, &petsc_snes_form_func, &petsc_snes_func_ctx);
         IBTK_CHKERRQ(ierr);
-        d_F = new PETScSNESFunctionGOWrapper(
-            d_object_name + "::SNESFunction Wrapper", d_petsc_snes, petsc_snes_form_func, petsc_snes_func_ctx);
+        d_F = new PETScSNESFunctionGOWrapper(d_object_name + "::SNESFunction Wrapper", d_petsc_snes,
+                                             petsc_snes_form_func, petsc_snes_func_ctx);
         d_F->setHomogeneousBc(d_homogeneous_bc);
         d_F->setSolutionTime(d_solution_time);
         d_F->setTimeInterval(d_current_time, d_new_time);
@@ -554,8 +555,8 @@ void PETScNewtonKrylovSolver::resetWrappedSNES(SNES& petsc_snes)
         void* petsc_snes_jac_ctx;
         ierr = SNESGetJacobian(d_petsc_snes, NULL, NULL, &petsc_snes_form_jac, &petsc_snes_jac_ctx);
         IBTK_CHKERRQ(ierr);
-        d_J = new PETScSNESJacobianJOWrapper(
-            d_object_name + "::SNESJacobian Wrapper", d_petsc_snes, petsc_snes_form_jac, petsc_snes_jac_ctx);
+        d_J = new PETScSNESJacobianJOWrapper(d_object_name + "::SNESJacobian Wrapper", d_petsc_snes,
+                                             petsc_snes_form_jac, petsc_snes_jac_ctx);
         d_J->setHomogeneousBc(true);
         d_J->setSolutionTime(d_solution_time);
         d_J->setTimeInterval(d_current_time, d_new_time);
@@ -571,8 +572,8 @@ void PETScNewtonKrylovSolver::resetWrappedSNES(SNES& petsc_snes)
 
     // Reset the member state variables to correspond to the values used by the
     // SNES object.
-    ierr = SNESGetTolerances(
-        d_petsc_snes, &d_abs_residual_tol, &d_rel_residual_tol, &d_solution_tol, &d_max_iterations, &d_max_evaluations);
+    ierr = SNESGetTolerances(d_petsc_snes, &d_abs_residual_tol, &d_rel_residual_tol, &d_solution_tol, &d_max_iterations,
+                             &d_max_evaluations);
     IBTK_CHKERRQ(ierr);
     return;
 } // resetWrappedSNES
@@ -580,8 +581,8 @@ void PETScNewtonKrylovSolver::resetWrappedSNES(SNES& petsc_snes)
 void PETScNewtonKrylovSolver::resetSNESOptions()
 {
     if (!d_petsc_snes) return;
-    int ierr = SNESSetTolerances(
-        d_petsc_snes, d_abs_residual_tol, d_rel_residual_tol, d_solution_tol, d_max_iterations, d_max_evaluations);
+    int ierr = SNESSetTolerances(d_petsc_snes, d_abs_residual_tol, d_rel_residual_tol, d_solution_tol, d_max_iterations,
+                                 d_max_evaluations);
     IBTK_CHKERRQ(ierr);
     return;
 } // resetSNESSNESOptions
@@ -589,8 +590,8 @@ void PETScNewtonKrylovSolver::resetSNESOptions()
 void PETScNewtonKrylovSolver::resetSNESFunction()
 {
     if (!d_petsc_snes) return;
-    int ierr = SNESSetFunction(
-        d_petsc_snes, d_petsc_r, PETScNewtonKrylovSolver::FormFunction_SAMRAI, static_cast<void*>(this));
+    int ierr = SNESSetFunction(d_petsc_snes, d_petsc_r, PETScNewtonKrylovSolver::FormFunction_SAMRAI,
+                               static_cast<void*>(this));
     IBTK_CHKERRQ(ierr);
     return;
 } // resetSNESFunction
@@ -609,11 +610,11 @@ void PETScNewtonKrylovSolver::resetSNESJacobian()
     }
     if (d_J && d_user_provided_jacobian)
     {
-        ierr = MatCreateShell(
-            d_petsc_comm, 1, 1, PETSC_DETERMINE, PETSC_DETERMINE, static_cast<void*>(this), &d_petsc_jac);
+        ierr = MatCreateShell(d_petsc_comm, 1, 1, PETSC_DETERMINE, PETSC_DETERMINE, static_cast<void*>(this),
+                              &d_petsc_jac);
         IBTK_CHKERRQ(ierr);
-        ierr = MatShellSetOperation(
-            d_petsc_jac, MATOP_MULT, reinterpret_cast<void (*)(void)>(PETScNewtonKrylovSolver::MatVecMult_SAMRAI));
+        ierr = MatShellSetOperation(d_petsc_jac, MATOP_MULT,
+                                    reinterpret_cast<void (*)(void)>(PETScNewtonKrylovSolver::MatVecMult_SAMRAI));
         IBTK_CHKERRQ(ierr);
     }
     else
@@ -633,8 +634,8 @@ void PETScNewtonKrylovSolver::resetSNESJacobian()
     }
 
     // Reset the configuration of the PETSc SNES object.
-    ierr = SNESSetJacobian(
-        d_petsc_snes, d_petsc_jac, d_petsc_jac, PETScNewtonKrylovSolver::FormJacobian_SAMRAI, static_cast<void*>(this));
+    ierr = SNESSetJacobian(d_petsc_snes, d_petsc_jac, d_petsc_jac, PETScNewtonKrylovSolver::FormJacobian_SAMRAI,
+                           static_cast<void*>(this));
     IBTK_CHKERRQ(ierr);
     return;
 } // resetSNESJacobian
@@ -653,11 +654,7 @@ PetscErrorCode PETScNewtonKrylovSolver::FormFunction_SAMRAI(SNES /*snes*/, Vec x
     PetscFunctionReturn(0);
 } // FormFunction_SAMRAI
 
-PetscErrorCode PETScNewtonKrylovSolver::FormJacobian_SAMRAI(SNES snes,
-                                                            Vec x,
-                                                            Mat A,
-                                                            Mat /*B*/,
-                                                            void* p_ctx)
+PetscErrorCode PETScNewtonKrylovSolver::FormJacobian_SAMRAI(SNES snes, Vec x, Mat A, Mat /*B*/, void* p_ctx)
 {
     int ierr;
     PETScNewtonKrylovSolver* newton_solver = static_cast<PETScNewtonKrylovSolver*>(p_ctx);

--- a/ibtk/src/solvers/interfaces/GeneralOperator.cpp
+++ b/ibtk/src/solvers/interfaces/GeneralOperator.cpp
@@ -159,7 +159,8 @@ void GeneralOperator::deallocateOperatorState()
     return;
 } // deallocateOperatorState
 
-void GeneralOperator::imposeSolBc(SAMRAIVectorReal<NDIM, double>& /*u*/)
+void GeneralOperator::modifySolverVecsForBcs(SAMRAIVectorReal<NDIM, double>& /*u*/,
+                                             SAMRAIVectorReal<NDIM, double>& /*f*/)
 {
     // intentionally blank
     return;

--- a/ibtk/src/solvers/interfaces/GeneralOperator.cpp
+++ b/ibtk/src/solvers/interfaces/GeneralOperator.cpp
@@ -159,6 +159,12 @@ void GeneralOperator::deallocateOperatorState()
     return;
 } // deallocateOperatorState
 
+void GeneralOperator::imposeSolBc(SAMRAIVectorReal<NDIM, double>& /*u*/)
+{
+    // intentionally blank
+    return;
+} // imposeSolBc
+
 void GeneralOperator::setLoggingEnabled(bool enable_logging)
 {
     d_enable_logging = enable_logging;

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1109,7 +1109,6 @@ void INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const double 
     d_U_bdry_bc_fill_op->fillData(current_time);
     StaggeredStokesPhysicalBoundaryHelper::resetBcCoefObjects(d_U_bc_coefs,
                                                               /*P_bc_coef*/ NULL);
-    //  d_bc_helper->enforceDivergenceFreeConditionAtBoundary(d_U_scratch_idx);
     d_hier_math_ops->laplace(
         U_rhs_idx, U_rhs_var, U_rhs_problem_coefs, d_U_scratch_idx, d_U_var, d_no_fill_op, current_time);
     d_hier_sc_data_ops->copyData(d_U_src_idx, d_U_scratch_idx, /*interior_only*/ false);
@@ -2006,8 +2005,6 @@ void INSStaggeredHierarchyIntegrator::setupPlotDataSpecialized()
         }
         d_hier_sc_data_ops->copyData(d_U_scratch_idx, d_U_current_idx);
         d_U_bdry_bc_fill_op->fillData(d_integrator_time);
-        //      d_bc_helper->cacheBcCoefData(d_bc_coefs, d_integrator_time, d_hierarchy);
-        //      d_bc_helper->enforceDivergenceFreeConditionAtBoundary(d_U_scratch_idx);
         d_hier_math_ops->curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_no_fill_op, d_integrator_time);
         for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
         {


### PR DESCRIPTION
This is an attempt to simplify the boundary condition handling for cases in which some DOFs live on the domain boundary (e.g. node, side/face, or edge data).