### PR TITLE
add option to emit an error message if any IB points "escape" from the computational domain

### DIFF
--- a/ibtk/include/ibtk/LDataManager.h
+++ b/ibtk/include/ibtk/LDataManager.h
@@ -142,6 +142,7 @@ public:
     getManager(const std::string& name,
                const std::string& default_interp_kernel_fcn,
                const std::string& default_spread_kernel_fcn,
+               bool error_if_points_leave_domain = false,
                const SAMRAI::hier::IntVector<NDIM>& min_ghost_width = SAMRAI::hier::IntVector<NDIM>(0),
                bool register_for_restart = true);
 
@@ -902,6 +903,7 @@ protected:
     LDataManager(const std::string& object_name,
                  const std::string& default_interp_kernel_fcn,
                  const std::string& default_spread_kernel_fcn,
+                 bool error_if_points_leave_domain,
                  const SAMRAI::hier::IntVector<NDIM>& ghost_width,
                  bool register_for_restart = true);
 
@@ -1089,6 +1091,12 @@ private:
      */
     const std::string d_default_interp_kernel_fcn;
     const std::string d_default_spread_kernel_fcn;
+
+    /*
+     * Whether to emit an error message if IB points "escape" from the computational
+     * domain.
+     */
+    bool d_error_if_points_leave_domain;
 
     /*
      * SAMRAI::hier::IntVector object that determines the ghost cell width of

--- a/include/ibamr/IBMethod.h
+++ b/include/ibamr/IBMethod.h
@@ -532,6 +532,7 @@ protected:
      */
     IBTK::LDataManager* d_l_data_manager;
     std::string d_interp_kernel_fcn, d_spread_kernel_fcn;
+    bool d_error_if_points_leave_domain;
     SAMRAI::hier::IntVector<NDIM> d_ghosts;
 
     /*

--- a/include/ibamr/IMPMethod.h
+++ b/include/ibamr/IMPMethod.h
@@ -364,6 +364,7 @@ protected:
      * data on the patch hierarchy.
      */
     IBTK::LDataManager* d_l_data_manager;
+    bool d_error_if_points_leave_domain;
     SAMRAI::hier::IntVector<NDIM> d_ghosts;
 
     /*

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -165,6 +165,7 @@ IBMethod::IBMethod(const std::string& object_name, Pointer<Database> input_db, b
     // Set some default values.
     d_interp_kernel_fcn = "IB_4";
     d_spread_kernel_fcn = "IB_4";
+    d_error_if_points_leave_domain = false;
     d_ghosts = std::max(LEInteractor::getMinimumGhostWidth(d_interp_kernel_fcn),
                         LEInteractor::getMinimumGhostWidth(d_spread_kernel_fcn));
     d_force_jac_mffd = false;
@@ -186,8 +187,12 @@ IBMethod::IBMethod(const std::string& object_name, Pointer<Database> input_db, b
     }
 
     // Get the Lagrangian Data Manager.
-    d_l_data_manager = LDataManager::getManager(
-        d_object_name + "::LDataManager", d_interp_kernel_fcn, d_spread_kernel_fcn, d_ghosts, d_registered_for_restart);
+    d_l_data_manager = LDataManager::getManager(d_object_name + "::LDataManager",
+                                                d_interp_kernel_fcn,
+                                                d_spread_kernel_fcn,
+                                                d_error_if_points_leave_domain,
+                                                d_ghosts,
+                                                d_registered_for_restart);
     d_ghosts = d_l_data_manager->getGhostCellWidth();
 
     // Create the instrument panel object.
@@ -2061,6 +2066,8 @@ IBMethod::getFromInput(Pointer<Database> db, bool is_from_restart)
         if (db->isBool("normalize_source_strength"))
             d_normalize_source_strength = db->getBool("normalize_source_strength");
     }
+    if (db->keyExists("error_if_points_leave_domain"))
+        d_error_if_points_leave_domain = db->getBool("error_if_points_leave_domain");
     if (db->keyExists("force_jac_mffd")) d_force_jac_mffd = db->getBool("force_jac_mffd");
     if (db->keyExists("do_log"))
         d_do_log = db->getBool("do_log");

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -193,6 +193,7 @@ IMPMethod::IMPMethod(const std::string& object_name, Pointer<Database> input_db,
     d_silo_writer = NULL;
 
     // Set some default values.
+    d_error_if_points_leave_domain = false;
     d_ghosts = LEInteractor::getMinimumGhostWidth(KERNEL_FCN);
     d_do_log = false;
 
@@ -202,8 +203,12 @@ IMPMethod::IMPMethod(const std::string& object_name, Pointer<Database> input_db,
     if (input_db) getFromInput(input_db, from_restart);
 
     // Get the Lagrangian Data Manager.
-    d_l_data_manager = LDataManager::getManager(
-        d_object_name + "::LDataManager", KERNEL_FCN, KERNEL_FCN, d_ghosts, d_registered_for_restart);
+    d_l_data_manager = LDataManager::getManager(d_object_name + "::LDataManager",
+                                                KERNEL_FCN,
+                                                KERNEL_FCN,
+                                                d_error_if_points_leave_domain,
+                                                d_ghosts,
+                                                d_registered_for_restart);
     d_ghosts = d_l_data_manager->getGhostCellWidth();
 
     // Reset the current time step interval.
@@ -1257,6 +1262,8 @@ IMPMethod::getFromInput(Pointer<Database> db, bool is_from_restart)
             d_ghosts = static_cast<int>(std::ceil(db->getDouble("min_ghost_cell_width")));
         }
     }
+    if (db->keyExists("error_if_points_leave_domain"))
+        d_error_if_points_leave_domain = db->getBool("error_if_points_leave_domain");
     if (db->keyExists("do_log"))
         d_do_log = db->getBool("do_log");
     else if (db->keyExists("enable_logging"))


### PR DESCRIPTION
This is optional (off by default) and only applies to non-periodic boundaries.