### PR TITLE
Adding Galerkin Stokes-IB MG method

### DIFF
--- a/ibtk/include/ibtk/PETScLevelSolver.h
+++ b/ibtk/include/ibtk/PETScLevelSolver.h
@@ -240,6 +240,16 @@ public:
      */
     void addLinearOperator(Mat& op);
 
+    /*!
+     * \brief Use externally provided linear operator.
+     * \NOTE this function should be called prior to initializing the solver
+     * state.
+     *
+     * \param op PETSc Mat to be used as linear operator.
+     *
+     */
+    void useLinearOperator(Mat& op);
+
     //\}
 
 protected:
@@ -317,7 +327,7 @@ protected:
     std::string d_options_prefix;
     KSP d_petsc_ksp;
     Mat d_petsc_mat, d_petsc_pc;
-    Mat d_petsc_extern_mat;
+    Mat d_petsc_extern_mat, d_petsc_add_mat;
     MatNullSpace d_petsc_nullsp;
     Vec d_petsc_x, d_petsc_b;
     //\}

--- a/ibtk/src/math/PETScVecUtilities.cpp
+++ b/ibtk/src/math/PETScVecUtilities.cpp
@@ -665,6 +665,8 @@ PETScVecUtilities::constructPatchLevelAO_cell(AO& ao,
 #endif
     const Index<NDIM>& domain_lower = domain_boxes[0].lower();
     const Index<NDIM>& domain_upper = domain_boxes[0].upper();
+    Pointer<CartesianGridGeometry<NDIM> > grid_geom = patch_level->getGridGeometry();
+    IntVector<NDIM> periodic_shift = grid_geom->getPeriodicShift(patch_level->getRatio());
     Index<NDIM> num_cells = 1;
     num_cells += domain_upper - domain_lower;
 
@@ -696,7 +698,8 @@ PETScVecUtilities::constructPatchLevelAO_cell(AO& ao,
                 TBOX_ASSERT(dof_idx >= i_lower && dof_idx < i_upper);
 #endif
                 petsc_idxs[counter] = dof_idx;
-                samrai_idxs[counter] = IndexUtilities::mapIndexToInteger(i, domain_lower, num_cells, d, ao_offset);
+                samrai_idxs[counter] =
+                    IndexUtilities::mapIndexToInteger(i, domain_lower, num_cells, d, ao_offset, periodic_shift);
             }
         }
     }

--- a/ibtk/src/solvers/impls/PETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScLevelSolver.cpp
@@ -137,6 +137,7 @@ PETScLevelSolver::PETScLevelSolver()
       d_petsc_mat(NULL),
       d_petsc_pc(NULL),
       d_petsc_extern_mat(NULL),
+      d_petsc_add_mat(NULL),
       d_petsc_x(NULL),
       d_petsc_b(NULL)
 {
@@ -741,6 +742,17 @@ PETScLevelSolver::deallocateSolverState()
 
 void
 PETScLevelSolver::addLinearOperator(Mat& op)
+{
+#if !defined(NDEBUG)
+    TBOX_ASSERT(!d_is_initialized);
+    TBOX_ASSERT(op);
+#endif
+    d_petsc_add_mat = op;
+    return;
+} // addLinearOperator
+
+void
+PETScLevelSolver::useLinearOperator(Mat& op)
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(!d_is_initialized);

--- a/include/ibamr/StaggeredStokesIBLevelRelaxationFACOperator.h
+++ b/include/ibamr/StaggeredStokesIBLevelRelaxationFACOperator.h
@@ -291,6 +291,13 @@ private:
     StaggeredStokesIBLevelRelaxationFACOperator& operator=(const StaggeredStokesIBLevelRelaxationFACOperator& that);
 
     /*
+     * Whether we re-discretize the Stokes operator on coarser level or are
+     * using Galerkin projection.
+     */
+    bool d_rediscretize_stokes;
+    bool d_res_rediscretized_stokes;
+
+    /*
      * Level solvers and solver parameters.
      */
     std::string d_level_solver_type, d_level_solver_default_options_prefix;
@@ -300,14 +307,14 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> d_level_solver_db;
 
     /*
-     * Velocity prolongation type.
+     * Velocity and pressure prolongation type.
      */
-    std::string d_u_petsc_prolongation_method;
+    std::string d_u_petsc_prolongation_method, d_p_petsc_prolongation_method;
 
     /*
-     * Application ordering of u from MAC DOFs on various patch levels.
+     * Application ordering of u and p from MAC DOFs on various patch levels.
      */
-    std::vector<AO> d_u_app_ordering;
+    std::vector<AO> d_u_p_app_ordering;
 
     /*
      * Eulerian data for storing u and p DOFs indexing.
@@ -333,12 +340,12 @@ private:
     Mat d_J_mat;
 
     /*
-     * Data structures for elasticity and prolongation operator respresentation
+     * Data structures for elasticity and prolongation operator representation
      * on various patch levels.
      */
-    double d_SAJ_fill;
-    std::vector<Mat> d_SAJ_mat, d_prolongation_mat;
-    std::vector<Vec> d_scale_restriction_mat;
+    double d_SAJ_fill, d_RStokesIBP_fill;
+    std::vector<Mat> d_SAJ_mat, d_SAJ_prolongation_mat, d_stokesib_prolongation_mat, d_galerkin_stokesib_mat;
+    std::vector<Vec> d_scale_SAJ_restriction_mat, d_scale_stokesib_restriction_mat;
 
     /*
      * Mappings from patch indices to patch operators.

--- a/include/ibamr/StaggeredStokesPETScMatUtilities.h
+++ b/include/ibamr/StaggeredStokesPETScMatUtilities.h
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "PoissonSpecifications.h"
+#include "petscao.h"
 #include "petscmat.h"
 #include "tbox/Pointer.h"
 
@@ -113,6 +114,24 @@ public:
                                           int u_dof_index_idx,
                                           int p_dof_index_idx,
                                           SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM> > patch_level);
+
+    /*!
+     * \brief Construct a parallel PETSc Mat object corresponding to data
+     * prolongation from a coarser level to a finer level.
+     */
+    static void constructProlongationOp(Mat& mat,
+                                        const std::string& u_op_type,
+                                        const std::string& p_op_type,
+                                        int u_dof_index_idx,
+                                        int p_dof_index_idx,
+                                        const std::vector<int>& num_fine_dofs_per_proc,
+                                        const std::vector<int>& num_coarse_dofs_per_proc,
+                                        SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM> > fine_patch_level,
+                                        SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM> > coarse_patch_level,
+                                        const AO& coarse_level_ao,
+                                        const int u_coarse_ao_offset,
+                                        const int p_coarse_ao_offset);
+
     //\}
 
 protected:

--- a/include/ibamr/StaggeredStokesPETScVecUtilities.h
+++ b/include/ibamr/StaggeredStokesPETScVecUtilities.h
@@ -37,6 +37,7 @@
 
 #include <vector>
 
+#include "petscao.h"
 #include "petscvec.h"
 #include "tbox/Pointer.h"
 
@@ -130,6 +131,26 @@ public:
                                               int u_dof_index_idx,
                                               int p_dof_index_idx,
                                               SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM> > patch_level);
+
+    /*!
+     * \brief Create an application ordering object (AO) that creates a mapping
+     * between global PETSc indices and mapping of SAMRAI data indices for patch
+     * data index \em dof_index_idx to a nonnegative integer \f$ (i,j,k,d):-> p \f$
+     * on a SAMRAI::hier::PatchLevel.
+     *
+     *\see IndexUtilities::mapIndexToInteger() for
+     * details on the integer mapping of SAMRAI data indices.
+     *
+     * \param ao_offset An integer offset used for integer mapping of SAMRAI
+     * data indices.
+     */
+    static void constructPatchLevelAO(AO& ao,
+                                      std::vector<int>& num_dofs_per_proc,
+                                      int u_dof_index_idx,
+                                      int p_dof_index_idx,
+                                      SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM> > patch_level,
+                                      int& u_ao_offset,
+                                      int& p_ao_offset);
 
     //\}
 

--- a/src/navier_stokes/StaggeredStokesPETScLevelSolver.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScLevelSolver.cpp
@@ -196,17 +196,26 @@ StaggeredStokesPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVe
     IBTK_CHKERRQ(ierr);
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_b);
     IBTK_CHKERRQ(ierr);
-    StaggeredStokesPETScMatUtilities::constructPatchLevelMACStokesOp(d_petsc_mat,
-                                                                     d_U_problem_coefs,
-                                                                     d_U_bc_coefs,
-                                                                     d_new_time,
-                                                                     d_num_dofs_per_proc,
-                                                                     d_u_dof_index_idx,
-                                                                     d_p_dof_index_idx,
-                                                                     d_level);
+
     if (d_petsc_extern_mat)
     {
-        ierr = MatAXPY(d_petsc_mat, 1.0, d_petsc_extern_mat, DIFFERENT_NONZERO_PATTERN);
+        d_petsc_mat = d_petsc_extern_mat;
+        PetscObjectReference((PetscObject)d_petsc_extern_mat);
+    }
+    else
+    {
+        StaggeredStokesPETScMatUtilities::constructPatchLevelMACStokesOp(d_petsc_mat,
+                                                                         d_U_problem_coefs,
+                                                                         d_U_bc_coefs,
+                                                                         d_new_time,
+                                                                         d_num_dofs_per_proc,
+                                                                         d_u_dof_index_idx,
+                                                                         d_p_dof_index_idx,
+                                                                         d_level);
+    }
+    if (d_petsc_add_mat)
+    {
+        ierr = MatAXPY(d_petsc_mat, 1.0, d_petsc_add_mat, DIFFERENT_NONZERO_PATTERN);
         IBTK_CHKERRQ(ierr);
     }
     d_petsc_pc = d_petsc_mat;

--- a/tests/Stokes-IB/test1/input2d.shell
+++ b/tests/Stokes-IB/test1/input2d.shell
@@ -99,11 +99,10 @@ IBHierarchyIntegrator {
    {
 	num_pre_sweeps  = 1
 	num_post_sweeps = 1
-	//U_prolongation_method = "LINEAR_REFINE"
-	//P_prolongation_method = "LINEAR_REFINE"
-	//U_restriction_method  = "CONSERVATIVE_COARSEN"
-	//P_restriction_method  = "CONSERVATIVE_COARSEN"
-        smoother_type = "REDBLACK"
+        U_petsc_prolongation_method = "LINEAR"                 // "RT0"    
+        P_petsc_prolongation_method = "CONSERVATIVE"
+        rediscretize_stokes = FALSE
+        res_rediscretized_stokes = FALSE
 
 	level_solver_type   = "PETSC_LEVEL_SOLVER"
 	level_solver_rel_residual_tol = 1.0e-12


### PR DESCRIPTION
@boyceg: Check tests/Stokes-IB/test1. Galerkin Stokes-IB is not performing better than rediscretized Stokes. input2d.shell has the necessary algorithmic controls.
