### PR TITLE
Adding provisions to allow ASM preconditioning for PETSc level Poisson solvers

### DIFF
--- a/ibtk/include/ibtk/CCPoissonPETScLevelSolver.h
+++ b/ibtk/include/ibtk/CCPoissonPETScLevelSolver.h
@@ -134,6 +134,10 @@ public:
 
 protected:
     /*!
+     * \brief Generate IS/subdomains for Schwartz type preconditioners.
+     */
+    void generateASMSubdomains(std::vector<std::set<int> >& overlap_is, std::vector<std::set<int> >& nonoverlap_is);
+    /*!
      * \brief Compute hierarchy dependent data required for solving \f$Ax=b\f$.
      */
     void initializeSolverStateSpecialized(const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x,

--- a/ibtk/include/ibtk/SCPoissonPETScLevelSolver.h
+++ b/ibtk/include/ibtk/SCPoissonPETScLevelSolver.h
@@ -134,6 +134,10 @@ public:
 
 protected:
     /*!
+     * \brief Generate IS/subdomains for Schwartz type preconditioners.
+     */
+    void generateASMSubdomains(std::vector<std::set<int> >& overlap_is, std::vector<std::set<int> >& nonoverlap_is);
+    /*!
      * \brief Compute hierarchy dependent data required for solving \f$Ax=b\f$.
      */
     void initializeSolverStateSpecialized(const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x,

--- a/ibtk/src/solvers/impls/CCPoissonPETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonPETScLevelSolver.cpp
@@ -113,6 +113,22 @@ CCPoissonPETScLevelSolver::~CCPoissonPETScLevelSolver()
 /////////////////////////////// PROTECTED ////////////////////////////////////
 
 void
+CCPoissonPETScLevelSolver::generateASMSubdomains(std::vector<std::set<int> >& /*overlap_is*/,
+                                                 std::vector<std::set<int> >& /*nonoverlap_is*/)
+{
+    // Construct subdomains for ASM and MSM preconditioner, indexed directly by PETSc IS.
+    PETScMatUtilities::constructPatchLevelASMSubdomains(d_overlap_is,
+                                                        d_nonoverlap_is,
+                                                        d_box_size,
+                                                        d_overlap_size,
+                                                        d_num_dofs_per_proc,
+                                                        d_dof_index_idx,
+                                                        d_level,
+                                                        d_cf_boundary);
+    return;
+} // generateASMSubdomains
+
+void
 CCPoissonPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVectorReal<NDIM, double>& x,
                                                             const SAMRAIVectorReal<NDIM, double>& /*b*/)
 {
@@ -137,14 +153,6 @@ CCPoissonPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVectorRe
     PETScMatUtilities::constructPatchLevelCCLaplaceOp(
         d_petsc_mat, d_poisson_spec, d_bc_coefs, d_solution_time, d_num_dofs_per_proc, d_dof_index_idx, d_level);
     d_petsc_pc = d_petsc_mat;
-    PETScMatUtilities::constructPatchLevelASMSubdomains(d_overlap_is,
-                                                        d_nonoverlap_is,
-                                                        d_box_size,
-                                                        d_overlap_size,
-                                                        d_num_dofs_per_proc,
-                                                        d_dof_index_idx,
-                                                        d_level,
-                                                        d_cf_boundary);
 
     // Setup SAMRAI communication objects.
     d_data_synch_sched = PETScVecUtilities::constructDataSynchSchedule(x_idx, d_level);

--- a/ibtk/src/solvers/impls/PETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScLevelSolver.cpp
@@ -400,9 +400,14 @@ PETScLevelSolver::initializeSolverState(const SAMRAIVectorReal<NDIM, double>& x,
         // Generate user-defined subdomains.
         std::vector<std::set<int> > overlap_is, nonoverlap_is;
         generateASMSubdomains(overlap_is, nonoverlap_is);
-        generate_petsc_is_from_std_is(overlap_is, nonoverlap_is, d_overlap_is, d_nonoverlap_is);
 
-        int num_subdomains = static_cast<int>(overlap_is.size());
+        // Generate PETSc IS in cases where they have not been generated directly.
+        if (!d_overlap_is.size())
+        {
+            generate_petsc_is_from_std_is(overlap_is, nonoverlap_is, d_overlap_is, d_nonoverlap_is);
+        }
+
+        int num_subdomains = static_cast<int>(d_overlap_is.size());
         if (num_subdomains == 0)
         {
             IS is;
@@ -462,9 +467,14 @@ PETScLevelSolver::initializeSolverState(const SAMRAIVectorReal<NDIM, double>& x,
         // Generate user-defined subdomains.
         std::vector<std::set<int> > overlap_is, nonoverlap_is;
         generateASMSubdomains(overlap_is, nonoverlap_is);
-        d_n_local_subdomains = static_cast<int>(overlap_is.size());
+        d_n_local_subdomains = static_cast<int>(d_overlap_is.size());
         d_n_subdomains_max = SAMRAI_MPI::maxReduction(d_n_local_subdomains);
-        generate_petsc_is_from_std_is(overlap_is, nonoverlap_is, d_overlap_is, d_nonoverlap_is);
+
+        // Generate PETSc IS in cases where they have not been generated directly.
+        if (!d_overlap_is.size())
+        {
+            generate_petsc_is_from_std_is(overlap_is, nonoverlap_is, d_overlap_is, d_nonoverlap_is);
+        }
 
         // Get the local submatrices.
         ierr = MatGetSubMatrices(

--- a/ibtk/src/solvers/impls/SCPoissonPETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonPETScLevelSolver.cpp
@@ -113,6 +113,22 @@ SCPoissonPETScLevelSolver::~SCPoissonPETScLevelSolver()
 /////////////////////////////// PROTECTED ////////////////////////////////////
 
 void
+SCPoissonPETScLevelSolver::generateASMSubdomains(std::vector<std::set<int> >& /*overlap_is*/,
+                                                 std::vector<std::set<int> >& /*nonoverlap_is*/)
+{
+    // Construct subdomains for ASM and MSM preconditioner, indexed directly by PETSc IS.
+    PETScMatUtilities::constructPatchLevelASMSubdomains(d_overlap_is,
+                                                        d_nonoverlap_is,
+                                                        d_box_size,
+                                                        d_overlap_size,
+                                                        d_num_dofs_per_proc,
+                                                        d_dof_index_idx,
+                                                        d_level,
+                                                        d_cf_boundary);
+    return;
+} // generateASMSubdomains
+
+void
 SCPoissonPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVectorReal<NDIM, double>& x,
                                                             const SAMRAIVectorReal<NDIM, double>& /*b*/)
 {
@@ -137,14 +153,6 @@ SCPoissonPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVectorRe
     PETScMatUtilities::constructPatchLevelSCLaplaceOp(
         d_petsc_mat, d_poisson_spec, d_bc_coefs, d_solution_time, d_num_dofs_per_proc, d_dof_index_idx, d_level);
     d_petsc_pc = d_petsc_mat;
-    PETScMatUtilities::constructPatchLevelASMSubdomains(d_overlap_is,
-                                                        d_nonoverlap_is,
-                                                        d_box_size,
-                                                        d_overlap_size,
-                                                        d_num_dofs_per_proc,
-                                                        d_dof_index_idx,
-                                                        d_level,
-                                                        d_cf_boundary);
 
     // Setup SAMRAI communication objects.
     d_data_synch_sched = PETScVecUtilities::constructDataSynchSchedule(x_idx, d_level);


### PR DESCRIPTION
@boyceg, @amneetb: I moved the constructPatchLevelASMSubdomains calls for the PETSc level Poisson solvers to a generateASMSubdomains function. Moreover, I added provisions to ensure that generate_petsc_is_from_std_is is never called from PETScLevelSolver when subdomains are indexed by PETSc IS indexing directly.

This allows for ASM preconditioning to be used for PETSc level Possion solvers; it was encountering TBOX_ERROR before.