### PR TITLE
Update const function in LInitStrategy and add init call to IBRedundantInitializer

### DIFF
--- a/ibtk/include/ibtk/LDataManager.h
+++ b/ibtk/include/ibtk/LDataManager.h
@@ -476,6 +476,9 @@ public:
     /*!
      * Register a concrete strategy object with the integrator that specifies
      * the initial configuration of the curvilinear mesh nodes.
+     *
+     * \note This function calls LInitStrategy::init(). All preprocessing should be completed before
+     * registering a LInitStrategy object.
      */
     void registerLInitStrategy(SAMRAI::tbox::Pointer<LInitStrategy> lag_init);
 

--- a/ibtk/include/ibtk/LInitStrategy.h
+++ b/ibtk/include/ibtk/LInitStrategy.h
@@ -112,6 +112,13 @@ public:
                                       bool initial_time) = 0;
 
     /*!
+     * \brief Initialize structure specific configurations.
+     *
+     * \note A default empty implementation is provided.
+     */
+    virtual void init() {};
+
+    /*!
      * \brief Initialize the structure indexing information on the patch level.
      *
      * \note A default empty implementation is provided.

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -845,6 +845,7 @@ LDataManager::registerLInitStrategy(Pointer<LInitStrategy> lag_init)
     TBOX_ASSERT(lag_init);
 #endif
     d_lag_init = lag_init;
+    d_lag_init->init();
     return;
 } // registerLInitStrategy
 

--- a/include/ibamr/IBRedundantInitializer.h
+++ b/include/ibamr/IBRedundantInitializer.h
@@ -483,6 +483,13 @@ public:
      */
     void setStructureNamesOnLevel(const int& level_num, const std::vector<std::string>& strct_names);
 
+    /*!
+     * \brief Initialize structure specific configurations.
+     *
+     * \note All functions should be registered with the object before init is called.
+     */
+    virtual void init();
+
 protected:
     /*!
      * \brief Default constructor.
@@ -510,11 +517,6 @@ protected:
      * \return A reference to this object.
      */
     IBRedundantInitializer& operator=(const IBRedundantInitializer& that);
-
-    /*!
-     * \brief Initialize structure specific configurations.
-     */
-    virtual void init();
 
     /*!
      * \brief Configure the Lagrangian Silo data writer to plot the data

--- a/include/ibamr/IBStandardInitializer.h
+++ b/include/ibamr/IBStandardInitializer.h
@@ -436,13 +436,13 @@ public:
      */
     ~IBStandardInitializer();
 
-protected:
-private:
     /*!
      * \brief Initialize structure specific configurations.
      */
     void init();
 
+protected:
+private:
     /*!
      * \brief Default constructor.
      *
@@ -545,11 +545,6 @@ private:
      * and for error reporting purposes.
      */
     std::string d_object_name;
-
-    /*!
-     * Checking if user defined data has been processed./
-     */
-    bool d_data_processed;
 
     /*
      * The boolean value determines whether file read batons are employed to

--- a/src/IB/IBRedundantInitializer.cpp
+++ b/src/IB/IBRedundantInitializer.cpp
@@ -176,8 +176,9 @@ IBRedundantInitializer::registerLSiloDataWriter(Pointer<LSiloDataWriter> silo_wr
     // restart file.
     if (!is_from_restart)
     {
-        // Check if data has been processed.
-        init();
+#if !defined(NDEBUG)
+        TBOX_ASSERT(d_data_processed);
+#endif
 
         for (int ln = 0; ln < d_max_levels; ++ln)
         {
@@ -193,6 +194,10 @@ IBRedundantInitializer::registerLSiloDataWriter(Pointer<LSiloDataWriter> silo_wr
 bool
 IBRedundantInitializer::getLevelHasLagrangianData(const int level_number, const bool /*can_be_refined*/) const
 {
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_data_processed);
+#endif
+
     return !d_num_vertex[level_number].empty();
 } // getLevelHasLagrangianData
 
@@ -203,8 +208,9 @@ IBRedundantInitializer::computeGlobalNodeCountOnPatchLevel(const Pointer<PatchHi
                                                            const bool /*can_be_refined*/,
                                                            const bool /*initial_time*/)
 {
-    // Check if data has been processed.
-    init();
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_data_processed);
+#endif
 
     return std::accumulate(d_num_vertex[level_number].begin(), d_num_vertex[level_number].end(), 0);
 }
@@ -216,8 +222,9 @@ IBRedundantInitializer::computeLocalNodeCountOnPatchLevel(const Pointer<PatchHie
                                                           const bool /*can_be_refined*/,
                                                           const bool /*initial_time*/)
 {
-    // Check if data has been processed.
-    init();
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_data_processed);
+#endif
     // Determine the extents of the physical domain.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
 
@@ -248,8 +255,9 @@ IBRedundantInitializer::initializeStructureIndexingOnPatchLevel(
     const bool /*initial_time*/,
     LDataManager* const /*l_data_manager*/)
 {
-    // Check if data has been processed.
-    init();
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_data_processed);
+#endif
 
     int offset = 0;
     for (int j = 0; j < static_cast<int>(d_base_filename[level_number].size()); ++j)
@@ -984,8 +992,9 @@ IBRedundantInitializer::initializeDataOnPatchLevel(const int lag_node_index_idx,
                                                    const bool /*initial_time*/,
                                                    LDataManager* const /*l_data_manager*/)
 {
-    // Check if data has been processed.
-    init();
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_data_processed);
+#endif
 
     // Determine the extents of the physical domain.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
@@ -1130,8 +1139,9 @@ IBRedundantInitializer::initializeMassDataOnPatchLevel(const unsigned int /*glob
                                                        const bool /*initial_time*/,
                                                        LDataManager* const /*l_data_manager*/)
 {
-    // Check if data has been processed.
-    init();
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_data_processed);
+#endif
 
     // Determine the extents of the physical domain.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
@@ -1193,8 +1203,9 @@ IBRedundantInitializer::initializeDirectorDataOnPatchLevel(const unsigned int /*
                                                            const bool /*initial_time*/,
                                                            LDataManager* const /*l_data_manager*/)
 {
-    // Check if data has been processed.
-    init();
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_data_processed);
+#endif
 
     // Determine the extents of the physical domain.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
@@ -1238,8 +1249,9 @@ IBRedundantInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarch
                                                      const double /*error_data_time*/,
                                                      const int tag_index)
 {
-    // Check if data has been processed.
-    init();
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_data_processed);
+#endif
 
     // Determine the extents of the physical domain.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
@@ -1299,10 +1311,6 @@ IBRedundantInitializer::setStructureNamesOnLevel(const int& level_num, const std
     return;
 }
 
-/////////////////////////////// PROTECTED ////////////////////////////////////
-
-/////////////////////////////// PRIVATE //////////////////////////////////////
-
 void
 IBRedundantInitializer::init()
 {
@@ -1330,6 +1338,10 @@ IBRedundantInitializer::init()
 
     return;
 }
+
+/////////////////////////////// PROTECTED ////////////////////////////////////
+
+/////////////////////////////// PRIVATE //////////////////////////////////////
 
 void
 IBRedundantInitializer::initializeLSiloDataWriter(const int level_number)

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -130,7 +130,6 @@ discard_comments(const std::string& input_string)
 IBStandardInitializer::IBStandardInitializer(const std::string& object_name, Pointer<Database> input_db)
     : IBRedundantInitializer(object_name, input_db),
       d_object_name(object_name),
-      d_data_processed(false),
       d_use_file_batons(true),
       d_max_levels(-1),
       d_level_is_initialized(),
@@ -195,6 +194,7 @@ IBStandardInitializer::IBStandardInitializer(const std::string& object_name, Poi
     // user data.
     RestartManager* restart_manager = RestartManager::getManager();
     const bool is_from_restart = restart_manager->isFromRestart();
+    d_data_processed = false;
     if (is_from_restart)
     {
         d_data_processed = true;
@@ -208,10 +208,6 @@ IBStandardInitializer::~IBStandardInitializer()
     pout << d_object_name << ":  Deallocating initialization data.\n";
     return;
 } // ~IBStandardInitializer
-
-/////////////////////////////// PROTECTED ////////////////////////////////////
-
-/////////////////////////////// PRIVATE //////////////////////////////////////
 
 void
 IBStandardInitializer::init()
@@ -261,6 +257,10 @@ IBStandardInitializer::init()
 
     return;
 }
+
+/////////////////////////////// PROTECTED ////////////////////////////////////
+
+/////////////////////////////// PRIVATE //////////////////////////////////////
 
 void
 IBStandardInitializer::readVertexFiles(const std::string& extension)


### PR DESCRIPTION
This fixes the issues addressed in #278 for `IBRedundantInitializer`. It removes `const` from a member function in `LInitStrategy` and adds an extra `init` call to `IBRedundantInitializer`.

This change should fix the issue for `IBStandardInitializer` as well.