### PR TITLE
Fix fortran warnings

### DIFF
--- a/ibtk/src/lagrangian/fortran/lagrangian_delta.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_delta.f.m4
@@ -398,8 +398,8 @@ c
       subroutine lagrangian_ib_4_table_init(ib_4_table,NTABLE)
 c
       implicit none
-      double precision lagrangian_ib_4_delta,ib_4_table(0:NTABLE),x
       integer NTABLE,k
+      double precision lagrangian_ib_4_delta,ib_4_table(0:NTABLE),x
 c
       do k = 0,NTABLE
          x = 2.d0*dble(k)/dble(NTABLE)
@@ -583,8 +583,8 @@ c
       subroutine lagrangian_ib_6_table_init(ib_6_table,NTABLE)
 c
       implicit none
-      double precision lagrangian_ib_6_delta,ib_6_table(0:NTABLE),x
       integer NTABLE,k
+      double precision lagrangian_ib_6_delta,ib_6_table(0:NTABLE),x
 c
       do k = 0,NTABLE
          x = 3.d0*dble(k)/dble(NTABLE)

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -1196,11 +1196,15 @@ c
       INTEGER ig_lower(0:NDIM-1),ig_upper(0:NDIM-1)
       INTEGER ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER istart0,istop0,istart1,istop1
-      INTEGER d,k,l,s
+      INTEGER d,l,s
 
       REAL X_o_dx,q0,q1,r0,r1
-      REAL w0(0:3),w1(0:3),f(0:3)
+      REAL w0(0:3),w1(0:3)
       REAL w(0:3,0:3),wy
+c
+c     Prevent compiler warning about unused variables.
+c
+      x_upper(0) = x_upper(0)
 c
 c     Compute the extents of the ghost box.
 c
@@ -1313,11 +1317,15 @@ c
       INTEGER ig_lower(0:NDIM-1),ig_upper(0:NDIM-1)
       INTEGER ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER istart0,istop0,istart1,istop1
-      INTEGER d,k,l,s
+      INTEGER d,l,s
 
       REAL X_o_dx,q0,q1,r0,r1
-      REAL w0(0:3),w1(0:3),f(0:3)
+      REAL w0(0:3),w1(0:3)
       REAL w(0:3,0:3),wy
+c
+c     Prevent compiler warning about unused variables.
+c
+      x_upper(0) = x_upper(0)
 c
 c     Compute the extents of the ghost box.
 c
@@ -3288,4 +3296,3 @@ c
       end
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
@@ -1290,11 +1290,15 @@ c
       INTEGER ig_lower(0:NDIM-1),ig_upper(0:NDIM-1)
       INTEGER ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER istart0,istop0,istart1,istop1,istart2,istop2
-      INTEGER d,k,l,s
+      INTEGER d,l,s
 
       REAL X_o_dx,q0,q1,q2,r0,r1,r2
-      REAL w0(0:3),w1(0:3),w2(0:3),f(0:3)
+      REAL w0(0:3),w1(0:3),w2(0:3)
       REAL w(0:3,0:3,0:3),wyz,wz
+c
+c     Prevent compiler warning about unused variables.
+c
+      x_upper(0) = x_upper(0)
 c
 c     Compute the extents of the ghost box.
 c
@@ -1427,11 +1431,15 @@ c
       INTEGER ig_lower(0:NDIM-1),ig_upper(0:NDIM-1)
       INTEGER ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER istart0,istop0,istart1,istop1,istart2,istop2
-      INTEGER d,k,l,s
+      INTEGER d,l,s
 
       REAL X_o_dx,q0,q1,q2,r0,r1,r2
-      REAL w0(0:3),w1(0:3),w2(0:3),f(0:3)
+      REAL w0(0:3),w1(0:3),w2(0:3)
       REAL w(0:3,0:3,0:3),wyz,wz
+c
+c     Prevent compiler warning about unused variables.
+c
+      x_upper(0) = x_upper(0)
 c
 c     Compute the extents of the ghost box.
 c

--- a/src/adv_diff/fortran/adv_diff_wp_convective_op2d.f.m4
+++ b/src/adv_diff/fortran/adv_diff_wp_convective_op2d.f.m4
@@ -137,6 +137,10 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
        INTEGER i0, i1
 
        REAL WENO5_interp
+c
+c     Prevent compiler warning about unused variables.
+c
+      k = k
 
 c     X DIRECTION
       do i1 = ilower1, iupper1

--- a/src/adv_diff/fortran/adv_diff_wp_convective_op3d.f.m4
+++ b/src/adv_diff/fortran/adv_diff_wp_convective_op3d.f.m4
@@ -154,6 +154,10 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       INTEGER i0, i1, i2
       REAL WENO5_interp
+c
+c     Prevent compiler warning about unused variables.
+c
+      k = k
 
 c     X-Direction
       do i2 = ilower2, iupper2; do i1 = ilower1, iupper1

--- a/src/level_set/fortran/levelsetops2d.f.m4
+++ b/src/level_set/fortran/levelsetops2d.f.m4
@@ -89,8 +89,11 @@ c
       REAL function S_eps(x,eps)
       implicit none
 include(TOP_SRCDIR/src/fortran/const.i)dnl
-      REAL H_eps
       REAL x,eps
+c
+c     Prevent compiler warning about unused variables.
+c
+      eps = eps
 
 C       S_eps = two*H_eps(x,eps) - one
 C       S_eps = x/sqrt(x**2+eps**2)

--- a/src/level_set/fortran/levelsetops3d.f.m4
+++ b/src/level_set/fortran/levelsetops3d.f.m4
@@ -89,8 +89,11 @@ c
       REAL function S_eps(x,eps)
       implicit none
 include(TOP_SRCDIR/src/fortran/const.i)dnl
-      REAL H_eps
       REAL x,eps
+c
+c     Prevent compiler warning about unused variables.
+c
+      eps = eps
 
 C       S_eps = two*H_eps(x,eps) - one
 C       S_eps = x/sqrt(x**2+eps**2)


### PR DESCRIPTION
After some issues with AFS I finally have things set up. Here is a little PR to get started!

1. gfortran rightfully complains that the integral types should be declared before the real ones since they are used to define the real ones.
2. I removed unused local variables or used the technique applied elsewhere (`x = x`) to suppress warnings.