### PR TITLE
disabling gtest for Jenkins CI tests

### DIFF
--- a/.jenkins_quicktest
+++ b/.jenkins_quicktest
@@ -31,4 +31,5 @@ config() {
 
 config
 make -kj4 lib
-make gtest
+make -kj4 examples
+#make gtest


### PR DESCRIPTION
Our current CI server is getting bogged down with the full gtests. For now, let's just run those in the nightly builds.