### PR TITLE
Convert some pointers to mutable variables.

### DIFF
--- a/ibtk/include/ibtk/muParserRobinBcCoefs.h
+++ b/ibtk/include/ibtk/muParserRobinBcCoefs.h
@@ -93,11 +93,6 @@ public:
                          SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom);
 
     /*!
-     * \brief Destructor.
-     */
-    ~muParserRobinBcCoefs();
-
-    /*!
      * \name Implementation of SAMRAI::solv::RobinBcCoefStrategy interface.
      */
     //\{
@@ -186,6 +181,27 @@ private:
     muParserRobinBcCoefs& operator=(const muParserRobinBcCoefs& that);
 
     /*!
+     * Current time value used by the mu::Parser instances.
+     *
+     * This value is mutable since the mu::Parser objects each store a pointer
+     * to it but its specific value (the present time) changes during each
+     * call to muParserRobinBcCoefs::setBcCoefs. The alternative would be to
+     * rebuild the mu::Parser objects during each call to
+     * muParserRobinBcCoefs::setBcCoefs, which is much more expensive. Since
+     * this variable is only written to and subsequently read from in that
+     * function this is reasonable.
+     */
+    mutable double d_parser_time;
+
+    /*!
+     * Current space point used by the mu::Parser instances.
+     *
+     * This value is mutable for the same reasons that
+     * muParserRobinBcCoefs::d_parser_time is mutable.
+     */
+    mutable Point d_parser_posn;
+
+    /*!
      * The Cartesian grid geometry object provides the extents of the
      * computational domain.
      */
@@ -210,12 +226,6 @@ private:
     std::vector<mu::Parser> d_acoef_parsers;
     std::vector<mu::Parser> d_bcoef_parsers;
     std::vector<mu::Parser> d_gcoef_parsers;
-
-    /*!
-     * Time and position variables.
-     */
-    double* d_parser_time;
-    Point* d_parser_posn;
 };
 } // namespace IBTK
 


### PR DESCRIPTION
The present implementation works since modifying a variable through a pointer is permissible in a const function.

Since we write to these variables and then read them through Eval(), it is reasonable to mark them as mutable since the value set at by the end of the function won't be read again after the function returns.

Mentioned in #258.