### PR TITLE
Initialize IBStandardInitializer in its ctor.

### DIFF
--- a/examples/CIB/ex0/input2d.test
+++ b/examples/CIB/ex0/input2d.test
@@ -271,7 +271,10 @@ Main {
 
 // visualization dump parameters
    viz_writer                  = "VisIt","Silo"
-   viz_dump_interval           = int(END_TIME/(3*DT))
+   // Do not write any output (previous versions of IBStandardInitializer had a
+   // bug where setting this to zero triggered an abort, so its set to zero now
+   // to ensure that that bug is fixed)
+   viz_dump_interval           = 0
    viz_dump_dirname            = "viz_cylinder2d"
    visit_number_procs_per_file = 1
 

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -200,7 +200,7 @@ IBStandardInitializer::IBStandardInitializer(const std::string& object_name, Poi
         d_data_processed = true;
     }
 
-    return;
+    init();
 } // IBStandardInitializer
 
 IBStandardInitializer::~IBStandardInitializer()


### PR DESCRIPTION
This fixes an issue related to the current failure of the `CIB/ex0` test: if, in that test, output is disabled, then `init()` is never run, which leads to failed assertions later on. Since `init()` does not rely on any data not set in the constructor (i.e., the class members are set by `getFromInput`) we can run it there.