### PR TITLE
Change implementation of IndexUtilities to guarantee consistent indexing

### DIFF
--- a/ibtk/include/ibtk/IndexUtilities.h
+++ b/ibtk/include/ibtk/IndexUtilities.h
@@ -38,6 +38,7 @@
 #include <functional>
 
 #include "CartesianGridGeometry.h"
+#include "CartesianPatchGeometry.h"
 #include "CellIndex.h"
 #include "Index.h"
 #include "IntVector.h"
@@ -90,43 +91,48 @@ public:
      *
      * \note Because of round-off error in floating point, this routine
      * cannot guarantee that the same spatial location X is assigned the
-     * same cell index for different values of x_lower, x_upper, ilower,
-     * and iupper.  To obtain a unique index, use the non-static member
-     * function getCellIndexGlobal().
+     * same cell index for different patches.  To obtain a unique index,
+     * use the globalized version.
+     *
+     * \see SAMRAI::geom::CartesianPatchGeometry
+     * \see SAMRAI::geom::CartesianPatchGeometry
+     */
+    template <class DoubleArray>
+    static SAMRAI::hier::Index<NDIM> getCellIndex(const DoubleArray& X,
+                                                  const double* x_lower,
+                                                  const double* x_upper,
+                                                  const double* dx,
+                                                  const SAMRAI::hier::Index<NDIM>& ilower,
+                                                  const SAMRAI::hier::Index<NDIM>& iupper);
+
+    /*!
+     * \return The cell index corresponding to location \p X relative
+     * to the extents of the supplied Cartesian grid patch geometry and
+     * patch box.
+     *
+     * \note Because of round-off error in floating point, this routine
+     * cannot guarantee that the same spatial location X is assigned the
+     * same cell index for different patches.  To obtain a unique index,
+     * use the globalized version.
      *
      * \see SAMRAI::geom::CartesianPatchGeometry
      */
     template <class DoubleArray>
-    static SAMRAI::hier::Index<NDIM> getCellIndexLocal(const DoubleArray& X,
-                                                       const double* x_lower,
-                                                       const double* x_upper,
-                                                       const double* dx,
-                                                       const SAMRAI::hier::Index<NDIM>& ilower,
-                                                       const SAMRAI::hier::Index<NDIM>& iupper);
-
-    /*!
-     * \brief Constructor.
-     */
-    IndexUtilities(SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom);
-
-    /*!
-     * \brief Destructor.
-     */
-    ~IndexUtilities();
+    static SAMRAI::hier::Index<NDIM> getCellIndex(const DoubleArray& X,
+                                                  const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianPatchGeometry<NDIM> >& patch_geom,
+                                                  const SAMRAI::hier::Box<NDIM>& patch_box);
 
     /*!
      * \return The cell index corresponding to location \p X relative
      * to the corner of the computational domain specified by the grid
-     * geometry object associated with this class.
-     *
-     * \note dx must be related by an integer refinement rato to the 
-     * base grid spacing dx0 associated with the grid geometry object.
+     * geometry object.
      *
      * \see SAMRAI::geom::CartesianGridGeometry
      */
     template <class DoubleArray>
-    SAMRAI::hier::Index<NDIM> getCellIndexGlobal(const DoubleArray& X,
-                                                 const double* dx) const;
+    static SAMRAI::hier::Index<NDIM> getCellIndex(const DoubleArray& X,
+                                                  const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> >& grid_geom,
+                                                  const SAMRAI::hier::IntVector<NDIM>& ratio);
 
 private:
     /*!
@@ -148,6 +154,11 @@ private:
     IndexUtilities(const IndexUtilities& from);
 
     /*!
+     * \brief Unimplemented destructor.
+     */
+    ~IndexUtilities();
+
+    /*!
      * \brief Assignment operator.
      *
      * \note This operator is not implemented and should not be used.
@@ -157,11 +168,6 @@ private:
      * \return A reference to this object.
      */
     IndexUtilities& operator=(const IndexUtilities& that);
-
-    /*!
-     * The grid geometry object associated with this class.
-     */
-    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/IndexUtilities.h
+++ b/ibtk/include/ibtk/IndexUtilities.h
@@ -37,6 +37,7 @@
 
 #include <functional>
 
+#include "CartesianGridGeometry.h"
 #include "CellIndex.h"
 #include "Index.h"
 #include "IntVector.h"
@@ -84,18 +85,48 @@ public:
 
     /*!
      * \return The cell index corresponding to location \p X relative
-     * to \p XLower and \p XUpper for the specified Cartesian grid
+     * to \p x_lower and \p x_upper for the specified Cartesian grid
      * spacings \p dx and box extents \p ilower and \p iupper.
+     *
+     * \note Because of round-off error in floating point, this routine
+     * cannot guarantee that the same spatial location X is assigned the
+     * same cell index for different values of x_lower, x_upper, ilower,
+     * and iupper.  To obtain a unique index, use the non-static member
+     * function getCellIndexGlobal().
      *
      * \see SAMRAI::geom::CartesianPatchGeometry
      */
     template <class DoubleArray>
-    static SAMRAI::hier::Index<NDIM> getCellIndex(const DoubleArray& X,
-                                                  const double* x_lower,
-                                                  const double* x_upper,
-                                                  const double* dx,
-                                                  const SAMRAI::hier::Index<NDIM>& ilower,
-                                                  const SAMRAI::hier::Index<NDIM>& iupper);
+    static SAMRAI::hier::Index<NDIM> getCellIndexLocal(const DoubleArray& X,
+                                                       const double* x_lower,
+                                                       const double* x_upper,
+                                                       const double* dx,
+                                                       const SAMRAI::hier::Index<NDIM>& ilower,
+                                                       const SAMRAI::hier::Index<NDIM>& iupper);
+
+    /*!
+     * \brief Constructor.
+     */
+    IndexUtilities(SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom);
+
+    /*!
+     * \brief Destructor.
+     */
+    ~IndexUtilities();
+
+    /*!
+     * \return The cell index corresponding to location \p X relative
+     * to the corner of the computational domain specified by the grid
+     * geometry object associated with this class.
+     *
+     * \note dx must be related by an integer refinement rato to the 
+     * base grid spacing dx0 associated with the grid geometry object.
+     *
+     * \see SAMRAI::geom::CartesianGridGeometry
+     */
+    template <class DoubleArray>
+    SAMRAI::hier::Index<NDIM> getCellIndexGlobal(const DoubleArray& X,
+                                                 const double* dx) const;
 
 private:
     /*!
@@ -117,11 +148,6 @@ private:
     IndexUtilities(const IndexUtilities& from);
 
     /*!
-     * \brief Unimplemented destructor.
-     */
-    ~IndexUtilities();
-
-    /*!
      * \brief Assignment operator.
      *
      * \note This operator is not implemented and should not be used.
@@ -131,6 +157,11 @@ private:
      * \return A reference to this object.
      */
     IndexUtilities& operator=(const IndexUtilities& that);
+
+    /*!
+     * The grid geometry object associated with this class.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/private/IndexUtilities-inl.h
+++ b/ibtk/include/ibtk/private/IndexUtilities-inl.h
@@ -66,16 +66,25 @@ inline SAMRAI::hier::Index<NDIM> IndexUtilities::refine(const SAMRAI::hier::Inde
 template <class DoubleArray>
 inline SAMRAI::hier::Index<NDIM> IndexUtilities::getCellIndex(const DoubleArray& X,
                                                               const double* const x_lower,
-                                                              const double* const /*x_upper*/,
+                                                              const double* const x_upper,
                                                               const double* const dx,
                                                               const SAMRAI::hier::Index<NDIM>& ilower,
-                                                              const SAMRAI::hier::Index<NDIM>& /*iupper*/)
+                                                              const SAMRAI::hier::Index<NDIM>& iupper)
 {
+    // NOTE: This expression guarantees consistency between neighboring patches, but it is still possible to get
+    // inconsitent mappings on disjoint patches.
     SAMRAI::hier::Index<NDIM> idx;
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        const double dX_lower = X[d] - x_lower[d];
-        idx(d) = ilower(d) + std::floor(dX_lower / dx[d]);
+        double dX_lower = X[d] - x_lower[d], dX_upper = X[d] - x_upper[d];
+        if (std::abs(dX_lower) <= std::abs(dX_upper))
+        {
+            idx(d) = ilower(d) + floor(dX_lower / dx[d]);
+        }
+        else
+        {
+            idx(d) = iupper(d) + floor(dX_upper / dx[d]) + 1;
+        }
     }
     return idx;
 }// getCellIndex

--- a/ibtk/include/ibtk/private/IndexUtilities-inl.h
+++ b/ibtk/include/ibtk/private/IndexUtilities-inl.h
@@ -63,14 +63,14 @@ inline SAMRAI::hier::Index<NDIM> IndexUtilities::refine(const SAMRAI::hier::Inde
 } // refine
 
 template <class DoubleArray>
-inline SAMRAI::hier::Index<NDIM> IndexUtilities::getCellIndex(const DoubleArray& X,
-                                                              const double* const x_lower,
-                                                              const double* const x_upper,
-                                                              const double* const dx,
-                                                              const SAMRAI::hier::Index<NDIM>& ilower,
-                                                              const SAMRAI::hier::Index<NDIM>& iupper)
+inline SAMRAI::hier::Index<NDIM> IndexUtilities::getCellIndexLocal(const DoubleArray& X,
+                                                                   const double* const x_lower,
+                                                                   const double* const x_upper,
+                                                                   const double* const dx,
+                                                                   const SAMRAI::hier::Index<NDIM>& ilower,
+                                                                   const SAMRAI::hier::Index<NDIM>& iupper)
 {
-    // TODO: This expression guarantees consistency between neighboring patches, but it is still possible to get
+    // NOTE: This expression guarantees consistency between neighboring patches, but it is still possible to get
     // inconsitent mappings on disjoint patches.
     SAMRAI::hier::Index<NDIM> idx;
     for (unsigned int d = 0; d < NDIM; ++d)
@@ -78,16 +78,58 @@ inline SAMRAI::hier::Index<NDIM> IndexUtilities::getCellIndex(const DoubleArray&
         double dX_lower = X[d] - x_lower[d], dX_upper = X[d] - x_upper[d];
         if (std::abs(dX_lower) <= std::abs(dX_upper))
         {
-            idx(d) = ilower(d) + floor(dX_lower / dx[d]);
+            idx(d) = ilower(d) + std::floor(dX_lower / dx[d]);
         }
         else
         {
-            idx(d) = iupper(d) + floor(dX_upper / dx[d]) + 1;
+            idx(d) = iupper(d) + std::floor(dX_upper / dx[d]) + 1;
         }
     }
     return idx;
-} // getCellIndex
+} // getCellIndexLocal
 
+inline IndexUtilities::IndexUtilities(SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom) : d_grid_geom(grid_geom)
+{
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_grid_geom);
+#endif
+    // intentionally blank
+    return;
+}// IndexUtilities
+
+inline IndexUtilities::~IndexUtilities()
+{
+    // intentionally blank
+    return;
+}// ~IndexUtilities
+
+template <class DoubleArray>
+inline SAMRAI::hier::Index<NDIM> IndexUtilities::getCellIndexGlobal(const DoubleArray& X,
+                                                                    const double* const dx) const
+{
+    const double* const x_lower = d_grid_geom->getXLower();
+    const double* const dx0 = d_grid_geom->getDx();
+    SAMRAI::hier::Index<NDIM> ratio;
+    for (unsigned int d = 0; d < NDIM; ++d)
+    {
+        ratio(d) = std::round(dx0[d] / dx[d]);
+#if !defined(NDEBUG)
+        TBOX_ASSERT(SAMRAI::tbox::MathUtilities<double>::equalEps(dx0[d], ratio(d) * dx[d]));
+#endif
+    }
+    const SAMRAI::hier::Box<NDIM> domain_box = d_grid_geom->getPhysicalDomain()[0];
+    const SAMRAI::hier::Index<NDIM> ilower0 = domain_box.lower();
+    const SAMRAI::hier::Index<NDIM> ilower = IndexUtilities::refine(ilower0, ratio);
+
+    SAMRAI::hier::Index<NDIM> idx;
+    for (unsigned int d = 0; d < NDIM; ++d)
+    {
+        const double dX_lower = X[d] - x_lower[d];
+        idx(d) = ilower(d) + std::floor(dX_lower / dx[d]);
+    }
+    return idx;
+} // getCellIndexGlobal
+ 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
 /////////////////////////////// PROTECTED ////////////////////////////////////

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -750,8 +750,9 @@ void FEDataManager::prolongData(const int f_data_idx,
     std::vector<libMesh::Point> intersection_ref_coords;
     std::vector<SideIndex<NDIM> > intersection_indices;
     Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(d_level_number);
+    const IntVector<NDIM>& ratio = level->getRatio();
+    const Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
     int local_patch_num = 0;
-    const IndexUtilities indexer(level->getGridGeometry());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++local_patch_num)
     {
         // The relevant collection of elements.
@@ -764,10 +765,8 @@ void FEDataManager::prolongData(const int f_data_idx,
         if (!accumulate_on_grid) f_data->fillAll(0.0);
         const Box<NDIM>& patch_box = patch->getBox();
         const CellIndex<NDIM>& patch_lower = patch_box.lower();
-        const CellIndex<NDIM>& patch_upper = patch_box.upper();
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
         const double* const patch_x_lower = patch_geom->getXLower();
-        const double* const patch_x_upper = patch_geom->getXUpper();
         const double* const patch_dx = patch_geom->getDx();
 
         boost::array<Box<NDIM>, NDIM> side_boxes;
@@ -809,8 +808,8 @@ void FEDataManager::prolongData(const int f_data_idx,
                 }
                 elem->point(k) = X;
             }
-            Box<NDIM> box(indexer.getCellIndexGlobal(&X_min[0], patch_dx),
-                          indexer.getCellIndexGlobal(&X_max[0], patch_dx));
+            Box<NDIM> box(IndexUtilities::getCellIndex(&X_min[0], grid_geom, ratio),
+                          IndexUtilities::getCellIndex(&X_max[0], grid_geom, ratio));
             box.grow(IntVector<NDIM>(1));
             box = box * patch_box;
 
@@ -1201,8 +1200,9 @@ void FEDataManager::restrictData(const int f_data_idx,
     std::vector<libMesh::Point> intersection_ref_coords;
     std::vector<SideIndex<NDIM> > intersection_indices;
     Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(d_level_number);
+    const IntVector<NDIM>& ratio = level->getRatio();
+    const Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
     int local_patch_num = 0;
-    const IndexUtilities indexer(level->getGridGeometry());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++local_patch_num)
     {
         // The relevant collection of elements.
@@ -1214,10 +1214,8 @@ void FEDataManager::restrictData(const int f_data_idx,
         Pointer<SideData<NDIM, double> > f_data = patch->getPatchData(f_data_idx);
         const Box<NDIM>& patch_box = patch->getBox();
         const CellIndex<NDIM>& patch_lower = patch_box.lower();
-        const CellIndex<NDIM>& patch_upper = patch_box.upper();
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
         const double* const patch_x_lower = patch_geom->getXLower();
-        const double* const patch_x_upper = patch_geom->getXUpper();
         const double* const patch_dx = patch_geom->getDx();
         double dV = 1.0;
         for (unsigned int d = 0; d < NDIM; ++d) dV *= patch_dx[d];
@@ -1261,8 +1259,8 @@ void FEDataManager::restrictData(const int f_data_idx,
                 }
                 elem->point(k) = X_node_cache[k];
             }
-            Box<NDIM> box(indexer.getCellIndexGlobal(&X_min[0], patch_dx),
-                          indexer.getCellIndexGlobal(&X_max[0], patch_dx));
+            Box<NDIM> box(IndexUtilities::getCellIndex(&X_min[0], grid_geom, ratio),
+                          IndexUtilities::getCellIndex(&X_max[0], grid_geom, ratio));
             box.grow(IntVector<NDIM>(1));
             box = box * patch_box;
 
@@ -1864,8 +1862,9 @@ void FEDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM>
         boost::multi_array<double, 2> X_node;
         Point X_qp;
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(level_number);
+        const IntVector<NDIM>& ratio = level->getRatio();
+        const Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
         int local_patch_num = 0;
-        const IndexUtilities indexer(level->getGridGeometry());
         for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++local_patch_num)
         {
             // The relevant collection of elements.
@@ -1903,7 +1902,7 @@ void FEDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM>
                 for (unsigned int qp = 0; qp < qrule->n_points(); ++qp)
                 {
                     interpolate(&X_qp[0], qp, X_node, phi);
-                    const Index<NDIM> i = indexer.getCellIndexGlobal(X_qp, patch_dx);
+                    const Index<NDIM> i = IndexUtilities::getCellIndex(X_qp, grid_geom, ratio);
                     tag_data->fill(1, Box<NDIM>(i - Index<NDIM>(1), i + Index<NDIM>(1)));
                 }
             }
@@ -2054,11 +2053,12 @@ void FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int fi
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        const IntVector<NDIM>& ratio = level->getRatio();
+        const Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
         if (!level->checkAllocated(d_qp_count_idx)) level->allocatePatchData(d_qp_count_idx);
         HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(d_hierarchy, ln, ln);
         hier_cc_data_ops.setToScalar(d_qp_count_idx, 0.0);
         if (ln != d_level_number) continue;
-        const IndexUtilities indexer(level->getGridGeometry());
 
         // Extract the mesh.
         const MeshBase& mesh = d_es->get_mesh();
@@ -2125,7 +2125,7 @@ void FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int fi
                 for (unsigned int qp = 0; qp < qrule->n_points(); ++qp)
                 {
                     interpolate(&X_qp[0], qp, X_node, phi);
-                    const Index<NDIM> i = indexer.getCellIndexGlobal(X_qp, patch_dx);
+                    const Index<NDIM> i = IndexUtilities::getCellIndex(X_qp, grid_geom, ratio);
                     if (patch_box.contains(i)) (*qp_count_data)(i) += 1.0;
                 }
             }
@@ -2233,7 +2233,8 @@ void FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >&
 
     // Setup data structures used to assign elements to patches.
     Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(level_number);
-    const IndexUtilities indexer(level->getGridGeometry());
+    const IntVector<NDIM>& ratio = level->getRatio();
+    const Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
     const int num_local_patches = level->getProcessorMapping().getNumberOfLocalIndices();
     std::vector<std::set<Elem*> > local_patch_elems(num_local_patches);
     std::vector<std::set<Elem*> > nonlocal_patch_elems(num_local_patches);
@@ -2320,11 +2321,7 @@ void FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >&
             const Pointer<Patch<NDIM> > patch = level->getPatch(p());
             const Box<NDIM>& patch_box = patch->getBox();
             const Box<NDIM> ghost_box = Box<NDIM>::grow(patch_box, ghost_width);
-            const CellIndex<NDIM>& patch_lower = patch_box.lower();
-            const CellIndex<NDIM>& patch_upper = patch_box.upper();
             const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const double* const patch_x_lower = patch_geom->getXLower();
-            const double* const patch_x_upper = patch_geom->getXUpper();
             const double* const patch_dx = patch_geom->getDx();
             const double patch_dx_min = *std::min_element(patch_dx, patch_dx + NDIM);
 
@@ -2354,7 +2351,7 @@ void FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >&
                 for (unsigned int qp = 0; qp < qrule->n_points() && !found_qp; ++qp)
                 {
                     interpolate(&X_qp[0], qp, X_node, phi);
-                    const Index<NDIM> i = indexer.getCellIndexGlobal(X_qp, patch_dx);
+                    const Index<NDIM> i = IndexUtilities::getCellIndex(X_qp, grid_geom, ratio);
                     if (ghost_box.contains(i))
                     {
                         local_elems.insert(elem);

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -808,10 +808,10 @@ void FEDataManager::prolongData(const int f_data_idx,
                 }
                 elem->point(k) = X;
             }
-            Box<NDIM> box(IndexUtilities::getCellIndex(&X_min[0], patch_x_lower, patch_x_upper, patch_dx, patch_lower,
-                                                       patch_upper),
-                          IndexUtilities::getCellIndex(&X_max[0], patch_x_lower, patch_x_upper, patch_dx, patch_lower,
-                                                       patch_upper));
+            Box<NDIM> box(IndexUtilities::getCellIndexLocal(&X_min[0], patch_x_lower, patch_x_upper, patch_dx, patch_lower,
+                                                            patch_upper),
+                          IndexUtilities::getCellIndexLocal(&X_max[0], patch_x_lower, patch_x_upper, patch_dx, patch_lower,
+                                                            patch_upper));
             box.grow(IntVector<NDIM>(1));
             box = box * patch_box;
 
@@ -1261,10 +1261,10 @@ void FEDataManager::restrictData(const int f_data_idx,
                 }
                 elem->point(k) = X_node_cache[k];
             }
-            Box<NDIM> box(IndexUtilities::getCellIndex(&X_min[0], patch_x_lower, patch_x_upper, patch_dx, patch_lower,
-                                                       patch_upper),
-                          IndexUtilities::getCellIndex(&X_max[0], patch_x_lower, patch_x_upper, patch_dx, patch_lower,
-                                                       patch_upper));
+            Box<NDIM> box(IndexUtilities::getCellIndexLocal(&X_min[0], patch_x_lower, patch_x_upper, patch_dx, patch_lower,
+                                                            patch_upper),
+                          IndexUtilities::getCellIndexLocal(&X_max[0], patch_x_lower, patch_x_upper, patch_dx, patch_lower,
+                                                            patch_upper));
             box.grow(IntVector<NDIM>(1));
             box = box * patch_box;
 
@@ -1909,8 +1909,8 @@ void FEDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM>
                 for (unsigned int qp = 0; qp < qrule->n_points(); ++qp)
                 {
                     interpolate(&X_qp[0], qp, X_node, phi);
-                    const Index<NDIM> i = IndexUtilities::getCellIndex(X_qp, patch_x_lower, patch_x_upper, patch_dx,
-                                                                       patch_lower, patch_upper);
+                    const Index<NDIM> i = IndexUtilities::getCellIndexLocal(X_qp, patch_x_lower, patch_x_upper, patch_dx,
+                                                                            patch_lower, patch_upper);
                     tag_data->fill(1, Box<NDIM>(i - Index<NDIM>(1), i + Index<NDIM>(1)));
                 }
             }
@@ -2135,8 +2135,8 @@ void FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int fi
                 for (unsigned int qp = 0; qp < qrule->n_points(); ++qp)
                 {
                     interpolate(&X_qp[0], qp, X_node, phi);
-                    const Index<NDIM> i = IndexUtilities::getCellIndex(X_qp, patch_x_lower, patch_x_upper, patch_dx,
-                                                                       patch_lower, patch_upper);
+                    const Index<NDIM> i = IndexUtilities::getCellIndexLocal(X_qp, patch_x_lower, patch_x_upper, patch_dx,
+                                                                            patch_lower, patch_upper);
                     if (patch_box.contains(i)) (*qp_count_data)(i) += 1.0;
                 }
             }
@@ -2364,8 +2364,8 @@ void FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >&
                 for (unsigned int qp = 0; qp < qrule->n_points() && !found_qp; ++qp)
                 {
                     interpolate(&X_qp[0], qp, X_node, phi);
-                    const Index<NDIM> i = IndexUtilities::getCellIndex(X_qp, patch_x_lower, patch_x_upper, patch_dx,
-                                                                       patch_lower, patch_upper);
+                    const Index<NDIM> i = IndexUtilities::getCellIndexLocal(X_qp, patch_x_lower, patch_x_upper, patch_dx,
+                                                                            patch_lower, patch_upper);
                     if (ghost_box.contains(i))
                     {
                         local_elems.insert(elem);

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -2428,15 +2428,11 @@ void LDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> 
 
         // Tag cells for refinement within the bounding boxes of any displaced
         // structures on finer levels of the patch hierarchy.
+        const IndexUtilities indexer(level->getGridGeometry());
         for (PatchLevel<NDIM>::Iterator p(level); p; p++)
         {
             const Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& patch_box = patch->getBox();
             const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const CellIndex<NDIM>& patch_lower = patch_box.lower();
-            const CellIndex<NDIM>& patch_upper = patch_box.upper();
-            const double* const patch_x_lower = patch_geom->getXLower();
-            const double* const patch_x_upper = patch_geom->getXUpper();
             const double* const patch_dx = patch_geom->getDx();
 
             Pointer<CellData<NDIM, int> > tag_data = patch->getPatchData(tag_index);
@@ -2452,10 +2448,10 @@ void LDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> 
 
                     // Determine the region of index space covered by the
                     // displaced structure bounding box.
-                    const CellIndex<NDIM> bbox_lower = IndexUtilities::getCellIndexLocal(
-                        bounding_box.first, patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
-                    const CellIndex<NDIM> bbox_upper = IndexUtilities::getCellIndexLocal(
-                        bounding_box.second, patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
+                    const Point& X_lower = bounding_box.first;
+                    const Point& X_upper = bounding_box.second;
+                    const CellIndex<NDIM> bbox_lower = indexer.getCellIndexGlobal(X_lower, patch_dx);
+                    const CellIndex<NDIM> bbox_upper = indexer.getCellIndexGlobal(X_upper, patch_dx);
                     const Box<NDIM> tag_box(bbox_lower, bbox_upper);
                     tag_data->fillAll(1, tag_box);
                 }

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -1423,6 +1423,7 @@ void LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int f
     // multiple grid cells within the ghost cell region.  We must therefore
     // ensure that nodes passing through periodic boundaries are added to the
     // patch only once.
+    const IndexUtilities indexer(d_grid_geom);
     for (int level_number = coarsest_ln; level_number <= finest_ln; ++level_number)
     {
         if (!d_level_contains_lag_data[level_number]) continue;
@@ -1437,10 +1438,6 @@ void LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int f
                 new LNodeSetData(current_idx_data->getBox(), current_idx_data->getGhostCellWidth());
             const Box<NDIM>& patch_box = patch->getBox();
             const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const CellIndex<NDIM>& patch_lower = patch_box.lower();
-            const CellIndex<NDIM>& patch_upper = patch_box.upper();
-            const double* const patch_x_lower = patch_geom->getXLower();
-            const double* const patch_x_upper = patch_geom->getXUpper();
             const double* const patch_dx = patch_geom->getDx();
             std::set<int> registered_periodic_idx;
             for (LNodeSetData::CellIterator it(Box<NDIM>::grow(patch_box, IntVector<NDIM>(CFL_WIDTH))); it; it++)
@@ -1454,8 +1451,7 @@ void LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int f
                         LNodeSet::value_type& node_idx = *n;
                         const int local_idx = node_idx->getLocalPETScIndex();
                         double* const X = &X_data[local_idx][0];
-                        const CellIndex<NDIM> new_cell_idx = IndexUtilities::getCellIndex(
-                            X, patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
+                        const CellIndex<NDIM> new_cell_idx = indexer.getCellIndexGlobal(X, patch_dx);
                         if (patch_box.contains(new_cell_idx))
                         {
                             std::map<int, IntVector<NDIM> >::const_iterator it_offset =
@@ -1525,8 +1521,7 @@ void LDataManager::endDataRedistribution(const int coarsest_ln_in, const int fin
 
     // Update parallel data structures to account for any displaced nodes.
     const double* const dx0 = d_grid_geom->getDx();
-    const double* const domain_x_lower = d_grid_geom->getXLower();
-    const double* const domain_x_upper = d_grid_geom->getXUpper();
+    const IndexUtilities indexer(d_grid_geom);
     for (int level_number = coarsest_ln; level_number <= finest_ln; ++level_number)
     {
         if (!d_level_contains_lag_data[level_number] || d_displaced_strct_ids[level_number].empty()) continue;
@@ -1535,9 +1530,6 @@ void LDataManager::endDataRedistribution(const int coarsest_ln_in, const int fin
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(level_number);
         Pointer<BoxTree<NDIM> > box_tree = level->getBoxTree();
         const ProcessorMapping& processor_mapping = level->getProcessorMapping();
-        const Box<NDIM>& domain_box = level->getPhysicalDomain()[0];
-        const CellIndex<NDIM>& domain_lower = domain_box.lower();
-        const CellIndex<NDIM>& domain_upper = domain_box.upper();
         const IntVector<NDIM>& ratio = level->getRatio();
         boost::array<double, NDIM> dx;
         for (unsigned int d = 0; d < NDIM; ++d)
@@ -1556,8 +1548,7 @@ void LDataManager::endDataRedistribution(const int coarsest_ln_in, const int fin
         {
             LNodeSet::value_type& lag_idx = d_displaced_strct_lnode_idxs[level_number][k];
             const Point& posn = d_displaced_strct_lnode_posns[level_number][k];
-            const CellIndex<NDIM> cell_idx = IndexUtilities::getCellIndex(
-                posn, domain_x_lower, domain_x_upper, dx.data(), domain_lower, domain_upper);
+            const CellIndex<NDIM> cell_idx = indexer.getCellIndexGlobal(posn, dx.data());
 
             Array<int> indices;
             box_tree->findOverlapIndices(indices, Box<NDIM>(cell_idx, cell_idx));
@@ -1630,8 +1621,7 @@ void LDataManager::endDataRedistribution(const int coarsest_ln_in, const int fin
         {
             const LNodeSet::value_type& lag_idx = d_displaced_strct_lnode_idxs[level_number][k];
             const Point& posn = d_displaced_strct_lnode_posns[level_number][k];
-            const CellIndex<NDIM> cell_idx = IndexUtilities::getCellIndex(
-                posn, domain_x_lower, domain_x_upper, dx.data(), domain_lower, domain_upper);
+            const CellIndex<NDIM> cell_idx = indexer.getCellIndexGlobal(posn, dx.data());
 
             Array<int> indices;
             box_tree->findOverlapIndices(indices, Box<NDIM>(cell_idx, cell_idx));
@@ -2462,9 +2452,9 @@ void LDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> 
 
                     // Determine the region of index space covered by the
                     // displaced structure bounding box.
-                    const CellIndex<NDIM> bbox_lower = IndexUtilities::getCellIndex(
+                    const CellIndex<NDIM> bbox_lower = IndexUtilities::getCellIndexLocal(
                         bounding_box.first, patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
-                    const CellIndex<NDIM> bbox_upper = IndexUtilities::getCellIndex(
+                    const CellIndex<NDIM> bbox_upper = IndexUtilities::getCellIndexLocal(
                         bounding_box.second, patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
                     const Box<NDIM> tag_box(bbox_lower, bbox_upper);
                     tag_data->fillAll(1, tag_box);

--- a/ibtk/src/lagrangian/LEInteractor.cpp
+++ b/ibtk/src/lagrangian/LEInteractor.cpp
@@ -3132,7 +3132,7 @@ void LEInteractor::buildLocalIndices(std::vector<int>& local_indices,
     {
         const double* const X = &X_data[NDIM * k];
         const Index<NDIM> i =
-            IndexUtilities::getCellIndex(X, patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
+            IndexUtilities::getCellIndexLocal(X, patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
         if (box.contains(i)) local_indices.push_back(k);
     }
     return;

--- a/ibtk/src/lagrangian/LEInteractor.cpp
+++ b/ibtk/src/lagrangian/LEInteractor.cpp
@@ -3119,20 +3119,12 @@ void LEInteractor::buildLocalIndices(std::vector<int>& local_indices,
     if (upper_bound == 0) return;
 
     const Box<NDIM>& patch_box = patch->getBox();
-    const CellIndex<NDIM>& patch_lower = patch_box.lower();
-    const CellIndex<NDIM>& patch_upper = patch_box.upper();
-
     const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-    const double* const patch_x_lower = patch_geom->getXLower();
-    const double* const patch_x_upper = patch_geom->getXUpper();
-    const double* const patch_dx = patch_geom->getDx();
-
     local_indices.reserve(upper_bound);
     for (int k = 0; k < X_size / X_depth; ++k)
     {
         const double* const X = &X_data[NDIM * k];
-        const Index<NDIM> i =
-            IndexUtilities::getCellIndexLocal(X, patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
+        const Index<NDIM> i = IndexUtilities::getCellIndex(X, patch_geom, patch_box);
         if (box.contains(i)) local_indices.push_back(k);
     }
     return;

--- a/ibtk/src/math/PETScMatUtilities.cpp
+++ b/ibtk/src/math/PETScMatUtilities.cpp
@@ -641,7 +641,7 @@ void PETScMatUtilities::constructPatchLevelSCInterpOp(Mat& mat,
     for (int k = 0; k < n_local_points; ++k)
     {
         const double* const X = &X_arr[NDIM * k];
-        const Index<NDIM> X_idx = IndexUtilities::getCellIndex(X, x_lower, x_upper, dx, domain_lower, domain_upper);
+        const Index<NDIM> X_idx = IndexUtilities::getCellIndexLocal(X, x_lower, x_upper, dx, domain_lower, domain_upper);
 
 // Determine the position of the center of the Cartesian grid cell
 // containing the IB point.

--- a/ibtk/src/math/PETScMatUtilities.cpp
+++ b/ibtk/src/math/PETScMatUtilities.cpp
@@ -598,7 +598,6 @@ void PETScMatUtilities::constructPatchLevelSCInterpOp(Mat& mat,
     // Determine the grid extents.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = patch_level->getGridGeometry();
     const double* const x_lower = grid_geom->getXLower();
-    const double* const x_upper = grid_geom->getXUpper();
     const double* const dx0 = grid_geom->getDx();
     const IntVector<NDIM>& ratio = patch_level->getRatio();
     double dx[NDIM];
@@ -611,7 +610,6 @@ void PETScMatUtilities::constructPatchLevelSCInterpOp(Mat& mat,
     TBOX_ASSERT(domain_boxes.size() == 1);
 #endif
     const Index<NDIM>& domain_lower = domain_boxes[0].lower();
-    const Index<NDIM>& domain_upper = domain_boxes[0].upper();
 
     // Determine the matrix dimensions and index ranges.
     int m_local;
@@ -638,10 +636,11 @@ void PETScMatUtilities::constructPatchLevelSCInterpOp(Mat& mat,
     std::vector<int> patch_num(n_local_points);
     std::vector<std::vector<Box<NDIM> > > stencil_box(n_local_points, std::vector<Box<NDIM> >(NDIM));
     std::vector<int> d_nnz(m_local, 0), o_nnz(m_local, 0);
+    const IndexUtilities indexer(grid_geom);
     for (int k = 0; k < n_local_points; ++k)
     {
         const double* const X = &X_arr[NDIM * k];
-        const Index<NDIM> X_idx = IndexUtilities::getCellIndexLocal(X, x_lower, x_upper, dx, domain_lower, domain_upper);
+        const Index<NDIM> X_idx = indexer.getCellIndexGlobal(X, dx);
 
 // Determine the position of the center of the Cartesian grid cell
 // containing the IB point.

--- a/ibtk/src/math/PETScMatUtilities.cpp
+++ b/ibtk/src/math/PETScMatUtilities.cpp
@@ -636,11 +636,10 @@ void PETScMatUtilities::constructPatchLevelSCInterpOp(Mat& mat,
     std::vector<int> patch_num(n_local_points);
     std::vector<std::vector<Box<NDIM> > > stencil_box(n_local_points, std::vector<Box<NDIM> >(NDIM));
     std::vector<int> d_nnz(m_local, 0), o_nnz(m_local, 0);
-    const IndexUtilities indexer(grid_geom);
     for (int k = 0; k < n_local_points; ++k)
     {
         const double* const X = &X_arr[NDIM * k];
-        const Index<NDIM> X_idx = indexer.getCellIndexGlobal(X, dx);
+        const Index<NDIM> X_idx = IndexUtilities::getCellIndex(X, grid_geom, ratio);
 
 // Determine the position of the center of the Cartesian grid cell
 // containing the IB point.

--- a/ibtk/src/refine_ops/LMarkerRefine.cpp
+++ b/ibtk/src/refine_ops/LMarkerRefine.cpp
@@ -150,7 +150,7 @@ void LMarkerRefine::refine(Patch<NDIM>& fine,
                     X_shifted[d] = X[d] + static_cast<double>(offset(d)) * coarse_patchDx[d];
                 }
 
-                const Index<NDIM> fine_i = IndexUtilities::getCellIndex(
+                const Index<NDIM> fine_i = IndexUtilities::getCellIndexLocal(
                     X_shifted, fine_patchXLower, fine_patchXUpper, fine_patchDx, fine_patch_lower, fine_patch_upper);
                 if (fine_box.contains(fine_i))
                 {

--- a/ibtk/src/refine_ops/LMarkerRefine.cpp
+++ b/ibtk/src/refine_ops/LMarkerRefine.cpp
@@ -152,11 +152,13 @@ void LMarkerRefine::refine(Patch<NDIM>& fine,
                 Index<NDIM> fine_i = IndexUtilities::getCellIndexLocal(
                     X_shifted, fine_patchXLower, fine_patchXUpper, fine_patchDx, fine_patch_lower, fine_patch_upper);
                 
-                // Catch corner cases in which roundoff error can cause problems.
+                // Catch edge cases in which roundoff error can cause problems.
                 //
                 // NOTE: This can permit markers to "escape" out the "top" of the domain if
                 // the marker position is equal to the upper domain extent.  The marker
                 // advection code needs to keep markers from hitting the domain boundaries.
+                // (Note that bad things also happen if IB points hit the domain boundaries,
+                // so this is not an issue that is unique to markers.)
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {
                     if (MathUtilities<double>::equalEps(X_shifted[d], fine_patchXLower[d]))

--- a/ibtk/src/refine_ops/LMarkerRefine.cpp
+++ b/ibtk/src/refine_ops/LMarkerRefine.cpp
@@ -149,9 +149,28 @@ void LMarkerRefine::refine(Patch<NDIM>& fine,
                 {
                     X_shifted[d] = X[d] + static_cast<double>(offset(d)) * coarse_patchDx[d];
                 }
-
-                const Index<NDIM> fine_i = IndexUtilities::getCellIndexLocal(
+                Index<NDIM> fine_i = IndexUtilities::getCellIndexLocal(
                     X_shifted, fine_patchXLower, fine_patchXUpper, fine_patchDx, fine_patch_lower, fine_patch_upper);
+                
+                // Catch corner cases in which roundoff error can cause problems.
+                //
+                // NOTE: This can permit markers to "escape" out the "top" of the domain if
+                // the marker position is equal to the upper domain extent.  The marker
+                // advection code needs to keep markers from hitting the domain boundaries.
+                for (unsigned int d = 0; d < NDIM; ++d)
+                {
+                    if (MathUtilities<double>::equalEps(X_shifted[d], fine_patchXLower[d]))
+                    {
+                        X_shifted[d] = fine_patchXLower[d];
+                        fine_i(d) = fine_patch_lower(d);
+                    }
+                    else if (MathUtilities<double>::equalEps(X_shifted[d], fine_patchXUpper[d]))
+                    {
+                        X_shifted[d] = fine_patchXUpper[d];
+                        fine_i(d) = fine_patch_upper(d) + 1;
+                    }
+                }
+                
                 if (fine_box.contains(fine_i))
                 {
                     if (!dst_mark_data->isElement(fine_i))

--- a/ibtk/src/refine_ops/LMarkerRefine.cpp
+++ b/ibtk/src/refine_ops/LMarkerRefine.cpp
@@ -127,7 +127,6 @@ void LMarkerRefine::refine(Patch<NDIM>& fine,
     const Index<NDIM>& fine_patch_upper = fine_patch_box.upper();
     const double* const fine_patchXLower = fine_patch_geom->getXLower();
     const double* const fine_patchXUpper = fine_patch_geom->getXUpper();
-    const double* const fine_patchDx = fine_patch_geom->getDx();
 
     const Pointer<CartesianPatchGeometry<NDIM> > coarse_patch_geom = coarse.getPatchGeometry();
     const double* const coarse_patchDx = coarse_patch_geom->getDx();
@@ -149,8 +148,7 @@ void LMarkerRefine::refine(Patch<NDIM>& fine,
                 {
                     X_shifted[d] = X[d] + static_cast<double>(offset(d)) * coarse_patchDx[d];
                 }
-                Index<NDIM> fine_i = IndexUtilities::getCellIndexLocal(
-                    X_shifted, fine_patchXLower, fine_patchXUpper, fine_patchDx, fine_patch_lower, fine_patch_upper);
+                Index<NDIM> fine_i = IndexUtilities::getCellIndex(X_shifted, fine_patch_geom, fine_patch_box);
                 
                 // Catch edge cases in which roundoff error can cause problems.
                 //

--- a/ibtk/src/utilities/LMarkerUtilities.cpp
+++ b/ibtk/src/utilities/LMarkerUtilities.cpp
@@ -550,14 +550,11 @@ void LMarkerUtilities::collectMarkersOnPatchHierarchy(const int mark_idx, Pointe
     mark_level_fill_alg->registerRefine(mark_idx, mark_idx, mark_idx, NULL);
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(coarsest_ln);
     mark_level_fill_alg->createSchedule(level, NULL)->fillData(0.0);
+    const IndexUtilities indexer(hierarchy->getGridGeometry());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
-        const Box<NDIM>& patch_box = patch->getBox();
-
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-        const Index<NDIM>& patch_lower = patch_box.lower();
-        const Index<NDIM>& patch_upper = patch_box.upper();
         const double* const patchXLower = patch_geom->getXLower();
         const double* const patchXUpper = patch_geom->getXUpper();
         const double* const patchDx = patch_geom->getDx();
@@ -587,8 +584,7 @@ void LMarkerUtilities::collectMarkersOnPatchHierarchy(const int mark_idx, Pointe
                 ;
             if (patch_owns_mark_at_new_loc)
             {
-                const Index<NDIM> i = IndexUtilities::getCellIndex(
-                    X_shifted, patchXLower, patchXUpper, patchDx, patch_lower, patch_upper);
+                const Index<NDIM> i = indexer.getCellIndexGlobal(X_shifted, patchDx);
                 if (!mark_data_new->isElement(i))
                 {
                     mark_data_new->appendItemPointer(i, new LMarkerSet());
@@ -628,6 +624,7 @@ void LMarkerUtilities::initializeMarkersOnLevel(const int mark_idx,
                                                 const Pointer<BasePatchLevel<NDIM> > old_level)
 {
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
+    const IndexUtilities indexer(hierarchy->getGridGeometry());
 
     // On the coarsest level of the patch hierarchy, copy marker data from the
     // old coarse level.  Otherwise, refine marker data from the coarsest level
@@ -637,10 +634,7 @@ void LMarkerUtilities::initializeMarkersOnLevel(const int mark_idx,
         for (PatchLevel<NDIM>::Iterator p(level); p; p++)
         {
             Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& patch_box = patch->getBox();
             const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const Index<NDIM>& patch_lower = patch_box.lower();
-            const Index<NDIM>& patch_upper = patch_box.upper();
             const double* const patchXLower = patch_geom->getXLower();
             const double* const patchXUpper = patch_geom->getXUpper();
             const double* const patchDx = patch_geom->getDx();
@@ -660,8 +654,7 @@ void LMarkerUtilities::initializeMarkersOnLevel(const int mark_idx,
                     ;
                 if (patch_owns_mark_at_loc)
                 {
-                    const Index<NDIM> i =
-                        IndexUtilities::getCellIndex(X, patchXLower, patchXUpper, patchDx, patch_lower, patch_upper);
+                    const Index<NDIM> i = indexer.getCellIndexGlobal(X, patchDx);
                     if (!mark_data->isElement(i))
                     {
                         mark_data->appendItemPointer(i, new LMarkerSet());

--- a/ibtk/src/utilities/LMarkerUtilities.cpp
+++ b/ibtk/src/utilities/LMarkerUtilities.cpp
@@ -549,8 +549,9 @@ void LMarkerUtilities::collectMarkersOnPatchHierarchy(const int mark_idx, Pointe
     Pointer<RefineAlgorithm<NDIM> > mark_level_fill_alg = new RefineAlgorithm<NDIM>();
     mark_level_fill_alg->registerRefine(mark_idx, mark_idx, mark_idx, NULL);
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(coarsest_ln);
+    const IntVector<NDIM>& ratio = level->getRatio();
+    const Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
     mark_level_fill_alg->createSchedule(level, NULL)->fillData(0.0);
-    const IndexUtilities indexer(hierarchy->getGridGeometry());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
@@ -584,7 +585,7 @@ void LMarkerUtilities::collectMarkersOnPatchHierarchy(const int mark_idx, Pointe
                 ;
             if (patch_owns_mark_at_new_loc)
             {
-                const Index<NDIM> i = indexer.getCellIndexGlobal(X_shifted, patchDx);
+                const Index<NDIM> i = IndexUtilities::getCellIndex(X_shifted, grid_geom, ratio);
                 if (!mark_data_new->isElement(i))
                 {
                     mark_data_new->appendItemPointer(i, new LMarkerSet());
@@ -624,7 +625,8 @@ void LMarkerUtilities::initializeMarkersOnLevel(const int mark_idx,
                                                 const Pointer<BasePatchLevel<NDIM> > old_level)
 {
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-    const IndexUtilities indexer(hierarchy->getGridGeometry());
+    const IntVector<NDIM>& ratio = level->getRatio();
+    const Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
 
     // On the coarsest level of the patch hierarchy, copy marker data from the
     // old coarse level.  Otherwise, refine marker data from the coarsest level
@@ -637,7 +639,6 @@ void LMarkerUtilities::initializeMarkersOnLevel(const int mark_idx,
             const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
             const double* const patchXLower = patch_geom->getXLower();
             const double* const patchXUpper = patch_geom->getXUpper();
-            const double* const patchDx = patch_geom->getDx();
 
             Pointer<LMarkerSetData> mark_data = patch->getPatchData(mark_idx);
             for (unsigned int k = 0; k < mark_init_posns.size(); ++k)
@@ -654,7 +655,7 @@ void LMarkerUtilities::initializeMarkersOnLevel(const int mark_idx,
                     ;
                 if (patch_owns_mark_at_loc)
                 {
-                    const Index<NDIM> i = indexer.getCellIndexGlobal(X, patchDx);
+                    const Index<NDIM> i = IndexUtilities::getCellIndex(X, grid_geom, ratio);
                     if (!mark_data->isElement(i))
                     {
                         mark_data->appendItemPointer(i, new LMarkerSet());

--- a/include/ibamr/IBStandardInitializer.h
+++ b/include/ibamr/IBStandardInitializer.h
@@ -44,7 +44,6 @@
 #include "IntVector.h"
 #include "boost/array.hpp"
 #include "ibamr/IBRodForceSpec.h"
-#include "ibtk/IndexUtilities.h"
 #include "ibtk/LInitStrategy.h"
 #include "ibtk/LSiloDataWriter.h"
 #include "ibtk/ibtk_utilities.h"
@@ -643,17 +642,21 @@ private:
     void readSourceFiles(const std::string& file_extension);
 
     /*!
-     * \brief Determine the indices of any vertices initially located within the
+     * \brief Determine the indices of any vertices initially owned by the
      * specified patch.
      */
     void getPatchVertices(std::vector<std::pair<int, int> >& point_indices,
                           SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM> > patch,
-                          int level_number,
-                          bool can_be_refined,
-                          const double* domain_x_lower,
-                          const double* domain_x_upper,
-                          const SAMRAI::hier::IntVector<NDIM>& periodic_shift,
-                          const IBTK::IndexUtilities& indexer) const;
+                          SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy) const;
+
+    /*!
+     * \brief Determine the indices of any vertices associated with a given
+     * level number initially located within the specified patch.
+     */
+    void getPatchVerticesAtLevel(std::vector<std::pair<int, int> >& point_indices,
+                                 SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM> > patch,
+                                 SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                                 int level_number) const;
 
     /*!
      * \return The canonical Lagrangian index of the specified vertex.

--- a/include/ibamr/IBStandardInitializer.h
+++ b/include/ibamr/IBStandardInitializer.h
@@ -44,6 +44,7 @@
 #include "IntVector.h"
 #include "boost/array.hpp"
 #include "ibamr/IBRodForceSpec.h"
+#include "ibtk/IndexUtilities.h"
 #include "ibtk/LInitStrategy.h"
 #include "ibtk/LSiloDataWriter.h"
 #include "ibtk/ibtk_utilities.h"
@@ -651,7 +652,8 @@ private:
                           bool can_be_refined,
                           const double* domain_x_lower,
                           const double* domain_x_upper,
-                          const SAMRAI::hier::IntVector<NDIM>& periodic_shift) const;
+                          const SAMRAI::hier::IntVector<NDIM>& periodic_shift,
+                          const IBTK::IndexUtilities& indexer) const;
 
     /*!
      * \return The canonical Lagrangian index of the specified vertex.

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1716,8 +1716,8 @@ void IBFEMethod::imposeJumpConditions(const int f_data_idx,
                     }
                     side_elem->point(k) = X;
                 }
-                Box<NDIM> box(IndexUtilities::getCellIndex(&X_min[0], x_lower, x_upper, dx, patch_lower, patch_upper),
-                              IndexUtilities::getCellIndex(&X_max[0], x_lower, x_upper, dx, patch_lower, patch_upper));
+                Box<NDIM> box(IndexUtilities::getCellIndexLocal(&X_min[0], x_lower, x_upper, dx, patch_lower, patch_upper),
+                              IndexUtilities::getCellIndexLocal(&X_max[0], x_lower, x_upper, dx, patch_lower, patch_upper));
                 box.grow(IntVector<NDIM>(1));
                 box = box * patch_box;
 

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1646,8 +1646,9 @@ void IBFEMethod::imposeJumpConditions(const int f_data_idx,
     std::vector<SideIndex<NDIM> > intersection_indices;
     std::vector<std::pair<double, libMesh::Point> > intersections;
     Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(level_num);
+    const IntVector<NDIM>& ratio = level->getRatio();
+    const Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
     int local_patch_num = 0;
-    const IndexUtilities indexer(d_hierarchy->getGridGeometry());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++local_patch_num)
     {
         // The relevant collection of elements.
@@ -1659,10 +1660,8 @@ void IBFEMethod::imposeJumpConditions(const int f_data_idx,
         Pointer<SideData<NDIM, double> > f_data = patch->getPatchData(f_data_idx);
         const Box<NDIM>& patch_box = patch->getBox();
         const CellIndex<NDIM>& patch_lower = patch_box.lower();
-        const CellIndex<NDIM>& patch_upper = patch_box.upper();
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
         const double* const x_lower = patch_geom->getXLower();
-        const double* const x_upper = patch_geom->getXUpper();
         const double* const dx = patch_geom->getDx();
 
         SideData<NDIM, int> num_intersections(patch_box, 1, IntVector<NDIM>(0));
@@ -1717,7 +1716,8 @@ void IBFEMethod::imposeJumpConditions(const int f_data_idx,
                     }
                     side_elem->point(k) = X;
                 }
-                Box<NDIM> box(indexer.getCellIndexGlobal(&X_min[0], dx), indexer.getCellIndexGlobal(&X_max[0], dx));
+                Box<NDIM> box(IndexUtilities::getCellIndex(&X_min[0], grid_geom, ratio),
+                              IndexUtilities::getCellIndex(&X_max[0], grid_geom, ratio));
                 box.grow(IntVector<NDIM>(1));
                 box = box * patch_box;
 

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1647,6 +1647,7 @@ void IBFEMethod::imposeJumpConditions(const int f_data_idx,
     std::vector<std::pair<double, libMesh::Point> > intersections;
     Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(level_num);
     int local_patch_num = 0;
+    const IndexUtilities indexer(d_hierarchy->getGridGeometry());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++local_patch_num)
     {
         // The relevant collection of elements.
@@ -1716,8 +1717,7 @@ void IBFEMethod::imposeJumpConditions(const int f_data_idx,
                     }
                     side_elem->point(k) = X;
                 }
-                Box<NDIM> box(IndexUtilities::getCellIndexLocal(&X_min[0], x_lower, x_upper, dx, patch_lower, patch_upper),
-                              IndexUtilities::getCellIndexLocal(&X_max[0], x_lower, x_upper, dx, patch_lower, patch_upper));
+                Box<NDIM> box(indexer.getCellIndexGlobal(&X_min[0], dx), indexer.getCellIndexGlobal(&X_max[0], dx));
                 box.grow(IntVector<NDIM>(1));
                 box = box * patch_box;
 

--- a/src/IB/IBInstrumentPanel.cpp
+++ b/src/IB/IBInstrumentPanel.cpp
@@ -878,14 +878,14 @@ void IBInstrumentPanel::initializeHierarchyDependentData(const Pointer<PatchHier
                 for (unsigned int n = 0; n < d_X_web[l].shape()[1]; ++n)
                 {
                     const Point& X = d_X_web[l][m][n];
-                    const Index<NDIM> i = IndexUtilities::getCellIndexLocal(
+                    const Index<NDIM> i = IndexUtilities::getCellIndex(
                         X, domainXLower, domainXUpper, dx.data(), domain_box_level_lower, domain_box_level_upper);
-                    const Index<NDIM> finer_i = IndexUtilities::getCellIndexLocal(X,
-                                                                                  domainXLower,
-                                                                                  domainXUpper,
-                                                                                  finer_dx.data(),
-                                                                                  finer_domain_box_level_lower,
-                                                                                  finer_domain_box_level_upper);
+                    const Index<NDIM> finer_i = IndexUtilities::getCellIndex(X,
+                                                                             domainXLower,
+                                                                             domainXUpper,
+                                                                             finer_dx.data(),
+                                                                             finer_domain_box_level_lower,
+                                                                             finer_domain_box_level_upper);
                     if (level->getBoxes().contains(i) &&
                         (ln == finest_ln || !finer_level->getBoxes().contains(finer_i)))
                     {
@@ -900,14 +900,14 @@ void IBInstrumentPanel::initializeHierarchyDependentData(const Pointer<PatchHier
 
             // Setup the web centroid mapping.
             const Point& X = d_X_centroid[l];
-            const Index<NDIM> i = IndexUtilities::getCellIndexLocal(
+            const Index<NDIM> i = IndexUtilities::getCellIndex(
                 X, domainXLower, domainXUpper, dx.data(), domain_box_level_lower, domain_box_level_upper);
-            const Index<NDIM> finer_i = IndexUtilities::getCellIndexLocal(X,
-                                                                          domainXLower,
-                                                                          domainXUpper,
-                                                                          finer_dx.data(),
-                                                                          finer_domain_box_level_lower,
-                                                                          finer_domain_box_level_upper);
+            const Index<NDIM> finer_i = IndexUtilities::getCellIndex(X,
+                                                                     domainXLower,
+                                                                     domainXUpper,
+                                                                     finer_dx.data(),
+                                                                     finer_domain_box_level_lower,
+                                                                     finer_domain_box_level_upper);
             if (level->getBoxes().contains(i) && (ln == finest_ln || !finer_level->getBoxes().contains(finer_i)))
             {
                 WebCentroid c;

--- a/src/IB/IBInstrumentPanel.cpp
+++ b/src/IB/IBInstrumentPanel.cpp
@@ -878,14 +878,14 @@ void IBInstrumentPanel::initializeHierarchyDependentData(const Pointer<PatchHier
                 for (unsigned int n = 0; n < d_X_web[l].shape()[1]; ++n)
                 {
                     const Point& X = d_X_web[l][m][n];
-                    const Index<NDIM> i = IndexUtilities::getCellIndex(
+                    const Index<NDIM> i = IndexUtilities::getCellIndexLocal(
                         X, domainXLower, domainXUpper, dx.data(), domain_box_level_lower, domain_box_level_upper);
-                    const Index<NDIM> finer_i = IndexUtilities::getCellIndex(X,
-                                                                             domainXLower,
-                                                                             domainXUpper,
-                                                                             finer_dx.data(),
-                                                                             finer_domain_box_level_lower,
-                                                                             finer_domain_box_level_upper);
+                    const Index<NDIM> finer_i = IndexUtilities::getCellIndexLocal(X,
+                                                                                  domainXLower,
+                                                                                  domainXUpper,
+                                                                                  finer_dx.data(),
+                                                                                  finer_domain_box_level_lower,
+                                                                                  finer_domain_box_level_upper);
                     if (level->getBoxes().contains(i) &&
                         (ln == finest_ln || !finer_level->getBoxes().contains(finer_i)))
                     {
@@ -900,14 +900,14 @@ void IBInstrumentPanel::initializeHierarchyDependentData(const Pointer<PatchHier
 
             // Setup the web centroid mapping.
             const Point& X = d_X_centroid[l];
-            const Index<NDIM> i = IndexUtilities::getCellIndex(
+            const Index<NDIM> i = IndexUtilities::getCellIndexLocal(
                 X, domainXLower, domainXUpper, dx.data(), domain_box_level_lower, domain_box_level_upper);
-            const Index<NDIM> finer_i = IndexUtilities::getCellIndex(X,
-                                                                     domainXLower,
-                                                                     domainXUpper,
-                                                                     finer_dx.data(),
-                                                                     finer_domain_box_level_lower,
-                                                                     finer_domain_box_level_upper);
+            const Index<NDIM> finer_i = IndexUtilities::getCellIndexLocal(X,
+                                                                          domainXLower,
+                                                                          domainXUpper,
+                                                                          finer_dx.data(),
+                                                                          finer_domain_box_level_lower,
+                                                                          finer_domain_box_level_upper);
             if (level->getBoxes().contains(i) && (ln == finest_ln || !finer_level->getBoxes().contains(finer_i)))
             {
                 WebCentroid c;

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -837,7 +837,7 @@ void IBMethod::spreadFluidSource(const int q_data_idx,
 
                 // Determine the approximate source stencil box.
                 const Index<NDIM> i_center =
-                    IndexUtilities::getCellIndex(d_X_src[ln][n], xLower, xUpper, dx, patch_lower, patch_upper);
+                    IndexUtilities::getCellIndexLocal(d_X_src[ln][n], xLower, xUpper, dx, patch_lower, patch_upper);
                 Box<NDIM> stencil_box(i_center, i_center);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {
@@ -1037,7 +1037,7 @@ void IBMethod::interpolatePressure(int p_data_idx,
 
                 // Determine the approximate source stencil box.
                 const Index<NDIM> i_center =
-                    IndexUtilities::getCellIndex(d_X_src[ln][n], xLower, xUpper, dx, patch_lower, patch_upper);
+                    IndexUtilities::getCellIndexLocal(d_X_src[ln][n], xLower, xUpper, dx, patch_lower, patch_upper);
                 Box<NDIM> stencil_box(i_center, i_center);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {
@@ -1366,7 +1366,7 @@ void IBMethod::applyGradientDetector(Pointer<BasePatchHierarchy<NDIM> > base_hie
             }
 
             // Determine the approximate source stencil box.
-            const Index<NDIM> i_center = IndexUtilities::getCellIndex(
+            const Index<NDIM> i_center = IndexUtilities::getCellIndexLocal(
                 d_X_src[finer_level_number][n], xLower, xUpper, dx_finer.data(), lower, upper);
             Box<NDIM> stencil_box(i_center, i_center);
             for (unsigned int d = 0; d < NDIM; ++d)

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -807,6 +807,7 @@ void IBMethod::spreadFluidSource(const int q_data_idx,
     }
 
     // Spread the sources/sinks onto the Cartesian grid.
+    const IndexUtilities indexer(d_hierarchy->getGridGeometry());
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
     {
         if (d_n_src[ln] == 0) continue;
@@ -836,8 +837,7 @@ void IBMethod::spreadFluidSource(const int q_data_idx,
                 }
 
                 // Determine the approximate source stencil box.
-                const Index<NDIM> i_center =
-                    IndexUtilities::getCellIndexLocal(d_X_src[ln][n], xLower, xUpper, dx, patch_lower, patch_upper);
+                const Index<NDIM> i_center = indexer.getCellIndexGlobal(d_X_src[ln][n], dx);
                 Box<NDIM> stencil_box(i_center, i_center);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {
@@ -1014,15 +1014,14 @@ void IBMethod::interpolatePressure(int p_data_idx,
     {
         if (d_n_src[ln] == 0) continue;
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        const IndexUtilities indexer(level->getGridGeometry());
         for (PatchLevel<NDIM>::Iterator p(level); p; p++)
         {
             Pointer<Patch<NDIM> > patch = level->getPatch(p());
             const Box<NDIM>& patch_box = patch->getBox();
             const Index<NDIM>& patch_lower = patch_box.lower();
-            const Index<NDIM>& patch_upper = patch_box.upper();
             const Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
             const double* const xLower = pgeom->getXLower();
-            const double* const xUpper = pgeom->getXUpper();
             const double* const dx = pgeom->getDx();
             const Pointer<CellData<NDIM, double> > p_data = patch->getPatchData(p_data_idx);
             for (int n = 0; n < d_n_src[ln]; ++n)
@@ -1036,8 +1035,7 @@ void IBMethod::interpolatePressure(int p_data_idx,
                 }
 
                 // Determine the approximate source stencil box.
-                const Index<NDIM> i_center =
-                    IndexUtilities::getCellIndexLocal(d_X_src[ln][n], xLower, xUpper, dx, patch_lower, patch_upper);
+                const Index<NDIM> i_center = indexer.getCellIndexGlobal(d_X_src[ln][n], dx);
                 Box<NDIM> stencil_box(i_center, i_center);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {
@@ -1340,12 +1338,8 @@ void IBMethod::applyGradientDetector(Pointer<BasePatchHierarchy<NDIM> > base_hie
     {
         Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
         if (!grid_geom->getDomainIsSingleBox()) TBOX_ERROR("physical domain must be a single box...\n");
-
-        const Index<NDIM>& lower = grid_geom->getPhysicalDomain()[0].lower();
-        const Index<NDIM>& upper = grid_geom->getPhysicalDomain()[0].upper();
-        const double* const xLower = grid_geom->getXLower();
-        const double* const xUpper = grid_geom->getXUpper();
         const double* const dx = grid_geom->getDx();
+        const IndexUtilities indexer(grid_geom);
 
         const int finer_level_number = level_number + 1;
         Pointer<PatchLevel<NDIM> > finer_level = hierarchy->getPatchLevel(finer_level_number);
@@ -1366,8 +1360,8 @@ void IBMethod::applyGradientDetector(Pointer<BasePatchHierarchy<NDIM> > base_hie
             }
 
             // Determine the approximate source stencil box.
-            const Index<NDIM> i_center = IndexUtilities::getCellIndexLocal(
-                d_X_src[finer_level_number][n], xLower, xUpper, dx_finer.data(), lower, upper);
+            const Index<NDIM> i_center = indexer.getCellIndexGlobal(
+                d_X_src[finer_level_number][n], dx_finer.data());
             Box<NDIM> stencil_box(i_center, i_center);
             for (unsigned int d = 0; d < NDIM; ++d)
             {

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -57,6 +57,7 @@
 #include "PatchHierarchy.h"
 #include "PatchLevel.h"
 #include "boost/array.hpp"
+#include "boost/math/special_functions/round.hpp"
 #include "boost/multi_array.hpp"
 #include "ibamr/IBAnchorPointSpec.h"
 #include "ibamr/IBBeamForceSpec.h"
@@ -121,11 +122,6 @@ inline std::string discard_comments(const std::string& input_string)
     string_stream.clear();
     return output_string;
 } // discard_comments
-
-inline int round(double x)
-{
-    return floor(x + 0.5);
-} // round
 }
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
@@ -260,20 +256,16 @@ IBStandardInitializer::computeGlobalNodeCountOnPatchLevel(const Pointer<PatchHie
 unsigned int IBStandardInitializer::computeLocalNodeCountOnPatchLevel(const Pointer<PatchHierarchy<NDIM> > hierarchy,
                                                                       const int level_number,
                                                                       const double /*init_data_time*/,
-                                                                      const bool can_be_refined,
+                                                                      const bool /*can_be_refined*/,
                                                                       const bool /*initial_time*/)
 {
     // Determine the extents of the physical domain.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
-    const double* const domain_x_lower = grid_geom->getXLower();
-    const double* const domain_x_upper = grid_geom->getXUpper();
-    const IndexUtilities indexer(grid_geom);
 
     // Loop over all patches in the specified level of the patch level and count
     // the number of local vertices.
     int local_node_count = 0;
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-    const IntVector<NDIM>& periodic_shift = grid_geom->getPeriodicShift(level->getRatio());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
@@ -281,8 +273,7 @@ unsigned int IBStandardInitializer::computeLocalNodeCountOnPatchLevel(const Poin
         // Count the number of vertices whose initial locations will be within
         // the given patch.
         std::vector<std::pair<int, int> > patch_vertices;
-        getPatchVertices(
-            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift, indexer);
+        getPatchVertices(patch_vertices, patch, hierarchy);
         local_node_count += patch_vertices.size();
     }
     return local_node_count;
@@ -315,7 +306,7 @@ unsigned int IBStandardInitializer::initializeDataOnPatchLevel(const int lag_nod
                                                                const Pointer<PatchHierarchy<NDIM> > hierarchy,
                                                                const int level_number,
                                                                const double /*init_data_time*/,
-                                                               const bool can_be_refined,
+                                                               const bool /*can_be_refined*/,
                                                                const bool /*initial_time*/,
                                                                LDataManager* const /*l_data_manager*/)
 {
@@ -328,7 +319,6 @@ unsigned int IBStandardInitializer::initializeDataOnPatchLevel(const int lag_nod
     {
         domain_length[d] = domain_x_upper[d] - domain_x_lower[d];
     }
-    const IndexUtilities indexer(grid_geom);
 
     // Set the global index offset.  This is equal to the number of Lagrangian
     // indices that have already been initialized on the specified level.
@@ -341,7 +331,8 @@ unsigned int IBStandardInitializer::initializeDataOnPatchLevel(const int lag_nod
     int local_idx = -1;
     int local_node_count = 0;
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-    const IntVector<NDIM>& periodic_shift = grid_geom->getPeriodicShift(level->getRatio());
+    const IntVector<NDIM>& ratio = level->getRatio();
+    const IntVector<NDIM>& periodic_shift = grid_geom->getPeriodicShift(ratio);
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
@@ -353,8 +344,7 @@ unsigned int IBStandardInitializer::initializeDataOnPatchLevel(const int lag_nod
         // Initialize the vertices whose initial locations will be within the
         // given patch.
         std::vector<std::pair<int, int> > patch_vertices;
-        getPatchVertices(
-            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift, indexer);
+        getPatchVertices(patch_vertices, patch, hierarchy);
         local_node_count += patch_vertices.size();
         for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin(); it != patch_vertices.end();
              ++it)
@@ -371,7 +361,7 @@ unsigned int IBStandardInitializer::initializeDataOnPatchLevel(const int lag_nod
             IntVector<NDIM> periodic_offset;
             for (int d = 0; d < NDIM; ++d)
             {
-                periodic_offset[d] = round(periodic_displacement[d] / patch_dx[d]);
+                periodic_offset[d] = boost::math::round(periodic_displacement[d] / patch_dx[d]);
             }
 
             // Ensure that all points are initially within the computational
@@ -403,7 +393,7 @@ unsigned int IBStandardInitializer::initializeDataOnPatchLevel(const int lag_nod
 
             // Get the index of the cell in which the present vertex is
             // initially located.
-            const CellIndex<NDIM> idx = indexer.getCellIndexGlobal(X, patch_dx);
+            const CellIndex<NDIM> idx = IndexUtilities::getCellIndex(X, grid_geom, ratio);
 
             // Initialize the specification objects associated with the present
             // vertex.
@@ -450,15 +440,12 @@ unsigned int IBStandardInitializer::initializeMassDataOnPatchLevel(const unsigne
                                                                    const Pointer<PatchHierarchy<NDIM> > hierarchy,
                                                                    const int level_number,
                                                                    const double /*init_data_time*/,
-                                                                   const bool can_be_refined,
+                                                                   const bool /*can_be_refined*/,
                                                                    const bool /*initial_time*/,
                                                                    LDataManager* const /*l_data_manager*/)
 {
     // Determine the extents of the physical domain.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
-    const double* const domain_x_lower = grid_geom->getXLower();
-    const double* const domain_x_upper = grid_geom->getXUpper();
-    const IndexUtilities indexer(grid_geom);
 
     // Loop over all patches in the specified level of the patch level and
     // initialize the local vertices.
@@ -467,7 +454,6 @@ unsigned int IBStandardInitializer::initializeMassDataOnPatchLevel(const unsigne
     int local_idx = -1;
     int local_node_count = 0;
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-    const IntVector<NDIM>& periodic_shift = grid_geom->getPeriodicShift(level->getRatio());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
@@ -475,8 +461,7 @@ unsigned int IBStandardInitializer::initializeMassDataOnPatchLevel(const unsigne
         // Initialize the vertices whose initial locations will be within the
         // given patch.
         std::vector<std::pair<int, int> > patch_vertices;
-        getPatchVertices(
-            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift, indexer);
+        getPatchVertices(patch_vertices, patch, hierarchy);
         local_node_count += patch_vertices.size();
         for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin(); it != patch_vertices.end();
              ++it)
@@ -514,15 +499,12 @@ unsigned int IBStandardInitializer::initializeDirectorDataOnPatchLevel(const uns
                                                                        const Pointer<PatchHierarchy<NDIM> > hierarchy,
                                                                        const int level_number,
                                                                        const double /*init_data_time*/,
-                                                                       const bool can_be_refined,
+                                                                       const bool /*can_be_refined*/,
                                                                        const bool /*initial_time*/,
                                                                        LDataManager* const /*l_data_manager*/)
 {
     // Determine the extents of the physical domain.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
-    const double* const domain_x_lower = grid_geom->getXLower();
-    const double* const domain_x_upper = grid_geom->getXUpper();
-    const IndexUtilities indexer(grid_geom);
 
     // Loop over all patches in the specified level of the patch level and
     // initialize the local vertices.
@@ -530,7 +512,6 @@ unsigned int IBStandardInitializer::initializeDirectorDataOnPatchLevel(const uns
     int local_idx = -1;
     int local_node_count = 0;
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-    const IntVector<NDIM>& periodic_shift = grid_geom->getPeriodicShift(level->getRatio());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
@@ -538,8 +519,7 @@ unsigned int IBStandardInitializer::initializeDirectorDataOnPatchLevel(const uns
         // Initialize the vertices whose initial locations will be within the
         // given patch.
         std::vector<std::pair<int, int> > patch_vertices;
-        getPatchVertices(
-            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift, indexer);
+        getPatchVertices(patch_vertices, patch, hierarchy);
         local_node_count += patch_vertices.size();
         for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin(); it != patch_vertices.end();
              ++it)
@@ -568,30 +548,28 @@ void IBStandardInitializer::tagCellsForInitialRefinement(const Pointer<PatchHier
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
     const double* const domain_x_lower = grid_geom->getXLower();
     const double* const domain_x_upper = grid_geom->getXUpper();
-    const IndexUtilities indexer(grid_geom);
 
     // Loop over all patches in the specified level of the patch level and tag
     // cells for refinement wherever there are vertices assigned to a finer
     // level of the Cartesian grid.
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-    const IntVector<NDIM>& periodic_shift = grid_geom->getPeriodicShift(level->getRatio());
+    const IntVector<NDIM>& ratio = level->getRatio();
+    const IntVector<NDIM>& periodic_shift = grid_geom->getPeriodicShift(ratio);
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
         const Box<NDIM>& patch_box = patch->getBox();
-        const double* const dx = patch_geom->getDx();
 
         Pointer<CellData<NDIM, int> > tag_data = patch->getPatchData(tag_index);
 
         // Tag cells for refinement whenever there are vertices whose initial
         // locations will be within the index space of the given patch, but on
         // the finer levels of the AMR patch hierarchy.
-        const bool can_be_refined = level_can_be_refined(level_number, d_max_levels);
         for (int ln = level_number + 1; ln < d_max_levels; ++ln)
         {
             std::vector<std::pair<int, int> > patch_vertices;
-            getPatchVertices(patch_vertices, patch, ln, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift, indexer);
+            getPatchVerticesAtLevel(patch_vertices, patch, hierarchy, ln);
             for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin();
                  it != patch_vertices.end();
                  ++it)
@@ -603,7 +581,7 @@ void IBStandardInitializer::tagCellsForInitialRefinement(const Pointer<PatchHier
 
                 // Get the index of the cell in which the present vertex is
                 // initially located.
-                const CellIndex<NDIM> i = indexer.getCellIndexGlobal(X, dx);
+                const CellIndex<NDIM> i = IndexUtilities::getCellIndex(X, grid_geom, ratio);
 
                 // Tag the cell for refinement.
                 if (patch_box.contains(i)) (*tag_data)(i) = 1;
@@ -2686,13 +2664,32 @@ void IBStandardInitializer::readSourceFiles(const std::string& extension)
 
 void IBStandardInitializer::getPatchVertices(std::vector<std::pair<int, int> >& patch_vertices,
                                              const Pointer<Patch<NDIM> > patch,
-                                             const int level_number,
-                                             const bool /*can_be_refined*/,
-                                             const double* const domain_x_lower,
-                                             const double* const domain_x_upper,
-                                             const IntVector<NDIM>& periodic_shift,
-                                             const IndexUtilities& indexer) const
+                                             const Pointer<PatchHierarchy<NDIM> > hierarchy) const
 {
+#if !defined(NDEBUG)
+    TBOX_ASSERT(patch->inHierarchy());
+#endif
+    const int level_number = patch->getPatchLevelNumber();
+    getPatchVerticesAtLevel(patch_vertices, patch, hierarchy, level_number);
+    return;
+} // getPatchVertices
+
+void IBStandardInitializer::getPatchVerticesAtLevel(std::vector<std::pair<int, int> >& patch_vertices,
+                                                    const Pointer<Patch<NDIM> > patch,
+                                                    const Pointer<PatchHierarchy<NDIM> > hierarchy,
+                                                    const int vertex_level_number) const
+{
+    const Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
+    const double* const domain_x_lower = grid_geom->getXLower();
+    const double* const domain_x_upper = grid_geom->getXUpper();
+#if !defined(NDEBUG)
+    TBOX_ASSERT(patch->inHierarchy());
+#endif
+    const int level_number = patch->getPatchLevelNumber();
+    const Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
+    const IntVector<NDIM>& ratio = level->getRatio();
+    const IntVector<NDIM>& periodic_shift = grid_geom->getPeriodicShift(ratio);
+
     // Loop over all of the vertices to determine the indices of those vertices
     // within the present patch.
     //
@@ -2700,20 +2697,19 @@ void IBStandardInitializer::getPatchVertices(std::vector<std::pair<int, int> >& 
     // now.
     const Box<NDIM>& patch_box = patch->getBox();
     const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-    const double* const patch_dx = patch_geom->getDx();
-    for (unsigned int j = 0; j < d_num_vertex[level_number].size(); ++j)
+    for (unsigned int j = 0; j < d_num_vertex[vertex_level_number].size(); ++j)
     {
-        for (int k = 0; k < d_num_vertex[level_number][j]; ++k)
+        for (int k = 0; k < d_num_vertex[vertex_level_number][j]; ++k)
         {
             std::pair<int, int> point_index(j, k);
             const Point& X =
-                getShiftedVertexPosn(point_index, level_number, domain_x_lower, domain_x_upper, periodic_shift);
-            const CellIndex<NDIM> idx = indexer.getCellIndexGlobal(X, patch_dx);
+                getShiftedVertexPosn(point_index, vertex_level_number, domain_x_lower, domain_x_upper, periodic_shift);
+            const CellIndex<NDIM> idx = IndexUtilities::getCellIndex(X, grid_geom, ratio);
             if (patch_box.contains(idx)) patch_vertices.push_back(point_index);
         }
     }
     return;
-} // getPatchVertices
+} // getPatchVerticesAtLevel
 
 int IBStandardInitializer::getCanonicalLagrangianIndex(const std::pair<int, int>& point_index,
                                                        const int level_number) const

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -267,6 +267,7 @@ unsigned int IBStandardInitializer::computeLocalNodeCountOnPatchLevel(const Poin
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
     const double* const domain_x_lower = grid_geom->getXLower();
     const double* const domain_x_upper = grid_geom->getXUpper();
+    const IndexUtilities indexer(grid_geom);
 
     // Loop over all patches in the specified level of the patch level and count
     // the number of local vertices.
@@ -281,7 +282,7 @@ unsigned int IBStandardInitializer::computeLocalNodeCountOnPatchLevel(const Poin
         // the given patch.
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(
-            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift);
+            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift, indexer);
         local_node_count += patch_vertices.size();
     }
     return local_node_count;
@@ -327,6 +328,7 @@ unsigned int IBStandardInitializer::initializeDataOnPatchLevel(const int lag_nod
     {
         domain_length[d] = domain_x_upper[d] - domain_x_lower[d];
     }
+    const IndexUtilities indexer(grid_geom);
 
     // Set the global index offset.  This is equal to the number of Lagrangian
     // indices that have already been initialized on the specified level.
@@ -343,12 +345,7 @@ unsigned int IBStandardInitializer::initializeDataOnPatchLevel(const int lag_nod
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
-        const Box<NDIM>& patch_box = patch->getBox();
-        const CellIndex<NDIM>& patch_lower = patch_box.lower();
-        const CellIndex<NDIM>& patch_upper = patch_box.upper();
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-        const double* const patch_x_lower = patch_geom->getXLower();
-        const double* const patch_x_upper = patch_geom->getXUpper();
         const double* const patch_dx = patch_geom->getDx();
 
         Pointer<LNodeSetData> index_data = patch->getPatchData(lag_node_index_idx);
@@ -357,7 +354,7 @@ unsigned int IBStandardInitializer::initializeDataOnPatchLevel(const int lag_nod
         // given patch.
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(
-            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift);
+            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift, indexer);
         local_node_count += patch_vertices.size();
         for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin(); it != patch_vertices.end();
              ++it)
@@ -406,8 +403,7 @@ unsigned int IBStandardInitializer::initializeDataOnPatchLevel(const int lag_nod
 
             // Get the index of the cell in which the present vertex is
             // initially located.
-            const CellIndex<NDIM> idx =
-                IndexUtilities::getCellIndex(X, patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
+            const CellIndex<NDIM> idx = indexer.getCellIndexGlobal(X, patch_dx);
 
             // Initialize the specification objects associated with the present
             // vertex.
@@ -462,6 +458,7 @@ unsigned int IBStandardInitializer::initializeMassDataOnPatchLevel(const unsigne
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
     const double* const domain_x_lower = grid_geom->getXLower();
     const double* const domain_x_upper = grid_geom->getXUpper();
+    const IndexUtilities indexer(grid_geom);
 
     // Loop over all patches in the specified level of the patch level and
     // initialize the local vertices.
@@ -479,7 +476,7 @@ unsigned int IBStandardInitializer::initializeMassDataOnPatchLevel(const unsigne
         // given patch.
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(
-            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift);
+            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift, indexer);
         local_node_count += patch_vertices.size();
         for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin(); it != patch_vertices.end();
              ++it)
@@ -525,6 +522,7 @@ unsigned int IBStandardInitializer::initializeDirectorDataOnPatchLevel(const uns
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
     const double* const domain_x_lower = grid_geom->getXLower();
     const double* const domain_x_upper = grid_geom->getXUpper();
+    const IndexUtilities indexer(grid_geom);
 
     // Loop over all patches in the specified level of the patch level and
     // initialize the local vertices.
@@ -541,7 +539,7 @@ unsigned int IBStandardInitializer::initializeDirectorDataOnPatchLevel(const uns
         // given patch.
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(
-            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift);
+            patch_vertices, patch, level_number, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift, indexer);
         local_node_count += patch_vertices.size();
         for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin(); it != patch_vertices.end();
              ++it)
@@ -570,6 +568,7 @@ void IBStandardInitializer::tagCellsForInitialRefinement(const Pointer<PatchHier
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
     const double* const domain_x_lower = grid_geom->getXLower();
     const double* const domain_x_upper = grid_geom->getXUpper();
+    const IndexUtilities indexer(grid_geom);
 
     // Loop over all patches in the specified level of the patch level and tag
     // cells for refinement wherever there are vertices assigned to a finer
@@ -596,7 +595,7 @@ void IBStandardInitializer::tagCellsForInitialRefinement(const Pointer<PatchHier
         for (int ln = level_number + 1; ln < d_max_levels; ++ln)
         {
             std::vector<std::pair<int, int> > patch_vertices;
-            getPatchVertices(patch_vertices, patch, ln, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift);
+            getPatchVertices(patch_vertices, patch, ln, can_be_refined, domain_x_lower, domain_x_upper, periodic_shift, indexer);
             for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin();
                  it != patch_vertices.end();
                  ++it)
@@ -609,7 +608,7 @@ void IBStandardInitializer::tagCellsForInitialRefinement(const Pointer<PatchHier
                 // Get the index of the cell in which the present vertex is
                 // initially located.
                 const CellIndex<NDIM> i =
-                    IndexUtilities::getCellIndex(X, x_lower, x_upper, dx, patch_lower, patch_upper);
+                    IndexUtilities::getCellIndexLocal(X, x_lower, x_upper, dx, patch_lower, patch_upper);
 
                 // Tag the cell for refinement.
                 if (patch_box.contains(i)) (*tag_data)(i) = 1;
@@ -2696,7 +2695,8 @@ void IBStandardInitializer::getPatchVertices(std::vector<std::pair<int, int> >& 
                                              const bool /*can_be_refined*/,
                                              const double* const domain_x_lower,
                                              const double* const domain_x_upper,
-                                             const IntVector<NDIM>& periodic_shift) const
+                                             const IntVector<NDIM>& periodic_shift,
+                                             const IndexUtilities& indexer) const
 {
     // Loop over all of the vertices to determine the indices of those vertices
     // within the present patch.
@@ -2704,11 +2704,7 @@ void IBStandardInitializer::getPatchVertices(std::vector<std::pair<int, int> >& 
     // NOTE: This is clearly not the best way to do this, but it will work for
     // now.
     const Box<NDIM>& patch_box = patch->getBox();
-    const CellIndex<NDIM>& patch_lower = patch_box.lower();
-    const CellIndex<NDIM>& patch_upper = patch_box.upper();
     const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-    const double* const patch_x_lower = patch_geom->getXLower();
-    const double* const patch_x_upper = patch_geom->getXUpper();
     const double* const patch_dx = patch_geom->getDx();
     for (unsigned int j = 0; j < d_num_vertex[level_number].size(); ++j)
     {
@@ -2717,8 +2713,7 @@ void IBStandardInitializer::getPatchVertices(std::vector<std::pair<int, int> >& 
             std::pair<int, int> point_index(j, k);
             const Point& X =
                 getShiftedVertexPosn(point_index, level_number, domain_x_lower, domain_x_upper, periodic_shift);
-            const CellIndex<NDIM> idx =
-                IndexUtilities::getCellIndex(X, patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
+            const CellIndex<NDIM> idx = indexer.getCellIndexGlobal(X, patch_dx);
             if (patch_box.contains(idx)) patch_vertices.push_back(point_index);
         }
     }

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -580,10 +580,6 @@ void IBStandardInitializer::tagCellsForInitialRefinement(const Pointer<PatchHier
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
         const Box<NDIM>& patch_box = patch->getBox();
-        const CellIndex<NDIM>& patch_lower = patch_box.lower();
-        const CellIndex<NDIM>& patch_upper = patch_box.upper();
-        const double* const x_lower = patch_geom->getXLower();
-        const double* const x_upper = patch_geom->getXUpper();
         const double* const dx = patch_geom->getDx();
 
         Pointer<CellData<NDIM, int> > tag_data = patch->getPatchData(tag_index);
@@ -607,8 +603,7 @@ void IBStandardInitializer::tagCellsForInitialRefinement(const Pointer<PatchHier
 
                 // Get the index of the cell in which the present vertex is
                 // initially located.
-                const CellIndex<NDIM> i =
-                    IndexUtilities::getCellIndexLocal(X, x_lower, x_upper, dx, patch_lower, patch_upper);
+                const CellIndex<NDIM> i = indexer.getCellIndexGlobal(X, dx);
 
                 // Tag the cell for refinement.
                 if (patch_box.contains(i)) (*tag_data)(i) = 1;

--- a/src/IB/IMPInitializer.cpp
+++ b/src/IB/IMPInitializer.cpp
@@ -412,15 +412,12 @@ void IMPInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarchy<N
     // cells for refinement wherever there are vertices assigned to a finer
     // level of the Cartesian grid.
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
+    const IndexUtilities indexer(level->getGridGeometry());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
         const Box<NDIM>& patch_box = patch->getBox();
-        const CellIndex<NDIM>& patch_lower = patch_box.lower();
-        const CellIndex<NDIM>& patch_upper = patch_box.upper();
-        const double* const patch_x_lower = patch_geom->getXLower();
-        const double* const patch_x_upper = patch_geom->getXUpper();
         const double* const patch_dx = patch_geom->getDx();
 
         Pointer<CellData<NDIM, int> > tag_data = patch->getPatchData(tag_index);
@@ -440,8 +437,7 @@ void IMPInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarchy<N
             {
                 const std::pair<int, int>& point_idx = (*it);
                 const libMesh::Point& X = getVertexPosn(point_idx, ln);
-                const CellIndex<NDIM> i = IndexUtilities::getCellIndexLocal(
-                    &X(0), patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
+                const CellIndex<NDIM> i = indexer.getCellIndexGlobal(&X(0), patch_dx);
                 if (patch_box.contains(i)) (*tag_data)(i) = 1;
             }
         }

--- a/src/IB/IMPInitializer.cpp
+++ b/src/IB/IMPInitializer.cpp
@@ -318,7 +318,6 @@ unsigned int IMPInitializer::initializeDataOnPatchLevel(const int lag_node_index
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
     const double* const grid_x_lower = grid_geom->getXLower();
     const double* const grid_x_upper = grid_geom->getXUpper();
-    const IndexUtilities indexer(grid_geom);
 
     // Loop over all patches in the specified level of the patch level and
     // initialize the local vertices.
@@ -327,11 +326,11 @@ unsigned int IMPInitializer::initializeDataOnPatchLevel(const int lag_node_index
     int local_idx = -1;
     int local_node_count = 0;
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
+    const IntVector<NDIM>& ratio = level->getRatio();
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-        const double* const patch_dx = patch_geom->getDx();
 
         Pointer<LNodeSetData> index_data = patch->getPatchData(lag_node_index_idx);
 
@@ -350,7 +349,7 @@ unsigned int IMPInitializer::initializeDataOnPatchLevel(const int lag_node_index
 
             // Get the coordinates of the present vertex.
             const libMesh::Point& X = getVertexPosn(point_idx, level_number);
-            const CellIndex<NDIM> idx = indexer.getCellIndexGlobal(&X(0), patch_dx);
+            const CellIndex<NDIM> idx = IndexUtilities::getCellIndex(&X(0), grid_geom, ratio);
             for (int d = 0; d < NDIM; ++d)
             {
                 X_array[local_petsc_idx][d] = X(d);
@@ -412,13 +411,13 @@ void IMPInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarchy<N
     // cells for refinement wherever there are vertices assigned to a finer
     // level of the Cartesian grid.
     Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-    const IndexUtilities indexer(level->getGridGeometry());
+    const Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
+    const IntVector<NDIM>& ratio = level->getRatio();
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
         const Box<NDIM>& patch_box = patch->getBox();
-        const double* const patch_dx = patch_geom->getDx();
 
         Pointer<CellData<NDIM, int> > tag_data = patch->getPatchData(tag_index);
 
@@ -437,7 +436,7 @@ void IMPInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarchy<N
             {
                 const std::pair<int, int>& point_idx = (*it);
                 const libMesh::Point& X = getVertexPosn(point_idx, ln);
-                const CellIndex<NDIM> i = indexer.getCellIndexGlobal(&X(0), patch_dx);
+                const CellIndex<NDIM> i = IndexUtilities::getCellIndex(&X(0), grid_geom, ratio);
                 if (patch_box.contains(i)) (*tag_data)(i) = 1;
             }
         }

--- a/src/IB/IMPInitializer.cpp
+++ b/src/IB/IMPInitializer.cpp
@@ -318,6 +318,7 @@ unsigned int IMPInitializer::initializeDataOnPatchLevel(const int lag_node_index
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
     const double* const grid_x_lower = grid_geom->getXLower();
     const double* const grid_x_upper = grid_geom->getXUpper();
+    const IndexUtilities indexer(grid_geom);
 
     // Loop over all patches in the specified level of the patch level and
     // initialize the local vertices.
@@ -330,11 +331,6 @@ unsigned int IMPInitializer::initializeDataOnPatchLevel(const int lag_node_index
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
         const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-        const Box<NDIM>& patch_box = patch->getBox();
-        const CellIndex<NDIM>& patch_lower = patch_box.lower();
-        const CellIndex<NDIM>& patch_upper = patch_box.upper();
-        const double* const patch_x_lower = patch_geom->getXLower();
-        const double* const patch_x_upper = patch_geom->getXUpper();
         const double* const patch_dx = patch_geom->getDx();
 
         Pointer<LNodeSetData> index_data = patch->getPatchData(lag_node_index_idx);
@@ -354,8 +350,7 @@ unsigned int IMPInitializer::initializeDataOnPatchLevel(const int lag_node_index
 
             // Get the coordinates of the present vertex.
             const libMesh::Point& X = getVertexPosn(point_idx, level_number);
-            const CellIndex<NDIM> idx =
-                IndexUtilities::getCellIndex(&X(0), patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
+            const CellIndex<NDIM> idx = indexer.getCellIndexGlobal(&X(0), patch_dx);
             for (int d = 0; d < NDIM; ++d)
             {
                 X_array[local_petsc_idx][d] = X(d);
@@ -445,7 +440,7 @@ void IMPInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarchy<N
             {
                 const std::pair<int, int>& point_idx = (*it);
                 const libMesh::Point& X = getVertexPosn(point_idx, ln);
-                const CellIndex<NDIM> i = IndexUtilities::getCellIndex(
+                const CellIndex<NDIM> i = IndexUtilities::getCellIndexLocal(
                     &X(0), patch_x_lower, patch_x_upper, patch_dx, patch_lower, patch_upper);
                 if (patch_box.contains(i)) (*tag_data)(i) = 1;
             }

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -67,6 +67,7 @@
 #include "Variable.h"
 #include "VariableDatabase.h"
 #include "boost/array.hpp"
+#include "boost/math/special_functions/round.hpp"
 #include "boost/multi_array.hpp"
 #include "ibamr/IMPMethod.h"
 #include "ibamr/MaterialPointSpec.h"
@@ -128,7 +129,7 @@ void kernel(const double X,
             boost::multi_array<double, 1>& dphi)
 {
     const double X_o_dx = (X - patch_x_lower) / dx;
-    stencil_box_lower = round(X_o_dx) + patch_box_lower - kernel_width;
+    stencil_box_lower = boost::math::round(X_o_dx) + patch_box_lower - kernel_width;
     stencil_box_upper = stencil_box_lower + 2 * kernel_width - 1;
     const double r = 1.0 - X_o_dx + ((stencil_box_lower + kernel_width - 1 - patch_box_lower) + 0.5);
 


### PR DESCRIPTION
Add support for globalized indexing in IndexUtilities. It makes IndexUtilities a lightweight object that has an associated GridGeometry object that is used to compute unique Index values for a given position.

This PR replaces #38. It differs from that PR in that it avoids static global variables. This PR fixes #25.