### PR TITLE
Use ternary if in muparser.

### DIFF
--- a/examples/ConstraintIB/impulsively_started_cylinder/input2d
+++ b/examples/ConstraintIB/impulsively_started_cylinder/input2d
@@ -96,8 +96,8 @@ ForcingFunction {
     YCOM = 0.0
     RADIUS = R
     F      = RHO/DT_MAX
-    
-    function_0 = "if( (X0 - XCOM)^2 + (X1-YCOM)^2  < RADIUS^2, 400*exp(-400*t), 0)"
+
+    function_0 = "(X0 - XCOM)^2 + (X1-YCOM)^2  < RADIUS^2 ? 400*exp(-400*t) : 0"
     function_1 = "0.0"
 }
 

--- a/examples/ConstraintIB/impulsively_started_cylinder/input2d.test
+++ b/examples/ConstraintIB/impulsively_started_cylinder/input2d.test
@@ -96,8 +96,8 @@ ForcingFunction {
     YCOM = 0.0
     RADIUS = R
     F      = RHO/DT_MAX
-    
-    function_0 = "if( (X0 - XCOM)^2 + (X1-YCOM)^2  < RADIUS^2, 400*exp(-400*t), 0)"
+
+    function_0 = "(X0 - XCOM)^2 + (X1-YCOM)^2  < RADIUS^2 ? 400*exp(-400*t) : 0"
     function_1 = "0.0"
 }
 

--- a/examples/IB/explicit/ex0/input2d
+++ b/examples/IB/explicit/ex0/input2d
@@ -86,7 +86,7 @@ VelocityBcCoefs_1 {
 PressureInitialConditions {
    R = 0.25
    mu = K
-   function = "if( (X_0-0.5)^2 + (X_1-0.5)^2 <= R^2,mu*(1/R - pi*R),-mu*pi*R )"
+   function = "(X_0-0.5)^2 + (X_1-0.5)^2 <= R^2 ? mu*(1/R - pi*R) : -mu*pi*R"
 }
 
 IBHierarchyIntegrator {

--- a/examples/IB/explicit/ex0/input2d.shell
+++ b/examples/IB/explicit/ex0/input2d.shell
@@ -90,7 +90,7 @@ PressureInitialConditions {
    mu = K
    p0_smooth = (mu*PI/(3*w))*(R^2 - (R+w)^3/R)
    p0_sharp = mu*PI*R
-   function = "if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R,(p0_sharp - mu/(R+w)),if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w,(p0_sharp + (mu/w)*R/(R+w)),p0_sharp)) + if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R,(p0_smooth + (mu/R)),if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w,(p0_smooth + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))),p0_smooth))"
+   function = "(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R ? (p0_sharp - mu/(R+w)) : (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w ? (p0_sharp + (mu/w)*R/(R+w)) : p0_sharp)) + (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R ? (p0_smooth + (mu/R)) : (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w ? (p0_smooth + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))) : p0_smooth))"
 }
 
 IBHierarchyIntegrator {

--- a/examples/IB/explicit/ex0/input2d.shell_circum_fibers
+++ b/examples/IB/explicit/ex0/input2d.shell_circum_fibers
@@ -89,7 +89,7 @@ PressureInitialConditions {
    w = W
    mu = K
    p0 = (mu*PI/(3*w))*(R^2 - (R+w)^3/R)
-   function = "if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R,(p0 + (mu/R)),if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w,(p0 + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))),p0))"
+   function = "sqrt((X0-0.5)^2 + (X1-0.5)^2) < R ? (p0 + (mu/R)) : (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w ? (p0 + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))) : p0)"
 }
 
 IBHierarchyIntegrator {

--- a/examples/IB/explicit/ex0/input2d.test
+++ b/examples/IB/explicit/ex0/input2d.test
@@ -86,7 +86,7 @@ VelocityBcCoefs_1 {
 PressureInitialConditions {
    R = 0.25
    mu = K
-   function = "if( (X_0-0.5)^2 + (X_1-0.5)^2 <= R^2,mu*(1/R - pi*R),-mu*pi*R )"
+   function = "(X_0-0.5)^2 + (X_1-0.5)^2 <= R^2 ? mu*(1/R - pi*R) : -mu*pi*R"
 }
 
 IBHierarchyIntegrator {

--- a/examples/IBFE/explicit/ex0/input2d
+++ b/examples/IBFE/explicit/ex0/input2d
@@ -32,10 +32,10 @@ PressureInitialConditions {
    p0_sharp = mu*PI*R
 
 // smooth case
-// function = "if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R,(p0_smooth + (mu/R)),if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w,(p0_smooth + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))),p0_smooth))"
+// function = "sqrt((X0-0.5)^2 + (X1-0.5)^2) < R ? (p0_smooth + (mu/R)) : (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w ? (p0_smooth + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))) : p0_smooth)"
 
 // sharp case
-   function = "if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R,(p0_sharp - mu/(R+w)),if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w,(p0_sharp + (mu/w)*R/(R+w)),p0_sharp)) + if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R,(p0_smooth + (mu/R)),if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w,(p0_smooth + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))),p0_smooth))"
+   function = "(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R ? (p0_sharp - mu/(R+w)) : (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w ? (p0_sharp + (mu/w)*R/(R+w)) : p0_sharp)) + (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R ? (p0_smooth + (mu/R)) : (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w ? (p0_smooth + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))) : p0_smooth))"
 }
 
 // solver parameters

--- a/examples/IBFE/explicit/ex0/input2d.test
+++ b/examples/IBFE/explicit/ex0/input2d.test
@@ -33,10 +33,10 @@ PressureInitialConditions {
    p0_sharp = mu*PI*R
 
 // smooth case
-// function = "if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R,(p0_smooth + (mu/R)),if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w,(p0_smooth + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))),p0_smooth))"
+// function = "(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R ? (p0_smooth + (mu/R)) : (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w ? (p0_smooth + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))) : p0_smooth))"
 
 // sharp case
-   function = "if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R,(p0_sharp - mu/(R+w)),if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w,(p0_sharp + (mu/w)*R/(R+w)),p0_sharp)) + if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R,(p0_smooth + (mu/R)),if(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w,(p0_smooth + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))),p0_smooth))"
+   function = "(sqrt((X0-0.5)^2 + (X1-0.5)^2) < R ? (p0_sharp - mu/(R+w)) : (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w ? (p0_sharp + (mu/w)*R/(R+w)) : p0_sharp)) + (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R ? (p0_smooth + (mu/R)) : (sqrt((X0-0.5)^2 + (X1-0.5)^2) < R+w ? (p0_smooth + (mu/w)*(1/R)*(R+w-sqrt((X0-0.5)^2 + (X1-0.5)^2))) : p0_smooth))"
 }
 
 // solver parameters

--- a/examples/IBFE/explicit/ex3/input2d
+++ b/examples/IBFE/explicit/ex3/input2d
@@ -67,7 +67,7 @@ VelocityBcCoefs_0 {
    gcoef_function_0 = "0.0"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
-   gcoef_function_3 = "0.5 * if(X_0 < 0.3,sin(PI*X_0/0.6)^2,if(X_0 > 1.7,sin(PI*(X_0-2.0)/0.6)^2,1.0))"
+   gcoef_function_3 = "0.5 * (X_0 < 0.3 ? sin(PI*X_0/0.6)^2 : (X_0 > 1.7 ? sin(PI*(X_0-2.0)/0.6)^2 : 1.0))"
 }
 
 VelocityBcCoefs_1 {

--- a/examples/IBFE/explicit/ex3/input2d.test
+++ b/examples/IBFE/explicit/ex3/input2d.test
@@ -67,7 +67,7 @@ VelocityBcCoefs_0 {
    gcoef_function_0 = "0.0"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
-   gcoef_function_3 = "0.5 * if(X_0 < 0.3,sin(PI*X_0/0.6)^2,if(X_0 > 1.7,sin(PI*(X_0-2.0)/0.6)^2,1.0))"
+   gcoef_function_3 = "0.5 * (X_0 < 0.3 ? sin(PI*X_0/0.6)^2 : (X_0 > 1.7 ? sin(PI*(X_0-2.0)/0.6)^2 : 1.0))"
 }
 
 VelocityBcCoefs_1 {

--- a/examples/IBFE/explicit/ex6/input2d
+++ b/examples/IBFE/explicit/ex6/input2d
@@ -76,7 +76,7 @@ VelocityBcCoefs_0 {
    bcoef_function_2 = "0.0"
    bcoef_function_3 = "0.0"
 
-   gcoef_function_0 = "1.5*U_bar*X1*(H-X1)/((H/2)^2)*if(t < 2.0,0.5*(1.0-cos(0.5*pi*t)),1.0)"
+   gcoef_function_0 = "1.5*U_bar*X1*(H-X1)/((H/2)^2)*(t < 2.0 ? 0.5*(1.0-cos(0.5*pi*t)) : 1.0)"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
    gcoef_function_3 = "0.0"

--- a/examples/IBFE/explicit/ex6/input2d.test
+++ b/examples/IBFE/explicit/ex6/input2d.test
@@ -72,7 +72,7 @@ VelocityBcCoefs_0 {
    bcoef_function_2 = "0.0"
    bcoef_function_3 = "0.0"
 
-   gcoef_function_0 = "1.5*U_bar*4.0*X1*(0.41-X1)/0.1681*if(t < 2.0,0.5*(1.0-cos(0.5*pi*t)),1.0)"
+   gcoef_function_0 = "1.5*U_bar*4.0*X1*(0.41-X1)/0.1681*(t < 2.0 ? 0.5*(1.0-cos(0.5*pi*t)) : 1.0)"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
    gcoef_function_3 = "0.0"

--- a/examples/IBFE/explicit/ex7/input2d.caseC
+++ b/examples/IBFE/explicit/ex7/input2d.caseC
@@ -67,16 +67,16 @@ VelocityBcCoefs_0 {
    tau = 1.0
 
    acoef_function_0 = "1.0"
-   acoef_function_1 = "if( X1 < X1_lower,1.0,if( X1 > X1_upper,1.0,0.0 ) )"
+   acoef_function_1 = "X1 < X1_lower ? 1.0 : (X1 > X1_upper ? 1.0 : 0.0)"
    acoef_function_2 = "1.0"
    acoef_function_3 = "1.0"
 
    bcoef_function_0 = "0.0"
-   bcoef_function_1 = "if( X1 < X1_lower,0.0,if( X1 > X1_upper,0.0,1.0 ) )"
+   bcoef_function_1 = "X1 < X1_lower ? 0.0 : (X1 > X1_upper ? 0.0 : 1.0)"
    bcoef_function_2 = "0.0"
    bcoef_function_3 = "0.0"
 
-   gcoef_function_0 = "if( X1 < X1_lower,0.0,if( X1 > X1_upper,0.0,1.5*U_bar*(X1-X1_lower)*(X1-X1_upper)/((X1_mid-X1_lower)*(X1_mid-X1_upper))*if(t < tau,0.5*(1.0-cos(pi*t/tau)),1.0) ) )"
+   gcoef_function_0 = "X1 < X1_lower ? 0.0 : (X1 > X1_upper ? 0.0 : 1.5*U_bar*(X1-X1_lower)*(X1-X1_upper)/((X1_mid-X1_lower)*(X1_mid-X1_upper))*(t < tau ? 0.5*(1.0-cos(pi*t/tau)) : 1.0))"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
    gcoef_function_3 = "0.0"
@@ -99,7 +99,7 @@ VelocityBcCoefs_1 {
    gcoef_function_0 = "0.0"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
-   gcoef_function_3 = "-p_e*if(t < tau,0.5*(1.0-cos(pi*t/tau)),1.0)"
+   gcoef_function_3 = "-p_e*(t < tau ? 0.5*(1.0-cos(pi*t/tau)) : 1.0)"
 }
 
 SpongeLayerForceFunction {

--- a/examples/IBFE/explicit/ex7/input2d.caseS2
+++ b/examples/IBFE/explicit/ex7/input2d.caseS2
@@ -67,16 +67,16 @@ VelocityBcCoefs_0 {
    tau = 1.0
 
    acoef_function_0 = "1.0"
-   acoef_function_1 = "if( X1 < X1_lower,1.0,if( X1 > X1_upper,1.0,0.0 ) )"
+   acoef_function_1 = "X1 < X1_lower ? 1.0 : ( X1 > X1_upper ? 1.0 : 0.0)"
    acoef_function_2 = "1.0"
    acoef_function_3 = "1.0"
 
    bcoef_function_0 = "0.0"
-   bcoef_function_1 = "if( X1 < X1_lower,0.0,if( X1 > X1_upper,0.0,1.0 ) )"
+   bcoef_function_1 = "X1 < X1_lower ? 0.0 : (X1 > X1_upper ? 0.0 : 1.0)"
    bcoef_function_2 = "0.0"
    bcoef_function_3 = "0.0"
 
-   gcoef_function_0 = "if( X1 < X1_lower,0.0,if( X1 > X1_upper,0.0,1.5*U_bar*(X1-X1_lower)*(X1-X1_upper)/((X1_mid-X1_lower)*(X1_mid-X1_upper))*if(t < tau,0.5*(1.0-cos(pi*t/tau)),1.0) ) )"
+   gcoef_function_0 = " X1 < X1_lower ? 0.0 : (X1 > X1_upper ? 0.0 : 1.5*U_bar*(X1-X1_lower)*(X1-X1_upper)/((X1_mid-X1_lower)*(X1_mid-X1_upper))*(t < tau ? 0.5*(1.0-cos(pi*t/tau)) : 1.0))"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
    gcoef_function_3 = "0.0"
@@ -99,7 +99,7 @@ VelocityBcCoefs_1 {
    gcoef_function_0 = "0.0"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
-   gcoef_function_3 = "-p_e*if(t < tau,0.5*(1.0-cos(pi*t/tau)),1.0)"
+   gcoef_function_3 = "-p_e*(t < tau ? 0.5*(1.0-cos(pi*t/tau)) : 1.0)"
 }
 
 SpongeLayerForceFunction {

--- a/examples/IBFE/explicit/ex7/input2d.caseSP
+++ b/examples/IBFE/explicit/ex7/input2d.caseSP
@@ -67,17 +67,17 @@ VelocityBcCoefs_0 {
    X1_mid   = 0.5*(X1_lower + X1_upper)
    tau = 1.0
 
-   acoef_function_0 = "if( X1 < X1_lower,1.0,if( X1 > X1_upper,1.0,0.0 ) )"
-   acoef_function_1 = "if( X1 < X1_lower,1.0,if( X1 > X1_upper,1.0,0.0 ) )"
+   acoef_function_0 = "X1 < X1_lower ? 1.0 : (X1 > X1_upper ? 1.0 : 0.0)"
+   acoef_function_1 = "X1 < X1_lower ? 1.0 : (X1 > X1_upper ? 1.0 : 0.0)"
    acoef_function_2 = "1.0"
    acoef_function_3 = "1.0"
 
-   bcoef_function_0 = "if( X1 < X1_lower,0.0,if( X1 > X1_upper,0.0,1.0 ) )"
-   bcoef_function_1 = "if( X1 < X1_lower,0.0,if( X1 > X1_upper,0.0,1.0 ) )"
+   bcoef_function_0 = "X1 < X1_lower ? 0.0 : (X1 > X1_upper ? 0.0 : 1.0)"
+   bcoef_function_1 = "X1 < X1_lower ? 0.0 : (X1 > X1_upper ? 0.0 : 1.0)"
    bcoef_function_2 = "0.0"
    bcoef_function_3 = "0.0"
 
-   gcoef_function_0 = "if( X1 < X1_lower,0.0,if( X1 > X1_upper,0.0,-p_u*if(t < tau,0.5*(1.0-cos(pi*t/tau)),1.0) ) )"
+   gcoef_function_0 = "X1 < X1_lower ? 0.0 : (X1 > X1_upper ? 0.0 : -p_u*(t < tau ? 0.5*(1.0-cos(pi*t/tau)) : 1.0))"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
    gcoef_function_3 = "0.0"
@@ -100,7 +100,7 @@ VelocityBcCoefs_1 {
    gcoef_function_0 = "0.0"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
-   gcoef_function_3 = "-p_e*if(t < tau,0.5*(1.0-cos(pi*t/tau)),1.0)"
+   gcoef_function_3 = "-p_e*(t < tau ? 0.5*(1.0-cos(pi*t/tau)) : 1.0)"
 }
 
 SpongeLayerForceFunction {

--- a/examples/IBFE/explicit/ex7/input2d.test
+++ b/examples/IBFE/explicit/ex7/input2d.test
@@ -67,16 +67,16 @@ VelocityBcCoefs_0 {
    tau = 1.0
 
    acoef_function_0 = "1.0"
-   acoef_function_1 = "if( X1 < X1_lower,1.0,if( X1 > X1_upper,1.0,0.0 ) )"
+   acoef_function_1 = "X1 < X1_lower ? 1.0 : (X1 > X1_upper ? 1.0 : 0.0)"
    acoef_function_2 = "1.0"
    acoef_function_3 = "1.0"
 
    bcoef_function_0 = "0.0"
-   bcoef_function_1 = "if( X1 < X1_lower,0.0,if( X1 > X1_upper,0.0,1.0 ) )"
+   bcoef_function_1 = " X1 < X1_lower ? 0.0 : (X1 > X1_upper ? 0.0 : 1.0)"
    bcoef_function_2 = "0.0"
    bcoef_function_3 = "0.0"
 
-   gcoef_function_0 = "if( X1 < X1_lower,0.0,if( X1 > X1_upper,0.0,1.5*U_bar*(X1-X1_lower)*(X1-X1_upper)/((X1_mid-X1_lower)*(X1_mid-X1_upper))*if(t < tau,0.5*(1.0-cos(pi*t/tau)),1.0) ) )"
+   gcoef_function_0 = " X1 < X1_lower ? 0.0 : (X1 > X1_upper ? 0.0 : 1.5*U_bar*(X1-X1_lower)*(X1-X1_upper)/((X1_mid-X1_lower)*(X1_mid-X1_upper))*(t < tau ? 0.5*(1.0-cos(pi*t/tau)) : 1.0))"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
    gcoef_function_3 = "0.0"
@@ -99,7 +99,7 @@ VelocityBcCoefs_1 {
    gcoef_function_0 = "0.0"
    gcoef_function_1 = "0.0"
    gcoef_function_2 = "0.0"
-   gcoef_function_3 = "-p_e*if(t < tau,0.5*(1.0-cos(pi*t/tau)),1.0)"
+   gcoef_function_3 = "-p_e*(t < tau ? 0.5*(1.0-cos(pi*t/tau)) : 1.0)"
 }
 
 SpongeLayerForceFunction {

--- a/examples/IBFE/explicit/ex8/input2d
+++ b/examples/IBFE/explicit/ex8/input2d
@@ -61,13 +61,13 @@ BLOCK_KAPPA_S = SAFETY * 1.0e2 * DX / DT^2
 BEAM_KAPPA_S  = SAFETY * 5.0e1 * DX / DT^2
 
 VelocityBcCoefs_0 {
-   acoef_function_0 = "if((X_1 < 0.5), 1.0 , 0.0)"
-   acoef_function_1 = "if((X_1 < 0.5), 1.0 , 0.0)"
+   acoef_function_0 = "(X_1 < 0.5) ? 1.0 : 0.0"
+   acoef_function_1 = "(X_1 < 0.5) ? 1.0 : 0.0"
    acoef_function_2 = "1.0"
    acoef_function_3 = "1.0"
 
-   bcoef_function_0 = "if((X_1 < 0.5), 0.0 , 1.0)"
-   bcoef_function_1 = "if((X_1 < 0.5), 0.0 , 1.0)"
+   bcoef_function_0 = "(X_1 < 0.5) ? 0.0 : 1.0"
+   bcoef_function_1 = "(X_1 < 0.5) ? 0.0 : 1.0"
    bcoef_function_2 = "0.0"
    bcoef_function_3 = "0.0"
 
@@ -83,17 +83,17 @@ VelocityBcCoefs_1 {
 
    acoef_function_0 = "1.0"
    acoef_function_1 = "1.0"
-   acoef_function_2 = "if((X_0 > 0.5) && (X_0 < 1.5), 0.0 , 1.0)"
+   acoef_function_2 = "(X_0 > 0.5) && (X_0 < 1.5) ? 0.0 : 1.0"
    acoef_function_3 = "0.0"
 
    bcoef_function_0 = "0.0"
    bcoef_function_1 = "0.0"
-   bcoef_function_2 = "if((X_0 > 0.5) && (X_0 < 1.5), 1.0 , 0.0)"
+   bcoef_function_2 = "(X_0 > 0.5) && (X_0 < 1.5) ? 1.0 : 0.0"
    bcoef_function_3 = "1.0"
 
    gcoef_function_0 = "0.0"
    gcoef_function_1 = "0.0"
-   gcoef_function_2 = "if((X_0 > 0.5) && (X_0 < 1.5), -p_max * min(1.0 , t/t_end) , 0.0)"
+   gcoef_function_2 = "(X_0 > 0.5) && (X_0 < 1.5) ? -p_max * min(1.0, t/t_end) : 0.0"
    gcoef_function_3 = "0.0"
 }
 

--- a/examples/IBFE/explicit/ex8/input2d.test
+++ b/examples/IBFE/explicit/ex8/input2d.test
@@ -61,13 +61,13 @@ BLOCK_KAPPA_S = SAFETY * 1.0e2 * DX / DT^2
 BEAM_KAPPA_S  = SAFETY * 5.0e1 * DX / DT^2
 
 VelocityBcCoefs_0 {
-   acoef_function_0 = "if((X_1 < 0.5), 1.0 , 0.0)"
-   acoef_function_1 = "if((X_1 < 0.5), 1.0 , 0.0)"
+   acoef_function_0 = "(X_1 < 0.5) ? 1.0 : 0.0"
+   acoef_function_1 = "(X_1 < 0.5) ? 1.0 : 0.0"
    acoef_function_2 = "1.0"
    acoef_function_3 = "1.0"
 
-   bcoef_function_0 = "if((X_1 < 0.5), 0.0 , 1.0)"
-   bcoef_function_1 = "if((X_1 < 0.5), 0.0 , 1.0)"
+   bcoef_function_0 = "(X_1 < 0.5) ? 0.0 : 1.0"
+   bcoef_function_1 = "(X_1 < 0.5) ? 0.0 : 1.0"
    bcoef_function_2 = "0.0"
    bcoef_function_3 = "0.0"
 
@@ -83,17 +83,17 @@ VelocityBcCoefs_1 {
 
    acoef_function_0 = "1.0"
    acoef_function_1 = "1.0"
-   acoef_function_2 = "if((X_0 > 0.5) && (X_0 < 1.5), 0.0 , 1.0)"
+   acoef_function_2 = "(X_0 > 0.5) && (X_0 < 1.5) ? 0.0 : 1.0"
    acoef_function_3 = "0.0"
 
    bcoef_function_0 = "0.0"
    bcoef_function_1 = "0.0"
-   bcoef_function_2 = "if((X_0 > 0.5) && (X_0 < 1.5), 1.0 , 0.0)"
+   bcoef_function_2 = "(X_0 > 0.5) && (X_0 < 1.5) ? 1.0 : 0.0"
    bcoef_function_3 = "1.0"
 
    gcoef_function_0 = "0.0"
    gcoef_function_1 = "0.0"
-   gcoef_function_2 = "if((X_0 > 0.5) && (X_0 < 1.5), -p_max * min(1.0 , t/t_end) , 0.0)"
+   gcoef_function_2 = "(X_0 > 0.5) && (X_0 < 1.5) ? -p_max * min(1.0 , t/t_end) : 0.0"
    gcoef_function_3 = "0.0"
 }
 

--- a/examples/navier_stokes/ex1/input2d
+++ b/examples/navier_stokes/ex1/input2d
@@ -38,7 +38,7 @@ SECOND_ORDER_PRESSURE_UPDATE = TRUE
 VelocityInitialConditions {
    rho = 80.0
    delta = 0.05
-   function_0 = "if(X1 < 0.5,tanh(rho*(X1-0.25)),tanh(rho*(0.75-X1)))"
+   function_0 = "X1 < 0.5 ? tanh(rho*(X1-0.25)) : tanh(rho*(0.75-X1))"
    function_1 = "delta*sin(2.0*pi*(X0+0.25))"
 }
 

--- a/examples/navier_stokes/ex1/input2d.test
+++ b/examples/navier_stokes/ex1/input2d.test
@@ -38,7 +38,7 @@ SECOND_ORDER_PRESSURE_UPDATE = TRUE
 VelocityInitialConditions {
    rho = 80.0
    delta = 0.05
-   function_0 = "if(X1 < 0.5,tanh(rho*(X1-0.25)),tanh(rho*(0.75-X1)))"
+   function_0 = "X1 < 0.5 ? tanh(rho*(X1-0.25)) : tanh(rho*(0.75-X1))"
    function_1 = "delta*sin(2.0*pi*(X0+0.25))"
 }
 

--- a/examples/navier_stokes/ex1/input3d
+++ b/examples/navier_stokes/ex1/input3d
@@ -38,7 +38,7 @@ SECOND_ORDER_PRESSURE_UPDATE = TRUE
 VelocityInitialConditions {
    rho = 80.0
    delta = 0.05
-   function_0 = "if(X1 < 0.5,tanh(rho*(X1-0.25)),tanh(rho*(0.75-X1)))"
+   function_0 = "X1 < 0.5 ? tanh(rho*(X1-0.25)) : tanh(rho*(0.75-X1))"
    function_1 = "delta*sin(2.0*pi*(X0+0.25))*sin(2.0*pi*(X2+0.25))"
    function_2 = "0.0"
 }

--- a/examples/navier_stokes/ex1/input3d.test
+++ b/examples/navier_stokes/ex1/input3d.test
@@ -38,7 +38,7 @@ SECOND_ORDER_PRESSURE_UPDATE = TRUE
 VelocityInitialConditions {
    rho = 80.0
    delta = 0.05
-   function_0 = "if(X1 < 0.5,tanh(rho*(X1-0.25)),tanh(rho*(0.75-X1)))"
+   function_0 = "X1 < 0.5 ? tanh(rho*(X1-0.25)) : tanh(rho*(0.75-X1))"
    function_1 = "delta*sin(2.0*pi*(X0+0.25))*sin(2.0*pi*(X2+0.25))"
    function_2 = "0.0"
 }

--- a/ibtk/examples/PETScOps/ProlongationMat/input2d
+++ b/ibtk/examples/PETScOps/ProlongationMat/input2d
@@ -1,6 +1,6 @@
 f {
-   function_0 = "if(X0 < 0, -X0, X0)"
-   function_1 = "if(X1 < 0, -X1, X1)"
+   function_0 = "X0 < 0 ? -X0 : X0"
+   function_1 = "X1 < 0 ? -X1 : X1"
 }
 
 prolongation_op_type = "LINEAR"

--- a/ibtk/examples/PETScOps/ProlongationMat/input2d.test
+++ b/ibtk/examples/PETScOps/ProlongationMat/input2d.test
@@ -1,6 +1,6 @@
 f {
-   function_0 = "if(X0 < 0, -X0, X0)"
-   function_1 = "if(X1 < 0, -X1, X1)"
+   function_0 = "X0 < 0 ? -X0 : X0"
+   function_1 = "X1 < 0 ? -X1 : X1"
 }
 
 prolongation_op_type = "LINEAR"

--- a/ibtk/examples/PETScOps/ProlongationMat/input3d
+++ b/ibtk/examples/PETScOps/ProlongationMat/input3d
@@ -1,7 +1,7 @@
 f {
-    function_0 = "if(X0 < 0, -X0, X0)"
-    function_1 = "if(X1 < 0, -X1, X1)"
-    function_2 = "if(X2 < 0, -X2, X2)"
+    function_0 = "X0 < 0 ? -X0 : X0"
+    function_1 = "X1 < 0 ? -X1 : X1"
+    function_2 = "X2 < 0 ? -X2 : X2"
 }
 
 prolongation_op_type = "LINEAR"

--- a/ibtk/examples/PETScOps/ProlongationMat/input3d.test
+++ b/ibtk/examples/PETScOps/ProlongationMat/input3d.test
@@ -1,7 +1,7 @@
 f {
-    function_0 = "if(X0 < 0, -X0, X0)"
-    function_1 = "if(X1 < 0, -X1, X1)"
-    function_2 = "if(X2 < 0, -X2, X2)"
+    function_0 = "X0 < 0 ? -X0 : X0"
+    function_1 = "X1 < 0 ? -X1 : X1"
+    function_2 = "X2 < 0 ? -X2 : X2"
 }
 
 prolongation_op_type = "LINEAR"


### PR DESCRIPTION
Newer versions of muparser removed the `if(A,B,C)` function, so we cannot run the test suite with them.

The ternary syntax is supported by (IIRC) version 2 and newer, which includes the bundled copy of muparser.