### PR TITLE
Fixed small memory leak in IB data writer.

### DIFF
--- a/ibtk/src/lagrangian/LSiloDataWriter.cpp
+++ b/ibtk/src/lagrangian/LSiloDataWriter.cpp
@@ -2074,6 +2074,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
             }
         }
 
+        DBFreeOptlist(optlist);
         DBClose(dbfile);
 
         // Create or update the dumps file on the root MPI process.


### PR DESCRIPTION
An option list wasn't being deallocated in the data writer. It caused leaks on the order of ~100 bytes when writing data.