### PR TITLE
Delayed initial Lagrangian data movement until after all Lag data has been set up.

### DIFF
--- a/include/ibamr/PenaltyIBMethod.h
+++ b/include/ibamr/PenaltyIBMethod.h
@@ -149,6 +149,20 @@ public:
         bool initial_time);
 
     /*!
+     * Initialize data on a new level after it is inserted into an AMR patch
+     * hierarchy by the gridding algorithm.
+     *
+     * \see SAMRAI::mesh::StandardTagAndInitStrategy::initializeLevelData
+     */
+    void initializeLevelData(SAMRAI::tbox::Pointer<SAMRAI::hier::BasePatchHierarchy<NDIM> > hierarchy,
+                             int level_number,
+                             double init_data_time,
+                             bool can_be_refined,
+                             bool initial_time,
+                             SAMRAI::tbox::Pointer<SAMRAI::hier::BasePatchLevel<NDIM> > old_level,
+                             bool allocate_data);
+
+    /*!
      * Write out object state to the given database.
      */
     void putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db);

--- a/src/IB/IBHierarchyIntegrator.cpp
+++ b/src/IB/IBHierarchyIntegrator.cpp
@@ -409,6 +409,12 @@ IBHierarchyIntegrator::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > h
     // Initialize Eulerian data.
     HierarchyIntegrator::initializePatchHierarchy(hierarchy, gridding_alg);
 
+    // Begin Lagrangian data movement.
+    d_ib_method_ops->beginDataRedistribution(hierarchy, gridding_alg);
+
+    // Finish Lagrangian data movement.
+    d_ib_method_ops->endDataRedistribution(hierarchy, gridding_alg);
+
     // Initialize Lagrangian data on the patch hierarchy.
     const int coarsest_ln = 0;
     const int finest_ln = hierarchy->getFinestLevelNumber();
@@ -432,12 +438,6 @@ IBHierarchyIntegrator::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > h
                                               d_integrator_step,
                                               d_integrator_time,
                                               initial_time);
-
-    // Begin Lagrangian data movement.
-    d_ib_method_ops->beginDataRedistribution(hierarchy, gridding_alg);
-
-    // Finish Lagrangian data movement.
-    d_ib_method_ops->endDataRedistribution(hierarchy, gridding_alg);
 
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
     {

--- a/src/IB/IBHierarchyIntegrator.cpp
+++ b/src/IB/IBHierarchyIntegrator.cpp
@@ -409,12 +409,6 @@ IBHierarchyIntegrator::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > h
     // Initialize Eulerian data.
     HierarchyIntegrator::initializePatchHierarchy(hierarchy, gridding_alg);
 
-    // Begin Lagrangian data movement.
-    d_ib_method_ops->beginDataRedistribution(hierarchy, gridding_alg);
-
-    // Finish Lagrangian data movement.
-    d_ib_method_ops->endDataRedistribution(hierarchy, gridding_alg);
-
     // Initialize Lagrangian data on the patch hierarchy.
     const int coarsest_ln = 0;
     const int finest_ln = hierarchy->getFinestLevelNumber();
@@ -438,6 +432,13 @@ IBHierarchyIntegrator::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > h
                                               d_integrator_step,
                                               d_integrator_time,
                                               initial_time);
+
+    // Begin Lagrangian data movement.
+    d_ib_method_ops->beginDataRedistribution(hierarchy, gridding_alg);
+
+    // Finish Lagrangian data movement.
+    d_ib_method_ops->endDataRedistribution(hierarchy, gridding_alg);
+
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);

--- a/src/IB/IBHierarchyIntegrator.cpp
+++ b/src/IB/IBHierarchyIntegrator.cpp
@@ -438,7 +438,6 @@ IBHierarchyIntegrator::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > h
                                               d_integrator_step,
                                               d_integrator_time,
                                               initial_time);
-
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);

--- a/src/IB/PenaltyIBMethod.cpp
+++ b/src/IB/PenaltyIBMethod.cpp
@@ -403,7 +403,7 @@ PenaltyIBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarc
                                        init_data_time,
                                        initial_time);
 
-    // Initialize Velocity and Position data objects for massive points.
+    // Initialize velocity and position data objects for massive points.
     if (initial_time)
     {
         const int coarsest_ln = 0;

--- a/src/IB/PenaltyIBMethod.cpp
+++ b/src/IB/PenaltyIBMethod.cpp
@@ -403,7 +403,7 @@ PenaltyIBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarc
                                        init_data_time,
                                        initial_time);
 
-    // Initialize various Lagrangian data objects.
+    // Initialize Velocity and Position data objects for massive points.
     if (initial_time)
     {
         const int coarsest_ln = 0;
@@ -412,29 +412,14 @@ PenaltyIBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarc
         {
             if (!d_l_data_manager->levelContainsLagrangianData(ln)) continue;
 
-            const bool can_be_refined = ln < finest_ln || d_gridding_alg->levelCanBeRefined(ln);
 
             Pointer<LData> X_data = d_l_data_manager->getLData(LDataManager::POSN_DATA_NAME, ln);
             Pointer<LData> U_data = d_l_data_manager->getLData(LDataManager::VEL_DATA_NAME, ln);
-            Pointer<LData> M_data = d_l_data_manager->createLData("M", ln, 1, /*manage_data*/ true);
-            Pointer<LData> K_data = d_l_data_manager->createLData("K", ln, 1, /*manage_data*/ true);
             Pointer<LData> Y_data = d_l_data_manager->createLData("Y", ln, NDIM, /*manage_data*/ true);
             Pointer<LData> V_data = d_l_data_manager->createLData("V", ln, NDIM, /*manage_data*/ true);
-            static const int global_index_offset = 0;
-            static const int local_index_offset = 0;
-            d_l_initializer->initializeMassDataOnPatchLevel(global_index_offset,
-                                                            local_index_offset,
-                                                            M_data,
-                                                            K_data,
-                                                            d_hierarchy,
-                                                            ln,
-                                                            init_data_time,
-                                                            can_be_refined,
-                                                            initial_time,
-                                                            d_l_data_manager);
+
             if (d_silo_writer)
             {
-                d_silo_writer->registerVariableData("M", M_data, ln);
                 d_silo_writer->registerVariableData("Y", Y_data, ln);
             }
 
@@ -448,6 +433,56 @@ PenaltyIBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarc
     }
     return;
 } // initializePatchHierarchy
+
+void
+PenaltyIBMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
+                                         int level_number,
+                                         double init_data_time,
+                                         bool can_be_refined,
+                                         bool initial_time,
+                                         Pointer<BasePatchLevel<NDIM> > old_level,
+                                         bool allocate_data)
+{
+    IBMethod::initializeLevelData(hierarchy,
+                                  level_number,
+                                  init_data_time,
+                                  can_be_refined,
+                                  initial_time,
+                                  old_level,
+                                  allocate_data);
+
+    if (initial_time && d_l_data_manager->levelContainsLagrangianData(level_number))
+    {
+        // Initialize Mass and Spring constant data.
+        // Position and Velocity will be copied later.
+        Pointer<LData> M_data = d_l_data_manager->createLData("M",
+                                                              level_number,
+                                                              1,
+                                                              /*manage_data*/ true);
+        Pointer<LData> K_data = d_l_data_manager->createLData("K",
+                                                              level_number,
+                                                              1,
+                                                              /*manage_data*/ true);
+        static const int global_index_offset = 0;
+        static const int local_index_offset = 0;
+        d_l_initializer->initializeMassDataOnPatchLevel(global_index_offset,
+                                                        local_index_offset,
+                                                        M_data,
+                                                        K_data,
+                                                        hierarchy,
+                                                        level_number,
+                                                        init_data_time,
+                                                        can_be_refined,
+                                                        initial_time,
+                                                        d_l_data_manager);
+
+        if (d_silo_writer)
+        {
+            d_silo_writer->registerVariableData("M", M_data, level_number);
+        }
+    }
+    return;
+}
 
 void
 PenaltyIBMethod::putToDatabase(Pointer<Database> db)


### PR DESCRIPTION
Lagrangian data in the penalty IB method was being initialized *after* all other Lagrangian data had been redistributed.

@boyceg It seems that the penalty IB method is the only IBMethod class that initializes method specific Lagrangian data in the initializePatchHierarchy() function. For example, the generalized IB method initializes director vectors in the initializeLevelData() function. Would it be better to move penalty IB method Lagrangian data initialization to the initializeLevelData() function?