### PR TITLE
Fix some unused variable warnings.

### DIFF
--- a/examples/ConstraintIB/impulsively_started_cylinder/RigidBodyKinematics.cpp
+++ b/examples/ConstraintIB/impulsively_started_cylinder/RigidBodyKinematics.cpp
@@ -202,10 +202,12 @@ RigidBodyKinematics::setRigidBodySpecificVelocity(const double time,
     for (int d = 0; d < NDIM; ++d) d_parser_posn[d] = center_of_mass[d];
     for (int d = 0; d < NDIM; ++d) vel_parser[d] = d_kinematicsvel_parsers[d]->Eval();
     const StructureParameters& struct_param = getStructureParameters();
-    const int finest_ln = struct_param.getFinestLevelNumber();
-    const int coarsest_ln = struct_param.getCoarsestLevelNumber();
 #if !defined(NDEBUG)
-    TBOX_ASSERT(finest_ln == coarsest_ln);
+    {
+        const int finest_ln = struct_param.getFinestLevelNumber();
+        const int coarsest_ln = struct_param.getCoarsestLevelNumber();
+        TBOX_ASSERT(finest_ln == coarsest_ln);
+    }
 #endif
     const std::vector<std::pair<int, int> >& idx_range = struct_param.getLagIdxRange();
     const int nodes_this_ln = idx_range[0].second - idx_range[0].first;

--- a/ibtk/src/math/PETScMatUtilities.cpp
+++ b/ibtk/src/math/PETScMatUtilities.cpp
@@ -1302,6 +1302,8 @@ PETScMatUtilities::constructConservativeProlongationOp_cell(Mat& mat,
                 local_row[d] = (*dof_fine_data)(i_fine, d);
 #if !defined(NDEBUG)
                 TBOX_ASSERT(local_row[d] >= i_fine_lower && local_row[d] < i_fine_upper);
+#else
+                NULL_USE(i_fine_upper);
 #endif
                 local_row[d] -= i_fine_lower;
             }
@@ -2511,10 +2513,12 @@ PETScMatUtilities::constructPatchLevelASMSubdomains_side(std::vector<IS>& is_ove
             side_patch_box[axis] = SideGeometry<NDIM>::toSideBox(patch_box, axis);
         }
         Pointer<SideData<NDIM, int> > dof_data = patch->getPatchData(dof_index_idx);
-        const int data_depth = dof_data->getDepth();
 #if !defined(NDEBUG)
-        TBOX_ASSERT(data_depth == 1);
-        TBOX_ASSERT(dof_data->getGhostCellWidth().min() >= overlap_size.max());
+        {
+            const int data_depth = dof_data->getDepth();
+            TBOX_ASSERT(data_depth == 1);
+            TBOX_ASSERT(dof_data->getGhostCellWidth().min() >= overlap_size.max());
+        }
 #endif
 
         // Check if the patch touches physical boundary.

--- a/ibtk/src/math/PETScVecUtilities.cpp
+++ b/ibtk/src/math/PETScVecUtilities.cpp
@@ -696,6 +696,8 @@ PETScVecUtilities::constructPatchLevelAO_cell(AO& ao,
                 const int dof_idx = (*dof_index_data)(i, d);
 #if !defined(NDEBUG)
                 TBOX_ASSERT(dof_idx >= i_lower && dof_idx < i_upper);
+#else
+                NULL_USE(i_upper);
 #endif
                 petsc_idxs[counter] = dof_idx;
                 samrai_idxs[counter] =

--- a/src/IB/CIBFEMethod.cpp
+++ b/src/IB/CIBFEMethod.cpp
@@ -552,6 +552,8 @@ CIBFEMethod::setConstraintForce(Vec L, const double data_time, const double scal
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+#else
+    NULL_USE(data_time);
 #endif
     // Unpack the Lambda vector.
     Vec* vL;
@@ -697,6 +699,8 @@ CIBFEMethod::setInterpolatedVelocityVector(Vec /*V*/, const double data_time)
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+#else
+    NULL_USE(data_time);
 #endif
     d_lag_velvec_is_initialized = true;
 } // setInterpolatedVelocityVector
@@ -706,6 +710,8 @@ CIBFEMethod::getInterpolatedVelocity(Vec V, const double data_time, const double
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+#else
+    NULL_USE(data_time);
 #endif
     // Unpack the velocity vector.
     Vec* vV;

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -931,6 +931,8 @@ CIBMethod::setConstraintForce(Vec L, const double data_time, const double scale)
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+#else
+    NULL_USE(data_time);
 #endif
 
     const int struct_ln = getStructuresLevelNumber();
@@ -954,6 +956,8 @@ CIBMethod::getConstraintForce(Vec* L, const double data_time)
 #if !defined(NDEBUG)
     TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_current_time) ||
                 MathUtilities<double>::equalEps(data_time, d_new_time));
+#else
+    NULL_USE(data_time);
 #endif
     const int struct_ln = getStructuresLevelNumber();
     Pointer<LData> ptr_lagmultpr = d_l_data_manager->getLData("lambda", struct_ln);
@@ -1047,6 +1051,8 @@ CIBMethod::setInterpolatedVelocityVector(Vec /*V*/, const double data_time)
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+#else
+    NULL_USE(data_time);
 #endif
     d_lag_velvec_is_initialized = true;
 
@@ -1058,6 +1064,8 @@ CIBMethod::getInterpolatedVelocity(Vec V, const double data_time, const double s
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+#else
+    NULL_USE(data_time);
 #endif
 
     const int struct_ln = getStructuresLevelNumber();

--- a/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
@@ -725,14 +725,16 @@ StaggeredStokesPETScMatUtilities::constructPatchLevelASMSubdomains(std::vector<s
         }
         Pointer<SideData<NDIM, bool> > u_mastr_loc_data = patch->getPatchData(u_mastr_loc_idx);
         Pointer<SideData<NDIM, int> > u_dof_data = patch->getPatchData(u_dof_index_idx);
-        const int u_data_depth = u_dof_data->getDepth();
         Pointer<CellData<NDIM, int> > p_dof_data = patch->getPatchData(p_dof_index_idx);
-        const int p_data_depth = p_dof_data->getDepth();
 #if !defined(NDEBUG)
-        TBOX_ASSERT(u_data_depth == 1);
-        TBOX_ASSERT(p_data_depth == 1);
-        TBOX_ASSERT(u_dof_data->getGhostCellWidth().min() >= overlap_size.max());
-        TBOX_ASSERT(p_dof_data->getGhostCellWidth().min() >= overlap_size.max());
+        {
+            const int u_data_depth = u_dof_data->getDepth();
+            const int p_data_depth = p_dof_data->getDepth();
+            TBOX_ASSERT(u_data_depth == 1);
+            TBOX_ASSERT(p_data_depth == 1);
+            TBOX_ASSERT(u_dof_data->getGhostCellWidth().min() >= overlap_size.max());
+            TBOX_ASSERT(p_dof_data->getGhostCellWidth().min() >= overlap_size.max());
+        }
 #endif
         int n_patch_subdomains = static_cast<int>(nonoverlap_boxes[patch_counter].size());
         for (int k = 0; k < n_patch_subdomains; ++k, ++subdomain_counter)


### PR DESCRIPTION
This uses the classic `(void)x;` trick or places things in a scope surrounded by `#if/#endif`.