### PR TITLE
set provided pre-commit hook only to check C/C++ files

### DIFF
--- a/scripts/check_formatting.sh
+++ b/scripts/check_formatting.sh
@@ -11,11 +11,11 @@ child_env = os.environ.copy()
 # when run from within an app (e.g. SourceTree), subprocess will throw an exception because
 # of the error from git clang-format. we'll ignore that to carry on
 import subprocess
-p = subprocess.Popen(["git", "clang-format", "--diff"], stdout=subprocess.PIPE, env=child_env)
+p = subprocess.Popen(["git", "clang-format", "--diff", "--extensions=C,c,cpp,h"], stdout=subprocess.PIPE, env=child_env)
 output, err = p.communicate()
 
 if output not in ['no modified files to format\n', 'clang-format did not modify any files\n']:
-    print "Run git clang-format, then commit.\n"        
+    print "Run git \"clang-format --extensions=C,c,cpp,h\", then commit.\n"        
     exit(1)
 else:
     exit(0)


### PR DESCRIPTION
Users have to re-run ./scripts/setup_clang_format_precommit_hook.sh in IBAMR root to get the updated file.

To run "git clang-format" only on C/C++ files, you can do "git clang-format --extensions=C,c,cpp,h".