### PR TITLE
Initial periodic shifts

### DIFF
--- a/ibtk/include/ibtk/LNode.h
+++ b/ibtk/include/ibtk/LNode.h
@@ -80,8 +80,10 @@ public:
     LNode(int lagrangian_nidx = -1,
           int global_petsc_nidx = -1,
           int local_petsc_nidx = -1,
-          const SAMRAI::hier::IntVector<NDIM>& periodic_offset = SAMRAI::hier::IntVector<NDIM>(0),
-          const Vector& periodic_displacement = Vector::Zero(),
+          const SAMRAI::hier::IntVector<NDIM>& initial_periodic_offset = SAMRAI::hier::IntVector<NDIM>(0),
+          const SAMRAI::hier::IntVector<NDIM>& current_periodic_offset = SAMRAI::hier::IntVector<NDIM>(0),
+          const Vector& initial_periodic_displacement = Vector::Zero(),
+          const Vector& current_periodic_displacement = Vector::Zero(),
           const std::vector<SAMRAI::tbox::Pointer<Streamable> >& node_data =
               std::vector<SAMRAI::tbox::Pointer<Streamable> >());
 

--- a/ibtk/include/ibtk/LNodeIndex.h
+++ b/ibtk/include/ibtk/LNodeIndex.h
@@ -77,8 +77,10 @@ public:
     LNodeIndex(int lagrangian_nidx = -1,
                int global_petsc_nidx = -1,
                int local_petsc_nidx = -1,
-               const SAMRAI::hier::IntVector<NDIM>& periodic_offset = SAMRAI::hier::IntVector<NDIM>(0),
-               const Vector& periodic_displacement = Vector::Zero());
+               const SAMRAI::hier::IntVector<NDIM>& initial_periodic_offset = SAMRAI::hier::IntVector<NDIM>(0),
+               const SAMRAI::hier::IntVector<NDIM>& current_periodic_offset = SAMRAI::hier::IntVector<NDIM>(0),
+               const Vector& initial_periodic_displacement = Vector::Zero(),
+               const Vector& current_periodic_displacement = Vector::Zero());
 
     /*!
      * \brief Copy constructor.
@@ -143,9 +145,19 @@ public:
     virtual void registerPeriodicShift(const SAMRAI::hier::IntVector<NDIM>& offset, const Vector& displacement);
 
     /*!
+     * \brief Get the initial (t = 0) periodic offset.
+     */
+    virtual const SAMRAI::hier::IntVector<NDIM>& getInitialPeriodicOffset() const;
+
+    /*!
      * \brief Get the periodic offset.
      */
     virtual const SAMRAI::hier::IntVector<NDIM>& getPeriodicOffset() const;
+
+    /*!
+     * \brief Get the initial (t = 0) periodic displacement.
+     */
+    virtual const Vector& getInitialPeriodicDisplacement() const;
 
     /*!
      * \brief Get the periodic displacement.
@@ -188,8 +200,8 @@ private:
     int d_local_petsc_nidx;  // the local PETSc index
 
     // the periodic offset and displacement
-    SAMRAI::hier::IntVector<NDIM> d_offset;
-    Vector d_displacement;
+    SAMRAI::hier::IntVector<NDIM> d_offset_0, d_offset;
+    Vector d_displacement_0, d_displacement;
 };
 
 /*!

--- a/ibtk/include/ibtk/private/LNode-inl.h
+++ b/ibtk/include/ibtk/private/LNode-inl.h
@@ -51,10 +51,18 @@ namespace IBTK
 inline LNode::LNode(const int lagrangian_nidx,
                     const int global_petsc_nidx,
                     const int local_petsc_nidx,
-                    const SAMRAI::hier::IntVector<NDIM>& periodic_offset,
-                    const Vector& periodic_displacement,
+                    const SAMRAI::hier::IntVector<NDIM>& initial_periodic_offset,
+                    const SAMRAI::hier::IntVector<NDIM>& current_periodic_offset,
+                    const Vector& initial_periodic_displacement,
+                    const Vector& current_periodic_displacement,
                     const std::vector<SAMRAI::tbox::Pointer<Streamable> >& node_data)
-    : LNodeIndex(lagrangian_nidx, global_petsc_nidx, local_petsc_nidx, periodic_offset, periodic_displacement),
+    : LNodeIndex(lagrangian_nidx,
+                 global_petsc_nidx,
+                 local_petsc_nidx,
+                 initial_periodic_offset,
+                 current_periodic_offset,
+                 initial_periodic_displacement,
+                 current_periodic_displacement),
       d_node_data(node_data)
 {
     setupNodeDataTypeArray();

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -463,8 +463,14 @@ IBStandardInitializer::initializeDataOnPatchLevel(const int lag_node_index_idx,
                 index_data->appendItemPointer(idx, new LNodeSet());
             }
             LNodeSet* const node_set = index_data->getItem(idx);
-            node_set->push_back(new LNode(
-                lagrangian_idx, global_petsc_idx, local_petsc_idx, periodic_offset, periodic_displacement, node_data));
+            node_set->push_back(new LNode(lagrangian_idx,
+                                          global_petsc_idx,
+                                          local_petsc_idx,
+                                          /*initial*/ periodic_offset,
+                                          /*current*/ periodic_offset,
+                                          /*initial*/ periodic_displacement,
+                                          /*current*/ periodic_displacement,
+                                          node_data));
 
             // Initialize the velocity of the present vertex.
             std::fill(&U_array[local_petsc_idx][0], &U_array[local_petsc_idx][0] + NDIM, 0.0);

--- a/src/IB/IMPInitializer.cpp
+++ b/src/IB/IMPInitializer.cpp
@@ -399,8 +399,14 @@ IMPInitializer::initializeDataOnPatchLevel(const int lag_node_index_idx,
                                       d_vertex_wgt[level_number][point_idx.first][point_idx.second],
                                       d_vertex_subdomain_id[level_number][point_idx.first][point_idx.second]);
             std::vector<Pointer<Streamable> > node_data(1, point_spec);
-            node_set->push_back(new LNode(
-                lagrangian_idx, global_petsc_idx, local_petsc_idx, periodic_offset, periodic_displacement, node_data));
+            node_set->push_back(new LNode(lagrangian_idx,
+                                          global_petsc_idx,
+                                          local_petsc_idx,
+                                          /*initial*/ periodic_offset,
+                                          /*current*/ periodic_offset,
+                                          /*initial*/ periodic_displacement,
+                                          /*current*/ periodic_displacement,
+                                          node_data));
 
             // Initialize the velocity of the present vertex.
             std::fill(&U_array[local_petsc_idx][0], &U_array[local_petsc_idx][0] + NDIM, 0.0);


### PR DESCRIPTION
This PR adds the feature to get initial periodic shifts and displacements for LNodes. This can be useful for certain cases of periodic boundary conditions where the initial unshifted position X0 is required.