### PR TITLE
update first-order explicit IB time stepping to use explicit forward/backward Euler

### DIFF
--- a/include/ibamr/IBHierarchyIntegrator.h
+++ b/include/ibamr/IBHierarchyIntegrator.h
@@ -259,6 +259,12 @@ protected:
     TimeSteppingType d_time_stepping_type;
 
     /*!
+     * Flag indicating whether to use an explicit predictor for the structure
+     * configuration in the time stepping scheme.
+     */
+    bool d_use_structure_predictor;
+
+    /*!
      * Flags to determine whether warnings or error messages should be emitted
      * when time step size changes are encountered.
      */

--- a/include/ibamr/IBImplicitStrategy.h
+++ b/include/ibamr/IBImplicitStrategy.h
@@ -156,11 +156,6 @@ public:
                                    int dof_index_idx,
                                    double data_time) = 0;
 
-    /*!
-    * Advance the positions of the Lagrangian structure using backward Euler.
-    */
-    virtual void backwardEulerStep(double current_time, double new_time) = 0;
-
 protected:
 private:
     /*!

--- a/include/ibamr/IBStrategy.h
+++ b/include/ibamr/IBStrategy.h
@@ -221,6 +221,15 @@ public:
 
     /*!
      * Advance the positions of the Lagrangian structure using the (explicit)
+     * backward Euler method.
+     *
+     * A default implementation is provided that emits an unrecoverable
+     * exception.
+     */
+    virtual void backwardEulerStep(double current_time, double new_time);
+
+    /*!
+     * Advance the positions of the Lagrangian structure using the (explicit)
      * midpoint rule.
      */
     virtual void midpointStep(double current_time, double new_time) = 0;

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -772,7 +772,7 @@ IBMethod::backwardEulerStep(const double current_time, const double new_time)
     *X_half_needs_ghost_fill = true;
 
     return;
-} // eulerStep
+} // backwardEulerStep
 
 void
 IBMethod::midpointStep(const double current_time, const double new_time)

--- a/src/IB/IBStrategy.cpp
+++ b/src/IB/IBStrategy.cpp
@@ -167,6 +167,13 @@ IBStrategy::updateFixedLEOperators()
     return;
 } // updateFixedLEOperators
 
+void
+IBStrategy::backwardEulerStep(double /*current_time*/, double /*new_time*/)
+{
+    TBOX_ERROR("IBStrategy::backwardEulerStep(): unimplemented\n");
+    return;
+} // backwardEulerStep
+
 bool
 IBStrategy::hasFluidSources() const
 {


### PR DESCRIPTION
Pure forward Euler IB time stepping appears to be rather unstable, requiring extremely small time step sizes for stability --- much smaller than the explicit midpoint and trapezoidal rules. This PR changes explicit Euler time stepping to use a combination of forward Euler and explicit backward Euler. Essentially we do an explicit predictor:

     X~(n+1) = X(n) + dt*U(n) = X(n) + dt*J[X(n)] u(n)

followed by an explicit "corrector":

     X(n+1) = X(n) + dt*U~(n+1) = X(n) + dt*J[X~(n)] u(n+1).

Simply using forward Euler, so that X(n+1) = X(n) + dt*U(n), appears to be unstable.

All structural forces are computed using the X(n) configuration:

     f = S[X(n)] F[X(n)]

I haven't experimented with all possible combinations, but it appears that using:

     f = S[X~(n+1)] F[X~(n+1)]

is unstable.

IBExplicitHierarchyIntegrator now uses the same IB time stepping algorithm for either FORWARD_EULER or BACKWARD_EULER.