### PR TITLE
Enable parallelization in example compilation.

### DIFF
--- a/examples/CIB/Makefile.am
+++ b/examples/CIB/Makefile.am
@@ -2,13 +2,13 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = ex0 ex1 ex2 ex3 ex4
 
-## Standard make targets.
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex3 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex4 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;
@@ -30,4 +30,3 @@ gtest-all:
 	@(cd ex2 && make gtest-long) || exit 1;
 	@(cd ex3 && make gtest-long) || exit 1;
 	@(cd ex4 && make gtest-long) || exit 1;
-

--- a/examples/CIB/Makefile.in
+++ b/examples/CIB/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = ex0 ex1 ex2 ex3 ex4
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,13 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex3 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex4 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/CIBFE/Makefile.am
+++ b/examples/CIBFE/Makefile.am
@@ -2,10 +2,13 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = ex0 ex1
 
-## Standard make targets.
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 

--- a/examples/CIBFE/Makefile.in
+++ b/examples/CIBFE/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = ex0 ex1
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,10 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 

--- a/examples/ConstraintIB/Makefile.am
+++ b/examples/ConstraintIB/Makefile.am
@@ -2,18 +2,13 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = eel2d eel3d
 
-## Standard make targets.
-examples:
-	@(cd eel2d                        && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd eel3d                        && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd falling_sphere               && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd flow_past_cylinder           && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd flow_past_cylinder_HF           && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd knifefish                    && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd impulsively_started_cylinder && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd moving_plate                 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd oscillating_rigid_cylinder   && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd stokes_first_problem         && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = eel2d eel3d falling_sphere flow_past_cylinder flow_past_cylinder_HF knifefish impulsively_started_cylinder moving_plate oscillating_rigid_cylinder stokes_first_problem
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 ## Make targets for gtests
 gtest:

--- a/examples/ConstraintIB/Makefile.in
+++ b/examples/ConstraintIB/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = eel2d eel3d
+COMPLETE_EXAMPLES = eel2d eel3d falling_sphere flow_past_cylinder flow_past_cylinder_HF knifefish impulsively_started_cylinder moving_plate oscillating_rigid_cylinder stokes_first_problem
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,18 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd eel2d                        && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd eel3d                        && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd falling_sphere               && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd flow_past_cylinder           && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd flow_past_cylinder_HF           && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd knifefish                    && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd impulsively_started_cylinder && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd moving_plate                 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd oscillating_rigid_cylinder   && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd stokes_first_problem         && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd eel2d                        && make gtest) || exit 1;

--- a/examples/IB/Makefile.am
+++ b/examples/IB/Makefile.am
@@ -2,11 +2,15 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = explicit
 
-## Standard make targets.
-examples:
-	@(cd explicit && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-gtest: 
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
+
+gtest:
 	@(cd explicit && make gtest) || exit 1;
 
 gtest-long:

--- a/examples/IB/Makefile.in
+++ b/examples/IB/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = explicit
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,11 +818,13 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd explicit && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
-gtest: 
+gtest:
 	@(cd explicit && make gtest) || exit 1;
 
 gtest-long:

--- a/examples/IB/explicit/Makefile.am
+++ b/examples/IB/explicit/Makefile.am
@@ -2,15 +2,13 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = ex0 ex1 ex2 ex3 ex4 ex5 ex6
 
-## Standard make targets.
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex3 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex4 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex5 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex6 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;
@@ -29,4 +27,3 @@ gtest-long:
 	@(cd ex4 && make gtest-long) || exit 1;
 	@(cd ex5 && make gtest-long) || exit 1;
 	@(cd ex6 && make gtest-long) || exit 1;
-

--- a/examples/IB/explicit/Makefile.in
+++ b/examples/IB/explicit/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = ex0 ex1 ex2 ex3 ex4 ex5 ex6
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,15 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex3 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex4 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex5 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex6 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/IBFE/Makefile.am
+++ b/examples/IBFE/Makefile.am
@@ -2,9 +2,13 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = explicit
 
-## Standard make targets.
-examples:
-	@(cd explicit && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd explicit && make gtest) || exit 1;

--- a/examples/IBFE/Makefile.in
+++ b/examples/IBFE/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = explicit
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,9 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd explicit && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd explicit && make gtest) || exit 1;

--- a/examples/IBFE/explicit/Makefile.am
+++ b/examples/IBFE/explicit/Makefile.am
@@ -1,21 +1,14 @@
 ## Process this file with automake to produce Makefile.in
 include $(top_srcdir)/config/Make-rules
-SUBDIRS = ex0 ex1 ex2 ex3 ex4 ex5 ex6 ex7 ex8 ex9 ex10 ex11 
+SUBDIRS = ex0 ex1 ex2 ex3 ex4 ex5 ex6 ex7 ex8 ex9 ex10 ex11
 
-## Standard make targets.
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex3 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex4 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex5 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex6 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex7 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex8 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex9 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex10 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex11 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/IBFE/explicit/Makefile.in
+++ b/examples/IBFE/explicit/Makefile.in
@@ -496,7 +496,9 @@ IBAMR2d_LIBS = ${top_builddir}/lib/libIBAMR2d.a ${top_builddir}/ibtk/lib/libIBTK
 IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK3d.a
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
-SUBDIRS = ex0 ex1 ex2 ex3 ex4 ex5 ex6 ex7 ex8 ex9 ex10 ex11 
+SUBDIRS = ex0 ex1 ex2 ex3 ex4 ex5 ex6 ex7 ex8 ex9 ex10 ex11
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,20 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex3 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex4 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex5 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex6 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex7 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex8 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex9 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex10 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex11 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/IMP/Makefile.am
+++ b/examples/IMP/Makefile.am
@@ -2,6 +2,10 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = explicit
 
-## Standard make targets.
-examples:
-	@(cd explicit && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples

--- a/examples/IMP/Makefile.in
+++ b/examples/IMP/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = explicit
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,9 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd explicit && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/examples/IMP/explicit/Makefile.am
+++ b/examples/IMP/explicit/Makefile.am
@@ -2,6 +2,10 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = ex0
 
-## Standard make targets.
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples

--- a/examples/IMP/explicit/Makefile.in
+++ b/examples/IMP/explicit/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = ex0
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,9 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -7,20 +7,14 @@ all:
 	  $(MAKE) examples ; \
 	fi ;
 
-## Standard make targets.
-examples:
-	@(cd IB               && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd IBFE             && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-##	@(cd IMP              && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd adv_diff         && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd advect           && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd navier_stokes    && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ConstraintIB     && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd CIB              && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-##	@(cd CIBFE            && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd level_set        && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd multiphase_flow  && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd vc_navier_stokes && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = IB IBFE adv_diff advect navier_stokes ConstraintIB CIB level_set multiphase_flow vc_navier_stokes
+# Not all examples can be compiled at the present time
+INCOMPLETE_EXAMPLES = IMP CIBFE
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 if GTEST_ENABLED
 gtest:

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -497,6 +497,9 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = IB IBFE IMP adv_diff advect navier_stokes ConstraintIB CIB CIBFE level_set multiphase_flow vc_navier_stokes
+COMPLETE_EXAMPLES = IB IBFE adv_diff advect navier_stokes ConstraintIB CIB level_set multiphase_flow vc_navier_stokes
+# Not all examples can be compiled at the present time
+INCOMPLETE_EXAMPLES = IMP CIBFE
 all: all-recursive
 
 .SUFFIXES:
@@ -821,18 +824,11 @@ all:
 	if test "$(CONFIGURATION_BUILD_DIR)" != ""; then \
 	  $(MAKE) examples ; \
 	fi ;
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd IB               && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd IBFE             && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd adv_diff         && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd advect           && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd navier_stokes    && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ConstraintIB     && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd CIB              && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd level_set        && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd multiphase_flow  && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd vc_navier_stokes && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 @GTEST_ENABLED_TRUE@gtest:
 @GTEST_ENABLED_TRUE@	@(cd IB               && make gtest) || exit 1;

--- a/examples/adv_diff/Makefile.am
+++ b/examples/adv_diff/Makefile.am
@@ -2,11 +2,13 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = ex0 ex1 ex2
 
-## Standard make targets.
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/adv_diff/Makefile.in
+++ b/examples/adv_diff/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = ex0 ex1 ex2
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,11 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/level_set/Makefile.am
+++ b/examples/level_set/Makefile.am
@@ -2,10 +2,13 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = ex0 ex1
 
-## Standard make targets.
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/level_set/Makefile.in
+++ b/examples/level_set/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = ex0 ex1
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,10 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/multiphase_flow/Makefile.am
+++ b/examples/multiphase_flow/Makefile.am
@@ -2,11 +2,13 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = ex0 ex1 ex2
 
-## Standard make targets.
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/multiphase_flow/Makefile.in
+++ b/examples/multiphase_flow/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = ex0 ex1 ex2
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,11 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/navier_stokes/Makefile.am
+++ b/examples/navier_stokes/Makefile.am
@@ -2,15 +2,13 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = ex0 ex1 ex2 ex3 ex4 ex5 ex6
 
-## Standard make targets.
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex3 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex4 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex5 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex6 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/navier_stokes/Makefile.in
+++ b/examples/navier_stokes/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = ex0 ex1 ex2 ex3 ex4 ex5 ex6
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,15 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex2 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex3 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex4 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex5 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex6 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/vc_navier_stokes/Makefile.am
+++ b/examples/vc_navier_stokes/Makefile.am
@@ -2,10 +2,13 @@
 include $(top_srcdir)/config/Make-rules
 SUBDIRS = ex0 ex1
 
-## Standard make targets.
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES =
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
+
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;

--- a/examples/vc_navier_stokes/Makefile.in
+++ b/examples/vc_navier_stokes/Makefile.in
@@ -497,6 +497,8 @@ IBAMR3d_LIBS = ${top_builddir}/lib/libIBAMR3d.a ${top_builddir}/ibtk/lib/libIBTK
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 SUBDIRS = ex0 ex1
+COMPLETE_EXAMPLES = $(SUBDIRS)
+INCOMPLETE_EXAMPLES = 
 all: all-recursive
 
 .SUFFIXES:
@@ -816,10 +818,11 @@ uninstall-am:
 
 .f.m4.f:
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+.PHONY: examples $(COMPLETE_EXAMPLES)
+examples: $(COMPLETE_EXAMPLES)
 
-examples:
-	@(cd ex0 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
-	@(cd ex1 && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
+$(COMPLETE_EXAMPLES):
+	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
 
 gtest:
 	@(cd ex0 && make gtest) || exit 1;


### PR DESCRIPTION
The example programs are currently compiled in the following way:
```makefile
examples:
	@(cd IB               && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
	@(cd IBFE             && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
	@(cd adv_diff         && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
	@(cd advect           && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
	@(cd navier_stokes    && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
	@(cd ConstraintIB     && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
	@(cd CIB              && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
	@(cd level_set        && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
	@(cd multiphase_flow  && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
	@(cd vc_navier_stokes && $(MAKE) $(AM_MAKEFLAGS) $@) || exit 1;
```
this prevents parallelization since the rule itself is a sequence of shell commands. Fortunately, since all of the examples are independent, we can simply express them as phony make targets:

```makefile
COMPLETE_EXAMPLES = IB IBFE adv_diff advect navier_stokes ConstraintIB CIB level_set multiphase_flow vc_navier_stokes
INCOMPLETE_EXAMPLES = IMP CIBFE
.PHONY: examples $(COMPLETE_EXAMPLES)
examples: $(COMPLETE_EXAMPLES)

$(COMPLETE_EXAMPLES):
	cd $@ && $(MAKE) $(AM_MAKEFLAGS) examples
```
where we use a static pattern target to expand the same rule for each directory. Since the rules starting with 'cd' have no interdependencies they can now be run concurrently; this significantly improves compilation performance on multicore systems. Before this patch building everything required (with `make -j20`) about 38 minutes of wall time; after we are down to about 11.

I don't think I have ever modified a build system without it failing horribly in some unexpected way but I would like to see, at least, if the testers are okay with this.