### PR TITLE
update to PETSc 3.6

### DIFF
--- a/configure
+++ b/configure
@@ -23019,14 +23019,14 @@ else
 fi
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libMesh version 0.9.4 or 0.9.5" >&5
-$as_echo_n "checking for libMesh version 0.9.4 or 0.9.5... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libMesh version 0.9.5 or newer" >&5
+$as_echo_n "checking for libMesh version 0.9.5 or newer... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <libmesh/libmesh_config.h>
 
-#if ((LIBMESH_MAJOR_VERSION == 0) && (LIBMESH_MINOR_VERSION == 9) && ((LIBMESH_MICRO_VERSION >= 4) && (LIBMESH_MICRO_VERSION <= 5)))
+#if ((LIBMESH_MAJOR_VERSION == 0) && (LIBMESH_MINOR_VERSION == 9) && (LIBMESH_MICRO_VERSION >= 5))
 #else
 asdf
 #endif
@@ -23056,7 +23056,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${LIBMESH_VERSION_VALID}" >&5
 $as_echo "${LIBMESH_VERSION_VALID}" >&6; }
   if test "$LIBMESH_VERSION_VALID" = no; then
-    as_fn_error $? "invalid libMesh version detected: please use libMesh 0.9.4 or 0.9.5" "$LINENO" 5
+    as_fn_error $? "invalid libMesh version detected: please use libMesh 0.9.5 or newer" "$LINENO" 5
   fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: obtaining libMesh configuration information from libmesh_common.h" >&5
 $as_echo "$as_me: obtaining libMesh configuration information from libmesh_common.h" >&6;}
@@ -27276,7 +27276,7 @@ FCLIBS="$PACKAGE_FCLIBS $FCLIBS"
 CONTRIB_LIBS="$PACKAGE_CONTRIB_LIBS $CONTRIB_LIBS"
 
 
-if test `grep -c HDF5 "${PETSC_DIR}/${PETSC_ARCH}/conf/petscvariables"` != 0 ; then
+if test `grep -c HDF5 "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables"` != 0 ; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: PETSc appears to provide HDF5; using PETSc HDF5 library" >&5
 $as_echo "$as_me: PETSc appears to provide HDF5; using PETSc HDF5 library" >&6;}
   PETSC_BUNDLES_HDF5=yes
@@ -28514,7 +28514,7 @@ FCLIBS="$PACKAGE_FCLIBS $FCLIBS"
 CONTRIB_LIBS="$PACKAGE_CONTRIB_LIBS $CONTRIB_LIBS"
 
 
-if test `grep -c HYPRE "${PETSC_DIR}/${PETSC_ARCH}/conf/petscvariables"` != 0 ; then
+if test `grep -c HYPRE "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables"` != 0 ; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: PETSc appears to provide hypre; using PETSc hypre library" >&5
 $as_echo "$as_me: PETSc appears to provide hypre; using PETSc hypre library" >&6;}
   PETSC_BUNDLES_HYPRE=yes
@@ -30408,9 +30408,9 @@ $as_echo "$as_me: using PETSC_DIR: ${PETSC_DIR}" >&6;}
 { $as_echo "$as_me:${as_lineno-$LINENO}: using PETSC_ARCH: ${PETSC_ARCH}" >&5
 $as_echo "$as_me: using PETSC_ARCH: ${PETSC_ARCH}" >&6;}
 
-PETSC_CC_INCLUDES=`grep "PETSC_CC_INCLUDES =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
-PETSC_EXTERNAL_LIB_BASIC=`grep "PETSC_EXTERNAL_LIB_BASIC =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
-PETSC_WITH_EXTERNAL_LIB=`grep "PETSC_WITH_EXTERNAL_LIB =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
+PETSC_CC_INCLUDES=`grep "PETSC_CC_INCLUDES =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
+PETSC_EXTERNAL_LIB_BASIC=`grep "PETSC_EXTERNAL_LIB_BASIC =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
+PETSC_WITH_EXTERNAL_LIB=`grep "PETSC_WITH_EXTERNAL_LIB =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
 
 CPPFLAGS="$PETSC_CC_INCLUDES $CPPFLAGS"
 
@@ -30423,8 +30423,8 @@ fi
 
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSc version 3.5" >&5
-$as_echo_n "checking for PETSc version 3.5... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSc version 3.6" >&5
+$as_echo_n "checking for PETSc version 3.6... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -30447,7 +30447,7 @@ int
 main ()
 {
 
-#if ((PETSC_VERSION_GE(3,5,0) && PETSC_VERSION_LT(3,6,0)) || !PETSC_VERSION_RELEASE)
+#if ((PETSC_VERSION_GE(3,6,0) && PETSC_VERSION_LT(3,7,0)) || !PETSC_VERSION_RELEASE)
 #else
 asdf
 #endif
@@ -30465,7 +30465,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${PETSC_VERSION_VALID}" >&5
 $as_echo "${PETSC_VERSION_VALID}" >&6; }
 if test "$PETSC_VERSION_VALID" = no; then
-  as_fn_error $? "invalid PETSc version detected: please use PETSc 3.5" "$LINENO" 5
+  as_fn_error $? "invalid PETSc version detected: please use PETSc 3.6" "$LINENO" 5
 fi
 
 LIBS="$PETSC_EXTERNAL_LIB_BASIC $LIBS"

--- a/examples/IBFE/explicit/ex0/main.cpp
+++ b/examples/IBFE/explicit/ex0/main.cpp
@@ -162,7 +162,7 @@ int main(int argc, char* argv[])
         //
         // Note that boundary condition data must be registered with each FE
         // system before calling IBFEMethod::initializeFEData().
-        Mesh mesh(NDIM);
+        Mesh mesh(init.comm(), NDIM);
         const double R = 0.25;
         const double w = 0.0625;
         const double dx0 = 1.0 / 64.0;

--- a/examples/IBFE/explicit/ex1/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex1/convergence_tester.cpp
@@ -395,14 +395,14 @@ int main(int argc, char* argv[])
             // Do the same thing for the FE data.
             string file_name;
 
-            Mesh mesh_coarse(NDIM);
+            Mesh mesh_coarse(init.comm(), NDIM);
             file_name = coarse_hier_dump_dirname + "/" + "fe_mesh.";
             sprintf(temp_buf, "%05d", coarse_iteration_num);
             file_name += temp_buf;
             file_name += ".xda";
             mesh_coarse.read(file_name);
 
-            Mesh mesh_fine(NDIM);
+            Mesh mesh_fine(init.comm(), NDIM);
             file_name = fine_hier_dump_dirname + "/" + "fe_mesh.";
             sprintf(temp_buf, "%05d", fine_iteration_num);
             file_name += temp_buf;

--- a/examples/IBFE/explicit/ex1/main.cpp
+++ b/examples/IBFE/explicit/ex1/main.cpp
@@ -164,7 +164,7 @@ int main(int argc, char* argv[])
         //
         // Note that boundary condition data must be registered with each FE
         // system before calling IBFEMethod::initializeFEData().
-        Mesh mesh(NDIM);
+        Mesh mesh(init.comm(), NDIM);
         const double R = 0.25;
         const double w = 0.0625;
         const double dx0 = 1.0 / 64.0;

--- a/examples/IBFE/explicit/ex2/main.cpp
+++ b/examples/IBFE/explicit/ex2/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char* argv[])
         //
         // Note that boundary condition data must be registered with each FE
         // system before calling IBFEMethod::initializeFEData().
-        Mesh mesh(NDIM);
+        Mesh mesh(init.comm(), NDIM);
         const double dx = input_db->getDouble("DX");
         const double ds = input_db->getDouble("MFAC") * dx;
         string elem_type = input_db->getString("ELEM_TYPE");

--- a/examples/IBFE/explicit/ex3/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex3/convergence_tester.cpp
@@ -395,14 +395,14 @@ int main(int argc, char* argv[])
             // Do the same thing for the FE data.
             string file_name;
 
-            Mesh mesh_coarse(NDIM);
+            Mesh mesh_coarse(init.comm(), NDIM);
             file_name = coarse_hier_dump_dirname + "/" + "fe_mesh.";
             sprintf(temp_buf, "%05d", coarse_iteration_num);
             file_name += temp_buf;
             file_name += ".xda";
             mesh_coarse.read(file_name);
 
-            Mesh mesh_fine(NDIM);
+            Mesh mesh_fine(init.comm(), NDIM);
             file_name = fine_hier_dump_dirname + "/" + "fe_mesh.";
             sprintf(temp_buf, "%05d", fine_iteration_num);
             file_name += temp_buf;

--- a/examples/IBFE/explicit/ex3/main.cpp
+++ b/examples/IBFE/explicit/ex3/main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char* argv[])
         //
         // Note that boundary condition data must be registered with each FE
         // system before calling IBFEMethod::initializeFEData().
-        Mesh mesh(NDIM);
+        Mesh mesh(init.comm(), NDIM);
         const double dx = input_db->getDouble("DX");
         const double ds = input_db->getDouble("MFAC") * dx;
         string elem_type = input_db->getString("ELEM_TYPE");

--- a/examples/IBFE/explicit/ex4/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex4/convergence_tester.cpp
@@ -395,14 +395,14 @@ int main(int argc, char* argv[])
             // Do the same thing for the FE data.
             string file_name;
 
-            Mesh mesh_coarse(NDIM);
+            Mesh mesh_coarse(init.comm(), NDIM);
             file_name = coarse_hier_dump_dirname + "/" + "fe_mesh.";
             sprintf(temp_buf, "%05d", coarse_iteration_num);
             file_name += temp_buf;
             file_name += ".xda";
             mesh_coarse.read(file_name);
 
-            Mesh mesh_fine(NDIM);
+            Mesh mesh_fine(init.comm(), NDIM);
             file_name = fine_hier_dump_dirname + "/" + "fe_mesh.";
             sprintf(temp_buf, "%05d", fine_iteration_num);
             file_name += temp_buf;

--- a/examples/IBFE/explicit/ex4/main.cpp
+++ b/examples/IBFE/explicit/ex4/main.cpp
@@ -167,7 +167,7 @@ int main(int argc, char* argv[])
         const int timer_dump_interval = app_initializer->getTimerDumpInterval();
 
         // Create a simple FE mesh.
-        Mesh mesh(NDIM);
+        Mesh mesh(init.comm(), NDIM);
         const double dx = input_db->getDouble("DX");
         const double ds = input_db->getDouble("MFAC") * dx;
         string elem_type = input_db->getString("ELEM_TYPE");

--- a/examples/IBFE/explicit/ex5/main.cpp
+++ b/examples/IBFE/explicit/ex5/main.cpp
@@ -194,7 +194,7 @@ int main(int argc, char* argv[])
         const int timer_dump_interval = app_initializer->getTimerDumpInterval();
 
         // Create a simple FE mesh.
-        Mesh solid_mesh(NDIM);
+        Mesh solid_mesh(init.comm(), NDIM);
         const double dx = input_db->getDouble("DX");
         const double ds = input_db->getDouble("MFAC") * dx;
         string elem_type = input_db->getString("ELEM_TYPE");

--- a/examples/IBFE/explicit/ex6/main.cpp
+++ b/examples/IBFE/explicit/ex6/main.cpp
@@ -198,7 +198,7 @@ int main(int argc, char* argv[])
         const double dx = input_db->getDouble("DX");
         const double ds = input_db->getDouble("MFAC") * dx;
 
-        Mesh block_mesh(NDIM);
+        Mesh block_mesh(init.comm(), NDIM);
         string block_elem_type = input_db->getString("BLOCK_ELEM_TYPE");
         const double R = 0.05;
         if (block_elem_type == "TRI3" || block_elem_type == "TRI6")
@@ -237,7 +237,7 @@ int main(int argc, char* argv[])
             n(1) += 0.2;
         }
 
-        Mesh beam_mesh(NDIM);
+        Mesh beam_mesh(init.comm(), NDIM);
         string beam_elem_type = input_db->getString("BEAM_ELEM_TYPE");
         MeshTools::Generation::build_square(beam_mesh, ceil(0.4 / ds), ceil(0.02 / ds), 0.2, 0.6, 0.19, 0.21,
                                             Utility::string_to_enum<ElemType>(beam_elem_type));

--- a/examples/IBFE/explicit/ex7/main.cpp
+++ b/examples/IBFE/explicit/ex7/main.cpp
@@ -195,7 +195,7 @@ int main(int argc, char* argv[])
 
         string elem_type = input_db->getString("ELEM_TYPE");
 
-        Mesh lower_mesh(NDIM);
+        Mesh lower_mesh(init.comm(), NDIM);
         MeshTools::Generation::build_square(lower_mesh, static_cast<int>(ceil(L / ds)), static_cast<int>(ceil(w / ds)),
                                             0.0, L, D - 0.5 * w, D + 0.5 * w,
                                             Utility::string_to_enum<ElemType>(elem_type));
@@ -219,7 +219,7 @@ int main(int argc, char* argv[])
             }
         }
 #endif
-        Mesh upper_mesh(NDIM);
+        Mesh upper_mesh(init.comm(), NDIM);
         MeshTools::Generation::build_square(upper_mesh, static_cast<int>(ceil(L / ds)), static_cast<int>(ceil(w / ds)),
                                             0.0, L, 2.0 * D - 0.5 * w, 2.0 * D + 0.5 * w,
                                             Utility::string_to_enum<ElemType>(elem_type));

--- a/examples/IBFE/explicit/ex8/main.cpp
+++ b/examples/IBFE/explicit/ex8/main.cpp
@@ -346,10 +346,10 @@ int main(int argc, char* argv[])
         string block_elem_type = input_db->getStringWithDefault("BLOCK_ELEM_TYPE", "QUAD9");
         string beam_elem_type = input_db->getStringWithDefault("BEAM_ELEM_TYPE", "QUAD9");
 
-        Mesh block1_mesh(NDIM);
+        Mesh block1_mesh(init.comm(), NDIM);
         MeshTools::Generation::build_square(block1_mesh, ceil(0.5 / ds_block), ceil(0.5 / ds_block), 0.0, 0.5, 0.0, 0.5,
                                             Utility::string_to_enum<ElemType>(block_elem_type));
-        Mesh block2_mesh(NDIM);
+        Mesh block2_mesh(init.comm(), NDIM);
         MeshTools::Generation::build_square(block2_mesh, ceil(0.5 / ds_block), ceil(0.5 / ds_block), 1.5, 2.0, 0.0, 0.5,
                                             Utility::string_to_enum<ElemType>(block_elem_type));
 
@@ -373,7 +373,7 @@ int main(int argc, char* argv[])
         const double beam_y_lower = 0.5 - 0.016;
         const double beam_y_upper = 0.5;
         int n_beam_y = max(static_cast<int>(ceil(beam_y_upper - beam_y_lower / ds_beam)), 4);
-        Mesh beam_mesh(NDIM);
+        Mesh beam_mesh(init.comm(), NDIM);
         MeshTools::Generation::build_square(beam_mesh, n_beam_x, n_beam_y, beam_x_lower, beam_x_upper, beam_y_lower,
                                             beam_y_upper, QUAD4);
         if (beam_use_mapped_grid)

--- a/examples/IMP/explicit/ex0/main.cpp
+++ b/examples/IMP/explicit/ex0/main.cpp
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
         const int timer_dump_interval = app_initializer->getTimerDumpInterval();
 
         // Create a simple FE mesh.
-        Mesh mesh(NDIM);
+        Mesh mesh(init.comm(), NDIM);
         const double dx = input_db->getDouble("DX");
         const double ds = input_db->getDouble("MFAC") * dx;
         string elem_type = input_db->getString("ELEM_TYPE");

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -23165,14 +23165,14 @@ else
 fi
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libMesh version 0.9.4 or 0.9.5" >&5
-$as_echo_n "checking for libMesh version 0.9.4 or 0.9.5... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libMesh version 0.9.5 or newer" >&5
+$as_echo_n "checking for libMesh version 0.9.5 or newer... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <libmesh/libmesh_config.h>
 
-#if ((LIBMESH_MAJOR_VERSION == 0) && (LIBMESH_MINOR_VERSION == 9) && ((LIBMESH_MICRO_VERSION >= 4) && (LIBMESH_MICRO_VERSION <= 5)))
+#if ((LIBMESH_MAJOR_VERSION == 0) && (LIBMESH_MINOR_VERSION == 9) && (LIBMESH_MICRO_VERSION >= 5))
 #else
 asdf
 #endif
@@ -23202,7 +23202,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${LIBMESH_VERSION_VALID}" >&5
 $as_echo "${LIBMESH_VERSION_VALID}" >&6; }
   if test "$LIBMESH_VERSION_VALID" = no; then
-    as_fn_error $? "invalid libMesh version detected: please use libMesh 0.9.4 or 0.9.5" "$LINENO" 5
+    as_fn_error $? "invalid libMesh version detected: please use libMesh 0.9.5 or newer" "$LINENO" 5
   fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: obtaining libMesh configuration information from libmesh_common.h" >&5
 $as_echo "$as_me: obtaining libMesh configuration information from libmesh_common.h" >&6;}
@@ -27422,7 +27422,7 @@ FCLIBS="$PACKAGE_FCLIBS $FCLIBS"
 CONTRIB_LIBS="$PACKAGE_CONTRIB_LIBS $CONTRIB_LIBS"
 
 
-if test `grep -c HDF5 "${PETSC_DIR}/${PETSC_ARCH}/conf/petscvariables"` != 0 ; then
+if test `grep -c HDF5 "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables"` != 0 ; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: PETSc appears to provide HDF5; using PETSc HDF5 library" >&5
 $as_echo "$as_me: PETSc appears to provide HDF5; using PETSc HDF5 library" >&6;}
   PETSC_BUNDLES_HDF5=yes
@@ -28660,7 +28660,7 @@ FCLIBS="$PACKAGE_FCLIBS $FCLIBS"
 CONTRIB_LIBS="$PACKAGE_CONTRIB_LIBS $CONTRIB_LIBS"
 
 
-if test `grep -c HYPRE "${PETSC_DIR}/${PETSC_ARCH}/conf/petscvariables"` != 0 ; then
+if test `grep -c HYPRE "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables"` != 0 ; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: PETSc appears to provide hypre; using PETSc hypre library" >&5
 $as_echo "$as_me: PETSc appears to provide hypre; using PETSc hypre library" >&6;}
   PETSC_BUNDLES_HYPRE=yes
@@ -30554,9 +30554,9 @@ $as_echo "$as_me: using PETSC_DIR: ${PETSC_DIR}" >&6;}
 { $as_echo "$as_me:${as_lineno-$LINENO}: using PETSC_ARCH: ${PETSC_ARCH}" >&5
 $as_echo "$as_me: using PETSC_ARCH: ${PETSC_ARCH}" >&6;}
 
-PETSC_CC_INCLUDES=`grep "PETSC_CC_INCLUDES =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
-PETSC_EXTERNAL_LIB_BASIC=`grep "PETSC_EXTERNAL_LIB_BASIC =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
-PETSC_WITH_EXTERNAL_LIB=`grep "PETSC_WITH_EXTERNAL_LIB =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
+PETSC_CC_INCLUDES=`grep "PETSC_CC_INCLUDES =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
+PETSC_EXTERNAL_LIB_BASIC=`grep "PETSC_EXTERNAL_LIB_BASIC =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
+PETSC_WITH_EXTERNAL_LIB=`grep "PETSC_WITH_EXTERNAL_LIB =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^ \t*//'`
 
 CPPFLAGS="$PETSC_CC_INCLUDES $CPPFLAGS"
 
@@ -30569,8 +30569,8 @@ fi
 
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSc version 3.5" >&5
-$as_echo_n "checking for PETSc version 3.5... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSc version 3.6" >&5
+$as_echo_n "checking for PETSc version 3.6... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -30593,7 +30593,7 @@ int
 main ()
 {
 
-#if ((PETSC_VERSION_GE(3,5,0) && PETSC_VERSION_LT(3,6,0)) || !PETSC_VERSION_RELEASE)
+#if ((PETSC_VERSION_GE(3,6,0) && PETSC_VERSION_LT(3,7,0)) || !PETSC_VERSION_RELEASE)
 #else
 asdf
 #endif
@@ -30611,7 +30611,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${PETSC_VERSION_VALID}" >&5
 $as_echo "${PETSC_VERSION_VALID}" >&6; }
 if test "$PETSC_VERSION_VALID" = no; then
-  as_fn_error $? "invalid PETSc version detected: please use PETSc 3.5" "$LINENO" 5
+  as_fn_error $? "invalid PETSc version detected: please use PETSc 3.6" "$LINENO" 5
 fi
 
 LIBS="$PETSC_EXTERNAL_LIB_BASIC $LIBS"

--- a/ibtk/include/ibtk/PETScKrylovLinearSolver.h
+++ b/ibtk/include/ibtk/PETScKrylovLinearSolver.h
@@ -375,10 +375,10 @@ private:
     void resetKSPPC();
 
     /*!
-     * \brief Reset the KSP nullspace object to correspond to the supplied
+     * \brief Reset the Mat nullspace object to correspond to the supplied
      * nullspace basis vectors.
      */
-    void resetKSPNullspace();
+    void resetMatNullspace();
 
     /*!
      * \brief Destroy data allocated to describe nullspace.

--- a/ibtk/include/ibtk/private/PETScSAMRAIVectorReal-inl.h
+++ b/ibtk/include/ibtk/private/PETScSAMRAIVectorReal-inl.h
@@ -37,8 +37,8 @@
 
 #include "ibtk/IBTK_CHKERRQ.h"
 #include "ibtk/PETScSAMRAIVectorReal.h"
-#include "petsc-private/petscimpl.h" // IWYU pragma: keep
-#include "petsc-private/vecimpl.h"   // IWYU pragma: keep
+#include "petsc/private/petscimpl.h" // IWYU pragma: keep
+#include "petsc/private/vecimpl.h"   // IWYU pragma: keep
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 

--- a/ibtk/m4/configure_hdf5.m4
+++ b/ibtk/m4/configure_hdf5.m4
@@ -8,7 +8,7 @@ echo "================================="
 
 PACKAGE_SETUP_ENVIRONMENT
 
-if test `grep -c HDF5 "${PETSC_DIR}/${PETSC_ARCH}/conf/petscvariables"` != 0 ; then
+if test `grep -c HDF5 "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables"` != 0 ; then
   AC_MSG_NOTICE([PETSc appears to provide HDF5; using PETSc HDF5 library])
   PETSC_BUNDLES_HDF5=yes
   CPPFLAGS_PREPEND("-I${PETSC_DIR}/${PETSC_ARCH}/include")

--- a/ibtk/m4/configure_hypre.m4
+++ b/ibtk/m4/configure_hypre.m4
@@ -8,7 +8,7 @@ echo "=================================="
 
 PACKAGE_SETUP_ENVIRONMENT
 
-if test `grep -c HYPRE "${PETSC_DIR}/${PETSC_ARCH}/conf/petscvariables"` != 0 ; then
+if test `grep -c HYPRE "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables"` != 0 ; then
   AC_MSG_NOTICE([PETSc appears to provide hypre; using PETSc hypre library])
   PETSC_BUNDLES_HYPRE=yes
 else

--- a/ibtk/m4/configure_libmesh.m4
+++ b/ibtk/m4/configure_libmesh.m4
@@ -52,18 +52,18 @@ if test "$LIBMESH_ENABLED" = yes; then
   CPPFLAGS_PREPEND($LIBMESH_CPPFLAGS)
   AC_CHECK_HEADER([libmesh/libmesh.h],,AC_MSG_ERROR([libMesh enabled but could not find working libmesh.h]))
   AC_CHECK_HEADER([libmesh/libmesh_config.h],,AC_MSG_ERROR([libMesh enabled but could not find working libmesh_config.h]))
-  AC_MSG_CHECKING([for libMesh version 0.9.4 or 0.9.5])
+  AC_MSG_CHECKING([for libMesh version 0.9.5 or newer])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <libmesh/libmesh_config.h>
 
-#if ((LIBMESH_MAJOR_VERSION == 0) && (LIBMESH_MINOR_VERSION == 9) && ((LIBMESH_MICRO_VERSION >= 4) && (LIBMESH_MICRO_VERSION <= 5)))
+#if ((LIBMESH_MAJOR_VERSION == 0) && (LIBMESH_MINOR_VERSION == 9) && (LIBMESH_MICRO_VERSION >= 5))
 #else
 asdf
 #endif
   ]])],[LIBMESH_VERSION_VALID=yes],[LIBMESH_VERSION_VALID=no])
   AC_MSG_RESULT([${LIBMESH_VERSION_VALID}])
   if test "$LIBMESH_VERSION_VALID" = no; then
-    AC_MSG_ERROR([invalid libMesh version detected: please use libMesh 0.9.4 or 0.9.5])
+    AC_MSG_ERROR([invalid libMesh version detected: please use libMesh 0.9.5 or newer])
   fi
   AC_MSG_NOTICE([obtaining libMesh configuration information from libmesh_common.h])
   AC_RUN_IFELSE([AC_LANG_SOURCE([

--- a/ibtk/m4/configure_petsc.m4
+++ b/ibtk/m4/configure_petsc.m4
@@ -16,14 +16,14 @@ AC_SUBST(PETSC_ARCH,$PETSC_ARCH)
 AC_MSG_NOTICE([using PETSC_DIR: ${PETSC_DIR}])
 AC_MSG_NOTICE([using PETSC_ARCH: ${PETSC_ARCH}])
 
-PETSC_CC_INCLUDES=`grep "PETSC_CC_INCLUDES =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
-PETSC_EXTERNAL_LIB_BASIC=`grep "PETSC_EXTERNAL_LIB_BASIC =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
-PETSC_WITH_EXTERNAL_LIB=`grep "PETSC_WITH_EXTERNAL_LIB =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
+PETSC_CC_INCLUDES=`grep "PETSC_CC_INCLUDES =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
+PETSC_EXTERNAL_LIB_BASIC=`grep "PETSC_EXTERNAL_LIB_BASIC =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
+PETSC_WITH_EXTERNAL_LIB=`grep "PETSC_WITH_EXTERNAL_LIB =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
 
 CPPFLAGS_PREPEND($PETSC_CC_INCLUDES)
 AC_CHECK_HEADER([petsc.h],,AC_MSG_ERROR([could not find header file petsc.h]))
 
-AC_MSG_CHECKING([for PETSc version 3.5])
+AC_MSG_CHECKING([for PETSc version 3.6])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <petscversion.h>
 
@@ -32,14 +32,14 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   (!PETSC_VERSION_LT(MAJOR,MINOR,SUBMINOR))
 #endif
 ]], [[
-#if ((PETSC_VERSION_GE(3,5,0) && PETSC_VERSION_LT(3,6,0)) || !PETSC_VERSION_RELEASE)
+#if ((PETSC_VERSION_GE(3,6,0) && PETSC_VERSION_LT(3,7,0)) || !PETSC_VERSION_RELEASE)
 #else
 asdf
 #endif
 ]])],[PETSC_VERSION_VALID=yes],[PETSC_VERSION_VALID=no])
 AC_MSG_RESULT([${PETSC_VERSION_VALID}])
 if test "$PETSC_VERSION_VALID" = no; then
-  AC_MSG_ERROR([invalid PETSc version detected: please use PETSc 3.5])
+  AC_MSG_ERROR([invalid PETSc version detected: please use PETSc 3.6])
 fi
 
 LIBS_PREPEND($PETSC_EXTERNAL_LIB_BASIC)

--- a/ibtk/src/solvers/impls/PETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScLevelSolver.cpp
@@ -336,7 +336,7 @@ void PETScLevelSolver::setupNullspace()
     for (unsigned k = 0; k < d_nullspace_basis_vecs.size(); ++k)
     {
         Vec& petsc_nullspace_vec = petsc_nullspace_basis_vecs[k];
-        ierr = MatGetVecs(d_petsc_mat, NULL, &petsc_nullspace_vec);
+        ierr = MatCreateVecs(d_petsc_mat, NULL, &petsc_nullspace_vec);
         IBTK_CHKERRQ(ierr);
         copyToPETScVec(petsc_nullspace_vec, *d_nullspace_basis_vecs[k], patch_level);
         double dot;
@@ -345,13 +345,12 @@ void PETScLevelSolver::setupNullspace()
         ierr = VecScale(petsc_nullspace_vec, 1.0 / sqrt(dot));
         IBTK_CHKERRQ(ierr);
     }
-    ierr = MatNullSpaceCreate(PETSC_COMM_WORLD,
-                              d_nullspace_contains_constant_vec ? PETSC_TRUE : PETSC_FALSE,
+    ierr = MatNullSpaceCreate(PETSC_COMM_WORLD, d_nullspace_contains_constant_vec ? PETSC_TRUE : PETSC_FALSE,
                               static_cast<int>(petsc_nullspace_basis_vecs.size()),
                               (petsc_nullspace_basis_vecs.empty() ? NULL : &petsc_nullspace_basis_vecs[0]),
                               &d_petsc_nullsp);
     IBTK_CHKERRQ(ierr);
-    ierr = KSPSetNullSpace(d_petsc_ksp, d_petsc_nullsp);
+    ierr = MatSetNullSpace(d_petsc_mat, d_petsc_nullsp);
     IBTK_CHKERRQ(ierr);
     for (unsigned k = 0; k < d_nullspace_basis_vecs.size(); ++k)
     {

--- a/ibtk/src/solvers/impls/PETScMultiVec.cpp
+++ b/ibtk/src/solvers/impls/PETScMultiVec.cpp
@@ -41,7 +41,7 @@
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
 #include "mpi.h"
-#include "petsc-private/vecimpl.h" // IWYU pragma: keep
+#include "petsc/private/vecimpl.h" // IWYU pragma: keep
 #include "petscerror.h"
 #include "petscis.h"
 #include "petscmath.h"
@@ -910,37 +910,19 @@ PetscErrorCode VecCreateMultiVec(MPI_Comm comm, PetscInt n, Vec vv[], Vec* v)
     // Assign vector operations to PETSc vector object.
     static struct _VecOps DvOps;
     IBTK_DO_ONCE(DvOps.duplicate = VecDuplicate_MultiVec; DvOps.duplicatevecs = VecDuplicateVecs_Default;
-                 DvOps.destroyvecs = VecDestroyVecs_Default;
-                 DvOps.dot = VecDot_MultiVec;
-                 DvOps.mdot = VecMDot_MultiVec;
-                 DvOps.norm = VecNorm_MultiVec;
-                 DvOps.tdot = VecTDot_MultiVec;
-                 DvOps.mtdot = VecMTDot_MultiVec;
-                 DvOps.scale = VecScale_MultiVec;
-                 DvOps.copy = VecCopy_MultiVec;
-                 DvOps.set = VecSet_MultiVec;
-                 DvOps.swap = VecSwap_MultiVec;
-                 DvOps.axpy = VecAXPY_MultiVec;
-                 DvOps.axpby = VecAXPBY_MultiVec;
-                 DvOps.maxpy = VecMAXPY_MultiVec;
-                 DvOps.aypx = VecAYPX_MultiVec;
-                 DvOps.waxpy = VecWAXPY_MultiVec;
-                 DvOps.axpbypcz = VecAXPBYPCZ_MultiVec;
-                 DvOps.pointwisemult = VecPointwiseMult_MultiVec;
-                 DvOps.pointwisedivide = VecPointwiseDivide_MultiVec;
-                 DvOps.getsize = VecGetSize_MultiVec;
-                 DvOps.getlocalsize = VecGetLocalSize_MultiVec;
-                 DvOps.max = VecMax_MultiVec;
-                 DvOps.min = VecMin_MultiVec;
-                 DvOps.setrandom = VecSetRandom_MultiVec;
-                 DvOps.destroy = VecDestroy_MultiVec;
-                 DvOps.dot_local = VecDot_local_MultiVec;
-                 DvOps.tdot_local = VecTDot_local_MultiVec;
-                 DvOps.norm_local = VecNorm_local_MultiVec;
-                 DvOps.mdot_local = VecMDot_local_MultiVec;
-                 DvOps.mtdot_local = VecMTDot_local_MultiVec;
-                 DvOps.maxpointwisedivide = VecMaxPointwiseDivide_MultiVec;
-                 DvOps.dotnorm2 = VecDotNorm2_MultiVec;);
+                 DvOps.destroyvecs = VecDestroyVecs_Default; DvOps.dot = VecDot_MultiVec; DvOps.mdot = VecMDot_MultiVec;
+                 DvOps.norm = VecNorm_MultiVec; DvOps.tdot = VecTDot_MultiVec; DvOps.mtdot = VecMTDot_MultiVec;
+                 DvOps.scale = VecScale_MultiVec; DvOps.copy = VecCopy_MultiVec; DvOps.set = VecSet_MultiVec;
+                 DvOps.swap = VecSwap_MultiVec; DvOps.axpy = VecAXPY_MultiVec; DvOps.axpby = VecAXPBY_MultiVec;
+                 DvOps.maxpy = VecMAXPY_MultiVec; DvOps.aypx = VecAYPX_MultiVec; DvOps.waxpy = VecWAXPY_MultiVec;
+                 DvOps.axpbypcz = VecAXPBYPCZ_MultiVec; DvOps.pointwisemult = VecPointwiseMult_MultiVec;
+                 DvOps.pointwisedivide = VecPointwiseDivide_MultiVec; DvOps.getsize = VecGetSize_MultiVec;
+                 DvOps.getlocalsize = VecGetLocalSize_MultiVec; DvOps.max = VecMax_MultiVec;
+                 DvOps.min = VecMin_MultiVec; DvOps.setrandom = VecSetRandom_MultiVec;
+                 DvOps.destroy = VecDestroy_MultiVec; DvOps.dot_local = VecDot_local_MultiVec;
+                 DvOps.tdot_local = VecTDot_local_MultiVec; DvOps.norm_local = VecNorm_local_MultiVec;
+                 DvOps.mdot_local = VecMDot_local_MultiVec; DvOps.mtdot_local = VecMTDot_local_MultiVec;
+                 DvOps.maxpointwisedivide = VecMaxPointwiseDivide_MultiVec; DvOps.dotnorm2 = VecDotNorm2_MultiVec;);
     ierr = PetscMemcpy((*v)->ops, &DvOps, sizeof(DvOps));
     CHKERRQ(ierr);
 

--- a/m4/configure_hdf5.m4
+++ b/m4/configure_hdf5.m4
@@ -8,7 +8,7 @@ echo "================================="
 
 PACKAGE_SETUP_ENVIRONMENT
 
-if test `grep -c HDF5 "${PETSC_DIR}/${PETSC_ARCH}/conf/petscvariables"` != 0 ; then
+if test `grep -c HDF5 "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables"` != 0 ; then
   AC_MSG_NOTICE([PETSc appears to provide HDF5; using PETSc HDF5 library])
   PETSC_BUNDLES_HDF5=yes
   CPPFLAGS_PREPEND("-I${PETSC_DIR}/${PETSC_ARCH}/include")

--- a/m4/configure_hypre.m4
+++ b/m4/configure_hypre.m4
@@ -8,7 +8,7 @@ echo "=================================="
 
 PACKAGE_SETUP_ENVIRONMENT
 
-if test `grep -c HYPRE "${PETSC_DIR}/${PETSC_ARCH}/conf/petscvariables"` != 0 ; then
+if test `grep -c HYPRE "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables"` != 0 ; then
   AC_MSG_NOTICE([PETSc appears to provide hypre; using PETSc hypre library])
   PETSC_BUNDLES_HYPRE=yes
 else

--- a/m4/configure_libmesh.m4
+++ b/m4/configure_libmesh.m4
@@ -52,18 +52,18 @@ if test "$LIBMESH_ENABLED" = yes; then
   CPPFLAGS_PREPEND($LIBMESH_CPPFLAGS)
   AC_CHECK_HEADER([libmesh/libmesh.h],,AC_MSG_ERROR([libMesh enabled but could not find working libmesh.h]))
   AC_CHECK_HEADER([libmesh/libmesh_config.h],,AC_MSG_ERROR([libMesh enabled but could not find working libmesh_config.h]))
-  AC_MSG_CHECKING([for libMesh version 0.9.4 or 0.9.5])
+  AC_MSG_CHECKING([for libMesh version 0.9.5 or newer])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <libmesh/libmesh_config.h>
 
-#if ((LIBMESH_MAJOR_VERSION == 0) && (LIBMESH_MINOR_VERSION == 9) && ((LIBMESH_MICRO_VERSION >= 4) && (LIBMESH_MICRO_VERSION <= 5)))
+#if ((LIBMESH_MAJOR_VERSION == 0) && (LIBMESH_MINOR_VERSION == 9) && (LIBMESH_MICRO_VERSION >= 5))
 #else
 asdf
 #endif
   ]])],[LIBMESH_VERSION_VALID=yes],[LIBMESH_VERSION_VALID=no])
   AC_MSG_RESULT([${LIBMESH_VERSION_VALID}])
   if test "$LIBMESH_VERSION_VALID" = no; then
-    AC_MSG_ERROR([invalid libMesh version detected: please use libMesh 0.9.4 or 0.9.5])
+    AC_MSG_ERROR([invalid libMesh version detected: please use libMesh 0.9.5 or newer])
   fi
   AC_MSG_NOTICE([obtaining libMesh configuration information from libmesh_common.h])
   AC_RUN_IFELSE([AC_LANG_SOURCE([

--- a/m4/configure_petsc.m4
+++ b/m4/configure_petsc.m4
@@ -16,14 +16,14 @@ AC_SUBST(PETSC_ARCH,$PETSC_ARCH)
 AC_MSG_NOTICE([using PETSC_DIR: ${PETSC_DIR}])
 AC_MSG_NOTICE([using PETSC_ARCH: ${PETSC_ARCH}])
 
-PETSC_CC_INCLUDES=`grep "PETSC_CC_INCLUDES =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
-PETSC_EXTERNAL_LIB_BASIC=`grep "PETSC_EXTERNAL_LIB_BASIC =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
-PETSC_WITH_EXTERNAL_LIB=`grep "PETSC_WITH_EXTERNAL_LIB =" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
+PETSC_CC_INCLUDES=`grep "PETSC_CC_INCLUDES =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
+PETSC_EXTERNAL_LIB_BASIC=`grep "PETSC_EXTERNAL_LIB_BASIC =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
+PETSC_WITH_EXTERNAL_LIB=`grep "PETSC_WITH_EXTERNAL_LIB =" $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables | sed -e 's/.*=//' -e 's/^[ \t]*//'`
 
 CPPFLAGS_PREPEND($PETSC_CC_INCLUDES)
 AC_CHECK_HEADER([petsc.h],,AC_MSG_ERROR([could not find header file petsc.h]))
 
-AC_MSG_CHECKING([for PETSc version 3.5])
+AC_MSG_CHECKING([for PETSc version 3.6])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <petscversion.h>
 
@@ -32,14 +32,14 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   (!PETSC_VERSION_LT(MAJOR,MINOR,SUBMINOR))
 #endif
 ]], [[
-#if ((PETSC_VERSION_GE(3,5,0) && PETSC_VERSION_LT(3,6,0)) || !PETSC_VERSION_RELEASE)
+#if ((PETSC_VERSION_GE(3,6,0) && PETSC_VERSION_LT(3,7,0)) || !PETSC_VERSION_RELEASE)
 #else
 asdf
 #endif
 ]])],[PETSC_VERSION_VALID=yes],[PETSC_VERSION_VALID=no])
 AC_MSG_RESULT([${PETSC_VERSION_VALID}])
 if test "$PETSC_VERSION_VALID" = no; then
-  AC_MSG_ERROR([invalid PETSc version detected: please use PETSc 3.5])
+  AC_MSG_ERROR([invalid PETSc version detected: please use PETSc 3.6])
 fi
 
 LIBS_PREPEND($PETSC_EXTERNAL_LIB_BASIC)

--- a/src/navier_stokes/StaggeredStokesBoxRelaxationFACOperator.cpp
+++ b/src/navier_stokes/StaggeredStokesBoxRelaxationFACOperator.cpp
@@ -322,19 +322,15 @@ void modifyRhsForBcs(Vec& v,
                 const Index<NDIM> u_rght = i + shift;
                 if (!side_box.contains(u_left))
                 {
-                    ierr = VecSetValue(v,
-                                       idx,
-                                       +D * U_data(SideIndex<NDIM>(u_left, axis, SideIndex<NDIM>::Lower)) /
-                                           (dx[d] * dx[d]),
+                    ierr = VecSetValue(v, idx, +D * U_data(SideIndex<NDIM>(u_left, axis, SideIndex<NDIM>::Lower)) /
+                                                   (dx[d] * dx[d]),
                                        ADD_VALUES);
                     IBTK_CHKERRQ(ierr);
                 }
                 if (!side_box.contains(u_rght))
                 {
-                    ierr = VecSetValue(v,
-                                       idx,
-                                       +D * U_data(SideIndex<NDIM>(u_rght, axis, SideIndex<NDIM>::Lower)) /
-                                           (dx[d] * dx[d]),
+                    ierr = VecSetValue(v, idx, +D * U_data(SideIndex<NDIM>(u_rght, axis, SideIndex<NDIM>::Lower)) /
+                                                   (dx[d] * dx[d]),
                                        ADD_VALUES);
                     IBTK_CHKERRQ(ierr);
                 }
@@ -537,8 +533,7 @@ void StaggeredStokesBoxRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM,
                     {
                         U_error_data->getArrayData(axis)
                             .copy(U_scratch_data->getArrayData(axis),
-                                  d_patch_side_bc_box_overlap[level_num][patch_counter][axis],
-                                  IntVector<NDIM>(0));
+                                  d_patch_side_bc_box_overlap[level_num][patch_counter][axis], IntVector<NDIM>(0));
                     }
 
                     Pointer<CellData<NDIM, double> > P_error_data = error.getComponentPatchData(1, *patch);
@@ -627,11 +622,12 @@ void StaggeredStokesBoxRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM,
 
 /////////////////////////////// PROTECTED ////////////////////////////////////
 
-void StaggeredStokesBoxRelaxationFACOperator::initializeOperatorStateSpecialized(
-    const SAMRAIVectorReal<NDIM, double>& /*solution*/,
-    const SAMRAIVectorReal<NDIM, double>& /*rhs*/,
-    const int coarsest_reset_ln,
-    const int finest_reset_ln)
+void StaggeredStokesBoxRelaxationFACOperator::initializeOperatorStateSpecialized(const SAMRAIVectorReal<NDIM, double>&
+                                                                                 /*solution*/,
+                                                                                 const SAMRAIVectorReal<NDIM, double>&
+                                                                                 /*rhs*/,
+                                                                                 const int coarsest_reset_ln,
+                                                                                 const int finest_reset_ln)
 {
     // Initialize the box relaxation data on each level of the patch hierarchy.
     d_box_op.resize(d_finest_ln + 1);
@@ -651,7 +647,7 @@ void StaggeredStokesBoxRelaxationFACOperator::initializeOperatorStateSpecialized
         }
         buildBoxOperator(d_box_op[ln], d_U_problem_coefs, box, box, dx);
         int ierr;
-        ierr = MatGetVecs(d_box_op[ln], &d_box_e[ln], &d_box_r[ln]);
+        ierr = MatCreateVecs(d_box_op[ln], &d_box_e[ln], &d_box_r[ln]);
         IBTK_CHKERRQ(ierr);
         ierr = KSPCreate(PETSC_COMM_SELF, &d_box_ksp[ln]);
         IBTK_CHKERRQ(ierr);


### PR DESCRIPTION
* add support for PETSc 3.6
* use new libMesh constructors in examples
* remove support for PETSc 3.5
* remove support for libMesh 0.9.4 (which requires PETSc 3.5)