### PR TITLE
moving data allocations/deallocations closer to points of use

### DIFF
--- a/ibtk/include/ibtk/HierarchyMathOps.h
+++ b/ibtk/include/ibtk/HierarchyMathOps.h
@@ -157,7 +157,7 @@ public:
      * If a cell is not refined in the hierarchy, its weight is set to its
      * volume.  If a cell is refined, its weight is set to zero.
      */
-    int getCellWeightPatchDescriptorIndex() const;
+    int getCellWeightPatchDescriptorIndex();
 
     /*!
      * \brief Access the SAMRAI::pdat::FaceVariable that is used to store face
@@ -176,7 +176,7 @@ public:
      * If a face is not refined in the hierarchy, its weight is set to its
      * volume.  If a face is refined, its weight is set to zero.
      */
-    int getFaceWeightPatchDescriptorIndex() const;
+    int getFaceWeightPatchDescriptorIndex();
 
     /*!
      * \brief Access the SAMRAI::pdat::SideVariable that is used to store side
@@ -195,7 +195,7 @@ public:
      * If a side is not refined in the hierarchy, its weight is set to its
      * volume.  If a side is refined, its weight is set to zero.
      */
-    int getSideWeightPatchDescriptorIndex() const;
+    int getSideWeightPatchDescriptorIndex();
 
     /*!
      * \brief Returns the volume of the physical domain.
@@ -1199,6 +1199,21 @@ private:
      */
     void xeqScheduleOutersideRestriction(int dst_idx, int src_idx, int dst_ln);
 
+    /*!
+     * \brief Reset cell-centered weights, allocating patch data if needed.
+     */
+    void resetCellWeights(int coarsest_ln, int finest_ln);
+
+    /*!
+     * \brief Reset face-centered weights, allocating patch data if needed.
+     */
+    void resetFaceWeights(int coarsest_ln, int finest_ln);
+
+    /*!
+     * \brief Reset side-centered weights, allocating patch data if needed.
+     */
+    void resetSideWeights(int coarsest_ln, int finest_ln);
+
     // Housekeeping.
     std::string d_object_name;
 
@@ -1238,6 +1253,7 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::FaceVariable<NDIM, double> > d_wgt_fc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double> > d_wgt_sc_var;
     int d_wgt_cc_idx, d_wgt_fc_idx, d_wgt_sc_idx;
+    bool d_using_wgt_cc, d_using_wgt_fc, d_using_wgt_sc;
     double d_volume;
 };
 } // namespace IBTK

--- a/ibtk/include/ibtk/PoissonFACPreconditionerStrategy.h
+++ b/ibtk/include/ibtk/PoissonFACPreconditionerStrategy.h
@@ -305,16 +305,6 @@ public:
      */
     void deallocateOperatorState();
 
-    /*!
-     * \brief Allocate scratch data.
-     */
-    void allocateScratchData();
-
-    /*!
-     * \brief Deallocate scratch data.
-     */
-    void deallocateScratchData();
-
     //\}
 
 protected:

--- a/ibtk/src/math/HierarchyMathOps.cpp
+++ b/ibtk/src/math/HierarchyMathOps.cpp
@@ -180,6 +180,9 @@ HierarchyMathOps::HierarchyMathOps(const std::string& name,
       d_wgt_cc_idx(-1),
       d_wgt_fc_idx(-1),
       d_wgt_sc_idx(-1),
+      d_using_wgt_cc(false),
+      d_using_wgt_fc(false),
+      d_using_wgt_sc(false),
       d_volume(0.0)
 {
     // Setup scratch variables.
@@ -343,231 +346,35 @@ HierarchyMathOps::resetLevels(const int coarsest_ln, const int finest_ln)
         d_os_coarsen_scheds[dst_ln] = d_os_coarsen_alg->createSchedule(dst_level, src_level);
     }
 
-    // Reset the hierarchy data ops.
-    d_hier_cc_data_ops->resetLevels(d_coarsest_ln, d_finest_ln);
-    d_hier_fc_data_ops->resetLevels(d_coarsest_ln, d_finest_ln);
-    d_hier_sc_data_ops->resetLevels(d_coarsest_ln, d_finest_ln);
-
-    // Reset the cell weights.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    // Reset the cell weights and compute the volume of the domain.
+    resetCellWeights(d_coarsest_ln, d_finest_ln);
+    if (d_using_wgt_fc) resetFaceWeights(d_coarsest_ln, d_finest_ln);
+    if (d_using_wgt_sc) resetSideWeights(d_coarsest_ln, d_finest_ln);
+    static bool initial_time = false;
+    double volume = d_hier_cc_data_ops->sumControlVolumes(d_wgt_cc_idx, d_wgt_cc_idx);
+    if (!initial_time && !MathUtilities<double>::equalEps(volume, d_volume))
     {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_wgt_cc_idx))
+        TBOX_WARNING(d_object_name << "::initializeLevelData():\n"
+                                   << "  change in domain volume as computed by summing control volumes\n"
+                                   << "    old volume = "
+                                   << d_volume
+                                   << "\n"
+                                   << "    new volume = "
+                                   << volume
+                                   << "\n"
+                                   << "  this may indicate overlapping patches in the AMR grid hierarchy.");
+    }
+    d_volume = volume;
+
+    // Deallocate scratch data.
+    if (!d_using_wgt_cc)
+    {
+        for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
         {
-            level->allocatePatchData(d_wgt_cc_idx);
-        }
-        if (!level->checkAllocated(d_wgt_fc_idx))
-        {
-            level->allocatePatchData(d_wgt_fc_idx);
-        }
-        if (!level->checkAllocated(d_wgt_sc_idx))
-        {
-            level->allocatePatchData(d_wgt_sc_idx);
+            Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+            level->deallocatePatchData(d_wgt_cc_idx);
         }
     }
-
-    // Each cell's weight is set to its cell volume, unless the cell is refined
-    // on a finer level, in which case the weight is set to zero.  This insures
-    // that no part of the physical domain is counted twice when discrete norms
-    // and integrals are calculated on the entire hierarchy.
-    //
-    // Away from coarse-fine interfaces and boundaries of the computational
-    // domain, each cell face's weight is set to the cell volume associated with
-    // the level of the patch hierarchy.  Along coarse-fine interfaces or
-    // physical boundaries, the weights associated with the cell faces are
-    // modified so that the sum of the weights equals to volume of the
-    // computational domain.
-    ArrayDataBasicOps<NDIM, double> array_ops;
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        BoxArray<NDIM> refined_region_boxes;
-
-        if (ln < d_finest_ln)
-        {
-            Pointer<PatchLevel<NDIM> > next_finer_level = d_hierarchy->getPatchLevel(ln + 1);
-            refined_region_boxes = next_finer_level->getBoxes();
-            refined_region_boxes.coarsen(next_finer_level->getRatioToCoarserLevel());
-        }
-
-        const IntVector<NDIM> max_gcw(1);
-        const CoarseFineBoundary<NDIM> cf_bdry(*d_hierarchy, ln, max_gcw);
-
-        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
-        {
-            Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& patch_box = patch->getBox();
-            Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
-
-            const double* const dx = pgeom->getDx();
-            const double cell_vol = dx[0] * dx[1]
-#if (NDIM > 2)
-                                    * dx[2]
-#endif
-                ;
-
-            Pointer<CellData<NDIM, double> > wgt_cc_data = patch->getPatchData(d_wgt_cc_idx);
-            wgt_cc_data->fillAll(cell_vol);
-
-            Pointer<FaceData<NDIM, double> > wgt_fc_data = patch->getPatchData(d_wgt_fc_idx);
-            wgt_fc_data->fillAll(cell_vol);
-
-            Pointer<SideData<NDIM, double> > wgt_sc_data = patch->getPatchData(d_wgt_sc_idx);
-            wgt_sc_data->fillAll(cell_vol);
-
-            // Rescale values along the edges of the patches.
-            for (unsigned int axis = 0; axis < NDIM; ++axis)
-            {
-                Box<NDIM> face_lower_box = FaceGeometry<NDIM>::toFaceBox(patch_box, axis);
-                face_lower_box.upper()(0) = face_lower_box.lower()(0);
-                array_ops.scale(wgt_fc_data->getArrayData(axis), 0.5, wgt_fc_data->getArrayData(axis), face_lower_box);
-                Box<NDIM> side_lower_box = SideGeometry<NDIM>::toSideBox(patch_box, axis);
-                side_lower_box.upper()(axis) = side_lower_box.lower()(axis);
-                array_ops.scale(wgt_sc_data->getArrayData(axis), 0.5, wgt_sc_data->getArrayData(axis), side_lower_box);
-            }
-            for (unsigned int axis = 0; axis < NDIM; ++axis)
-            {
-                Box<NDIM> face_upper_box = FaceGeometry<NDIM>::toFaceBox(patch_box, axis);
-                face_upper_box.lower()(0) = face_upper_box.upper()(0);
-                array_ops.scale(wgt_fc_data->getArrayData(axis), 0.5, wgt_fc_data->getArrayData(axis), face_upper_box);
-                Box<NDIM> side_upper_box = SideGeometry<NDIM>::toSideBox(patch_box, axis);
-                side_upper_box.lower()(axis) = side_upper_box.upper()(axis);
-                array_ops.scale(wgt_sc_data->getArrayData(axis), 0.5, wgt_sc_data->getArrayData(axis), side_upper_box);
-            }
-
-            // Correct the values along coarse-fine interfaces.
-            if (ln > d_coarsest_ln)
-            {
-                const IntVector<NDIM>& ratio = level->getRatioToCoarserLevel();
-                const int bdry_type = 1;
-                const Array<BoundaryBox<NDIM> >& cf_bdry_boxes = cf_bdry.getBoundaries(p(), bdry_type);
-                for (int k = 0; k < cf_bdry_boxes.getSize(); ++k)
-                {
-                    const Box<NDIM>& bdry_box = cf_bdry_boxes[k].getBox();
-                    const unsigned int axis = cf_bdry_boxes[k].getLocationIndex() / 2;
-                    const int lower_upper = cf_bdry_boxes[k].getLocationIndex() % 2;
-                    if (!pgeom->getTouchesRegularBoundary(axis, lower_upper))
-                    {
-                        const double extra_vol = 0.5 * static_cast<double>(ratio(axis)) * cell_vol;
-
-                        Box<NDIM> face_bdry_box = FaceGeometry<NDIM>::toFaceBox(bdry_box, axis);
-                        array_ops.addScalar(
-                            wgt_fc_data->getArrayData(axis), wgt_fc_data->getArrayData(axis), extra_vol, face_bdry_box);
-
-                        Box<NDIM> side_bdry_box = SideGeometry<NDIM>::toSideBox(bdry_box, axis);
-                        array_ops.addScalar(
-                            wgt_sc_data->getArrayData(axis), wgt_sc_data->getArrayData(axis), extra_vol, side_bdry_box);
-                    }
-                }
-            }
-
-            // Zero-out weights within the refined region.
-            if (ln < d_finest_ln)
-            {
-                const IntVector<NDIM>& periodic_shift = d_grid_geom->getPeriodicShift(level->getRatio());
-                for (int i = 0; i < refined_region_boxes.getNumberOfBoxes(); ++i)
-                {
-                    for (unsigned int axis = 0; axis < NDIM; ++axis)
-                    {
-                        if (periodic_shift(axis) != 0)
-                        {
-                            for (int sgn = -1; sgn <= 1; sgn += 2)
-                            {
-                                IntVector<NDIM> periodic_offset = 0;
-                                periodic_offset(axis) = sgn * periodic_shift(axis);
-                                const Box<NDIM> refined_box =
-                                    Box<NDIM>::shift(refined_region_boxes[i], periodic_offset);
-                                const Box<NDIM> intersection = Box<NDIM>::grow(patch_box, 1) * refined_box;
-                                if (!intersection.empty())
-                                {
-                                    wgt_cc_data->fillAll(0.0, intersection);
-                                    wgt_fc_data->fillAll(0.0, intersection);
-                                    wgt_sc_data->fillAll(0.0, intersection);
-                                }
-                            }
-                        }
-                    }
-                    const Box<NDIM>& refined_box = refined_region_boxes[i];
-                    const Box<NDIM> intersection = Box<NDIM>::grow(patch_box, 1) * refined_box;
-                    if (!intersection.empty())
-                    {
-                        wgt_cc_data->fillAll(0.0, intersection);
-                        wgt_fc_data->fillAll(0.0, intersection);
-                        wgt_sc_data->fillAll(0.0, intersection);
-                    }
-                }
-            }
-        }
-    }
-
-#if !defined(NDEBUG)
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        // Check for overlapping boxes on this level.
-        //
-        // (This is potentially fairly expensive and hence is only done when
-        // assertion checking is active.)
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        BoxList<NDIM> boxes(level->getBoxes());
-
-        std::vector<bool> patch_overlaps(boxes.getNumberOfItems());
-        std::vector<bool>::size_type j, k;
-
-        for (k = 0; k < patch_overlaps.size(); ++k)
-        {
-            patch_overlaps[k] = false;
-        }
-        k = 0;
-        while (!boxes.isEmpty())
-        {
-            j = k + 1;
-            Box<NDIM> tryme = boxes.getFirstItem();
-            boxes.removeFirstItem();
-
-            for (BoxList<NDIM>::Iterator ib(boxes); ib; ib++)
-            {
-                if (tryme.intersects(ib()))
-                {
-                    patch_overlaps[k] = true;
-                    patch_overlaps[j] = true;
-                }
-                ++j;
-            }
-            ++k;
-        }
-
-        for (k = 0; k < patch_overlaps.size(); ++k)
-        {
-            if (patch_overlaps[k])
-            {
-                TBOX_ERROR(d_object_name << "::initializeLevelData()\n"
-                                         << "  patch "
-                                         << k
-                                         << " overlaps another patch!\n");
-            }
-        }
-    }
-#endif
-
-    // Compute the volume of the physical domain.
-    const double volume_cc = d_hier_cc_data_ops->sumControlVolumes(d_wgt_cc_idx, d_wgt_cc_idx);
-    const double volume_fc =
-        d_hier_fc_data_ops->sumControlVolumes(d_wgt_fc_idx, d_wgt_fc_idx) / static_cast<double>(NDIM);
-    const double volume_sc =
-        d_hier_sc_data_ops->sumControlVolumes(d_wgt_sc_idx, d_wgt_sc_idx) / static_cast<double>(NDIM);
-    if (!MathUtilities<double>::equalEps(volume_cc, volume_fc) ||
-        !MathUtilities<double>::equalEps(volume_cc, volume_sc))
-    {
-        pout << "WARNING:\n"
-             << "HierarchyMathOps::resetLevels():\n"
-             << "  cell-centered, face-centered, and side-centered weights give different "
-                "total "
-                "volumes of the computational domain:\n"
-             << "      volume (cell-centered): " << volume_cc << "\n"
-             << "      volume (face-centered): " << volume_fc << "\n"
-             << "      volume (side-centered): " << volume_sc << std::endl;
-    }
-    d_volume = volume_cc;
     return;
 } // resetLevels
 
@@ -578,8 +385,10 @@ HierarchyMathOps::getCellWeightVariable() const
 } // getCellWeightVariable
 
 int
-HierarchyMathOps::getCellWeightPatchDescriptorIndex() const
+HierarchyMathOps::getCellWeightPatchDescriptorIndex()
 {
+    if (!d_using_wgt_cc) resetCellWeights(d_coarsest_ln, d_finest_ln);
+    d_using_wgt_cc = true;
     return d_wgt_cc_idx;
 } // getCellWeightPatchDescriptorIndex
 
@@ -590,8 +399,10 @@ HierarchyMathOps::getFaceWeightVariable() const
 } // getFaceWeightVariable
 
 int
-HierarchyMathOps::getFaceWeightPatchDescriptorIndex() const
+HierarchyMathOps::getFaceWeightPatchDescriptorIndex()
 {
+    if (!d_using_wgt_fc) resetFaceWeights(d_coarsest_ln, d_finest_ln);
+    d_using_wgt_fc = true;
     return d_wgt_fc_idx;
 } // getFaceWeightPatchDescriptorIndex
 
@@ -602,8 +413,10 @@ HierarchyMathOps::getSideWeightVariable() const
 } // getSideWeightVariable
 
 int
-HierarchyMathOps::getSideWeightPatchDescriptorIndex() const
+HierarchyMathOps::getSideWeightPatchDescriptorIndex()
 {
+    if (!d_using_wgt_sc) resetSideWeights(d_coarsest_ln, d_finest_ln);
+    d_using_wgt_sc = true;
     return d_wgt_sc_idx;
 } // getSideWeightPatchDescriptorIndex
 
@@ -3282,6 +3095,349 @@ HierarchyMathOps::xeqScheduleOutersideRestriction(const int dst_idx, const int s
     }
     return;
 } // xeqScheduleOutersideRestriction
+
+void
+HierarchyMathOps::resetCellWeights(const int coarsest_ln, const int finest_ln)
+{
+#if !defined(NDEBUG)
+    TBOX_ASSERT(coarsest_ln >= d_coarsest_ln);
+    TBOX_ASSERT(finest_ln <= d_finest_ln);
+#endif
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_wgt_cc_idx))
+        {
+            level->allocatePatchData(d_wgt_cc_idx);
+        }
+    }
+
+    // Each cell's weight is set to its cell volume, unless the cell is refined
+    // on a finer level, in which case the weight is set to zero.  This insures
+    // that no part of the physical domain is counted twice when discrete norms
+    // and integrals are calculated on the entire hierarchy.
+    ArrayDataBasicOps<NDIM, double> array_ops;
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        BoxArray<NDIM> refined_region_boxes;
+        if (ln < d_finest_ln)
+        {
+            Pointer<PatchLevel<NDIM> > next_finer_level = d_hierarchy->getPatchLevel(ln + 1);
+            refined_region_boxes = next_finer_level->getBoxes();
+            refined_region_boxes.coarsen(next_finer_level->getRatioToCoarserLevel());
+        }
+
+        const IntVector<NDIM> max_gcw(1);
+        const CoarseFineBoundary<NDIM> cf_bdry(*d_hierarchy, ln, max_gcw);
+
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM> > patch = level->getPatch(p());
+            const Box<NDIM>& patch_box = patch->getBox();
+            Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+            const double* const dx = pgeom->getDx();
+            const double cell_vol = dx[0] * dx[1]
+#if (NDIM > 2)
+                                    * dx[2]
+#endif
+                ;
+            Pointer<CellData<NDIM, double> > wgt_cc_data = patch->getPatchData(d_wgt_cc_idx);
+            wgt_cc_data->fillAll(cell_vol);
+
+            // Zero-out weights within the refined region.
+            if (ln < d_finest_ln)
+            {
+                const IntVector<NDIM>& periodic_shift = d_grid_geom->getPeriodicShift(level->getRatio());
+                for (int i = 0; i < refined_region_boxes.getNumberOfBoxes(); ++i)
+                {
+                    for (unsigned int axis = 0; axis < NDIM; ++axis)
+                    {
+                        if (periodic_shift(axis) != 0)
+                        {
+                            for (int sgn = -1; sgn <= 1; sgn += 2)
+                            {
+                                IntVector<NDIM> periodic_offset = 0;
+                                periodic_offset(axis) = sgn * periodic_shift(axis);
+                                const Box<NDIM> refined_box =
+                                    Box<NDIM>::shift(refined_region_boxes[i], periodic_offset);
+                                const Box<NDIM> intersection = Box<NDIM>::grow(patch_box, 1) * refined_box;
+                                if (!intersection.empty())
+                                {
+                                    wgt_cc_data->fillAll(0.0, intersection);
+                                }
+                            }
+                        }
+                    }
+                    const Box<NDIM>& refined_box = refined_region_boxes[i];
+                    const Box<NDIM> intersection = Box<NDIM>::grow(patch_box, 1) * refined_box;
+                    if (!intersection.empty())
+                    {
+                        wgt_cc_data->fillAll(0.0, intersection);
+                    }
+                }
+            }
+        }
+    }
+    return;
+}
+
+void
+HierarchyMathOps::resetFaceWeights(const int coarsest_ln, const int finest_ln)
+{
+#if !defined(NDEBUG)
+    TBOX_ASSERT(coarsest_ln >= d_coarsest_ln);
+    TBOX_ASSERT(finest_ln <= d_finest_ln);
+#endif
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (d_using_wgt_fc && !level->checkAllocated(d_wgt_fc_idx))
+        {
+            level->allocatePatchData(d_wgt_fc_idx);
+        }
+    }
+
+    // Each cell's weight is set to its cell volume, unless the cell is refined
+    // on a finer level, in which case the weight is set to zero.  This insures
+    // that no part of the physical domain is counted twice when discrete norms
+    // and integrals are calculated on the entire hierarchy.
+    //
+    // Away from coarse-fine interfaces and boundaries of the computational
+    // domain, each cell face's weight is set to the cell volume associated with
+    // the level of the patch hierarchy.  Along coarse-fine interfaces or
+    // physical boundaries, the weights associated with the cell faces are
+    // modified so that the sum of the weights equals to volume of the
+    // computational domain.
+    ArrayDataBasicOps<NDIM, double> array_ops;
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        BoxArray<NDIM> refined_region_boxes;
+        if (ln < d_finest_ln)
+        {
+            Pointer<PatchLevel<NDIM> > next_finer_level = d_hierarchy->getPatchLevel(ln + 1);
+            refined_region_boxes = next_finer_level->getBoxes();
+            refined_region_boxes.coarsen(next_finer_level->getRatioToCoarserLevel());
+        }
+
+        const IntVector<NDIM> max_gcw(1);
+        const CoarseFineBoundary<NDIM> cf_bdry(*d_hierarchy, ln, max_gcw);
+
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM> > patch = level->getPatch(p());
+            const Box<NDIM>& patch_box = patch->getBox();
+            Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+            const double* const dx = pgeom->getDx();
+            const double cell_vol = dx[0] * dx[1]
+#if (NDIM > 2)
+                                    * dx[2]
+#endif
+                ;
+            Pointer<FaceData<NDIM, double> > wgt_fc_data = patch->getPatchData(d_wgt_fc_idx);
+            wgt_fc_data->fillAll(cell_vol);
+
+            // Rescale values along the edges of the patches.
+            for (unsigned int axis = 0; axis < NDIM; ++axis)
+            {
+                Box<NDIM> face_lower_box = FaceGeometry<NDIM>::toFaceBox(patch_box, axis);
+                face_lower_box.upper()(0) = face_lower_box.lower()(0);
+                array_ops.scale(wgt_fc_data->getArrayData(axis), 0.5, wgt_fc_data->getArrayData(axis), face_lower_box);
+            }
+            for (unsigned int axis = 0; axis < NDIM; ++axis)
+            {
+                Box<NDIM> face_upper_box = FaceGeometry<NDIM>::toFaceBox(patch_box, axis);
+                face_upper_box.lower()(0) = face_upper_box.upper()(0);
+                array_ops.scale(wgt_fc_data->getArrayData(axis), 0.5, wgt_fc_data->getArrayData(axis), face_upper_box);
+            }
+
+            // Correct the values along coarse-fine interfaces.
+            if (ln > d_coarsest_ln)
+            {
+                const IntVector<NDIM>& ratio = level->getRatioToCoarserLevel();
+                const int bdry_type = 1;
+                const Array<BoundaryBox<NDIM> >& cf_bdry_boxes = cf_bdry.getBoundaries(p(), bdry_type);
+                for (int k = 0; k < cf_bdry_boxes.getSize(); ++k)
+                {
+                    const Box<NDIM>& bdry_box = cf_bdry_boxes[k].getBox();
+                    const unsigned int axis = cf_bdry_boxes[k].getLocationIndex() / 2;
+                    const int lower_upper = cf_bdry_boxes[k].getLocationIndex() % 2;
+                    if (!pgeom->getTouchesRegularBoundary(axis, lower_upper))
+                    {
+                        const double extra_vol = 0.5 * static_cast<double>(ratio(axis)) * cell_vol;
+                        Box<NDIM> face_bdry_box = FaceGeometry<NDIM>::toFaceBox(bdry_box, axis);
+                        array_ops.addScalar(
+                            wgt_fc_data->getArrayData(axis), wgt_fc_data->getArrayData(axis), extra_vol, face_bdry_box);
+                    }
+                }
+            }
+
+            // Zero-out weights within the refined region.
+            if (ln < d_finest_ln)
+            {
+                const IntVector<NDIM>& periodic_shift = d_grid_geom->getPeriodicShift(level->getRatio());
+                for (int i = 0; i < refined_region_boxes.getNumberOfBoxes(); ++i)
+                {
+                    for (unsigned int axis = 0; axis < NDIM; ++axis)
+                    {
+                        if (periodic_shift(axis) != 0)
+                        {
+                            for (int sgn = -1; sgn <= 1; sgn += 2)
+                            {
+                                IntVector<NDIM> periodic_offset = 0;
+                                periodic_offset(axis) = sgn * periodic_shift(axis);
+                                const Box<NDIM> refined_box =
+                                    Box<NDIM>::shift(refined_region_boxes[i], periodic_offset);
+                                const Box<NDIM> intersection = Box<NDIM>::grow(patch_box, 1) * refined_box;
+                                if (!intersection.empty())
+                                {
+                                    wgt_fc_data->fillAll(0.0, intersection);
+                                }
+                            }
+                        }
+                    }
+                    const Box<NDIM>& refined_box = refined_region_boxes[i];
+                    const Box<NDIM> intersection = Box<NDIM>::grow(patch_box, 1) * refined_box;
+                    if (!intersection.empty())
+                    {
+                        wgt_fc_data->fillAll(0.0, intersection);
+                    }
+                }
+            }
+        }
+    }
+    return;
+}
+
+void
+HierarchyMathOps::resetSideWeights(const int coarsest_ln, const int finest_ln)
+{
+#if !defined(NDEBUG)
+    TBOX_ASSERT(coarsest_ln >= d_coarsest_ln);
+    TBOX_ASSERT(finest_ln <= d_finest_ln);
+#endif
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_wgt_sc_idx))
+        {
+            level->allocatePatchData(d_wgt_sc_idx);
+        }
+    }
+
+    // Each cell's weight is set to its cell volume, unless the cell is refined
+    // on a finer level, in which case the weight is set to zero.  This insures
+    // that no part of the physical domain is counted twice when discrete norms
+    // and integrals are calculated on the entire hierarchy.
+    //
+    // Away from coarse-fine interfaces and boundaries of the computational
+    // domain, each cell face's weight is set to the cell volume associated with
+    // the level of the patch hierarchy.  Along coarse-fine interfaces or
+    // physical boundaries, the weights associated with the cell faces are
+    // modified so that the sum of the weights equals to volume of the
+    // computational domain.
+    ArrayDataBasicOps<NDIM, double> array_ops;
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        BoxArray<NDIM> refined_region_boxes;
+        if (ln < d_finest_ln)
+        {
+            Pointer<PatchLevel<NDIM> > next_finer_level = d_hierarchy->getPatchLevel(ln + 1);
+            refined_region_boxes = next_finer_level->getBoxes();
+            refined_region_boxes.coarsen(next_finer_level->getRatioToCoarserLevel());
+        }
+
+        const IntVector<NDIM> max_gcw(1);
+        const CoarseFineBoundary<NDIM> cf_bdry(*d_hierarchy, ln, max_gcw);
+
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM> > patch = level->getPatch(p());
+            const Box<NDIM>& patch_box = patch->getBox();
+            Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+
+            const double* const dx = pgeom->getDx();
+            const double cell_vol = dx[0] * dx[1]
+#if (NDIM > 2)
+                                    * dx[2]
+#endif
+                ;
+            Pointer<SideData<NDIM, double> > wgt_sc_data = patch->getPatchData(d_wgt_sc_idx);
+            wgt_sc_data->fillAll(cell_vol);
+
+            // Rescale values along the edges of the patches.
+            for (unsigned int axis = 0; axis < NDIM; ++axis)
+            {
+                Box<NDIM> side_lower_box = SideGeometry<NDIM>::toSideBox(patch_box, axis);
+                side_lower_box.upper()(axis) = side_lower_box.lower()(axis);
+                array_ops.scale(wgt_sc_data->getArrayData(axis), 0.5, wgt_sc_data->getArrayData(axis), side_lower_box);
+            }
+            for (unsigned int axis = 0; axis < NDIM; ++axis)
+            {
+                Box<NDIM> side_upper_box = SideGeometry<NDIM>::toSideBox(patch_box, axis);
+                side_upper_box.lower()(axis) = side_upper_box.upper()(axis);
+                array_ops.scale(wgt_sc_data->getArrayData(axis), 0.5, wgt_sc_data->getArrayData(axis), side_upper_box);
+            }
+
+            // Correct the values along coarse-fine interfaces.
+            if (ln > d_coarsest_ln)
+            {
+                const IntVector<NDIM>& ratio = level->getRatioToCoarserLevel();
+                const int bdry_type = 1;
+                const Array<BoundaryBox<NDIM> >& cf_bdry_boxes = cf_bdry.getBoundaries(p(), bdry_type);
+                for (int k = 0; k < cf_bdry_boxes.getSize(); ++k)
+                {
+                    const Box<NDIM>& bdry_box = cf_bdry_boxes[k].getBox();
+                    const unsigned int axis = cf_bdry_boxes[k].getLocationIndex() / 2;
+                    const int lower_upper = cf_bdry_boxes[k].getLocationIndex() % 2;
+                    if (!pgeom->getTouchesRegularBoundary(axis, lower_upper))
+                    {
+                        const double extra_vol = 0.5 * static_cast<double>(ratio(axis)) * cell_vol;
+                        Box<NDIM> side_bdry_box = SideGeometry<NDIM>::toSideBox(bdry_box, axis);
+                        array_ops.addScalar(
+                            wgt_sc_data->getArrayData(axis), wgt_sc_data->getArrayData(axis), extra_vol, side_bdry_box);
+                    }
+                }
+            }
+
+            // Zero-out weights within the refined region.
+            if (ln < d_finest_ln)
+            {
+                const IntVector<NDIM>& periodic_shift = d_grid_geom->getPeriodicShift(level->getRatio());
+                for (int i = 0; i < refined_region_boxes.getNumberOfBoxes(); ++i)
+                {
+                    for (unsigned int axis = 0; axis < NDIM; ++axis)
+                    {
+                        if (periodic_shift(axis) != 0)
+                        {
+                            for (int sgn = -1; sgn <= 1; sgn += 2)
+                            {
+                                IntVector<NDIM> periodic_offset = 0;
+                                periodic_offset(axis) = sgn * periodic_shift(axis);
+                                const Box<NDIM> refined_box =
+                                    Box<NDIM>::shift(refined_region_boxes[i], periodic_offset);
+                                const Box<NDIM> intersection = Box<NDIM>::grow(patch_box, 1) * refined_box;
+                                if (!intersection.empty())
+                                {
+                                    wgt_sc_data->fillAll(0.0, intersection);
+                                }
+                            }
+                        }
+                    }
+                    const Box<NDIM>& refined_box = refined_region_boxes[i];
+                    const Box<NDIM> intersection = Box<NDIM>::grow(patch_box, 1) * refined_box;
+                    if (!intersection.empty())
+                    {
+                        wgt_sc_data->fillAll(0.0, intersection);
+                    }
+                }
+            }
+        }
+    }
+    return;
+}
 
 ////////////////////////////////////////////////////////////////////////////
 

--- a/ibtk/src/solvers/impls/BGaussSeidelPreconditioner.cpp
+++ b/ibtk/src/solvers/impls/BGaussSeidelPreconditioner.cpp
@@ -164,13 +164,6 @@ BGaussSeidelPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAMRA
     std::vector<Pointer<SAMRAIVectorReal<NDIM, double> > > b_comps =
         getComponentVectors(Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false));
 
-    // Clone the right-hand-side vector to avoid modifying it during the
-    // preconditioning operation.
-    Pointer<SAMRAIVectorReal<NDIM, double> > f = b.cloneVector(b.getName());
-    f->allocateVectorData();
-    f->copyVector(Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false), false);
-    std::vector<Pointer<SAMRAIVectorReal<NDIM, double> > > f_comps = getComponentVectors(f);
-
     // Setup the order in which the component preconditioner are to be applied.
     const int ncomps = x.getNumberOfComponents();
     std::vector<int> comps;
@@ -205,6 +198,13 @@ BGaussSeidelPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAMRA
             }
         }
     }
+
+    // Clone the right-hand-side vector to avoid modifying it during the
+    // preconditioning operation.
+    Pointer<SAMRAIVectorReal<NDIM, double> > f = b.cloneVector(b.getName());
+    f->allocateVectorData();
+    f->copyVector(Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false), false);
+    std::vector<Pointer<SAMRAIVectorReal<NDIM, double> > > f_comps = getComponentVectors(f);
 
     // Apply the component preconditioners.
     int count = 0;

--- a/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
@@ -249,7 +249,7 @@ PETScKrylovLinearSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVe
     resetKSPOptions();
 
     // Allocate scratch data.
-    if (d_b) d_b->allocateVectorData();
+    d_b->allocateVectorData();
 
     // Solve the system using a PETSc KSP object.
     d_b->copyVector(Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false));
@@ -278,7 +278,7 @@ PETScKrylovLinearSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVe
     if (d_enable_logging) reportKSPConvergedReason(reason, plog);
 
     // Dealocate scratch data.
-    if (d_b) d_b->deallocateVectorData();
+    d_b->deallocateVectorData();
 
     // Deallocate the solver, when necessary.
     if (deallocate_after_solve) deallocateSolverState();

--- a/ibtk/src/solvers/impls/PETScMFFDJacobianOperator.cpp
+++ b/ibtk/src/solvers/impls/PETScMFFDJacobianOperator.cpp
@@ -125,6 +125,7 @@ PETScMFFDJacobianOperator::formJacobian(SAMRAIVectorReal<NDIM, double>& u)
     }
     else
     {
+        d_op_u->allocateVectorData();
         d_op_u->copyVector(Pointer<SAMRAIVectorReal<NDIM, double> >(&u, false), false);
         ierr = PetscObjectStateIncrease(reinterpret_cast<PetscObject>(d_petsc_u));
         IBTK_CHKERRQ(ierr);
@@ -134,6 +135,7 @@ PETScMFFDJacobianOperator::formJacobian(SAMRAIVectorReal<NDIM, double>& u)
         IBTK_CHKERRQ(ierr);
         ierr = MatAssemblyEnd(d_petsc_jac, MAT_FINAL_ASSEMBLY);
         IBTK_CHKERRQ(ierr);
+        d_op_u->deallocateVectorData();
     }
     return;
 } // formJacobian
@@ -192,7 +194,6 @@ PETScMFFDJacobianOperator::initializeOperatorState(const SAMRAIVectorReal<NDIM, 
 
     // Setup solution and rhs vectors.
     d_op_u = in.cloneVector(in.getName());
-    d_op_u->allocateVectorData();
     d_petsc_u = PETScSAMRAIVectorReal::createPETScVector(d_op_u, comm);
 
     d_op_x = in.cloneVector(in.getName());
@@ -215,7 +216,6 @@ PETScMFFDJacobianOperator::deallocateOperatorState()
     d_petsc_u = NULL;
     d_op_u->resetLevels(0,
                         std::min(d_op_u->getFinestLevelNumber(), d_op_u->getPatchHierarchy()->getFinestLevelNumber()));
-    d_op_u->deallocateVectorData();
     d_op_u->freeVectorComponents();
     d_op_u.setNull();
 

--- a/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
@@ -233,8 +233,8 @@ PETScNewtonKrylovSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVe
     if (p_krylov_solver) p_krylov_solver->resetKSPOptions();
 
     // Allocate scratch data.
-    if (d_b) d_b->allocateVectorData();
-    if (d_r) d_r->allocateVectorData();
+    d_b->allocateVectorData();
+    d_r->allocateVectorData();
 
     // Solve the system using a PETSc SNES object.
     d_b->copyVector(Pointer<SAMRAIVectorReal<NDIM, double> >(&b, false));
@@ -268,8 +268,8 @@ PETScNewtonKrylovSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVe
     if (d_enable_logging) reportSNESConvergedReason(reason, plog);
 
     // Deallocate scratch data.
-    if (d_b) d_b->deallocateVectorData();
-    if (d_r) d_r->deallocateVectorData();
+    d_b->deallocateVectorData();
+    d_r->deallocateVectorData();
 
     // Deallocate the solver, when necessary.
     if (deallocate_after_solve) deallocateSolverState();

--- a/ibtk/src/solvers/impls/PoissonFACPreconditionerStrategy.cpp
+++ b/ibtk/src/solvers/impls/PoissonFACPreconditionerStrategy.cpp
@@ -564,22 +564,6 @@ PoissonFACPreconditionerStrategy::deallocateOperatorState()
     return;
 } // deallocateOperatorState
 
-void
-PoissonFACPreconditionerStrategy::allocateScratchData()
-{
-    if (d_solution) d_solution->allocateVectorData();
-    if (d_rhs) d_rhs->allocateVectorData();
-    return;
-}
-
-void
-PoissonFACPreconditionerStrategy::deallocateScratchData()
-{
-    if (d_solution) d_solution->deallocateVectorData();
-    if (d_rhs) d_rhs->deallocateVectorData();
-    return;
-}
-
 /////////////////////////////// PROTECTED ////////////////////////////////////
 
 void

--- a/ibtk/src/solvers/impls/SCLaplaceOperator.cpp
+++ b/ibtk/src/solvers/impls/SCLaplaceOperator.cpp
@@ -165,7 +165,7 @@ SCLaplaceOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVectorReal<NDI
 #endif
 
     // Allocate scratch data.
-    if (d_x) d_x->allocateVectorData();
+    d_x->allocateVectorData();
 
     // Simultaneously fill ghost cell values for all components.
     typedef HierarchyGhostCellInterpolation::InterpolationTransactionComponent InterpolationTransactionComponent;
@@ -201,7 +201,7 @@ SCLaplaceOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVectorReal<NDI
     }
 
     // Deallocate scratch data.
-    if (d_x) d_x->deallocateVectorData();
+    d_x->deallocateVectorData();
 
     IBTK_TIMER_STOP(t_apply);
     return;

--- a/ibtk/src/solvers/impls/SCPoissonPETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonPETScLevelSolver.cpp
@@ -125,10 +125,10 @@ SCPoissonPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVectorRe
         var_db->getPatchDescriptor()->getPatchDataFactory(d_dof_index_idx);
     dof_index_fac->setDefaultDepth(depth);
     if (!d_level->checkAllocated(d_dof_index_idx)) d_level->allocatePatchData(d_dof_index_idx);
+    PETScVecUtilities::constructPatchLevelDOFIndices(d_num_dofs_per_proc, d_dof_index_idx, d_level);
 
     // Setup PETSc objects.
     int ierr;
-    PETScVecUtilities::constructPatchLevelDOFIndices(d_num_dofs_per_proc, d_dof_index_idx, d_level);
     const int mpi_rank = SAMRAI_MPI::getRank();
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_x);
     IBTK_CHKERRQ(ierr);

--- a/ibtk/src/solvers/interfaces/GeneralOperator.cpp
+++ b/ibtk/src/solvers/interfaces/GeneralOperator.cpp
@@ -157,9 +157,7 @@ GeneralOperator::applyAdd(SAMRAIVectorReal<NDIM, double>& x,
     zz->copyVector(Pointer<SAMRAIVectorReal<NDIM, double> >(&z, false));
     apply(x, *zz);
     z.add(Pointer<SAMRAIVectorReal<NDIM, double> >(&y, false), zz);
-    zz->deallocateVectorData();
     zz->freeVectorComponents();
-    zz.setNull();
     return;
 } // applyAdd
 

--- a/ibtk/src/solvers/interfaces/LinearOperator.cpp
+++ b/ibtk/src/solvers/interfaces/LinearOperator.cpp
@@ -76,9 +76,7 @@ LinearOperator::modifyRhsForBcs(SAMRAIVectorReal<NDIM, double>& y)
     x->setToScalar(0.0);
     apply(*x, *b);
     y.subtract(Pointer<SAMRAIVectorReal<NDIM, double> >(&y, false), b);
-    x->deallocateVectorData();
     x->freeVectorComponents();
-    b->deallocateVectorData();
     b->freeVectorComponents();
     return;
 } // modifyRhsForBcs

--- a/include/ibamr/StaggeredStokesFACPreconditionerStrategy.h
+++ b/include/ibamr/StaggeredStokesFACPreconditionerStrategy.h
@@ -331,16 +331,6 @@ public:
      */
     void deallocateOperatorState();
 
-    /*!
-     * \brief Allocate scratch data.
-     */
-    void allocateScratchData();
-
-    /*!
-     * \brief Deallocate scratch data.
-     */
-    void deallocateScratchData();
-
     //\}
 
 protected:

--- a/src/IB/ConstraintIBMethod.cpp
+++ b/src/IB/ConstraintIBMethod.cpp
@@ -501,9 +501,7 @@ ConstraintIBMethod::calculateEulerianMomentum()
 
         momentum[active] = d_hier_sc_data_ops->dot(d_u_fluidSolve_idx, wgt_sc_active_idx);
 
-        wgt_sc_active->deallocateVectorData();
         wgt_sc_active->freeVectorComponents();
-        wgt_sc_active.setNull();
     }
 
     if (!SAMRAI_MPI::getRank() && d_print_output && d_output_eul_mom && (d_timestep_counter % d_output_interval) == 0)

--- a/src/IB/StaggeredStokesIBBoxRelaxationFACOperator.cpp
+++ b/src/IB/StaggeredStokesIBBoxRelaxationFACOperator.cpp
@@ -431,7 +431,8 @@ StaggeredStokesIBBoxRelaxationFACOperator::initializeOperatorStateSpecialized(
         d_coarse_solver->setHomogeneousBc(true);
         d_coarse_solver->setComponentsHaveNullspace(d_has_velocity_nullspace, d_has_pressure_nullspace);
         Pointer<StaggeredStokesPETScLevelSolver> p_coarse_solver = d_coarse_solver;
-        if (p_coarse_solver) p_coarse_solver->addLinearOperator(d_SAJ_mat[d_coarsest_ln]);
+        if (p_coarse_solver)
+            p_coarse_solver->addLinearOperator(d_SAJ_mat[d_coarsest_ln]);
         else
             TBOX_ERROR("no mechanism for specifying SAJ part of operator!");
         d_coarse_solver->initializeSolverState(*getLevelSAMRAIVectorReal(*d_solution, d_coarsest_ln),

--- a/src/IB/StaggeredStokesIBLevelRelaxationFACOperator.cpp
+++ b/src/IB/StaggeredStokesIBLevelRelaxationFACOperator.cpp
@@ -519,7 +519,8 @@ StaggeredStokesIBLevelRelaxationFACOperator::initializeOperatorStateSpecialized(
         d_coarse_solver->setHomogeneousBc(true);
         d_coarse_solver->setComponentsHaveNullspace(d_has_velocity_nullspace, d_has_pressure_nullspace);
         Pointer<StaggeredStokesPETScLevelSolver> p_coarse_solver = d_coarse_solver;
-        if (p_coarse_solver) p_coarse_solver->addLinearOperator(d_SAJ_mat[d_coarsest_ln]);
+        if (p_coarse_solver)
+            p_coarse_solver->addLinearOperator(d_SAJ_mat[d_coarsest_ln]);
         else
             TBOX_ERROR("no mechanism for specifying SAJ part of operator!");
         d_coarse_solver->initializeSolverState(*getLevelSAMRAIVectorReal(*d_solution, d_coarsest_ln),

--- a/src/adv_diff/AdvDiffCenteredConvectiveOperator.cpp
+++ b/src/adv_diff/AdvDiffCenteredConvectiveOperator.cpp
@@ -405,6 +405,19 @@ AdvDiffCenteredConvectiveOperator::applyConvectiveOperator(const int Q_idx, cons
     }
 #endif
 
+    // Allocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_Q_scratch_idx))
+        {
+            level->allocatePatchData(d_Q_scratch_idx);
+            level->allocatePatchData(d_q_extrap_idx);
+            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
+                level->allocatePatchData(d_q_flux_idx);
+        }
+    }
+
     // Setup communications algorithm.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = d_hierarchy->getGridGeometry();
     Pointer<RefineAlgorithm<NDIM> > refine_alg = new RefineAlgorithm<NDIM>();
@@ -698,6 +711,25 @@ AdvDiffCenteredConvectiveOperator::applyConvectiveOperator(const int Q_idx, cons
             }
         }
     }
+
+    // Deallocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (level->checkAllocated(d_Q_scratch_idx))
+        {
+            level->deallocatePatchData(d_Q_scratch_idx);
+        }
+        if (level->checkAllocated(d_q_extrap_idx))
+        {
+            level->deallocatePatchData(d_q_extrap_idx);
+        }
+        if (level->checkAllocated(d_q_flux_idx))
+        {
+            level->deallocatePatchData(d_q_flux_idx);
+        }
+    }
+
     IBAMR_TIMER_STOP(t_apply_convective_operator);
     return;
 } // applyConvectiveOperator
@@ -751,18 +783,6 @@ AdvDiffCenteredConvectiveOperator::initializeOperatorState(const SAMRAIVectorRea
         d_ghostfill_scheds[ln] = d_ghostfill_alg->createSchedule(level, ln - 1, d_hierarchy, d_ghostfill_strategy);
     }
 
-    // Allocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_Q_scratch_idx))
-        {
-            level->allocatePatchData(d_Q_scratch_idx);
-            level->allocatePatchData(d_q_extrap_idx);
-            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
-                level->allocatePatchData(d_q_flux_idx);
-        }
-    }
     d_is_initialized = true;
 
     IBAMR_TIMER_STOP(t_initialize_operator_state);
@@ -775,24 +795,6 @@ AdvDiffCenteredConvectiveOperator::deallocateOperatorState()
     if (!d_is_initialized) return;
 
     IBAMR_TIMER_START(t_deallocate_operator_state);
-
-    // Deallocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_Q_scratch_idx))
-        {
-            level->deallocatePatchData(d_Q_scratch_idx);
-        }
-        if (level->checkAllocated(d_q_extrap_idx))
-        {
-            level->deallocatePatchData(d_q_extrap_idx);
-        }
-        if (level->checkAllocated(d_q_flux_idx))
-        {
-            level->deallocatePatchData(d_q_flux_idx);
-        }
-    }
 
     // Deallocate the refine algorithm, operator, patch strategy, and schedules.
     d_ghostfill_alg.setNull();

--- a/src/adv_diff/AdvDiffCenteredConvectiveOperator.cpp
+++ b/src/adv_diff/AdvDiffCenteredConvectiveOperator.cpp
@@ -409,13 +409,10 @@ AdvDiffCenteredConvectiveOperator::applyConvectiveOperator(const int Q_idx, cons
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_Q_scratch_idx))
-        {
-            level->allocatePatchData(d_Q_scratch_idx);
-            level->allocatePatchData(d_q_extrap_idx);
-            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
-                level->allocatePatchData(d_q_flux_idx);
-        }
+        level->allocatePatchData(d_Q_scratch_idx);
+        level->allocatePatchData(d_q_extrap_idx);
+        if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
+            level->allocatePatchData(d_q_flux_idx);
     }
 
     // Setup communications algorithm.
@@ -716,18 +713,10 @@ AdvDiffCenteredConvectiveOperator::applyConvectiveOperator(const int Q_idx, cons
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_Q_scratch_idx))
-        {
-            level->deallocatePatchData(d_Q_scratch_idx);
-        }
-        if (level->checkAllocated(d_q_extrap_idx))
-        {
-            level->deallocatePatchData(d_q_extrap_idx);
-        }
-        if (level->checkAllocated(d_q_flux_idx))
-        {
+        level->deallocatePatchData(d_Q_scratch_idx);
+        level->deallocatePatchData(d_q_extrap_idx);
+        if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
             level->deallocatePatchData(d_q_flux_idx);
-        }
     }
 
     IBAMR_TIMER_STOP(t_apply_convective_operator);

--- a/src/adv_diff/AdvDiffPPMConvectiveOperator.cpp
+++ b/src/adv_diff/AdvDiffPPMConvectiveOperator.cpp
@@ -436,13 +436,10 @@ AdvDiffPPMConvectiveOperator::applyConvectiveOperator(const int Q_idx, const int
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_Q_scratch_idx))
-        {
-            level->allocatePatchData(d_Q_scratch_idx);
-            level->allocatePatchData(d_q_extrap_idx);
-            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
-                level->allocatePatchData(d_q_flux_idx);
-        }
+        level->allocatePatchData(d_Q_scratch_idx);
+        level->allocatePatchData(d_q_extrap_idx);
+        if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
+            level->allocatePatchData(d_q_flux_idx);
     }
 
     // Setup communications algorithm.
@@ -779,18 +776,10 @@ AdvDiffPPMConvectiveOperator::applyConvectiveOperator(const int Q_idx, const int
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_Q_scratch_idx))
-        {
-            level->deallocatePatchData(d_Q_scratch_idx);
-        }
-        if (level->checkAllocated(d_q_extrap_idx))
-        {
-            level->deallocatePatchData(d_q_extrap_idx);
-        }
-        if (level->checkAllocated(d_q_flux_idx))
-        {
+        level->deallocatePatchData(d_Q_scratch_idx);
+        level->deallocatePatchData(d_q_extrap_idx);
+        if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
             level->deallocatePatchData(d_q_flux_idx);
-        }
     }
 
     IBAMR_TIMER_STOP(t_apply_convective_operator);

--- a/src/adv_diff/AdvDiffPPMConvectiveOperator.cpp
+++ b/src/adv_diff/AdvDiffPPMConvectiveOperator.cpp
@@ -432,6 +432,19 @@ AdvDiffPPMConvectiveOperator::applyConvectiveOperator(const int Q_idx, const int
     }
 #endif
 
+    // Allocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_Q_scratch_idx))
+        {
+            level->allocatePatchData(d_Q_scratch_idx);
+            level->allocatePatchData(d_q_extrap_idx);
+            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
+                level->allocatePatchData(d_q_flux_idx);
+        }
+    }
+
     // Setup communications algorithm.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = d_hierarchy->getGridGeometry();
     Pointer<RefineAlgorithm<NDIM> > refine_alg = new RefineAlgorithm<NDIM>();
@@ -761,6 +774,25 @@ AdvDiffPPMConvectiveOperator::applyConvectiveOperator(const int Q_idx, const int
             }
         }
     }
+
+    // Deallocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (level->checkAllocated(d_Q_scratch_idx))
+        {
+            level->deallocatePatchData(d_Q_scratch_idx);
+        }
+        if (level->checkAllocated(d_q_extrap_idx))
+        {
+            level->deallocatePatchData(d_q_extrap_idx);
+        }
+        if (level->checkAllocated(d_q_flux_idx))
+        {
+            level->deallocatePatchData(d_q_flux_idx);
+        }
+    }
+
     IBAMR_TIMER_STOP(t_apply_convective_operator);
     return;
 } // applyConvectiveOperator
@@ -814,18 +846,6 @@ AdvDiffPPMConvectiveOperator::initializeOperatorState(const SAMRAIVectorReal<NDI
         d_ghostfill_scheds[ln] = d_ghostfill_alg->createSchedule(level, ln - 1, d_hierarchy, d_ghostfill_strategy);
     }
 
-    // Allocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_Q_scratch_idx))
-        {
-            level->allocatePatchData(d_Q_scratch_idx);
-            level->allocatePatchData(d_q_extrap_idx);
-            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
-                level->allocatePatchData(d_q_flux_idx);
-        }
-    }
     d_is_initialized = true;
 
     IBAMR_TIMER_STOP(t_initialize_operator_state);
@@ -838,24 +858,6 @@ AdvDiffPPMConvectiveOperator::deallocateOperatorState()
     if (!d_is_initialized) return;
 
     IBAMR_TIMER_START(t_deallocate_operator_state);
-
-    // Deallocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_Q_scratch_idx))
-        {
-            level->deallocatePatchData(d_Q_scratch_idx);
-        }
-        if (level->checkAllocated(d_q_extrap_idx))
-        {
-            level->deallocatePatchData(d_q_extrap_idx);
-        }
-        if (level->checkAllocated(d_q_flux_idx))
-        {
-            level->deallocatePatchData(d_q_flux_idx);
-        }
-    }
 
     // Deallocate the refine algorithm, operator, patch strategy, and schedules.
     d_ghostfill_alg.setNull();

--- a/src/adv_diff/AdvDiffStochasticForcing.cpp
+++ b/src/adv_diff/AdvDiffStochasticForcing.cpp
@@ -201,12 +201,11 @@ AdvDiffStochasticForcing::setDataOnPatchHierarchy(const int data_idx,
         for (int level_num = coarsest_ln; level_num <= finest_ln; ++level_num)
         {
             Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_num);
-            if (!level->checkAllocated(d_C_current_cc_idx)) level->allocatePatchData(d_C_current_cc_idx);
-            if (!level->checkAllocated(d_C_half_cc_idx)) level->allocatePatchData(d_C_half_cc_idx);
-            if (!level->checkAllocated(d_C_new_cc_idx)) level->allocatePatchData(d_C_new_cc_idx);
-            if (!level->checkAllocated(d_F_sc_idx)) level->allocatePatchData(d_F_sc_idx);
-            for (int k = 0; k < d_num_rand_vals; ++k)
-                if (!level->checkAllocated(d_F_sc_idxs[k])) level->allocatePatchData(d_F_sc_idxs[k]);
+            level->allocatePatchData(d_C_current_cc_idx);
+            level->allocatePatchData(d_C_half_cc_idx);
+            level->allocatePatchData(d_C_new_cc_idx);
+            level->allocatePatchData(d_F_sc_idx);
+            for (int k = 0; k < d_num_rand_vals; ++k) level->allocatePatchData(d_F_sc_idxs[k]);
         }
 
         // Set concentration value used to compute concentration-dependent flux
@@ -386,6 +385,20 @@ AdvDiffStochasticForcing::setDataOnPatchHierarchy(const int data_idx,
     for (int level_num = coarsest_ln; level_num <= finest_ln; ++level_num)
     {
         setDataOnPatchLevel(data_idx, var, hierarchy->getPatchLevel(level_num), data_time, initial_time);
+    }
+
+    // Deallocate data to store components of the stochastic stress components.
+    if (!initial_time)
+    {
+        for (int level_num = coarsest_ln; level_num <= finest_ln; ++level_num)
+        {
+            Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_num);
+            level->deallocatePatchData(d_C_current_cc_idx);
+            level->deallocatePatchData(d_C_half_cc_idx);
+            level->deallocatePatchData(d_C_new_cc_idx);
+            level->deallocatePatchData(d_F_sc_idx);
+            for (int k = 0; k < d_num_rand_vals; ++k) level->deallocatePatchData(d_F_sc_idxs[k]);
+        }
     }
     return;
 } // setDataOnPatchHierarchy

--- a/src/navier_stokes/INSCollocatedCenteredConvectiveOperator.cpp
+++ b/src/navier_stokes/INSCollocatedCenteredConvectiveOperator.cpp
@@ -412,13 +412,10 @@ INSCollocatedCenteredConvectiveOperator::applyConvectiveOperator(const int U_idx
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_U_scratch_idx))
-        {
-            level->allocatePatchData(d_U_scratch_idx);
-            level->allocatePatchData(d_u_extrap_idx);
-            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
-                level->allocatePatchData(d_u_flux_idx);
-        }
+        level->allocatePatchData(d_U_scratch_idx);
+        level->allocatePatchData(d_u_extrap_idx);
+        if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
+            level->allocatePatchData(d_u_flux_idx);
     }
 
     // Setup communications algorithm.
@@ -709,18 +706,10 @@ INSCollocatedCenteredConvectiveOperator::applyConvectiveOperator(const int U_idx
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_U_scratch_idx))
-        {
-            level->deallocatePatchData(d_U_scratch_idx);
-        }
-        if (level->checkAllocated(d_u_extrap_idx))
-        {
-            level->deallocatePatchData(d_u_extrap_idx);
-        }
-        if (level->checkAllocated(d_u_flux_idx))
-        {
+        level->deallocatePatchData(d_U_scratch_idx);
+        level->deallocatePatchData(d_u_extrap_idx);
+        if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
             level->deallocatePatchData(d_u_flux_idx);
-        }
     }
 
     IBAMR_TIMER_STOP(t_apply_convective_operator);

--- a/src/navier_stokes/INSCollocatedCenteredConvectiveOperator.cpp
+++ b/src/navier_stokes/INSCollocatedCenteredConvectiveOperator.cpp
@@ -408,6 +408,19 @@ INSCollocatedCenteredConvectiveOperator::applyConvectiveOperator(const int U_idx
     }
 #endif
 
+    // Allocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_U_scratch_idx))
+        {
+            level->allocatePatchData(d_U_scratch_idx);
+            level->allocatePatchData(d_u_extrap_idx);
+            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
+                level->allocatePatchData(d_u_flux_idx);
+        }
+    }
+
     // Setup communications algorithm.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = d_hierarchy->getGridGeometry();
     Pointer<RefineAlgorithm<NDIM> > refine_alg = new RefineAlgorithm<NDIM>();
@@ -691,6 +704,25 @@ INSCollocatedCenteredConvectiveOperator::applyConvectiveOperator(const int U_idx
             }
         }
     }
+
+    // Deallocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (level->checkAllocated(d_U_scratch_idx))
+        {
+            level->deallocatePatchData(d_U_scratch_idx);
+        }
+        if (level->checkAllocated(d_u_extrap_idx))
+        {
+            level->deallocatePatchData(d_u_extrap_idx);
+        }
+        if (level->checkAllocated(d_u_flux_idx))
+        {
+            level->deallocatePatchData(d_u_flux_idx);
+        }
+    }
+
     IBAMR_TIMER_STOP(t_apply_convective_operator);
     return;
 } // applyConvectiveOperator
@@ -743,18 +775,6 @@ INSCollocatedCenteredConvectiveOperator::initializeOperatorState(const SAMRAIVec
         d_ghostfill_scheds[ln] = d_ghostfill_alg->createSchedule(level, ln - 1, d_hierarchy, d_ghostfill_strategy);
     }
 
-    // Allocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_U_scratch_idx))
-        {
-            level->allocatePatchData(d_U_scratch_idx);
-            level->allocatePatchData(d_u_extrap_idx);
-            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
-                level->allocatePatchData(d_u_flux_idx);
-        }
-    }
     d_is_initialized = true;
 
     IBAMR_TIMER_STOP(t_initialize_operator_state);
@@ -767,24 +787,6 @@ INSCollocatedCenteredConvectiveOperator::deallocateOperatorState()
     if (!d_is_initialized) return;
 
     IBAMR_TIMER_START(t_deallocate_operator_state);
-
-    // Deallocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_U_scratch_idx))
-        {
-            level->deallocatePatchData(d_U_scratch_idx);
-        }
-        if (level->checkAllocated(d_u_extrap_idx))
-        {
-            level->deallocatePatchData(d_u_extrap_idx);
-        }
-        if (level->checkAllocated(d_u_flux_idx))
-        {
-            level->deallocatePatchData(d_u_flux_idx);
-        }
-    }
 
     // Deallocate the refine algorithm, operator, patch strategy, and schedules.
     d_ghostfill_alg.setNull();

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -906,12 +906,15 @@ INSCollocatedHierarchyIntegrator::preprocessIntegrateHierarchy(const double curr
     // Allocate solver vectors.
     d_U_rhs_vec->allocateVectorData(current_time);
     d_U_rhs_vec->setToScalar(0.0);
-    d_U_adv_vec->allocateVectorData(current_time);
-    d_U_adv_vec->setToScalar(0.0);
-    d_N_vec->allocateVectorData(current_time);
-    d_N_vec->setToScalar(0.0);
     d_Phi_rhs_vec->allocateVectorData(current_time);
     d_Phi_rhs_vec->setToScalar(0.0);
+    if (!d_creeping_flow)
+    {
+        d_U_adv_vec->allocateVectorData(current_time);
+        d_U_adv_vec->setToScalar(0.0);
+        d_N_vec->allocateVectorData(current_time);
+        d_N_vec->setToScalar(0.0);
+    }
 
     // Initialize the right-hand side terms.
     const double rho = d_problem_coefs.getRho();
@@ -1487,9 +1490,12 @@ INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(const double cur
 
     // Deallocate scratch data.
     d_U_rhs_vec->deallocateVectorData();
-    d_U_adv_vec->deallocateVectorData();
-    d_N_vec->deallocateVectorData();
     d_Phi_rhs_vec->deallocateVectorData();
+    if (!d_creeping_flow)
+    {
+        d_U_adv_vec->deallocateVectorData();
+        d_N_vec->deallocateVectorData();
+    }
 
     // Deallocate any registered advection-diffusion solver.
     if (d_adv_diff_hier_integrator)

--- a/src/navier_stokes/INSCollocatedPPMConvectiveOperator.cpp
+++ b/src/navier_stokes/INSCollocatedPPMConvectiveOperator.cpp
@@ -433,6 +433,19 @@ INSCollocatedPPMConvectiveOperator::applyConvectiveOperator(const int U_idx, con
     }
 #endif
 
+    // Allocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_U_scratch_idx))
+        {
+            level->allocatePatchData(d_U_scratch_idx);
+            level->allocatePatchData(d_u_extrap_idx);
+            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
+                level->allocatePatchData(d_u_flux_idx);
+        }
+    }
+
     // Setup communications algorithm.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = d_hierarchy->getGridGeometry();
     Pointer<RefineAlgorithm<NDIM> > refine_alg = new RefineAlgorithm<NDIM>();
@@ -766,6 +779,25 @@ INSCollocatedPPMConvectiveOperator::applyConvectiveOperator(const int U_idx, con
             }
         }
     }
+
+    // Deallocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (level->checkAllocated(d_U_scratch_idx))
+        {
+            level->deallocatePatchData(d_U_scratch_idx);
+        }
+        if (level->checkAllocated(d_u_extrap_idx))
+        {
+            level->deallocatePatchData(d_u_extrap_idx);
+        }
+        if (level->checkAllocated(d_u_flux_idx))
+        {
+            level->deallocatePatchData(d_u_flux_idx);
+        }
+    }
+
     IBAMR_TIMER_STOP(t_apply_convective_operator);
     return;
 } // applyConvectiveOperator
@@ -818,18 +850,6 @@ INSCollocatedPPMConvectiveOperator::initializeOperatorState(const SAMRAIVectorRe
         d_ghostfill_scheds[ln] = d_ghostfill_alg->createSchedule(level, ln - 1, d_hierarchy, d_ghostfill_strategy);
     }
 
-    // Allocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_U_scratch_idx))
-        {
-            level->allocatePatchData(d_U_scratch_idx);
-            level->allocatePatchData(d_u_extrap_idx);
-            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
-                level->allocatePatchData(d_u_flux_idx);
-        }
-    }
     d_is_initialized = true;
 
     IBAMR_TIMER_STOP(t_initialize_operator_state);
@@ -842,24 +862,6 @@ INSCollocatedPPMConvectiveOperator::deallocateOperatorState()
     if (!d_is_initialized) return;
 
     IBAMR_TIMER_START(t_deallocate_operator_state);
-
-    // Deallocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_U_scratch_idx))
-        {
-            level->deallocatePatchData(d_U_scratch_idx);
-        }
-        if (level->checkAllocated(d_u_extrap_idx))
-        {
-            level->deallocatePatchData(d_u_extrap_idx);
-        }
-        if (level->checkAllocated(d_u_flux_idx))
-        {
-            level->deallocatePatchData(d_u_flux_idx);
-        }
-    }
 
     // Deallocate the refine algorithm, operator, patch strategy, and schedules.
     d_ghostfill_alg.setNull();

--- a/src/navier_stokes/INSCollocatedPPMConvectiveOperator.cpp
+++ b/src/navier_stokes/INSCollocatedPPMConvectiveOperator.cpp
@@ -437,13 +437,10 @@ INSCollocatedPPMConvectiveOperator::applyConvectiveOperator(const int U_idx, con
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_U_scratch_idx))
-        {
-            level->allocatePatchData(d_U_scratch_idx);
-            level->allocatePatchData(d_u_extrap_idx);
-            if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
-                level->allocatePatchData(d_u_flux_idx);
-        }
+        level->allocatePatchData(d_U_scratch_idx);
+        level->allocatePatchData(d_u_extrap_idx);
+        if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
+            level->allocatePatchData(d_u_flux_idx);
     }
 
     // Setup communications algorithm.
@@ -784,18 +781,10 @@ INSCollocatedPPMConvectiveOperator::applyConvectiveOperator(const int U_idx, con
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_U_scratch_idx))
-        {
-            level->deallocatePatchData(d_U_scratch_idx);
-        }
-        if (level->checkAllocated(d_u_extrap_idx))
-        {
-            level->deallocatePatchData(d_u_extrap_idx);
-        }
-        if (level->checkAllocated(d_u_flux_idx))
-        {
+        level->deallocatePatchData(d_U_scratch_idx);
+        level->deallocatePatchData(d_u_extrap_idx);
+        if (d_difference_form == CONSERVATIVE || d_difference_form == SKEW_SYMMETRIC)
             level->deallocatePatchData(d_u_flux_idx);
-        }
     }
 
     IBAMR_TIMER_STOP(t_apply_convective_operator);

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1082,12 +1082,15 @@ INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const double curre
     // Allocate solver vectors.
     d_U_rhs_vec->allocateVectorData(current_time);
     d_U_rhs_vec->setToScalar(0.0);
-    d_U_adv_vec->allocateVectorData(current_time);
-    d_U_adv_vec->setToScalar(0.0);
-    d_N_vec->allocateVectorData(current_time);
-    d_N_vec->setToScalar(0.0);
     d_P_rhs_vec->allocateVectorData(current_time);
     d_P_rhs_vec->setToScalar(0.0);
+    if (!d_creeping_flow)
+    {
+        d_U_adv_vec->allocateVectorData(current_time);
+        d_U_adv_vec->setToScalar(0.0);
+        d_N_vec->allocateVectorData(current_time);
+        d_N_vec->setToScalar(0.0);
+    }
 
     // Cache BC data.
     d_bc_helper->cacheBcCoefData(d_bc_coefs, new_time, d_hierarchy);
@@ -1389,9 +1392,12 @@ INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double curr
 
     // Deallocate scratch data.
     d_U_rhs_vec->deallocateVectorData();
-    d_U_adv_vec->deallocateVectorData();
-    d_N_vec->deallocateVectorData();
     d_P_rhs_vec->deallocateVectorData();
+    if (!d_creeping_flow)
+    {
+        d_U_adv_vec->deallocateVectorData();
+        d_N_vec->deallocateVectorData();
+    }
 
     // Deallocate any registered advection-diffusion solver.
     if (d_adv_diff_hier_integrator)

--- a/src/navier_stokes/INSStaggeredPPMConvectiveOperator.cpp
+++ b/src/navier_stokes/INSStaggeredPPMConvectiveOperator.cpp
@@ -546,10 +546,7 @@ INSStaggeredPPMConvectiveOperator::applyConvectiveOperator(const int U_idx, cons
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_U_scratch_idx))
-        {
-            level->allocatePatchData(d_U_scratch_idx);
-        }
+        level->allocatePatchData(d_U_scratch_idx);
     }
 
     // Fill ghost cell values for all components.
@@ -977,10 +974,7 @@ INSStaggeredPPMConvectiveOperator::applyConvectiveOperator(const int U_idx, cons
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_U_scratch_idx))
-        {
-            level->deallocatePatchData(d_U_scratch_idx);
-        }
+        level->deallocatePatchData(d_U_scratch_idx);
     }
 
     IBAMR_TIMER_STOP(t_apply_convective_operator);

--- a/src/navier_stokes/INSStaggeredPPMConvectiveOperator.cpp
+++ b/src/navier_stokes/INSStaggeredPPMConvectiveOperator.cpp
@@ -542,6 +542,16 @@ INSStaggeredPPMConvectiveOperator::applyConvectiveOperator(const int U_idx, cons
     TBOX_ASSERT(U_idx == d_u_idx);
 #endif
 
+    // Allocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_U_scratch_idx))
+        {
+            level->allocatePatchData(d_U_scratch_idx);
+        }
+    }
+
     // Fill ghost cell values for all components.
     static const bool homogeneous_bc = false;
     typedef HierarchyGhostCellInterpolation::InterpolationTransactionComponent InterpolationTransactionComponent;
@@ -963,6 +973,16 @@ INSStaggeredPPMConvectiveOperator::applyConvectiveOperator(const int U_idx, cons
         }
     }
 
+    // Deallocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (level->checkAllocated(d_U_scratch_idx))
+        {
+            level->deallocatePatchData(d_U_scratch_idx);
+        }
+    }
+
     IBAMR_TIMER_STOP(t_apply_convective_operator);
     return;
 } // applyConvectiveOperator
@@ -1007,15 +1027,6 @@ INSStaggeredPPMConvectiveOperator::initializeOperatorState(const SAMRAIVectorRea
     d_bc_helper = new StaggeredStokesPhysicalBoundaryHelper();
     d_bc_helper->cacheBcCoefData(d_bc_coefs, d_solution_time, d_hierarchy);
 
-    // Allocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_U_scratch_idx))
-        {
-            level->allocatePatchData(d_U_scratch_idx);
-        }
-    }
     d_is_initialized = true;
 
     IBAMR_TIMER_STOP(t_initialize_operator_state);
@@ -1028,16 +1039,6 @@ INSStaggeredPPMConvectiveOperator::deallocateOperatorState()
     if (!d_is_initialized) return;
 
     IBAMR_TIMER_START(t_deallocate_operator_state);
-
-    // Deallocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_U_scratch_idx))
-        {
-            level->deallocatePatchData(d_U_scratch_idx);
-        }
-    }
 
     // Deallocate the communications operators and BC helpers.
     d_hier_bdry_fill.setNull();

--- a/src/navier_stokes/INSStaggeredStabilizedPPMConvectiveOperator.cpp
+++ b/src/navier_stokes/INSStaggeredStabilizedPPMConvectiveOperator.cpp
@@ -576,10 +576,7 @@ INSStaggeredStabilizedPPMConvectiveOperator::applyConvectiveOperator(const int U
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_U_scratch_idx))
-        {
-            level->allocatePatchData(d_U_scratch_idx);
-        }
+        level->allocatePatchData(d_U_scratch_idx);
     }
 
     // Fill ghost cell values for all components.
@@ -1236,10 +1233,7 @@ INSStaggeredStabilizedPPMConvectiveOperator::applyConvectiveOperator(const int U
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_U_scratch_idx))
-        {
-            level->deallocatePatchData(d_U_scratch_idx);
-        }
+        level->deallocatePatchData(d_U_scratch_idx);
     }
 
     IBAMR_TIMER_STOP(t_apply_convective_operator);

--- a/src/navier_stokes/INSStaggeredStabilizedPPMConvectiveOperator.cpp
+++ b/src/navier_stokes/INSStaggeredStabilizedPPMConvectiveOperator.cpp
@@ -572,6 +572,16 @@ INSStaggeredStabilizedPPMConvectiveOperator::applyConvectiveOperator(const int U
     TBOX_ASSERT(U_idx == d_u_idx);
 #endif
 
+    // Allocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_U_scratch_idx))
+        {
+            level->allocatePatchData(d_U_scratch_idx);
+        }
+    }
+
     // Fill ghost cell values for all components.
     static const bool homogeneous_bc = false;
     typedef HierarchyGhostCellInterpolation::InterpolationTransactionComponent InterpolationTransactionComponent;
@@ -1222,6 +1232,16 @@ INSStaggeredStabilizedPPMConvectiveOperator::applyConvectiveOperator(const int U
         }
     }
 
+    // Deallocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (level->checkAllocated(d_U_scratch_idx))
+        {
+            level->deallocatePatchData(d_U_scratch_idx);
+        }
+    }
+
     IBAMR_TIMER_STOP(t_apply_convective_operator);
     return;
 } // applyConvectiveOperator
@@ -1266,15 +1286,6 @@ INSStaggeredStabilizedPPMConvectiveOperator::initializeOperatorState(const SAMRA
     d_bc_helper = new StaggeredStokesPhysicalBoundaryHelper();
     d_bc_helper->cacheBcCoefData(d_bc_coefs, d_solution_time, d_hierarchy);
 
-    // Allocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_U_scratch_idx))
-        {
-            level->allocatePatchData(d_U_scratch_idx);
-        }
-    }
     d_is_initialized = true;
 
     IBAMR_TIMER_STOP(t_initialize_operator_state);
@@ -1287,16 +1298,6 @@ INSStaggeredStabilizedPPMConvectiveOperator::deallocateOperatorState()
     if (!d_is_initialized) return;
 
     IBAMR_TIMER_START(t_deallocate_operator_state);
-
-    // Deallocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_U_scratch_idx))
-        {
-            level->deallocatePatchData(d_U_scratch_idx);
-        }
-    }
 
     // Deallocate the communications operators and BC helpers.
     d_hier_bdry_fill.setNull();

--- a/src/navier_stokes/INSStaggeredStochasticForcing.cpp
+++ b/src/navier_stokes/INSStaggeredStochasticForcing.cpp
@@ -290,18 +290,15 @@ INSStaggeredStochasticForcing::setDataOnPatchHierarchy(const int data_idx,
         for (int level_num = coarsest_ln; level_num <= finest_ln; ++level_num)
         {
             Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_num);
-            if (!level->checkAllocated(d_W_cc_idx)) level->allocatePatchData(d_W_cc_idx);
-            for (int k = 0; k < d_num_rand_vals; ++k)
-                if (!level->checkAllocated(d_W_cc_idxs[k])) level->allocatePatchData(d_W_cc_idxs[k]);
+            level->allocatePatchData(d_W_cc_idx);
+            for (int k = 0; k < d_num_rand_vals; ++k) level->allocatePatchData(d_W_cc_idxs[k]);
 #if (NDIM == 2)
-            if (!level->checkAllocated(d_W_nc_idx)) level->allocatePatchData(d_W_nc_idx);
-            for (int k = 0; k < d_num_rand_vals; ++k)
-                if (!level->checkAllocated(d_W_nc_idxs[k])) level->allocatePatchData(d_W_nc_idxs[k]);
+            level->allocatePatchData(d_W_nc_idx);
+            for (int k = 0; k < d_num_rand_vals; ++k) level->allocatePatchData(d_W_nc_idxs[k]);
 #endif
 #if (NDIM == 3)
-            if (!level->checkAllocated(d_W_ec_idx)) level->allocatePatchData(d_W_ec_idx);
-            for (int k = 0; k < d_num_rand_vals; ++k)
-                if (!level->checkAllocated(d_W_ec_idxs[k])) level->allocatePatchData(d_W_ec_idxs[k]);
+            level->allocatePatchData(d_W_ec_idx);
+            for (int k = 0; k < d_num_rand_vals; ++k) level->allocatePatchData(d_W_ec_idxs[k]);
 #endif
         }
 
@@ -657,6 +654,25 @@ INSStaggeredStochasticForcing::setDataOnPatchHierarchy(const int data_idx,
     for (int level_num = coarsest_ln; level_num <= finest_ln; ++level_num)
     {
         setDataOnPatchLevel(data_idx, var, hierarchy->getPatchLevel(level_num), data_time, initial_time);
+    }
+
+    // Deallocate data to store components of the stochastic stress components.
+    if (!initial_time)
+    {
+        for (int level_num = coarsest_ln; level_num <= finest_ln; ++level_num)
+        {
+            Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_num);
+            level->allocatePatchData(d_W_cc_idx);
+            for (int k = 0; k < d_num_rand_vals; ++k) level->allocatePatchData(d_W_cc_idxs[k]);
+#if (NDIM == 2)
+            level->allocatePatchData(d_W_nc_idx);
+            for (int k = 0; k < d_num_rand_vals; ++k) level->allocatePatchData(d_W_nc_idxs[k]);
+#endif
+#if (NDIM == 3)
+            level->allocatePatchData(d_W_ec_idx);
+            for (int k = 0; k < d_num_rand_vals; ++k) level->allocatePatchData(d_W_ec_idxs[k]);
+#endif
+        }
     }
     return;
 } // computeStochasticForcingOnPatchHierarchy

--- a/src/navier_stokes/INSStaggeredUpwindConvectiveOperator.cpp
+++ b/src/navier_stokes/INSStaggeredUpwindConvectiveOperator.cpp
@@ -401,6 +401,16 @@ INSStaggeredUpwindConvectiveOperator::applyConvectiveOperator(const int U_idx, c
     TBOX_ASSERT(U_idx == d_u_idx);
 #endif
 
+    // Allocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_U_scratch_idx))
+        {
+            level->allocatePatchData(d_U_scratch_idx);
+        }
+    }
+
     // Fill ghost cell values for all components.
     static const bool homogeneous_bc = false;
     typedef HierarchyGhostCellInterpolation::InterpolationTransactionComponent InterpolationTransactionComponent;
@@ -691,6 +701,16 @@ INSStaggeredUpwindConvectiveOperator::applyConvectiveOperator(const int U_idx, c
         }
     }
 
+    // Deallocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (level->checkAllocated(d_U_scratch_idx))
+        {
+            level->deallocatePatchData(d_U_scratch_idx);
+        }
+    }
+
     IBAMR_TIMER_STOP(t_apply_convective_operator);
     return;
 } // applyConvectiveOperator
@@ -735,15 +755,6 @@ INSStaggeredUpwindConvectiveOperator::initializeOperatorState(const SAMRAIVector
     d_bc_helper = new StaggeredStokesPhysicalBoundaryHelper();
     d_bc_helper->cacheBcCoefData(d_bc_coefs, d_solution_time, d_hierarchy);
 
-    // Allocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_U_scratch_idx))
-        {
-            level->allocatePatchData(d_U_scratch_idx);
-        }
-    }
     d_is_initialized = true;
 
     IBAMR_TIMER_STOP(t_initialize_operator_state);
@@ -756,16 +767,6 @@ INSStaggeredUpwindConvectiveOperator::deallocateOperatorState()
     if (!d_is_initialized) return;
 
     IBAMR_TIMER_START(t_deallocate_operator_state);
-
-    // Deallocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_U_scratch_idx))
-        {
-            level->deallocatePatchData(d_U_scratch_idx);
-        }
-    }
 
     // Deallocate the communications operators and BC helpers.
     d_hier_bdry_fill.setNull();

--- a/src/navier_stokes/INSStaggeredUpwindConvectiveOperator.cpp
+++ b/src/navier_stokes/INSStaggeredUpwindConvectiveOperator.cpp
@@ -405,10 +405,7 @@ INSStaggeredUpwindConvectiveOperator::applyConvectiveOperator(const int U_idx, c
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_U_scratch_idx))
-        {
-            level->allocatePatchData(d_U_scratch_idx);
-        }
+        level->allocatePatchData(d_U_scratch_idx);
     }
 
     // Fill ghost cell values for all components.
@@ -705,10 +702,7 @@ INSStaggeredUpwindConvectiveOperator::applyConvectiveOperator(const int U_idx, c
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_U_scratch_idx))
-        {
-            level->deallocatePatchData(d_U_scratch_idx);
-        }
+        level->deallocatePatchData(d_U_scratch_idx);
     }
 
     IBAMR_TIMER_STOP(t_apply_convective_operator);

--- a/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
@@ -286,9 +286,9 @@ StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorReal<ND
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_F_U_mod_idx)) level->allocatePatchData(d_F_U_mod_idx);
-        if (!level->checkAllocated(d_P_scratch_idx)) level->allocatePatchData(d_P_scratch_idx);
-        if (!level->checkAllocated(d_F_P_mod_idx)) level->allocatePatchData(d_F_P_mod_idx);
+        level->allocatePatchData(d_F_U_mod_idx);
+        level->allocatePatchData(d_P_scratch_idx);
+        level->allocatePatchData(d_F_P_mod_idx);
     }
 
     // Apply one of the approximate block-factorization preconditioners.
@@ -374,9 +374,9 @@ StaggeredStokesBlockFactorizationPreconditioner::solveSystem(SAMRAIVectorReal<ND
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_F_U_mod_idx)) level->deallocatePatchData(d_F_U_mod_idx);
-        if (level->checkAllocated(d_P_scratch_idx)) level->deallocatePatchData(d_P_scratch_idx);
-        if (level->checkAllocated(d_F_P_mod_idx)) level->deallocatePatchData(d_F_P_mod_idx);
+        level->deallocatePatchData(d_F_U_mod_idx);
+        level->deallocatePatchData(d_P_scratch_idx);
+        level->deallocatePatchData(d_F_P_mod_idx);
     }
 
     // Deallocate the solver (if necessary).

--- a/src/navier_stokes/StaggeredStokesFACPreconditionerStrategy.cpp
+++ b/src/navier_stokes/StaggeredStokesFACPreconditionerStrategy.cpp
@@ -973,22 +973,6 @@ StaggeredStokesFACPreconditionerStrategy::deallocateOperatorState()
     return;
 } // deallocateOperatorState
 
-void
-StaggeredStokesFACPreconditionerStrategy::allocateScratchData()
-{
-    if (d_solution) d_solution->allocateVectorData();
-    if (d_rhs) d_rhs->allocateVectorData();
-    return;
-}
-
-void
-StaggeredStokesFACPreconditionerStrategy::deallocateScratchData()
-{
-    if (d_solution) d_solution->deallocateVectorData();
-    if (d_rhs) d_rhs->deallocateVectorData();
-    return;
-}
-
 /////////////////////////////// PROTECTED ////////////////////////////////////
 
 void

--- a/src/navier_stokes/StaggeredStokesOperator.cpp
+++ b/src/navier_stokes/StaggeredStokesOperator.cpp
@@ -209,6 +209,9 @@ StaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVectorRe
 {
     IBAMR_TIMER_START(t_apply);
 
+    // Allocate scratch data.
+    d_x->allocateVectorData();
+
     // Get the vector components.
     const int U_idx = x.getComponentDescriptorIndex(0);
     const int P_idx = x.getComponentDescriptorIndex(1);
@@ -280,6 +283,9 @@ StaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVectorRe
                          /*cf_bdry_synch*/ true);
     d_bc_helper->copyDataAtDirichletBoundaries(A_U_idx, U_scratch_idx);
 
+    // Deallocate scratch data.
+    d_x->deallocateVectorData();
+
     IBAMR_TIMER_STOP(t_apply);
     return;
 } // apply
@@ -296,7 +302,6 @@ StaggeredStokesOperator::initializeOperatorState(const SAMRAIVectorReal<NDIM, do
     // Setup solution and rhs vectors.
     d_x = in.cloneVector(in.getName());
     d_b = out.cloneVector(out.getName());
-    d_x->allocateVectorData();
 
     // Setup the interpolation transaction information.
     d_U_fill_pattern = new SideNoCornersFillPattern(SIDEG, false, false, true);
@@ -403,9 +408,7 @@ StaggeredStokesOperator::modifyRhsForBcs(SAMRAIVectorReal<NDIM, double>& y)
         StaggeredStokesPhysicalBoundaryHelper::resetBcCoefObjects(d_U_bc_coefs, d_P_bc_coef);
         apply(*x, *b);
         y.subtract(Pointer<SAMRAIVectorReal<NDIM, double> >(&y, false), b);
-        x->deallocateVectorData();
         x->freeVectorComponents();
-        b->deallocateVectorData();
         b->freeVectorComponents();
     }
     const bool homogeneous_bc = true;

--- a/src/navier_stokes/StaggeredStokesPETScLevelSolver.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScLevelSolver.cpp
@@ -157,12 +157,11 @@ StaggeredStokesPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVe
     // Allocate DOF index data.
     if (!d_level->checkAllocated(d_u_dof_index_idx)) d_level->allocatePatchData(d_u_dof_index_idx);
     if (!d_level->checkAllocated(d_p_dof_index_idx)) d_level->allocatePatchData(d_p_dof_index_idx);
+    StaggeredStokesPETScVecUtilities::constructPatchLevelDOFIndices(
+        d_num_dofs_per_proc, d_u_dof_index_idx, d_p_dof_index_idx, d_level);
 
     // Setup PETSc objects.
     int ierr;
-    StaggeredStokesPETScVecUtilities::constructPatchLevelDOFIndices(
-        d_num_dofs_per_proc, d_u_dof_index_idx, d_p_dof_index_idx, d_level);
-    // Set KSP Mat, PC, and Vecs.
     const int mpi_rank = SAMRAI_MPI::getRank();
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_x);
     IBTK_CHKERRQ(ierr);
@@ -183,7 +182,7 @@ StaggeredStokesPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVe
     }
     d_petsc_pc = d_petsc_mat;
 
-    // Subdomains for ASM and MSM preconditioner
+    // Construct subdomains for ASM and MSM preconditioner.
     StaggeredStokesPETScMatUtilities::constructPatchLevelASMSubdomains(d_overlap_is,
                                                                        d_nonoverlap_is,
                                                                        d_box_size,
@@ -261,7 +260,6 @@ StaggeredStokesPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVe
     const int p_idx = x.getComponentDescriptorIndex(1);
     d_data_synch_sched = StaggeredStokesPETScVecUtilities::constructDataSynchSchedule(u_idx, p_idx, d_level);
     d_ghost_fill_sched = StaggeredStokesPETScVecUtilities::constructGhostFillSchedule(u_idx, p_idx, d_level);
-
     return;
 } // initializeSolverStateSpecialized
 

--- a/src/navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
@@ -227,14 +227,8 @@ StaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, doub
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_Phi_scratch_idx))
-        {
-            level->allocatePatchData(d_Phi_scratch_idx);
-        }
-        if (!level->checkAllocated(d_F_Phi_idx))
-        {
-            level->allocatePatchData(d_F_Phi_idx);
-        }
+        level->allocatePatchData(d_Phi_scratch_idx);
+        level->allocatePatchData(d_F_Phi_idx);
     }
 
     // (1) Solve the velocity sub-problem for an initial approximation to U.
@@ -344,14 +338,8 @@ StaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, doub
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_Phi_scratch_idx))
-        {
-            level->deallocatePatchData(d_Phi_scratch_idx);
-        }
-        if (level->checkAllocated(d_F_Phi_idx))
-        {
-            level->deallocatePatchData(d_F_Phi_idx);
-        }
+        level->deallocatePatchData(d_Phi_scratch_idx);
+        level->deallocatePatchData(d_F_Phi_idx);
     }
 
     // Deallocate the solver (if necessary).

--- a/src/navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
@@ -223,6 +223,20 @@ StaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, doub
     P_vec = new SAMRAIVectorReal<NDIM, double>(d_object_name + "::P", d_hierarchy, d_coarsest_ln, d_finest_ln);
     P_vec->addComponent(P_cc_var, P_idx, d_pressure_wgt_idx, d_pressure_data_ops);
 
+    // Allocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(d_Phi_scratch_idx))
+        {
+            level->allocatePatchData(d_Phi_scratch_idx);
+        }
+        if (!level->checkAllocated(d_F_Phi_idx))
+        {
+            level->allocatePatchData(d_F_Phi_idx);
+        }
+    }
+
     // (1) Solve the velocity sub-problem for an initial approximation to U.
     //
     // U^* := inv(rho/dt - K*mu*L) F_U
@@ -326,6 +340,20 @@ StaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, doub
     // Account for nullspace vectors.
     correctNullspace(U_vec, P_vec);
 
+    // Deallocate scratch data.
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        if (level->checkAllocated(d_Phi_scratch_idx))
+        {
+            level->deallocatePatchData(d_Phi_scratch_idx);
+        }
+        if (level->checkAllocated(d_F_Phi_idx))
+        {
+            level->deallocatePatchData(d_F_Phi_idx);
+        }
+    }
+
     // Deallocate the solver (if necessary).
     if (deallocate_at_completion) deallocateSolverState();
 
@@ -359,20 +387,6 @@ StaggeredStokesProjectionPreconditioner::initializeSolverState(const SAMRAIVecto
     d_Phi_bdry_fill_op->setHomogeneousBc(true);
     d_Phi_bdry_fill_op->initializeOperatorState(P_scratch_component, d_hierarchy);
 
-    // Allocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (!level->checkAllocated(d_Phi_scratch_idx))
-        {
-            level->allocatePatchData(d_Phi_scratch_idx);
-        }
-        if (!level->checkAllocated(d_F_Phi_idx))
-        {
-            level->allocatePatchData(d_F_Phi_idx);
-        }
-    }
-
     d_is_initialized = true;
 
     IBAMR_TIMER_STOP(t_initialize_solver_state);
@@ -391,20 +405,6 @@ StaggeredStokesProjectionPreconditioner::deallocateSolverState()
 
     // Deallocate hierarchy operators.
     d_Phi_bdry_fill_op.setNull();
-
-    // Deallocate scratch data.
-    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (level->checkAllocated(d_Phi_scratch_idx))
-        {
-            level->deallocatePatchData(d_Phi_scratch_idx);
-        }
-        if (level->checkAllocated(d_F_Phi_idx))
-        {
-            level->deallocatePatchData(d_F_Phi_idx);
-        }
-    }
 
     d_is_initialized = false;
 


### PR DESCRIPTION
* moves SAMRAI vector allocations/deallocations closer to points of use
* moves patch data allocations closer to points of use
* removes some unneeded calls to PatchLevel::checkAllocated()
* avoids allocating some patch data in HierachyMathOps