### PR TITLE
midpoint integrator fixed, for steady Stokes is just forward Euler.

### DIFF
--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -745,7 +745,7 @@ CIBMethod::midpointStep(const double current_time, const double new_time)
 
     // Fill the rotation matrix of structures with rotation angle (W^n+1)*dt.
     std::vector<Eigen::Matrix3d> rotation_mat(d_num_rigid_parts, Eigen::Matrix3d::Identity(3, 3));
-    setRotationMatrix(is_steady_stokes ? d_rot_vel_current : d_rot_vel_half,
+    setRotationMatrix(is_steady_stokes ? d_rot_vel_new : d_rot_vel_half,
                       d_quaternion_current,
                       d_quaternion_new,
                       rotation_mat,
@@ -806,7 +806,7 @@ CIBMethod::midpointStep(const double current_time, const double new_time)
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 X_new[d] = d_center_of_mass_current[struct_handle][d] + R_dr[d] +
-                           dt * (is_steady_stokes ? d_trans_vel_current[struct_handle][d] :
+                           dt * (is_steady_stokes ? d_trans_vel_new[struct_handle][d] :
                                                     d_trans_vel_half[struct_handle][d]);
 
                 if (periodic_shift[d])
@@ -836,7 +836,8 @@ CIBMethod::midpointStep(const double current_time, const double new_time)
         Eigen::Vector3d& current_com = d_center_of_mass_current[struct_no];
         for (unsigned int d = 0; d < NDIM; ++d)
         {
-            new_com[d] = current_com[d] + dt * d_trans_vel_half[struct_no][d];
+            new_com[d] = current_com[d] + dt * (is_steady_stokes ? d_trans_vel_new[struct_no][d] :
+						d_trans_vel_half[struct_no][d]);
 
             if (periodic_shift[d])
             {

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -745,11 +745,8 @@ CIBMethod::midpointStep(const double current_time, const double new_time)
 
     // Fill the rotation matrix of structures with rotation angle (W^n+1)*dt.
     std::vector<Eigen::Matrix3d> rotation_mat(d_num_rigid_parts, Eigen::Matrix3d::Identity(3, 3));
-    setRotationMatrix(is_steady_stokes ? d_rot_vel_new : d_rot_vel_half,
-                      d_quaternion_current,
-                      d_quaternion_new,
-                      rotation_mat,
-                      dt);
+    setRotationMatrix(
+        is_steady_stokes ? d_rot_vel_new : d_rot_vel_half, d_quaternion_current, d_quaternion_new, rotation_mat, dt);
 
     // Get the grid extents.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = d_hierarchy->getGridGeometry();
@@ -805,9 +802,9 @@ CIBMethod::midpointStep(const double current_time, const double new_time)
             R_dr = rotation_mat[struct_handle] * dr;
             for (unsigned int d = 0; d < NDIM; ++d)
             {
-                X_new[d] = d_center_of_mass_current[struct_handle][d] + R_dr[d] +
-                           dt * (is_steady_stokes ? d_trans_vel_new[struct_handle][d] :
-                                                    d_trans_vel_half[struct_handle][d]);
+                X_new[d] =
+                    d_center_of_mass_current[struct_handle][d] + R_dr[d] +
+                    dt * (is_steady_stokes ? d_trans_vel_new[struct_handle][d] : d_trans_vel_half[struct_handle][d]);
 
                 if (periodic_shift[d])
                 {
@@ -836,8 +833,8 @@ CIBMethod::midpointStep(const double current_time, const double new_time)
         Eigen::Vector3d& current_com = d_center_of_mass_current[struct_no];
         for (unsigned int d = 0; d < NDIM; ++d)
         {
-            new_com[d] = current_com[d] + dt * (is_steady_stokes ? d_trans_vel_new[struct_no][d] :
-						d_trans_vel_half[struct_no][d]);
+            new_com[d] = current_com[d] +
+                         dt * (is_steady_stokes ? d_trans_vel_new[struct_no][d] : d_trans_vel_half[struct_no][d]);
 
             if (periodic_shift[d])
             {


### PR DESCRIPTION
The center of mass (orientation) of the rigid bodies is updated with d_trans_vel_new in the midpoint method for steady Stokes flows (rho==0).