### PR TITLE
Fixed reset of advection-diffusion velocity after cycle 0.

### DIFF
--- a/include/ibamr/AdvDiffHierarchyIntegrator.h
+++ b/include/ibamr/AdvDiffHierarchyIntegrator.h
@@ -139,6 +139,9 @@ public:
      * Data management for the registered advection velocity will be handled by
      * the hierarchy integrator.
      *
+     * If a function is not provided, it is the responsibility of the user
+     * to ensure that the current and new contexts are set correctly.
+     *
      * \note By default, each registered advection velocity is assumed to be
      * divergence free.
      */
@@ -161,6 +164,9 @@ public:
     /*!
      * Supply an IBTK::CartGridFunction object to specify the value of a
      * particular advection velocity.
+     *
+     * If a function is not provided, it is the responsibility of the user
+     * to ensure that the current and new contexts are set correctly.
      */
     void setAdvectionVelocityFunction(SAMRAI::tbox::Pointer<SAMRAI::pdat::FaceVariable<NDIM, double> > u_var,
                                       SAMRAI::tbox::Pointer<IBTK::CartGridFunction> u_fcn);

--- a/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
@@ -756,10 +756,6 @@ AdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchy(const double current_
                 {
                     d_u_fcn[u_var]->setDataOnPatchHierarchy(u_new_idx, u_var, d_hierarchy, new_time);
                 }
-                else
-                {
-                    d_hier_fc_data_ops->copyData(u_new_idx, u_current_idx);
-                }
                 d_hier_fc_data_ops->linearSum(u_scratch_idx, 0.5, u_current_idx, 0.5, u_new_idx);
             }
         }


### PR DESCRIPTION
@boyceg Should I make a note in the documentation that if a function to set the velocity is not specified, the variable-context pairs of u_var and getCurrent/Scratch/NewContext() must be specified?