### PR TITLE
prevent namespace collision with standard C FILE type name

### DIFF
--- a/include/ibamr/ibamr_enums.h
+++ b/include/ibamr/ibamr_enums.h
@@ -303,7 +303,7 @@ enum_to_string<StochasticStressTensorType>(StochasticStressTensorType val)
  */
 enum MobilityMatrixType
 {
-    FILE,
+    READ_FROM_FILE,
     RPY,
     EMPIRICAL,
     UNKNOWN_MOBILITY_MATRIX_TYPE = -1
@@ -313,7 +313,7 @@ template <>
 inline MobilityMatrixType
 string_to_enum<MobilityMatrixType>(const std::string& val)
 {
-    if (strcasecmp(val.c_str(), "FILE") == 0) return FILE;
+    if (strcasecmp(val.c_str(), "READ_FROM_FILE") == 0) return READ_FROM_FILE;
     if (strcasecmp(val.c_str(), "RPY") == 0) return RPY;
     if (strcasecmp(val.c_str(), "EMPIRICAL") == 0) return EMPIRICAL;
     return UNKNOWN_MOBILITY_MATRIX_TYPE;
@@ -323,7 +323,7 @@ template <>
 inline std::string
 enum_to_string<MobilityMatrixType>(MobilityMatrixType val)
 {
-    if (val == FILE) return "FILE";
+    if (val == READ_FROM_FILE) return "READ_FROM_FILE";
     if (val == RPY) return "RPY";
     if (val == EMPIRICAL) return "EMPIRICAL";
     return "UNKNOWN_MOBILITY_MATRIX_TYPE";

--- a/src/IB/DirectMobilitySolver.cpp
+++ b/src/IB/DirectMobilitySolver.cpp
@@ -505,7 +505,7 @@ DirectMobilitySolver::initializeSolverState(Vec x, Vec /*b*/)
             const std::pair<double, double>& scale = d_mat_scale_map[mat_name];
             const int managing_proc = d_mat_proc_map[mat_name];
 
-            if (mat_type == FILE && !read_files[file_counter])
+            if (mat_type == READ_FROM_FILE && !read_files[file_counter])
             {
                 // Get the matrix from file.
                 const std::string& filename = d_mat_filename_map[mat_name];


### PR DESCRIPTION
FILE is a standard C type, there should not be an enum or type name with the same name.