### PR TITLE
ensure that IB points do not "leave" the computational domain

### DIFF
--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -822,8 +822,8 @@ FEDataManager::prolongData(const int f_data_idx,
             // correspond to the physical coordinates.
             s_node_cache.resize(n_node);
             X_node_cache.resize(n_node);
-            X_min = Point::Constant(+0.5 * std::numeric_limits<double>::max());
-            X_max = Point::Constant(-0.5 * std::numeric_limits<double>::max());
+            X_min = Point::Constant(std::numeric_limits<double>::max());
+            X_max = Point::Constant(std::numeric_limits<double>::lowest());
             for (unsigned int k = 0; k < n_node; ++k)
             {
                 s_node_cache[k] = elem->point(k);
@@ -1277,8 +1277,8 @@ FEDataManager::restrictData(const int f_data_idx,
             // correspond to the physical coordinates.
             s_node_cache.resize(n_node);
             X_node_cache.resize(n_node);
-            X_min = Point::Constant(0.5 * std::numeric_limits<double>::max());
-            X_max = Point::Constant(-0.5 * std::numeric_limits<double>::max());
+            X_min = Point::Constant(std::numeric_limits<double>::max());
+            X_max = Point::Constant(std::numeric_limits<double>::lowest());
             for (unsigned int k = 0; k < n_node; ++k)
             {
                 s_node_cache[k] = elem->point(k);
@@ -2233,8 +2233,8 @@ FEDataManager::computeActiveElementBoundingBoxes()
         const unsigned int elem_id = elem->id();
         Point& elem_lower_bound = d_active_elem_bboxes[elem_id].first;
         Point& elem_upper_bound = d_active_elem_bboxes[elem_id].second;
-        elem_lower_bound = Point::Constant(0.5 * std::numeric_limits<double>::max());
-        elem_upper_bound = Point::Constant(-0.5 * std::numeric_limits<double>::max());
+        elem_lower_bound = Point::Constant(std::numeric_limits<double>::max());
+        elem_upper_bound = Point::Constant(std::numeric_limits<double>::lowest());
 
         const unsigned int n_nodes = elem->n_nodes();
         dof_indices.clear();

--- a/ibtk/src/refine_ops/CartCellDoubleBoundsPreservingConservativeLinearRefine.cpp
+++ b/ibtk/src/refine_ops/CartCellDoubleBoundsPreservingConservativeLinearRefine.cpp
@@ -200,7 +200,7 @@ CartCellDoubleBoundsPreservingConservativeLinearRefine::refine(Patch<NDIM>& fine
             }
 
             double l = std::numeric_limits<double>::max();
-            double u = -(l - std::numeric_limits<double>::epsilon());
+            double u = std::numeric_limits<double>::lowest();
             for (Box<NDIM>::Iterator b(stencil_box_crse); b; b++)
             {
                 const double& m = (*cdata)(b(), depth);

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1802,8 +1802,8 @@ IBFEMethod::imposeJumpConditions(const int f_data_idx,
                 // to the physical coordinates.
                 s_node_cache.resize(n_node_side);
                 X_node_cache.resize(n_node_side);
-                X_min = IBTK::Point::Constant(+0.5 * std::numeric_limits<double>::max());
-                X_max = IBTK::Point::Constant(-0.5 * std::numeric_limits<double>::max());
+                X_min = IBTK::Point::Constant(std::numeric_limits<double>::max());
+                X_max = IBTK::Point::Constant(std::numeric_limits<double>::lowest());
                 for (unsigned int k = 0; k < n_node_side; ++k)
                 {
                     s_node_cache[k] = side_elem->point(k);


### PR DESCRIPTION
Currently LDataManager does not know what to do if an IB point happens to "leave" the computational domain via a non-periodic boundary. This PR attempts to ensure that points cannot accidentally "slip through" such boundaries due to floating point effects.