### PR TITLE
Removing exodus io from IBFEInstrumentPanel class

### DIFF
--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -126,6 +126,11 @@ private:
      * \brief write out meshes and equation systems in Exodus file.
      */
     void outputExodus(IBAMR::IBFEMethod* ib_method_ops, int timestep, double loop_time);
+    
+    /*!
+     * \brief write out meshes in STL file.
+     */
+    void outputSTL(IBAMR::IBFEMethod* ib_method_ops, int timestep, double loop_time);
 
     /*!
      * \brief write out nodes.

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -114,7 +114,7 @@ public:
     const libMesh::MeshBase& getMeterMesh(const unsigned int jj) const;
     
     /*!
-     * \return A reference to the EquationSystem object for jjth meter mesh
+     * \return A reference to the EquationSystems object for jjth meter mesh
      */
     const libMesh::EquationSystems& getMeterMeshEquationSystems(const unsigned int jj) const;
     

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -99,24 +99,39 @@ public:
                             double data_time);
 
     /*!
-     * \return get the instrument dump interval.
+     * \return get the instrument dump interval
      */
     int getInstrumentDumpInterval() const;
     
     /*!
+     * \return get the number of meter meshes
+     */
+    int getNumberOfMeterMeshes() const;
+    
+    /*!
      * \return get a pointer to the jjth meter mesh
      */
-    libMesh::SerialMesh* getMeterMesh(const unsigned int jj) const;
+    libMesh::MeshBase& getMeterMesh(const unsigned int jj) const;
     
     /*!
      * \return get a pointer to the EquationSystem object for jjth meter mesh
      */
-    libMesh::EquationSystems* getMeterMeshSystem(const unsigned int jj) const;
+    libMesh::EquationSystems& getMeterMeshEquationSystems(const unsigned int jj) const;
     
     /*!
      * \return get the name for jjth meter mesh
      */
     std::string getMeterMeshName(const unsigned int jj) const;
+    
+    /*!
+     * \return get the ordered vector or nodes for the jjth meter mesh
+     */
+    std::vector<libMesh::Point> getMeterMeshNodes(const unsigned int jj) const;
+    
+    /*!
+     * \return get the quadrature order for the jjth meter mesh
+     */
+    libMesh::Order getMeterMeshQuadOrder(const unsigned int jj) const;
     
 private:
     /*!

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -105,10 +105,25 @@ public:
     void outputMeterMeshes(IBAMR::IBFEMethod* ib_method_ops, int timestep_num, double data_time);
 
     /*!
-     * \return return the instrument dump interval.
+     * \return get the instrument dump interval.
      */
     int getInstrumentDumpInterval() const;
-
+    
+    /*!
+     * \return get a pointer to the jjth meter mesh
+     */
+    libMesh::SerialMesh* getMeterMesh(const unsigned int jj) const;
+    
+    /*!
+     * \return get a pointer to the EquationSystem object for jjth meter mesh
+     */
+    libMesh::EquationSystems* getMeterMeshSystem(const unsigned int jj) const;
+    
+    /*!
+     * \return get the name for jjth meter mesh
+     */
+    std::string getMeterMeshName(const unsigned int jj) const;
+    
 private:
     /*!
      * \brief initialize data which depend on the FE equation systems for
@@ -126,11 +141,6 @@ private:
      * \brief write out meshes and equation systems in Exodus file.
      */
     void outputExodus(IBAMR::IBFEMethod* ib_method_ops, int timestep, double loop_time);
-    
-    /*!
-     * \brief write out meshes in STL file.
-     */
-    void outputSTL(IBAMR::IBFEMethod* ib_method_ops, int timestep, double loop_time);
 
     /*!
      * \brief write out nodes.

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -99,37 +99,37 @@ public:
                             double data_time);
 
     /*!
-     * \return get the instrument dump interval
+     * \return The instrument dump interval
      */
     int getInstrumentDumpInterval() const;
     
     /*!
-     * \return get the number of meter meshes
+     * \return The number of meter meshes
      */
     int getNumberOfMeterMeshes() const;
     
     /*!
-     * \return get a pointer to the jjth meter mesh
+     * \return A reference to the jjth meter mesh
      */
-    libMesh::MeshBase& getMeterMesh(const unsigned int jj) const;
+    const libMesh::MeshBase& getMeterMesh(const unsigned int jj) const;
     
     /*!
-     * \return get a pointer to the EquationSystem object for jjth meter mesh
+     * \return A reference to the EquationSystem object for jjth meter mesh
      */
-    libMesh::EquationSystems& getMeterMeshEquationSystems(const unsigned int jj) const;
+    const libMesh::EquationSystems& getMeterMeshEquationSystems(const unsigned int jj) const;
     
     /*!
-     * \return get the name for jjth meter mesh
+     * \return The name for jjth meter mesh
      */
-    std::string getMeterMeshName(const unsigned int jj) const;
+    const std::string& getMeterMeshName(const unsigned int jj) const;
     
     /*!
-     * \return get the ordered vector or nodes for the jjth meter mesh
+     * \return An ordered vector of nodes for the jjth meter mesh
      */
-    std::vector<libMesh::Point> getMeterMeshNodes(const unsigned int jj) const;
+    const std::vector<libMesh::Point>& getMeterMeshNodes(const unsigned int jj) const;
     
     /*!
-     * \return get the quadrature order for the jjth meter mesh
+     * \return The quadrature order for the jjth meter mesh
      */
     libMesh::Order getMeterMeshQuadOrder(const unsigned int jj) const;
     

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -111,12 +111,12 @@ public:
     /*!
      * \return A reference to the jjth meter mesh
      */
-    const libMesh::MeshBase& getMeterMesh(const unsigned int jj) const;
+    libMesh::MeshBase& getMeterMesh(const unsigned int jj) const;
     
     /*!
      * \return A reference to the EquationSystems object for jjth meter mesh
      */
-    const libMesh::EquationSystems& getMeterMeshEquationSystems(const unsigned int jj) const;
+    libMesh::EquationSystems& getMeterMeshEquationSystems(const unsigned int jj) const;
     
     /*!
      * \return The name for jjth meter mesh

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -44,7 +44,6 @@
 #include "libmesh/enum_order.h"
 #include "libmesh/enum_quadrature_type.h"
 #include "libmesh/equation_systems.h"
-#include "libmesh/exodusII_io.h"
 #include "libmesh/mesh.h"
 #include "libmesh/point.h"
 #include "libmesh/serial_mesh.h"

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -102,37 +102,37 @@ public:
      * \return The instrument dump interval
      */
     int getInstrumentDumpInterval() const;
-    
+
     /*!
      * \return The number of meter meshes
      */
     int getNumberOfMeterMeshes() const;
-    
+
     /*!
      * \return A reference to the jjth meter mesh
      */
     libMesh::MeshBase& getMeterMesh(const unsigned int jj) const;
-    
+
     /*!
      * \return A reference to the EquationSystems object for jjth meter mesh
      */
     libMesh::EquationSystems& getMeterMeshEquationSystems(const unsigned int jj) const;
-    
+
     /*!
      * \return The name for jjth meter mesh
      */
     const std::string& getMeterMeshName(const unsigned int jj) const;
-    
+
     /*!
      * \return An ordered vector of nodes for the jjth meter mesh
      */
     const std::vector<libMesh::Point>& getMeterMeshNodes(const unsigned int jj) const;
-    
+
     /*!
      * \return The quadrature order for the jjth meter mesh
      */
     libMesh::Order getMeterMeshQuadOrder(const unsigned int jj) const;
-    
+
 private:
     /*!
      * \brief initialize data which depend on the FE equation systems for

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -138,11 +138,6 @@ private:
     void outputData(double data_time);
 
     /*!
-     * \brief write out meshes and equation systems in Exodus file.
-     */
-    void outputExodus(IBAMR::IBFEMethod* ib_method_ops, int timestep, double loop_time);
-
-    /*!
      * \brief write out nodes.
      */
     void outputNodes();
@@ -225,11 +220,6 @@ private:
      * \brief contains pointers to the equation systems for the meter mesh.
      */
     std::vector<libMesh::EquationSystems*> d_meter_systems;
-
-    /*!
-     * \brief vector of exodus io objects for data output.
-     */
-    std::vector<libMesh::ExodusII_IO*> d_exodus_io;
 
     /*!
      * \brief vector of meter mesh pointers.

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -100,11 +100,6 @@ public:
                             double data_time);
 
     /*!
-     * \brief output exodus files and .dat file for meshes and nodes.
-     */
-    void outputMeterMeshes(IBAMR::IBFEMethod* ib_method_ops, int timestep_num, double data_time);
-
-    /*!
      * \return get the instrument dump interval.
      */
     int getInstrumentDumpInterval() const;

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -315,7 +315,7 @@ IBFEInstrumentPanel::IBFEInstrumentPanel(SAMRAI::tbox::Pointer<SAMRAI::tbox::Dat
       d_meter_meshes(),
       d_meter_mesh_names(),
       d_nodeset_IDs_for_meters(),
-      d_instrument_dump_interval(), 
+      d_instrument_dump_interval(),
       d_flow_values(),
       d_mean_pressure_values(),
       d_plot_directory_name(NDIM == 2 ? "viz_inst2d" : "viz_inst3d"),
@@ -559,10 +559,6 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
             d_U_dof_idx[jj].push_back(U_dof_index);
         }
     }
-    
-    // output the nodes of each meter mesh into a .dat file
-    outputNodes();
-    
     d_initialized = true;
 }
 
@@ -971,22 +967,40 @@ IBFEInstrumentPanel::getInstrumentDumpInterval() const
     return d_instrument_dump_interval;
 }
 
-SerialMesh*
-IBFEInstrumentPanel::getMeterMesh(const unsigned int jj) const
+int 
+IBFEInstrumentPanel::getNumberOfMeterMeshes() const
 {
-    return d_meter_meshes[jj];
+    return d_num_meters;
 }
 
-EquationSystems*
-IBFEInstrumentPanel::getMeterMeshSystem(const unsigned int jj) const
+MeshBase&
+IBFEInstrumentPanel::getMeterMesh(const unsigned int jj) const
 {
-    return d_meter_systems[jj];
+    return *d_meter_meshes[jj];
+}
+
+EquationSystems&
+IBFEInstrumentPanel::getMeterMeshEquationSystems(const unsigned int jj) const
+{
+    return *d_meter_systems[jj];
 }
 
 std::string
 IBFEInstrumentPanel::getMeterMeshName(const unsigned int jj) const
 {
     return d_meter_mesh_names[jj];
+}
+
+std::vector<libMesh::Point>
+IBFEInstrumentPanel::getMeterMeshNodes(const unsigned int jj) const
+{
+    return d_nodes[jj];
+}
+
+Order
+IBFEInstrumentPanel::getMeterMeshQuadOrder(const unsigned int jj) const
+{
+    return d_quad_order[jj];
 }
 
 /////////////////////////////// PRIVATE //////////////////////////////////////
@@ -1133,27 +1147,6 @@ IBFEInstrumentPanel::outputData(const double data_time)
         }
         d_mean_pressure_stream << "\n";
         d_flux_stream << "\n";
-    }
-}
-
-void
-IBFEInstrumentPanel::outputNodes()
-{
-    for (unsigned int ii = 0; ii < d_num_meters; ++ii)
-    {
-        std::ofstream stuff_stream;
-        std::ostringstream node_output;
-        node_output << d_plot_directory_name << "/"
-                    << "" << d_meter_mesh_names[ii] << "_nodes.dat";
-        if (SAMRAI_MPI::getRank() == 0)
-        {
-            stuff_stream.open(node_output.str().c_str());
-            for (unsigned int dd = 0; dd < d_nodes[ii].size(); ++dd)
-            {
-                stuff_stream << d_nodes[ii][dd](0) << " " << d_nodes[ii][dd](1) << " " << d_nodes[ii][dd](2) << "\n";
-            }
-            stuff_stream.close();
-        }
     }
 }
 

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -78,7 +78,6 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/enum_quadrature_type.h"
 #include "libmesh/equation_systems.h"
-#include "libmesh/exodusII_io.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/linear_implicit_system.h"
 #include "libmesh/mesh.h"
@@ -316,7 +315,7 @@ IBFEInstrumentPanel::IBFEInstrumentPanel(SAMRAI::tbox::Pointer<SAMRAI::tbox::Dat
       d_meter_meshes(),
       d_meter_mesh_names(),
       d_nodeset_IDs_for_meters(),
-      d_instrument_dump_interval(),
+      d_instrument_dump_interval(), 
       d_flow_values(),
       d_mean_pressure_values(),
       d_plot_directory_name(NDIM == 2 ? "viz_inst2d" : "viz_inst3d"),
@@ -1064,7 +1063,7 @@ IBFEInstrumentPanel::initializeSystemDependentData(IBFEMethod* ib_method_ops, co
         displacement_coords.set(disp_dof_idx, mean_dX_dofs[d]);
     }
 
-    // also populate solution vector in the system for exodus IO
+    // also populate solution vector in the system
     MeshBase::const_node_iterator node_it = d_meter_meshes[meter_mesh_number]->local_nodes_begin();
     const MeshBase::const_node_iterator end_node_it = d_meter_meshes[meter_mesh_number]->local_nodes_end();
     for (; node_it != end_node_it; ++node_it)

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -967,7 +967,6 @@ IBFEInstrumentPanel::outputMeterMeshes(IBFEMethod* ib_method_ops, const int time
 {
     // things to do at initial timestep
     if (timestep_num == 1) outputNodes();
-    outputExodus(ib_method_ops, timestep_num, data_time);
 }
 
 int

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -973,13 +973,13 @@ IBFEInstrumentPanel::getNumberOfMeterMeshes() const
     return d_num_meters;
 }
 
-const MeshBase&
+MeshBase&
 IBFEInstrumentPanel::getMeterMesh(const unsigned int jj) const
 {
     return *d_meter_meshes[jj];
 }
 
-const EquationSystems&
+EquationSystems&
 IBFEInstrumentPanel::getMeterMeshEquationSystems(const unsigned int jj) const
 {
     return *d_meter_systems[jj];

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -560,6 +560,10 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
             d_U_dof_idx[jj].push_back(U_dof_index);
         }
     }
+    
+    // output the nodes of each meter mesh into a .dat file
+    outputNodes();
+    
     d_initialized = true;
 }
 
@@ -960,13 +964,6 @@ IBFEInstrumentPanel::getFromInput(Pointer<Database> db)
                    << " is only supported with QuadratureType QGRID.");
     }
     return;
-}
-
-void
-IBFEInstrumentPanel::outputMeterMeshes(IBFEMethod* ib_method_ops, const int timestep_num, const double data_time)
-{
-    // things to do at initial timestep
-    if (timestep_num == 1) outputNodes();
 }
 
 int

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -1140,6 +1140,18 @@ IBFEInstrumentPanel::outputExodus(IBFEMethod* ib_method_ops, const int timestep,
 }
 
 void
+IBFEInstrumentPanel::outputSTL(IBFEMethod* ib_method_ops, const int timestep, const double loop_time)
+{
+    for (unsigned int ii = 0; ii < d_num_meters; ++ii)
+    {
+        initializeSystemDependentData(ib_method_ops, ii);
+        std::ostringstream mesh_output;
+        mesh_output << d_plot_directory_name << "/"
+                    << "" << d_meter_mesh_names[ii] << ".stl";
+    }
+}
+
+void
 IBFEInstrumentPanel::outputNodes()
 {
     for (unsigned int ii = 0; ii < d_num_meters; ++ii)

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -700,7 +700,7 @@ IBFEInstrumentPanel::initializeHierarchyDependentData(IBFEMethod* ib_method_ops,
                 for (unsigned int d = 0; d < NDIM; ++d) normal[d] = normal_temp(d);
 
                 // loop over quadrature points, compute their physical locations
-                // after displacement, and stores their indices.
+                // after displacement, and store their indices.
                 for (unsigned int qp = 0; qp < qp_points.size(); ++qp)
                 {
                     Vector qp_temp;
@@ -979,6 +979,24 @@ IBFEInstrumentPanel::getInstrumentDumpInterval() const
     return d_instrument_dump_interval;
 }
 
+SerialMesh*
+IBFEInstrumentPanel::getMeterMesh(const unsigned int jj) const
+{
+    return d_meter_meshes[jj];
+}
+
+EquationSystems*
+IBFEInstrumentPanel::getMeterMeshSystem(const unsigned int jj) const
+{
+    return d_meter_systems[jj];
+}
+
+std::string
+IBFEInstrumentPanel::getMeterMeshName(const unsigned int jj) const
+{
+    return d_meter_mesh_names[jj];
+}
+
 /////////////////////////////// PRIVATE //////////////////////////////////////
 
 void
@@ -1136,18 +1154,6 @@ IBFEInstrumentPanel::outputExodus(IBFEMethod* ib_method_ops, const int timestep,
         mesh_output << d_plot_directory_name << "/"
                     << "" << d_meter_mesh_names[ii] << ".ex2";
         d_exodus_io[ii]->write_timestep(mesh_output.str(), *d_meter_systems[ii], timestep, loop_time);
-    }
-}
-
-void
-IBFEInstrumentPanel::outputSTL(IBFEMethod* ib_method_ops, const int timestep, const double loop_time)
-{
-    for (unsigned int ii = 0; ii < d_num_meters; ++ii)
-    {
-        initializeSystemDependentData(ib_method_ops, ii);
-        std::ostringstream mesh_output;
-        mesh_output << d_plot_directory_name << "/"
-                    << "" << d_meter_mesh_names[ii] << ".stl";
     }
 }
 

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -967,7 +967,7 @@ IBFEInstrumentPanel::getInstrumentDumpInterval() const
     return d_instrument_dump_interval;
 }
 
-int 
+int
 IBFEInstrumentPanel::getNumberOfMeterMeshes() const
 {
     return d_num_meters;

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -313,7 +313,6 @@ IBFEInstrumentPanel::IBFEInstrumentPanel(SAMRAI::tbox::Pointer<SAMRAI::tbox::Dat
       d_nodes(),
       d_node_dof_IDs(),
       d_meter_systems(),
-      d_exodus_io(),
       d_meter_meshes(),
       d_meter_mesh_names(),
       d_nodeset_IDs_for_meters(),
@@ -360,7 +359,6 @@ IBFEInstrumentPanel::~IBFEInstrumentPanel()
     // delete vectors of pointers
     for (unsigned int ii = 0; ii < d_num_meters; ++ii)
     {
-        delete d_exodus_io[ii];
         delete d_meter_systems[ii];
         delete d_meter_meshes[ii];
     }
@@ -521,7 +519,6 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
         }
         d_meter_meshes[ii]->allow_renumbering(false);
         d_meter_meshes[ii]->prepare_for_use();
-        d_exodus_io.push_back(new ExodusII_IO(*d_meter_meshes[ii]));
     } // loop over meters
 
     // initialize meter mesh equation systems, for both velocity and displacement
@@ -1141,19 +1138,6 @@ IBFEInstrumentPanel::outputData(const double data_time)
         }
         d_mean_pressure_stream << "\n";
         d_flux_stream << "\n";
-    }
-}
-
-void
-IBFEInstrumentPanel::outputExodus(IBFEMethod* ib_method_ops, const int timestep, const double loop_time)
-{
-    for (unsigned int ii = 0; ii < d_num_meters; ++ii)
-    {
-        initializeSystemDependentData(ib_method_ops, ii);
-        std::ostringstream mesh_output;
-        mesh_output << d_plot_directory_name << "/"
-                    << "" << d_meter_mesh_names[ii] << ".ex2";
-        d_exodus_io[ii]->write_timestep(mesh_output.str(), *d_meter_systems[ii], timestep, loop_time);
     }
 }
 

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -973,25 +973,25 @@ IBFEInstrumentPanel::getNumberOfMeterMeshes() const
     return d_num_meters;
 }
 
-MeshBase&
+const MeshBase&
 IBFEInstrumentPanel::getMeterMesh(const unsigned int jj) const
 {
     return *d_meter_meshes[jj];
 }
 
-EquationSystems&
+const EquationSystems&
 IBFEInstrumentPanel::getMeterMeshEquationSystems(const unsigned int jj) const
 {
     return *d_meter_systems[jj];
 }
 
-std::string
+const std::string&
 IBFEInstrumentPanel::getMeterMeshName(const unsigned int jj) const
 {
     return d_meter_mesh_names[jj];
 }
 
-std::vector<libMesh::Point>
+const std::vector<libMesh::Point>&
 IBFEInstrumentPanel::getMeterMeshNodes(const unsigned int jj) const
 {
     return d_nodes[jj];


### PR DESCRIPTION
removing exodus io and replacing probably with output to STLs.