### PR TITLE
changing PETScSAMRAIVectorReal API for getting/restoring SAMRAI vectors

### DIFF
--- a/ibtk/include/ibtk/PETScSAMRAIVectorReal.h
+++ b/ibtk/include/ibtk/PETScSAMRAIVectorReal.h
@@ -100,10 +100,37 @@ public:
     static void destroyPETScVector(Vec petsc_vec);
 
     /*!
-     * Return pointer to the SAMRAI vector object associated with the given
+     * Get a pointer to the SAMRAI vector object associated with the given
      * PETSc vector object.
+     *
+     * \note The SAMRAI vector must be restored by calling restoreSAMRAIVector().
      */
-    static SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, PetscScalar> > getSAMRAIVector(Vec petsc_vec);
+    static void getSAMRAIVector(Vec petsc_vec,
+                                SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, PetscScalar> >* samrai_vec);
+
+    /*!
+     * Restore the SAMRAI vector object associated with the given PETSc vector object.
+     */
+    static void
+    restoreSAMRAIVector(Vec petsc_vec,
+                        SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, PetscScalar> >* samrai_vec);
+
+    /*!
+     * Get a pointer to the SAMRAI vector object associated with the given
+     * PETSc vector object.  This vector must be treated as read only.
+     *
+     * \note The SAMRAI vector must be restored by calling restoreSAMRAIVectorRead().
+     */
+    static void
+    getSAMRAIVectorRead(Vec petsc_vec,
+                        SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, PetscScalar> >* samrai_vec);
+
+    /*!
+     * Restore the SAMRAI vector object associated with the given PETSc vector object.
+     */
+    static void
+    restoreSAMRAIVectorRead(Vec petsc_vec,
+                            SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, PetscScalar> >* samrai_vec);
 
     /*!
      * Replace the SAMRAI vector object associated with the given PETSc vector
@@ -170,6 +197,69 @@ private:
 
     static PetscErrorCode VecDestroy_SAMRAI(Vec v);
 
+    static PetscErrorCode VecDuplicateVecs_SAMRAI(Vec v, PetscInt m, Vec* V[]);
+
+    static PetscErrorCode VecDestroyVecs_SAMRAI(PetscInt m, Vec vv[]);
+
+    static PetscErrorCode VecDot_SAMRAI(Vec x, Vec y, PetscScalar* val);
+
+    static PetscErrorCode VecMDot_SAMRAI(Vec x, PetscInt nv, const Vec* y, PetscScalar* val);
+
+    static PetscErrorCode VecNorm_SAMRAI(Vec x, NormType type, PetscScalar* val);
+
+    static PetscErrorCode VecTDot_SAMRAI(Vec x, Vec y, PetscScalar* val);
+
+    static PetscErrorCode VecMTDot_SAMRAI(Vec x, PetscInt nv, const Vec* y, PetscScalar* val);
+
+    static PetscErrorCode VecScale_SAMRAI(Vec x, PetscScalar alpha);
+
+    static PetscErrorCode VecCopy_SAMRAI(Vec x, Vec y);
+
+    static PetscErrorCode VecSet_SAMRAI(Vec x, PetscScalar alpha);
+
+    static PetscErrorCode VecSwap_SAMRAI(Vec x, Vec y);
+
+    static PetscErrorCode VecAXPY_SAMRAI(Vec y, PetscScalar alpha, Vec x);
+
+    static PetscErrorCode VecAXPBY_SAMRAI(Vec y, PetscScalar alpha, PetscScalar beta, Vec x);
+
+    static PetscErrorCode VecMAXPY_SAMRAI(Vec y, PetscInt nv, const PetscScalar* alpha, Vec* x);
+
+    static PetscErrorCode VecAYPX_SAMRAI(Vec y, const PetscScalar alpha, Vec x);
+
+    static PetscErrorCode VecWAXPY_SAMRAI(Vec w, PetscScalar alpha, Vec x, Vec y);
+
+    static PetscErrorCode
+    VecAXPBYPCZ_SAMRAI(Vec z, PetscScalar alpha, PetscScalar beta, PetscScalar gamma, Vec x, Vec y);
+
+    static PetscErrorCode VecPointwiseMult_SAMRAI(Vec w, Vec x, Vec y);
+
+    static PetscErrorCode VecPointwiseDivide_SAMRAI(Vec w, Vec x, Vec y);
+
+    static PetscErrorCode VecGetSize_SAMRAI(Vec v, PetscInt* size);
+
+    static PetscErrorCode VecGetLocalSize_SAMRAI(Vec v, PetscInt* size);
+
+    static PetscErrorCode VecMax_SAMRAI(Vec x, PetscInt* p, PetscScalar* val);
+
+    static PetscErrorCode VecMin_SAMRAI(Vec x, PetscInt* p, PetscScalar* val);
+
+    static PetscErrorCode VecSetRandom_SAMRAI(Vec x, PetscRandom rctx);
+
+    static PetscErrorCode VecDot_local_SAMRAI(Vec x, Vec y, PetscScalar* val);
+
+    static PetscErrorCode VecTDot_local_SAMRAI(Vec x, Vec y, PetscScalar* val);
+
+    static PetscErrorCode VecNorm_local_SAMRAI(Vec x, NormType type, PetscScalar* val);
+
+    static PetscErrorCode VecMDot_local_SAMRAI(Vec x, PetscInt nv, const Vec* y, PetscScalar* val);
+
+    static PetscErrorCode VecMTDot_local_SAMRAI(Vec x, PetscInt nv, const Vec* y, PetscScalar* val);
+
+    static PetscErrorCode VecMaxPointwiseDivide_SAMRAI(Vec x, Vec y, PetscScalar* max);
+
+    static PetscErrorCode VecDotNorm2_SAMRAI(Vec s, Vec t, PetscScalar* dp, PetscScalar* nm);
+
     /*
      * Vector data is maintained in the SAMRAI vector structure.
      */
@@ -179,7 +269,7 @@ private:
      * PETSc vector object corresponding to this PETScAbstractVectorReal object.
      */
     Vec d_petsc_vector;
-    bool d_vector_created_via_duplicate;
+    bool d_vector_created_via_duplicate, d_vector_checked_out_read_write, d_vector_checked_out_read;
 };
 } // namespace IBTK
 

--- a/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
@@ -823,7 +823,7 @@ PETScKrylovLinearSolver::MatVecMult_SAMRAI(Mat A, Vec x, Vec y)
     int ierr;
     void* p_ctx;
     ierr = MatShellGetContext(A, &p_ctx);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     PETScKrylovLinearSolver* krylov_solver = static_cast<PETScKrylovLinearSolver*>(p_ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(krylov_solver);
@@ -844,7 +844,7 @@ PETScKrylovLinearSolver::PCApply_SAMRAI(PC pc, Vec x, Vec y)
     int ierr;
     void* ctx;
     ierr = PCShellGetContext(pc, &ctx);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     PETScKrylovLinearSolver* krylov_solver = static_cast<PETScKrylovLinearSolver*>(ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(krylov_solver);

--- a/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
@@ -829,9 +829,12 @@ PETScKrylovLinearSolver::MatVecMult_SAMRAI(Mat A, Vec x, Vec y)
     TBOX_ASSERT(krylov_solver);
     TBOX_ASSERT(krylov_solver->d_A);
 #endif
-    krylov_solver->d_A->apply(*PETScSAMRAIVectorReal::getSAMRAIVector(x), *PETScSAMRAIVectorReal::getSAMRAIVector(y));
-    ierr = PetscObjectStateIncrease(reinterpret_cast<PetscObject>(y));
-    IBTK_CHKERRQ(ierr);
+    Pointer<SAMRAIVectorReal<NDIM, double> > samrai_x, samrai_y;
+    PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &samrai_x);
+    PETScSAMRAIVectorReal::getSAMRAIVector(y, &samrai_y);
+    krylov_solver->d_A->apply(*samrai_x, *samrai_y);
+    PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &samrai_x);
+    PETScSAMRAIVectorReal::restoreSAMRAIVector(y, &samrai_y);
     PetscFunctionReturn(0);
 } // MatVecMult_SAMRAI
 
@@ -853,10 +856,12 @@ PETScKrylovLinearSolver::PCApply_SAMRAI(PC pc, Vec x, Vec y)
     krylov_solver->d_pc_solver->setInitialGuessNonzero(false);
 
     // Apply the preconditioner.
-    krylov_solver->d_pc_solver->solveSystem(*PETScSAMRAIVectorReal::getSAMRAIVector(y),
-                                            *PETScSAMRAIVectorReal::getSAMRAIVector(x));
-    ierr = PetscObjectStateIncrease(reinterpret_cast<PetscObject>(y));
-    IBTK_CHKERRQ(ierr);
+    Pointer<SAMRAIVectorReal<NDIM, double> > samrai_x, samrai_y;
+    PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &samrai_x);
+    PETScSAMRAIVectorReal::getSAMRAIVector(y, &samrai_y);
+    krylov_solver->d_pc_solver->solveSystem(*samrai_y, *samrai_x);
+    PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &samrai_x);
+    PETScSAMRAIVectorReal::restoreSAMRAIVector(y, &samrai_y);
 
     // Reset the configuration of the preconditioner object.
     krylov_solver->d_pc_solver->setInitialGuessNonzero(pc_initial_guess_nonzero);

--- a/ibtk/src/solvers/impls/PETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScLevelSolver.cpp
@@ -835,7 +835,7 @@ PETScLevelSolver::PCApply_Additive(PC pc, Vec x, Vec y)
     int ierr;
     void* ctx;
     ierr = PCShellGetContext(pc, &ctx);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     PETScLevelSolver* solver = static_cast<PETScLevelSolver*>(ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(solver);
@@ -853,24 +853,24 @@ PETScLevelSolver::PCApply_Additive(PC pc, Vec x, Vec y)
     for (int i = 0; i < n_subdomains_max; ++i)
     {
         ierr = VecScatterBegin(restriction[i], x, sub_x[i], INSERT_VALUES, SCATTER_FORWARD);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
     }
     for (int i = 0; i < n_subdomains_max; ++i)
     {
         ierr = VecScatterEnd(restriction[i], x, sub_x[i], INSERT_VALUES, SCATTER_FORWARD);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
         if (i < n_local_subdomains)
         {
             ierr = KSPSolve(sub_ksp[i], sub_x[i], sub_y[i]);
-            IBTK_CHKERRQ(ierr);
+            CHKERRQ(ierr);
         }
         ierr = VecScatterBegin(prolongation[i], sub_y[i], y, INSERT_VALUES, SCATTER_FORWARD_LOCAL);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
     }
     for (int i = 0; i < n_subdomains_max; ++i)
     {
         ierr = VecScatterEnd(prolongation[i], sub_y[i], y, INSERT_VALUES, SCATTER_FORWARD_LOCAL);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
     }
     PetscFunctionReturn(0);
 } // PCApply_Additive
@@ -881,13 +881,13 @@ PETScLevelSolver::PCApply_Multiplicative(PC pc, Vec x, Vec y)
     int ierr;
     void* ctx;
     ierr = PCShellGetContext(pc, &ctx);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     PETScLevelSolver* solver = static_cast<PETScLevelSolver*>(ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(solver);
 #endif
     ierr = VecZeroEntries(y);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     Vec local_y = solver->d_local_y;
     const int n_local_subdomains = solver->d_n_local_subdomains;
     const int n_subdomains_max = solver->d_n_subdomains_max;
@@ -903,30 +903,30 @@ PETScLevelSolver::PCApply_Multiplicative(PC pc, Vec x, Vec y)
     for (int i = 0; i < n_subdomains_max; ++i)
     {
         ierr = VecScatterBegin(restriction[i], x, sub_x[i], INSERT_VALUES, SCATTER_FORWARD);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
     }
     for (int i = 0; i < n_subdomains_max; ++i)
     {
         ierr = VecScatterEnd(restriction[i], x, sub_x[i], INSERT_VALUES, SCATTER_FORWARD);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
         if (i < n_local_subdomains)
         {
             if (i > 0)
             {
                 ierr = VecGetLocalVectorRead(y, local_y);
-                IBTK_CHKERRQ(ierr);
+                CHKERRQ(ierr);
                 ierr = MatMultAdd(sub_bc_mat[i], local_y, sub_x[i], sub_x[i]);
-                IBTK_CHKERRQ(ierr);
+                CHKERRQ(ierr);
                 ierr = VecRestoreLocalVectorRead(y, local_y);
-                IBTK_CHKERRQ(ierr);
+                CHKERRQ(ierr);
             }
             ierr = KSPSolve(sub_ksp[i], sub_x[i], sub_y[i]);
-            IBTK_CHKERRQ(ierr);
+            CHKERRQ(ierr);
         }
         ierr = VecScatterBegin(prolongation[i], sub_y[i], y, INSERT_VALUES, SCATTER_FORWARD_LOCAL);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
         ierr = VecScatterEnd(prolongation[i], sub_y[i], y, INSERT_VALUES, SCATTER_FORWARD_LOCAL);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
     }
     PetscFunctionReturn(0);
 } // PCApply_Multiplicative

--- a/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
@@ -122,8 +122,7 @@ PETScNewtonKrylovSolver::PETScNewtonKrylovSolver(const std::string& object_name,
 
     // Common constructor functionality.
     common_ctor();
-    return;
-} // PETScNewtonKrylovSolver()
+}
 
 PETScNewtonKrylovSolver::PETScNewtonKrylovSolver(const std::string& object_name, const SNES& petsc_snes)
     : d_reinitializing_solver(false),
@@ -141,8 +140,7 @@ PETScNewtonKrylovSolver::PETScNewtonKrylovSolver(const std::string& object_name,
     GeneralSolver::init(object_name, /*homogeneous_bc*/ false);
     if (d_petsc_snes) resetWrappedSNES(d_petsc_snes);
     common_ctor();
-    return;
-} // PETScNewtonKrylovSolver()
+}
 
 PETScNewtonKrylovSolver::~PETScNewtonKrylovSolver()
 {
@@ -162,21 +160,19 @@ PETScNewtonKrylovSolver::~PETScNewtonKrylovSolver()
         IBTK_CHKERRQ(ierr);
         d_petsc_snes = NULL;
     }
-    return;
-} // ~PETScNewtonKrylovSolver()
+}
 
 void
 PETScNewtonKrylovSolver::setOptionsPrefix(const std::string& options_prefix)
 {
     d_options_prefix = options_prefix;
-    return;
-} // setOptionsPrefix
+}
 
 const SNES&
 PETScNewtonKrylovSolver::getPETScSNES() const
 {
     return d_petsc_snes;
-} // getPETScSNES
+}
 
 void
 PETScNewtonKrylovSolver::setOperator(Pointer<GeneralOperator> F)
@@ -184,8 +180,7 @@ PETScNewtonKrylovSolver::setOperator(Pointer<GeneralOperator> F)
     NewtonKrylovSolver::setOperator(F);
     d_user_provided_function = true;
     resetSNESFunction();
-    return;
-} // setOperator
+}
 
 Pointer<SAMRAIVectorReal<NDIM, double> >
 PETScNewtonKrylovSolver::getSolutionVector() const
@@ -193,8 +188,12 @@ PETScNewtonKrylovSolver::getSolutionVector() const
     Vec petsc_x;
     int ierr = SNESGetSolution(d_petsc_snes, &petsc_x);
     IBTK_CHKERRQ(ierr);
-    return PETScSAMRAIVectorReal::getSAMRAIVector(petsc_x);
-} // getSolutionVector
+    Pointer<SAMRAIVectorReal<NDIM, double> > samrai_x;
+    PETScSAMRAIVectorReal::getSAMRAIVectorRead(petsc_x, &samrai_x);
+    Pointer<SAMRAIVectorReal<NDIM, double> > samrai_x_ptr(samrai_x, false);
+    PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(petsc_x, &samrai_x);
+    return samrai_x_ptr;
+}
 
 Pointer<SAMRAIVectorReal<NDIM, double> >
 PETScNewtonKrylovSolver::getFunctionVector() const
@@ -202,8 +201,12 @@ PETScNewtonKrylovSolver::getFunctionVector() const
     Vec petsc_f;
     int ierr = SNESGetFunction(d_petsc_snes, &petsc_f, NULL, NULL);
     IBTK_CHKERRQ(ierr);
-    return PETScSAMRAIVectorReal::getSAMRAIVector(petsc_f);
-} // getFunctionVector
+    Pointer<SAMRAIVectorReal<NDIM, double> > samrai_f;
+    PETScSAMRAIVectorReal::getSAMRAIVectorRead(petsc_f, &samrai_f);
+    Pointer<SAMRAIVectorReal<NDIM, double> > samrai_f_ptr(samrai_f, false);
+    PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(petsc_f, &samrai_f);
+    return samrai_f_ptr;
+}
 
 void
 PETScNewtonKrylovSolver::setJacobian(Pointer<JacobianOperator> J)
@@ -211,8 +214,7 @@ PETScNewtonKrylovSolver::setJacobian(Pointer<JacobianOperator> J)
     NewtonKrylovSolver::setJacobian(J);
     d_user_provided_jacobian = true;
     resetSNESJacobian();
-    return;
-} // setJacobian
+}
 
 bool
 PETScNewtonKrylovSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVectorReal<NDIM, double>& b)
@@ -275,7 +277,7 @@ PETScNewtonKrylovSolver::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVe
 
     IBTK_TIMER_STOP(t_solve_system);
     return converged;
-} // solveSystem
+}
 
 void
 PETScNewtonKrylovSolver::initializeSolverState(const SAMRAIVectorReal<NDIM, double>& x,
@@ -285,7 +287,6 @@ PETScNewtonKrylovSolver::initializeSolverState(const SAMRAIVectorReal<NDIM, doub
 
     int ierr;
 
-// Rudimentary error checking.
 #if !defined(NDEBUG)
     if (x.getNumberOfComponents() != b.getNumberOfComponents())
     {
@@ -413,8 +414,7 @@ PETScNewtonKrylovSolver::initializeSolverState(const SAMRAIVectorReal<NDIM, doub
     d_is_initialized = true;
 
     IBTK_TIMER_STOP(t_initialize_solver_state);
-    return;
-} // initializeSolverState
+}
 
 void
 PETScNewtonKrylovSolver::deallocateSolverState()
@@ -462,8 +462,7 @@ PETScNewtonKrylovSolver::deallocateSolverState()
     d_is_initialized = false;
 
     IBTK_TIMER_STOP(t_deallocate_solver_state);
-    return;
-} // deallocateSolverState
+}
 
 /////////////////////////////// PRIVATE //////////////////////////////////////
 
@@ -483,8 +482,7 @@ PETScNewtonKrylovSolver::common_ctor()
                      TimerManager::getManager()->getTimer("IBTK::PETScNewtonKrylovSolver::initializeOperatorState()");
                  t_deallocate_solver_state =
                      TimerManager::getManager()->getTimer("IBTK::PETScNewtonKrylovSolver::deallocateOperatorState()"););
-    return;
-} // common_ctor
+}
 
 void
 PETScNewtonKrylovSolver::reportSNESConvergedReason(const SNESConvergedReason& reason, std::ostream& os) const
@@ -538,8 +536,7 @@ PETScNewtonKrylovSolver::reportSNESConvergedReason(const SNESConvergedReason& re
         os << d_object_name << ": unknown completion code " << static_cast<int>(reason) << " reported.\n";
         break;
     }
-    return;
-} // reportSNESConvergedReason
+}
 
 void
 PETScNewtonKrylovSolver::resetWrappedSNES(SNES& petsc_snes)
@@ -580,7 +577,9 @@ PETScNewtonKrylovSolver::resetWrappedSNES(SNES& petsc_snes)
     }
 
     if (d_user_provided_jacobian)
+    {
         resetSNESJacobian();
+    }
     else
     {
         // Create a JacobianOperator wrapper to correspond to the SNES Jacobian.
@@ -608,8 +607,7 @@ PETScNewtonKrylovSolver::resetWrappedSNES(SNES& petsc_snes)
     ierr = SNESGetTolerances(
         d_petsc_snes, &d_abs_residual_tol, &d_rel_residual_tol, &d_solution_tol, &d_max_iterations, &d_max_evaluations);
     IBTK_CHKERRQ(ierr);
-    return;
-} // resetWrappedSNES
+}
 
 void
 PETScNewtonKrylovSolver::resetSNESOptions()
@@ -618,8 +616,7 @@ PETScNewtonKrylovSolver::resetSNESOptions()
     int ierr = SNESSetTolerances(
         d_petsc_snes, d_abs_residual_tol, d_rel_residual_tol, d_solution_tol, d_max_iterations, d_max_evaluations);
     IBTK_CHKERRQ(ierr);
-    return;
-} // resetSNESSNESOptions
+}
 
 void
 PETScNewtonKrylovSolver::resetSNESFunction()
@@ -628,8 +625,7 @@ PETScNewtonKrylovSolver::resetSNESFunction()
     int ierr = SNESSetFunction(
         d_petsc_snes, d_petsc_r, PETScNewtonKrylovSolver::FormFunction_SAMRAI, static_cast<void*>(this));
     IBTK_CHKERRQ(ierr);
-    return;
-} // resetSNESFunction
+}
 
 void
 PETScNewtonKrylovSolver::resetSNESJacobian()
@@ -673,23 +669,24 @@ PETScNewtonKrylovSolver::resetSNESJacobian()
     ierr = SNESSetJacobian(
         d_petsc_snes, d_petsc_jac, d_petsc_jac, PETScNewtonKrylovSolver::FormJacobian_SAMRAI, static_cast<void*>(this));
     IBTK_CHKERRQ(ierr);
-    return;
-} // resetSNESJacobian
+}
 
 PetscErrorCode
 PETScNewtonKrylovSolver::FormFunction_SAMRAI(SNES /*snes*/, Vec x, Vec f, void* p_ctx)
 {
-    int ierr;
     PETScNewtonKrylovSolver* newton_solver = static_cast<PETScNewtonKrylovSolver*>(p_ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(newton_solver);
     TBOX_ASSERT(newton_solver->d_F);
 #endif
-    newton_solver->d_F->apply(*PETScSAMRAIVectorReal::getSAMRAIVector(x), *PETScSAMRAIVectorReal::getSAMRAIVector(f));
-    ierr = PetscObjectStateIncrease(reinterpret_cast<PetscObject>(f));
-    IBTK_CHKERRQ(ierr);
+    Pointer<SAMRAIVectorReal<NDIM, double> > samrai_x, samrai_f;
+    PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &samrai_x);
+    PETScSAMRAIVectorReal::getSAMRAIVector(f, &samrai_f);
+    newton_solver->d_F->apply(*samrai_x, *samrai_f);
+    PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &samrai_x);
+    PETScSAMRAIVectorReal::restoreSAMRAIVector(f, &samrai_f);
     PetscFunctionReturn(0);
-} // FormFunction_SAMRAI
+}
 
 PetscErrorCode
 PETScNewtonKrylovSolver::FormJacobian_SAMRAI(SNES snes, Vec x, Mat A, Mat /*B*/, void* p_ctx)
@@ -701,7 +698,10 @@ PETScNewtonKrylovSolver::FormJacobian_SAMRAI(SNES snes, Vec x, Mat A, Mat /*B*/,
 #endif
     if (newton_solver->d_J)
     {
-        newton_solver->d_J->formJacobian(*PETScSAMRAIVectorReal::getSAMRAIVector(x));
+        Pointer<SAMRAIVectorReal<NDIM, double> > samrai_x;
+        PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &samrai_x);
+        newton_solver->d_J->formJacobian(*samrai_x);
+        PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &samrai_x);
     }
     else
     {
@@ -718,7 +718,7 @@ PETScNewtonKrylovSolver::FormJacobian_SAMRAI(SNES snes, Vec x, Mat A, Mat /*B*/,
         IBTK_CHKERRQ(ierr);
     }
     PetscFunctionReturn(0);
-} // FormJacobian_SAMRAI
+}
 
 PetscErrorCode
 PETScNewtonKrylovSolver::MatVecMult_SAMRAI(Mat A, Vec x, Vec y)
@@ -732,11 +732,14 @@ PETScNewtonKrylovSolver::MatVecMult_SAMRAI(Mat A, Vec x, Vec y)
     TBOX_ASSERT(newton_solver);
     TBOX_ASSERT(newton_solver->d_J);
 #endif
-    newton_solver->d_J->apply(*PETScSAMRAIVectorReal::getSAMRAIVector(x), *PETScSAMRAIVectorReal::getSAMRAIVector(y));
-    ierr = PetscObjectStateIncrease(reinterpret_cast<PetscObject>(y));
-    IBTK_CHKERRQ(ierr);
+    Pointer<SAMRAIVectorReal<NDIM, double> > samrai_x, samrai_y;
+    PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &samrai_x);
+    PETScSAMRAIVectorReal::getSAMRAIVector(y, &samrai_y);
+    newton_solver->d_J->apply(*samrai_x, *samrai_y);
+    PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &samrai_x);
+    PETScSAMRAIVectorReal::restoreSAMRAIVector(y, &samrai_y);
     PetscFunctionReturn(0);
-} // MatVecMult_SAMRAI
+}
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
@@ -707,15 +707,15 @@ PETScNewtonKrylovSolver::FormJacobian_SAMRAI(SNES snes, Vec x, Mat A, Mat /*B*/,
     {
         Vec u, f;
         ierr = SNESGetSolution(snes, &u);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
         ierr = SNESGetFunction(snes, &f, NULL, NULL);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
         ierr = MatMFFDSetBase(A, u, f);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
         ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
         ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
-        IBTK_CHKERRQ(ierr);
+        CHKERRQ(ierr);
     }
     PetscFunctionReturn(0);
 }
@@ -726,7 +726,7 @@ PETScNewtonKrylovSolver::MatVecMult_SAMRAI(Mat A, Vec x, Vec y)
     int ierr;
     void* p_ctx;
     ierr = MatShellGetContext(A, &p_ctx);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     PETScNewtonKrylovSolver* newton_solver = static_cast<PETScNewtonKrylovSolver*>(p_ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(newton_solver);

--- a/ibtk/src/solvers/wrappers/PETScSNESJacobianJOWrapper.cpp
+++ b/ibtk/src/solvers/wrappers/PETScSNESJacobianJOWrapper.cpp
@@ -76,31 +76,29 @@ PETScSNESJacobianJOWrapper::PETScSNESJacobianJOWrapper(
       d_petsc_z(NULL)
 {
     // intentionally blank
-    return;
-} // PETScSNESJacobianJOWrapper()
+}
 
 PETScSNESJacobianJOWrapper::~PETScSNESJacobianJOWrapper()
 {
     if (d_is_initialized) deallocateOperatorState();
-    return;
-} // ~PETScSNESJacobianJOWrapper()
+}
 
 const SNES&
 PETScSNESJacobianJOWrapper::getPETScSNES() const
 {
     return d_petsc_snes;
-} // getPETScSNES
+}
 
 PetscErrorCode (*PETScSNESJacobianJOWrapper::getPETScSNESFormJacobian())(SNES, Vec, Mat, Mat, void*)
 {
     return d_petsc_snes_form_jac;
-} // getPETScSNESFormJacobian
+}
 
 void*
 PETScSNESJacobianJOWrapper::getPETScSNESJacobianContext() const
 {
     return d_petsc_snes_jac_ctx;
-} // getPETScSNESJacobianContext
+}
 
 void
 PETScSNESJacobianJOWrapper::formJacobian(SAMRAIVectorReal<NDIM, double>& x)
@@ -115,8 +113,7 @@ PETScSNESJacobianJOWrapper::formJacobian(SAMRAIVectorReal<NDIM, double>& x)
     // Destroy the PETSc Vec wrappers.
     PETScSAMRAIVectorReal::destroyPETScVector(petsc_x);
     petsc_x = NULL;
-    return;
-} // formJacobian
+}
 
 Pointer<SAMRAIVectorReal<NDIM, double> >
 PETScSNESJacobianJOWrapper::getBaseVector() const
@@ -124,8 +121,12 @@ PETScSNESJacobianJOWrapper::getBaseVector() const
     Vec petsc_x;
     int ierr = SNESGetSolution(d_petsc_snes, &petsc_x);
     IBTK_CHKERRQ(ierr);
-    return PETScSAMRAIVectorReal::getSAMRAIVector(petsc_x);
-} // getBaseVector
+    Pointer<SAMRAIVectorReal<NDIM, double> > samrai_x;
+    PETScSAMRAIVectorReal::getSAMRAIVectorRead(petsc_x, &samrai_x);
+    Pointer<SAMRAIVectorReal<NDIM, double> > samrai_x_ptr = samrai_x;
+    PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(petsc_x, &samrai_x);
+    return samrai_x_ptr;
+}
 
 void
 PETScSNESJacobianJOWrapper::apply(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVectorReal<NDIM, double>& y)
@@ -140,7 +141,7 @@ PETScSNESJacobianJOWrapper::apply(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVecto
     int ierr = MatMult(d_petsc_snes_jac, d_petsc_x, d_petsc_y);
     IBTK_CHKERRQ(ierr);
     return;
-} // apply
+}
 
 void
 PETScSNESJacobianJOWrapper::applyAdd(SAMRAIVectorReal<NDIM, double>& x,
@@ -157,8 +158,7 @@ PETScSNESJacobianJOWrapper::applyAdd(SAMRAIVectorReal<NDIM, double>& x,
     // Apply the operator.
     int ierr = MatMultAdd(d_petsc_snes_jac, d_petsc_x, d_petsc_y, d_petsc_z);
     IBTK_CHKERRQ(ierr);
-    return;
-} // applyAdd
+}
 
 void
 PETScSNESJacobianJOWrapper::initializeOperatorState(const SAMRAIVectorReal<NDIM, double>& in,
@@ -175,8 +175,7 @@ PETScSNESJacobianJOWrapper::initializeOperatorState(const SAMRAIVectorReal<NDIM,
     d_petsc_y = PETScSAMRAIVectorReal::createPETScVector(d_y, comm);
     d_petsc_z = PETScSAMRAIVectorReal::createPETScVector(d_z, comm);
     d_is_initialized = true;
-    return;
-} // initializeOperatorState
+}
 
 void
 PETScSNESJacobianJOWrapper::deallocateOperatorState()
@@ -192,8 +191,7 @@ PETScSNESJacobianJOWrapper::deallocateOperatorState()
     d_z->freeVectorComponents();
     d_z.setNull();
     d_is_initialized = false;
-    return;
-} // deallocateOperatorState
+}
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/src/IB/CIBSaddlePointSolver.cpp
+++ b/src/IB/CIBSaddlePointSolver.cpp
@@ -489,10 +489,13 @@ CIBSaddlePointSolver::initializeSolverState(Vec x, Vec b)
     VecDuplicate(b, &d_petsc_b);
 
     // Initialize various operators and solvers.
-    d_A->initializeOperatorState(*IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0]),
-                                 *IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vb[0]));
-    initializeStokesSolver(*IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0]),
-                           *IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vb[0]));
+    Pointer<SAMRAIVectorReal<NDIM, double> > vx0, vb0;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0], &vx0);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vb[0], &vb0);
+    d_A->initializeOperatorState(*vx0, *vb0);
+    initializeStokesSolver(*vx0, *vb0);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vx[0], &vx0);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vb[0], &vb0);
 
     d_mob_solver->initializeSolverState(x, b);
 
@@ -500,10 +503,12 @@ CIBSaddlePointSolver::initializeSolverState(Vec x, Vec b)
     initializeKSP();
 
     // Get hierarchy information.
-    d_hierarchy = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->getPatchHierarchy();
-    const int u_data_idx = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->getComponentDescriptorIndex(0);
-    const int coarsest_ln = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->getCoarsestLevelNumber();
-    const int finest_ln = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->getFinestLevelNumber();
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0], &vx0);
+    d_hierarchy = vx0->getPatchHierarchy();
+    const int u_data_idx = vx0->getComponentDescriptorIndex(0);
+    const int coarsest_ln = vx0->getCoarsestLevelNumber();
+    const int finest_ln = vx0->getFinestLevelNumber();
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vx[0], &vx0);
 
     // Setup the interpolation transaction information.
     d_fill_pattern = NULL;
@@ -989,11 +994,15 @@ CIBSaddlePointSolver::PCApply_SaddlePoint(PC pc, Vec x, Vec y)
     VecNestGetSubVecs(y, &total_comps, &vy);
     VecGetSize(vx[2], &free_comps);
 
+    Pointer<SAMRAIVectorReal<NDIM, double> > vx0, vy0;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0], &vx0);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vy[0], &vy0);
+
     // Get the individual components.
-    Pointer<SAMRAIVectorReal<NDIM, double> > g_h = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->cloneVector("");
+    Pointer<SAMRAIVectorReal<NDIM, double> > g_h = vx0->cloneVector("");
     g_h->allocateVectorData();
-    g_h->copyVector(IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0]));
-    Pointer<SAMRAIVectorReal<NDIM, double> > u_p = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vy[0]);
+    g_h->copyVector(vx0);
+    Pointer<SAMRAIVectorReal<NDIM, double> > u_p = vy0;
 
     Vec W, Lambda, F_tilde;
     W = vx[1];
@@ -1103,6 +1112,9 @@ CIBSaddlePointSolver::PCApply_SaddlePoint(PC pc, Vec x, Vec y)
         VecDestroy(&delU);
         VecDestroy(&F_tilde);
     }
+
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vx[0], &vx0);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vy[0], &vy0);
 
     // Report change in the state of y to PETSc
     for (int k = 0; k < total_comps; ++k)

--- a/src/IB/CIBStaggeredStokesOperator.cpp
+++ b/src/IB/CIBStaggeredStokesOperator.cpp
@@ -130,7 +130,7 @@ CIBStaggeredStokesOperator::apply(Vec x, Vec y)
     VecNestGetSubVecs(x, NULL, &vx);
     VecNestGetSubVecs(y, NULL, &vy);
     Pointer<SAMRAIVectorReal<NDIM, double> > vx0, vy0;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0], &vx0);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(vx[0], &vx0);
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vy[0], &vy0);
     SAMRAIVectorReal<NDIM, double>& u_p = *vx0;
     Vec L = vx[1];
@@ -251,7 +251,7 @@ CIBStaggeredStokesOperator::apply(Vec x, Vec y)
     // Deallocate scratch data.
     d_x->deallocateVectorData();
 
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vx[0], &vx0);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(vx[0], &vx0);
     IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vy[0], &vy0);
 
     IBAMR_TIMER_STOP(t_apply);

--- a/src/IB/CIBStaggeredStokesOperator.cpp
+++ b/src/IB/CIBStaggeredStokesOperator.cpp
@@ -129,10 +129,13 @@ CIBStaggeredStokesOperator::apply(Vec x, Vec y)
     Vec *vx, *vy;
     VecNestGetSubVecs(x, NULL, &vx);
     VecNestGetSubVecs(y, NULL, &vy);
-    SAMRAIVectorReal<NDIM, double>& u_p = *PETScSAMRAIVectorReal::getSAMRAIVector(vx[0]);
+    Pointer<SAMRAIVectorReal<NDIM, double> > vx0, vy0;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0], &vx0);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vy[0], &vy0);
+    SAMRAIVectorReal<NDIM, double>& u_p = *vx0;
     Vec L = vx[1];
     Vec U = vx[2];
-    SAMRAIVectorReal<NDIM, double>& g_f = *PETScSAMRAIVectorReal::getSAMRAIVector(vy[0]);
+    SAMRAIVectorReal<NDIM, double>& g_f = *vy0;
     Vec V = vy[1];
     Vec F = vy[2];
 
@@ -248,6 +251,9 @@ CIBStaggeredStokesOperator::apply(Vec x, Vec y)
     // Deallocate scratch data.
     d_x->deallocateVectorData();
 
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vx[0], &vx0);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vy[0], &vy0);
+
     IBAMR_TIMER_STOP(t_apply);
 } // apply
 
@@ -321,7 +327,9 @@ CIBStaggeredStokesOperator::modifyRhsForBcs(Vec y)
     // Get vectors corresponding to fluid and Lagrangian velocity.
     Vec* vy;
     VecNestGetSubVecs(y, NULL, &vy);
-    SAMRAIVectorReal<NDIM, double>& b = *PETScSAMRAIVectorReal::getSAMRAIVector(vy[0]);
+    Pointer<SAMRAIVectorReal<NDIM, double> > vy0;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vy[0], &vy0);
+    SAMRAIVectorReal<NDIM, double>& b = *vy0;
     Vec W = vy[1];
 
     // Modify RHS for fluid Bcs.
@@ -370,6 +378,7 @@ CIBStaggeredStokesOperator::modifyRhsForBcs(Vec y)
         x->freeVectorComponents();
         VecDestroy(&V);
     }
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vy[0], &vy0);
 } // modifyRhsForBcs
 
 void
@@ -377,8 +386,11 @@ CIBStaggeredStokesOperator::imposeSolBcs(Vec x)
 {
     Vec* vx;
     VecNestGetSubVecs(x, NULL, &vx);
-    SAMRAIVectorReal<NDIM, double>& u_p = *PETScSAMRAIVectorReal::getSAMRAIVector(vx[0]);
+    Pointer<SAMRAIVectorReal<NDIM, double> > vx0;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0], &vx0);
+    SAMRAIVectorReal<NDIM, double>& u_p = *vx0;
     imposeSolBcs(u_p);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vx[0], &vx0);
 } // imposeSolBcs
 
 /////////////////////////////// PROTECTED ////////////////////////////////////

--- a/src/IB/DirectMobilitySolver.cpp
+++ b/src/IB/DirectMobilitySolver.cpp
@@ -392,7 +392,6 @@ DirectMobilitySolver::solveSystem(Vec x, Vec b)
             delete[] rhs;
         }
     }
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(x));
 
     IBAMR_TIMER_STOP(t_solve_system);
 
@@ -449,7 +448,6 @@ DirectMobilitySolver::solveBodySystem(Vec x, Vec b)
             delete[] rhs;
         }
     }
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(x));
 
     IBAMR_TIMER_STOP(t_solve_body_system);
 
@@ -476,10 +474,10 @@ DirectMobilitySolver::initializeSolverState(Vec x, Vec /*b*/)
         Vec* vx;
         VecNestGetSubVecs(x, NULL, &vx);
         Pointer<SAMRAIVectorReal<NDIM, double> > vx0;
-        IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0], &vx0);
+        IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(vx[0], &vx0);
         Pointer<PatchHierarchy<NDIM> > patch_hierarchy = vx0->getPatchHierarchy();
         const int finest_ln = patch_hierarchy->getFinestLevelNumber();
-        IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vx[0], &vx0);
+        IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(vx[0], &vx0);
         Pointer<PatchLevel<NDIM> > struct_patch_level = patch_hierarchy->getPatchLevel(finest_ln);
         const IntVector<NDIM>& ratio = struct_patch_level->getRatio();
         Pointer<CartesianGridGeometry<NDIM> > grid_geom = patch_hierarchy->getGridGeometry();

--- a/src/IB/DirectMobilitySolver.cpp
+++ b/src/IB/DirectMobilitySolver.cpp
@@ -475,9 +475,11 @@ DirectMobilitySolver::initializeSolverState(Vec x, Vec /*b*/)
         // Get grid-info
         Vec* vx;
         VecNestGetSubVecs(x, NULL, &vx);
-        Pointer<PatchHierarchy<NDIM> > patch_hierarchy =
-            IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->getPatchHierarchy();
+        Pointer<SAMRAIVectorReal<NDIM, double> > vx0;
+        IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0], &vx0);
+        Pointer<PatchHierarchy<NDIM> > patch_hierarchy = vx0->getPatchHierarchy();
         const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+        IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vx[0], &vx0);
         Pointer<PatchLevel<NDIM> > struct_patch_level = patch_hierarchy->getPatchLevel(finest_ln);
         const IntVector<NDIM>& ratio = struct_patch_level->getRatio();
         Pointer<CartesianGridGeometry<NDIM> > grid_geom = patch_hierarchy->getGridGeometry();

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -919,10 +919,10 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_position(SNES /*snes*/, Vec x
 
     Vec* component_sol_vecs;
     ierr = VecNestGetSubVecs(x, NULL, &component_sol_vecs);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     Vec* component_rhs_vecs;
     ierr = VecNestGetSubVecs(f, NULL, &component_rhs_vecs);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
 
     Pointer<SAMRAIVectorReal<NDIM, double> > u, f_u;
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(component_sol_vecs[0], &u);
@@ -1141,13 +1141,13 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_position(SNES /*snes*/, 
     }
 
     ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
 
     Vec* component_sol_vecs;
     ierr = VecNestGetSubVecs(x, NULL, &component_sol_vecs);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     Vec X = component_sol_vecs[1];
     d_ib_implicit_ops->setLinearizedPosition(X, data_time);
     return ierr;
@@ -1162,15 +1162,15 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_velocity(SNES /*snes*/, 
     const double half_time = current_time + 0.5 * d_current_dt;
 
     ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
 
     // Get the estimate of X^{n+1} from the current iterate U^{n+1} and set as it as
     // a base vector in matrix-free Lagrangian force Jacobian.
     Vec X_new;
     ierr = VecDuplicate(d_X_current, &X_new);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
 
     Pointer<SAMRAIVectorReal<NDIM, double> > u;
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &u);
@@ -1206,7 +1206,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_velocity(SNES /*snes*/, 
     IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &u);
 
     ierr = VecDestroy(&X_new);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     return ierr;
 } // IBJacobianSetup_velocity
 
@@ -1216,7 +1216,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_SAMRAI(Mat A, Vec x, Vec
     PetscErrorCode ierr = 1;
     void* ctx;
     ierr = MatShellGetContext(A, &ctx);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     IBImplicitStaggeredHierarchyIntegrator* ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
     if (ib_integrator->d_solve_for_position)
     {
@@ -1241,9 +1241,9 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_position(Vec x, Vec f)
     Vec* component_sol_vecs;
     Vec* component_rhs_vecs;
     ierr = VecNestGetSubVecs(x, NULL, &component_sol_vecs);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     ierr = VecNestGetSubVecs(f, NULL, &component_rhs_vecs);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
 
     Pointer<SAMRAIVectorReal<NDIM, double> > u, f_u;
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(component_sol_vecs[0], &u);
@@ -1392,7 +1392,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBPCApply_SAMRAI(PC pc, Vec x, Vec y)
     PetscErrorCode ierr = 1;
     void* ctx;
     ierr = PCShellGetContext(pc, &ctx);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     IBImplicitStaggeredHierarchyIntegrator* ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
     if (ib_integrator->d_solve_for_position)
     {
@@ -1402,7 +1402,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBPCApply_SAMRAI(PC pc, Vec x, Vec y)
     {
         ierr = ib_integrator->IBPCApply_velocity(x, y);
     }
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     return ierr;
 } // IBPCApply_SAMRAI
 
@@ -1417,9 +1417,9 @@ IBImplicitStaggeredHierarchyIntegrator::IBPCApply_position(Vec x, Vec y)
     Vec* component_x_vecs;
     Vec* component_y_vecs;
     ierr = VecNestGetSubVecs(x, NULL, &component_x_vecs);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     ierr = VecNestGetSubVecs(y, NULL, &component_y_vecs);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
 
     Pointer<SAMRAIVectorReal<NDIM, double> > eul_x, eul_y;
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(component_x_vecs[0], &eul_x);
@@ -1494,12 +1494,12 @@ IBImplicitStaggeredHierarchyIntegrator::IBPCApply_position(Vec x, Vec y)
 
     // Step 3: lag_y := inv(Sc)*lag_y
     ierr = KSPSolve(d_schur_solver, lag_y, lag_y);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
 
     // Step 4: eul_y := eul_y + inv(L)*S*A*lag_y/2
     d_ib_implicit_ops->computeLinearizedLagrangianForce(lag_y, half_time);
     ierr = VecScale(lag_y, 0.5);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0, /*interior_only*/ false);
     d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
     d_u_phys_bdry_op->setHomogeneousBc(true); // use homogeneous BCs to define spreading at physical boundaries
@@ -1539,7 +1539,7 @@ IBImplicitStaggeredHierarchyIntegrator::lagrangianSchurApply_SAMRAI(Mat A, Vec x
     PetscErrorCode ierr;
     void* ctx;
     ierr = MatShellGetContext(A, &ctx);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     IBImplicitStaggeredHierarchyIntegrator* ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
     ierr = ib_integrator->lagrangianSchurApply(x, y);
     return ierr;

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -924,8 +924,9 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_position(SNES /*snes*/, Vec x
     ierr = VecNestGetSubVecs(f, NULL, &component_rhs_vecs);
     IBTK_CHKERRQ(ierr);
 
-    Pointer<SAMRAIVectorReal<NDIM, double> > u = PETScSAMRAIVectorReal::getSAMRAIVector(component_sol_vecs[0]);
-    Pointer<SAMRAIVectorReal<NDIM, double> > f_u = PETScSAMRAIVectorReal::getSAMRAIVector(component_rhs_vecs[0]);
+    Pointer<SAMRAIVectorReal<NDIM, double> > u, f_u;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_sol_vecs[0], &u);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_rhs_vecs[0], &f_u);
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     Pointer<VariableContext> current_ctx = d_ins_hier_integrator->getCurrentContext();
@@ -998,6 +999,8 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_position(SNES /*snes*/, Vec x
                                            getGhostfillRefineSchedules(d_object_name + "::u"),
                                            velocity_time);
     d_ib_implicit_ops->computeResidual(R);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_sol_vecs[0], &u);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_rhs_vecs[0], &f_u);
     PetscObjectStateIncrease(reinterpret_cast<PetscObject>(f));
     return ierr;
 } // IBFunction_position
@@ -1010,8 +1013,9 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_velocity(SNES /*snes*/, Vec x
     const double new_time = current_time + d_current_dt;
     const double half_time = current_time + 0.5 * d_current_dt;
 
-    Pointer<SAMRAIVectorReal<NDIM, double> > u = PETScSAMRAIVectorReal::getSAMRAIVector(x);
-    Pointer<SAMRAIVectorReal<NDIM, double> > f_u = PETScSAMRAIVectorReal::getSAMRAIVector(f);
+    Pointer<SAMRAIVectorReal<NDIM, double> > u, f_u;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(x, &u);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(f, &f_u);
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     Pointer<VariableContext> current_ctx = d_ins_hier_integrator->getCurrentContext();
@@ -1093,6 +1097,8 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_velocity(SNES /*snes*/, Vec x
     d_ib_implicit_ops->spreadForce(
         d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), force_time);
     d_hier_velocity_data_ops->axpy(f_u_idx, -kappa, d_f_idx, f_u_idx);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(x, &u);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(f, &f_u);
     PetscObjectStateIncrease(reinterpret_cast<PetscObject>(f));
     return ierr;
 } // IBFunction_velocity
@@ -1169,7 +1175,8 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_velocity(SNES /*snes*/, 
     ierr = VecDuplicate(d_X_current, &X_new);
     IBTK_CHKERRQ(ierr);
 
-    Pointer<SAMRAIVectorReal<NDIM, double> > u = PETScSAMRAIVectorReal::getSAMRAIVector(x);
+    Pointer<SAMRAIVectorReal<NDIM, double> > u;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(x, &u);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     Pointer<VariableContext> current_ctx = d_ins_hier_integrator->getCurrentContext();
     Pointer<Variable<NDIM> > u_var = d_ins_hier_integrator->getVelocityVariable();
@@ -1199,6 +1206,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_velocity(SNES /*snes*/, 
                                                      velocity_time);
     d_ib_implicit_ops->computeLinearizedResidual(d_X_current, X_new);
     d_ib_implicit_ops->setLinearizedPosition(X_new, velocity_time);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(x, &u);
 
     ierr = VecDestroy(&X_new);
     IBTK_CHKERRQ(ierr);
@@ -1240,8 +1248,9 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_position(Vec x, Vec f)
     ierr = VecNestGetSubVecs(f, NULL, &component_rhs_vecs);
     IBTK_CHKERRQ(ierr);
 
-    Pointer<SAMRAIVectorReal<NDIM, double> > u = PETScSAMRAIVectorReal::getSAMRAIVector(component_sol_vecs[0]);
-    Pointer<SAMRAIVectorReal<NDIM, double> > f_u = PETScSAMRAIVectorReal::getSAMRAIVector(component_rhs_vecs[0]);
+    Pointer<SAMRAIVectorReal<NDIM, double> > u, f_u;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_sol_vecs[0], &u);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_rhs_vecs[0], &f_u);
 
     Pointer<Variable<NDIM> > u_var = d_ins_hier_integrator->getVelocityVariable();
     const int u_idx = u->getComponentDescriptorIndex(0);
@@ -1303,6 +1312,8 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_position(Vec x, Vec f)
                                                      getGhostfillRefineSchedules(d_object_name + "::u"),
                                                      velocity_time);
     d_ib_implicit_ops->computeLinearizedResidual(X, R);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_sol_vecs[0], &u);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_rhs_vecs[0], &f_u);
     PetscObjectStateIncrease(reinterpret_cast<PetscObject>(f));
     return ierr;
 } // IBJacobianApply_position
@@ -1314,8 +1325,9 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_velocity(Vec x, Vec f)
     const double new_time = current_time + d_current_dt;
     const double half_time = current_time + 0.5 * d_current_dt;
 
-    Pointer<SAMRAIVectorReal<NDIM, double> > u = PETScSAMRAIVectorReal::getSAMRAIVector(x);
-    Pointer<SAMRAIVectorReal<NDIM, double> > f_u = PETScSAMRAIVectorReal::getSAMRAIVector(f);
+    Pointer<SAMRAIVectorReal<NDIM, double> > u, f_u;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(x, &u);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(f, &f_u);
 
     const int u_idx = u->getComponentDescriptorIndex(0);
     const int f_u_idx = f_u->getComponentDescriptorIndex(0);
@@ -1373,7 +1385,8 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_velocity(Vec x, Vec f)
     d_ib_implicit_ops->spreadLinearizedForce(
         d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), force_time);
     d_hier_velocity_data_ops->axpy(f_u_idx, -kappa, d_f_idx, f_u_idx);
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(f));
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(x, &u);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(f, &f_u);
     return 0;
 } // IBJacobianApply_velocity
 
@@ -1412,8 +1425,9 @@ IBImplicitStaggeredHierarchyIntegrator::IBPCApply_position(Vec x, Vec y)
     ierr = VecNestGetSubVecs(y, NULL, &component_y_vecs);
     IBTK_CHKERRQ(ierr);
 
-    Pointer<SAMRAIVectorReal<NDIM, double> > eul_x = PETScSAMRAIVectorReal::getSAMRAIVector(component_x_vecs[0]);
-    Pointer<SAMRAIVectorReal<NDIM, double> > eul_y = PETScSAMRAIVectorReal::getSAMRAIVector(component_y_vecs[0]);
+    Pointer<SAMRAIVectorReal<NDIM, double> > eul_x, eul_y;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_x_vecs[0], &eul_x);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_y_vecs[0], &eul_y);
 
     Vec lag_x = component_x_vecs[1];
     Vec lag_y = component_y_vecs[1];
@@ -1509,14 +1523,17 @@ IBImplicitStaggeredHierarchyIntegrator::IBPCApply_position(Vec x, Vec y)
 PetscErrorCode
 IBImplicitStaggeredHierarchyIntegrator::IBPCApply_velocity(Vec x, Vec y)
 {
-    Pointer<SAMRAIVectorReal<NDIM, double> > f_g = PETScSAMRAIVectorReal::getSAMRAIVector(x);
-    Pointer<SAMRAIVectorReal<NDIM, double> > u_p = PETScSAMRAIVectorReal::getSAMRAIVector(y);
+    Pointer<SAMRAIVectorReal<NDIM, double> > f_g, u_p;
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(x, &f_g);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(y, &u_p);
     Pointer<IBImplicitStaggeredStokesSolver> p_stokes_solver = d_stokes_solver;
 #if !defined(NDEBUG)
     TBOX_ASSERT(p_stokes_solver);
 #endif
     bool converged = p_stokes_solver->getStaggeredStokesFACPreconditioner()->solveSystem(*u_p, *f_g);
     PetscErrorCode ierr = !converged;
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(x, &f_g);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(y, &u_p);
     PetscObjectStateIncrease(reinterpret_cast<PetscObject>(y));
     return ierr;
 } // IBPCApply_velocity

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -925,7 +925,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_position(SNES /*snes*/, Vec x
     IBTK_CHKERRQ(ierr);
 
     Pointer<SAMRAIVectorReal<NDIM, double> > u, f_u;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_sol_vecs[0], &u);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(component_sol_vecs[0], &u);
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_rhs_vecs[0], &f_u);
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -974,7 +974,8 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_position(SNES /*snes*/, Vec x
     d_ib_implicit_ops->spreadForce(
         d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), force_time);
     d_hier_velocity_data_ops->axpy(f_u_idx, -kappa, d_f_idx, f_u_idx);
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(component_rhs_vecs[0]));
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(component_sol_vecs[0], &u);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_rhs_vecs[0], &f_u);
 
     // Evaluate the Lagrangian terms.
     double velocity_time = std::numeric_limits<double>::quiet_NaN();
@@ -999,9 +1000,6 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_position(SNES /*snes*/, Vec x
                                            getGhostfillRefineSchedules(d_object_name + "::u"),
                                            velocity_time);
     d_ib_implicit_ops->computeResidual(R);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_sol_vecs[0], &u);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_rhs_vecs[0], &f_u);
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(f));
     return ierr;
 } // IBFunction_position
 
@@ -1014,7 +1012,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_velocity(SNES /*snes*/, Vec x
     const double half_time = current_time + 0.5 * d_current_dt;
 
     Pointer<SAMRAIVectorReal<NDIM, double> > u, f_u;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(x, &u);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &u);
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(f, &f_u);
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -1097,9 +1095,8 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_velocity(SNES /*snes*/, Vec x
     d_ib_implicit_ops->spreadForce(
         d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), force_time);
     d_hier_velocity_data_ops->axpy(f_u_idx, -kappa, d_f_idx, f_u_idx);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(x, &u);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &u);
     IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(f, &f_u);
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(f));
     return ierr;
 } // IBFunction_velocity
 
@@ -1176,7 +1173,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_velocity(SNES /*snes*/, 
     IBTK_CHKERRQ(ierr);
 
     Pointer<SAMRAIVectorReal<NDIM, double> > u;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(x, &u);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &u);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     Pointer<VariableContext> current_ctx = d_ins_hier_integrator->getCurrentContext();
     Pointer<Variable<NDIM> > u_var = d_ins_hier_integrator->getVelocityVariable();
@@ -1206,7 +1203,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_velocity(SNES /*snes*/, 
                                                      velocity_time);
     d_ib_implicit_ops->computeLinearizedResidual(d_X_current, X_new);
     d_ib_implicit_ops->setLinearizedPosition(X_new, velocity_time);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(x, &u);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &u);
 
     ierr = VecDestroy(&X_new);
     IBTK_CHKERRQ(ierr);
@@ -1249,7 +1246,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_position(Vec x, Vec f)
     IBTK_CHKERRQ(ierr);
 
     Pointer<SAMRAIVectorReal<NDIM, double> > u, f_u;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_sol_vecs[0], &u);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(component_sol_vecs[0], &u);
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_rhs_vecs[0], &f_u);
 
     Pointer<Variable<NDIM> > u_var = d_ins_hier_integrator->getVelocityVariable();
@@ -1287,7 +1284,9 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_position(Vec x, Vec f)
     d_ib_implicit_ops->spreadLinearizedForce(
         d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), force_time);
     d_hier_velocity_data_ops->subtract(f_u_idx, f_u_idx, d_f_idx);
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(component_rhs_vecs[0]));
+
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(component_sol_vecs[0], &u);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_rhs_vecs[0], &f_u);
 
     // Evaluate the Lagrangian terms.
     double velocity_time = std::numeric_limits<double>::quiet_NaN();
@@ -1312,9 +1311,6 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_position(Vec x, Vec f)
                                                      getGhostfillRefineSchedules(d_object_name + "::u"),
                                                      velocity_time);
     d_ib_implicit_ops->computeLinearizedResidual(X, R);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_sol_vecs[0], &u);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_rhs_vecs[0], &f_u);
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(f));
     return ierr;
 } // IBJacobianApply_position
 
@@ -1326,7 +1322,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_velocity(Vec x, Vec f)
     const double half_time = current_time + 0.5 * d_current_dt;
 
     Pointer<SAMRAIVectorReal<NDIM, double> > u, f_u;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(x, &u);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &u);
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(f, &f_u);
 
     const int u_idx = u->getComponentDescriptorIndex(0);
@@ -1385,7 +1381,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_velocity(Vec x, Vec f)
     d_ib_implicit_ops->spreadLinearizedForce(
         d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), force_time);
     d_hier_velocity_data_ops->axpy(f_u_idx, -kappa, d_f_idx, f_u_idx);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(x, &u);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &u);
     IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(f, &f_u);
     return 0;
 } // IBJacobianApply_velocity
@@ -1426,7 +1422,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBPCApply_position(Vec x, Vec y)
     IBTK_CHKERRQ(ierr);
 
     Pointer<SAMRAIVectorReal<NDIM, double> > eul_x, eul_y;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_x_vecs[0], &eul_x);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(component_x_vecs[0], &eul_x);
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_y_vecs[0], &eul_y);
 
     Vec lag_x = component_x_vecs[1];
@@ -1515,8 +1511,8 @@ IBImplicitStaggeredHierarchyIntegrator::IBPCApply_position(Vec x, Vec y)
     d_stokes_solver->setHomogeneousBc(true);
     d_stokes_solver->solveSystem(*d_u_scratch_vec, *d_f_scratch_vec);
     eul_y->add(eul_y, d_u_scratch_vec);
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(component_y_vecs[0]));
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(y));
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(component_x_vecs[0], &eul_x);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_y_vecs[0], &eul_y);
     return ierr;
 } // IBPCApply_position
 
@@ -1524,7 +1520,7 @@ PetscErrorCode
 IBImplicitStaggeredHierarchyIntegrator::IBPCApply_velocity(Vec x, Vec y)
 {
     Pointer<SAMRAIVectorReal<NDIM, double> > f_g, u_p;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(x, &f_g);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &f_g);
     IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(y, &u_p);
     Pointer<IBImplicitStaggeredStokesSolver> p_stokes_solver = d_stokes_solver;
 #if !defined(NDEBUG)
@@ -1532,9 +1528,8 @@ IBImplicitStaggeredHierarchyIntegrator::IBPCApply_velocity(Vec x, Vec y)
 #endif
     bool converged = p_stokes_solver->getStaggeredStokesFACPreconditioner()->solveSystem(*u_p, *f_g);
     PetscErrorCode ierr = !converged;
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(x, &f_g);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &f_g);
     IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(y, &u_p);
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(y));
     return ierr;
 } // IBPCApply_velocity
 

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -2153,7 +2153,7 @@ IBMethod::computeForce_SAMRAI(void* ctx, Vec X, Vec F)
     PetscErrorCode ierr;
     IBMethod* ib_method_ops = static_cast<IBMethod*>(ctx);
     ierr = ib_method_ops->computeForce(X, F);
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     return ierr;
 } // computeForce_SAMRAI
 
@@ -2167,14 +2167,14 @@ IBMethod::computeForce(Vec X, Vec F)
     getPositionData(&X_data, &X_needs_ghost_fill, d_force_jac_data_time);
     const int level_num = d_hierarchy->getFinestLevelNumber();
     ierr = VecSwap(X, (*X_data)[level_num]->getVec());
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     ierr = VecSwap(F, (*F_data)[level_num]->getVec());
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     computeLagrangianForce(d_force_jac_data_time);
     ierr = VecSwap(X, (*X_data)[level_num]->getVec());
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     ierr = VecSwap(F, (*F_data)[level_num]->getVec());
-    IBTK_CHKERRQ(ierr);
+    CHKERRQ(ierr);
     return ierr;
 } // computeForce
 

--- a/src/IB/KrylovFreeBodyMobilitySolver.cpp
+++ b/src/IB/KrylovFreeBodyMobilitySolver.cpp
@@ -490,7 +490,6 @@ KrylovFreeBodyMobilitySolver::MatVecMult_KFBMSolver(Mat A, Vec x, Vec y)
                                                             y,
                                                             /*only_free_dofs*/ true,
                                                             /*only_imposed_dofs*/ false);
-    PetscObjectStateIncrease(reinterpret_cast<PetscObject>(y));
     PetscFunctionReturn(0);
 } // MatVecMult_KFBMSolver
 

--- a/src/IB/KrylovMobilitySolver.cpp
+++ b/src/IB/KrylovMobilitySolver.cpp
@@ -459,13 +459,16 @@ KrylovMobilitySolver::initializeSolverState(Vec x, Vec b)
     Vec *vx, *vb;
     VecNestGetSubVecs(x, NULL, &vx);
     VecNestGetSubVecs(b, NULL, &vb);
+    Pointer<SAMRAIVectorReal<NDIM, double> > vx0, vb0;
 
     // Create the temporary storage for spreading and Stokes solve operation.
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0], &vx0);
     for (int i = 0; i < 2; ++i)
     {
-        d_samrai_temp[i] = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->cloneVector("");
+        d_samrai_temp[i] = vx0->cloneVector("");
         d_samrai_temp[i]->allocateVectorData();
     }
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vx[0], &vx0);
 
     // Create the RHS Vec to be used in the KSP object.
     VecDuplicate(vb[1], &d_petsc_b);
@@ -474,14 +477,17 @@ KrylovMobilitySolver::initializeSolverState(Vec x, Vec b)
     initializeKSP();
 
     // Initialize LInv (Stokes solver) required in the mobility matrix.
-    initializeStokesSolver(*IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0]),
-                           *IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vb[0]));
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0], &vx0);
+    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vb[0], &vb0);
+    initializeStokesSolver(*vx0, *vb0);
 
     // Get hierarchy information.
-    d_hierarchy = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->getPatchHierarchy();
-    const int u_data_idx = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->getComponentDescriptorIndex(0);
-    const int coarsest_ln = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->getCoarsestLevelNumber();
-    const int finest_ln = IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(vx[0])->getFinestLevelNumber();
+    d_hierarchy = vx0->getPatchHierarchy();
+    const int u_data_idx = vx0->getComponentDescriptorIndex(0);
+    const int coarsest_ln = vx0->getCoarsestLevelNumber();
+    const int finest_ln = vx0->getFinestLevelNumber();
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vx[0], &vx0);
+    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(vb[0], &vb0);
 
     // Setup the interpolation transaction information.
     d_fill_pattern = NULL;


### PR DESCRIPTION
This PR should remove the need to increase the "state" of PETSc vectors in library code outside of the PETScSAMRAIVectorReal implementation.