### PR TITLE
Update .jenkins* files

### DIFF
--- a/.jenkins_fulltest
+++ b/.jenkins_fulltest
@@ -18,7 +18,8 @@ set -o pipefail
   --with-boost=$HOME/linux/boost/1.61.0 \
   --enable-libmesh \
   --with-libmesh=$HOME/linux/libmesh/1.0.0/1.0.0-debug \
-  --with-libmesh-method=dbg
+  --with-libmesh-method=dbg \
+  --config-cache
 
 make -kj4 lib
 make -kj4 examples

--- a/.jenkins_fulltest
+++ b/.jenkins_fulltest
@@ -18,7 +18,7 @@ set -o pipefail
   --with-boost=$HOME/linux/boost/1.61.0 \
   --enable-libmesh \
   --with-libmesh=$HOME/linux/libmesh/1.0.0/1.0.0-debug \
-  --with-libmesh-method=dbg \
-  --config-cache
+  --with-libmesh-method=dbg
+
 make -kj4 lib
 make -kj4 examples

--- a/.jenkins_fulltest
+++ b/.jenkins_fulltest
@@ -2,16 +2,16 @@
 set -e 
 set -o pipefail
 ./configure \
-  CFLAGS="-g -O1 -Wall" \
-  CXXFLAGS="-g -O1 -Wall" \
-  FCFLAGS="-g -O1 -Wall" \
+  CFLAGS="-Wall" \
+  CXXFLAGS="-Wall" \
+  FCFLAGS="-Wall" \
   CC="ccache $HOME/linux/openmpi/1.10.2/bin/mpicc" \
   CXX="ccache $HOME/linux/openmpi/1.10.2/bin/mpicxx" \
   FC=$HOME/linux/openmpi/1.10.2/bin/mpif90 \
   CPPFLAGS="-DOMPI_SKIP_MPICXX" \
   LDFLAGS="-lgtest" \
   --with-hypre=$PETSC_DIR/$PETSC_ARCH \
-  --with-samrai=$HOME/samrai/2.4.4/linux-debug \
+  --with-samrai=$SAMRAI_DIR \
   --with-hdf5=$HOME/linux/hdf5/1.8.16 \
   --with-blitz=$HOME/linux/blitz/0.10 \
   --with-silo=$HOME/linux/silo/4.10 \

--- a/.jenkins_quicktest
+++ b/.jenkins_quicktest
@@ -18,7 +18,8 @@ set -o pipefail
   --with-boost=$HOME/linux/boost/1.61.0 \
   --enable-libmesh \
   --with-libmesh=$HOME/linux/libmesh/1.0.0/1.0.0-debug \
-  --with-libmesh-method=dbg
+  --with-libmesh-method=dbg \
+  --config-cache
 
 make -kj4 lib
 make -kj4 examples

--- a/.jenkins_quicktest
+++ b/.jenkins_quicktest
@@ -18,7 +18,7 @@ set -o pipefail
   --with-boost=$HOME/linux/boost/1.61.0 \
   --enable-libmesh \
   --with-libmesh=$HOME/linux/libmesh/1.0.0/1.0.0-debug \
-  --with-libmesh-method=dbg \
-  --config-cache
+  --with-libmesh-method=dbg
+
 make -kj4 lib
 make -kj4 examples

--- a/.jenkins_quicktest
+++ b/.jenkins_quicktest
@@ -2,16 +2,16 @@
 set -e 
 set -o pipefail
 ./configure \
-  CFLAGS="-g -O1 -Wall" \
-  CXXFLAGS="-g -O1 -Wall" \
-  FCFLAGS="-g -O1 -Wall" \
+  CFLAGS="-Wall" \
+  CXXFLAGS="-Wall" \
+  FCFLAGS="-Wall" \
   CC="ccache $HOME/linux/openmpi/1.10.2/bin/mpicc" \
   CXX="ccache $HOME/linux/openmpi/1.10.2/bin/mpicxx" \
   FC=$HOME/linux/openmpi/1.10.2/bin/mpif90 \
   CPPFLAGS="-DOMPI_SKIP_MPICXX" \
   LDFLAGS="-lgtest" \
   --with-hypre=$PETSC_DIR/$PETSC_ARCH \
-  --with-samrai=$HOME/samrai/2.4.4/linux-debug \
+  --with-samrai=$SAMRAI_DIR \
   --with-hdf5=$HOME/linux/hdf5/1.8.16 \
   --with-blitz=$HOME/linux/blitz/0.10 \
   --with-silo=$HOME/linux/silo/4.10 \


### PR DESCRIPTION
@boyceg 

I changed compiler flags to just "-Wall" and replaced the samrai path with "$SAMRAI_DIR" to allow for optimized builds. All the jenkins jobs have $SAMRAI_DIR defined, so hopefully this should work.

I still have yet to get the optimized build of SAMRAI built on the VM, but this will make it possible to get it running once it is in place.