### PR TITLE
adding option to convective boundary stabilization to use only the visous terms at the boundary

### DIFF
--- a/ibtk/Makefile.in
+++ b/ibtk/Makefile.in
@@ -185,7 +185,8 @@ am__DIST_COMMON = $(srcdir)/Makefile.in \
 	$(top_srcdir)/config/install-sh $(top_srcdir)/config/ltmain.sh \
 	$(top_srcdir)/config/missing config/compile \
 	config/config.guess config/config.rpath config/config.sub \
-	config/install-sh config/ltmain.sh config/missing
+	config/depcomp config/install-sh config/ltmain.sh \
+	config/missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)

--- a/include/ibamr/INSStaggeredStabilizedPPMConvectiveOperator.h
+++ b/include/ibamr/INSStaggeredStabilizedPPMConvectiveOperator.h
@@ -191,6 +191,7 @@ private:
     INSStaggeredStabilizedPPMConvectiveOperator& operator=(const INSStaggeredStabilizedPPMConvectiveOperator& that);
 
     // Operator configuration.
+    std::string d_stabilization_type;
     boost::array<bool, 2 * NDIM> d_open_bdry;
     boost::array<double, 2 * NDIM> d_width;
 


### PR DESCRIPTION
We commonly use flow straightening near open boundaries, but in these regions, u.grad(u) ~ 0.

In those regions, it may make sense to set u.grad(u) = 0 explicitly, to avoid instabilities that appear to be related to the treatment of open boundary conditions.
  
This PR allows us to explicitly remove the convective term in the "stabilization" region when using the "STABILIZED_PPM" convective operator.