### PR TITLE
updating to C++11 for newer libMesh versions

### DIFF
--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -556,7 +556,7 @@ FEDataManager::spread(const int f_data_idx,
     for (unsigned i = 0; i < n_vars; ++i) TBOX_ASSERT(F_dof_map.variable_type(i) == F_fe_type);
     FEType X_fe_type = X_dof_map.variable_type(0);
     for (unsigned d = 0; d < NDIM; ++d) TBOX_ASSERT(X_dof_map.variable_type(d) == X_fe_type);
-    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr(NULL);
+    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
     if (F_fe_type != X_fe_type)
     {
         X_fe_autoptr = UniquePtr<FEBase>(FEBase::build(dim, X_fe_type));
@@ -776,7 +776,7 @@ FEDataManager::prolongData(const int f_data_idx,
     for (unsigned i = 0; i < n_vars; ++i) TBOX_ASSERT(F_dof_map.variable_type(i) == F_fe_type);
     FEType X_fe_type = X_dof_map.variable_type(0);
     for (unsigned d = 0; d < NDIM; ++d) TBOX_ASSERT(X_dof_map.variable_type(d) == X_fe_type);
-    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr(NULL);
+    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
     if (F_fe_type != X_fe_type)
     {
         X_fe_autoptr = UniquePtr<FEBase>(FEBase::build(dim, X_fe_type));
@@ -1006,7 +1006,7 @@ FEDataManager::interpWeighted(const int f_data_idx,
     for (unsigned i = 0; i < n_vars; ++i) TBOX_ASSERT(F_dof_map.variable_type(i) == F_fe_type);
     FEType X_fe_type = X_dof_map.variable_type(0);
     for (unsigned d = 0; d < NDIM; ++d) TBOX_ASSERT(X_dof_map.variable_type(d) == X_fe_type);
-    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr(NULL);
+    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
     if (F_fe_type != X_fe_type)
     {
         X_fe_autoptr = UniquePtr<FEBase>(FEBase::build(dim, X_fe_type));
@@ -1269,7 +1269,7 @@ FEDataManager::restrictData(const int f_data_idx,
     for (unsigned i = 0; i < n_vars; ++i) TBOX_ASSERT(F_dof_map.variable_type(i) == F_fe_type);
     FEType X_fe_type = X_dof_map.variable_type(0);
     for (unsigned d = 0; d < NDIM; ++d) TBOX_ASSERT(X_dof_map.variable_type(d) == X_fe_type);
-    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr(NULL);
+    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
     if (F_fe_type != X_fe_type)
     {
         X_fe_autoptr = UniquePtr<FEBase>(FEBase::build(dim, X_fe_type));

--- a/src/IB/CIBFEMethod.cpp
+++ b/src/IB/CIBFEMethod.cpp
@@ -770,7 +770,7 @@ CIBFEMethod::computeNetRigidGeneralizedForce(const unsigned int part, Vec L, Rig
     std::vector<std::vector<unsigned int> > X_dof_indices(NDIM);
     FEType L_fe_type = L_dof_map.variable_type(0);
     FEType X_fe_type = X_dof_map.variable_type(0);
-    UniquePtr<FEBase> L_fe_autoptr(FEBase::build(dim, L_fe_type)), X_fe_autoptr(NULL);
+    UniquePtr<FEBase> L_fe_autoptr(FEBase::build(dim, L_fe_type)), X_fe_autoptr;
     if (L_fe_type != X_fe_type)
     {
         X_fe_autoptr = UniquePtr<FEBase>(FEBase::build(dim, X_fe_type));


### PR DESCRIPTION
Removed NULL in constructors of UniquePtr for compatibility with C++11 and and the newer version of libMesh. IBAMR now compiles with libMesh, commit  a3ca425d7e4b8f8c43417644e505ae8ac87ee410 (12/26/2017)