### PR TITLE
Fix aborting tests in adv_diff.

### DIFF
--- a/examples/adv_diff/ex1/input2d.test
+++ b/examples/adv_diff/ex1/input2d.test
@@ -141,7 +141,7 @@ Main {
 
 // visualization dump parameters
    viz_writer                  = "VisIt"
-   viz_dump_interval           = int(END_TIME/(3*DT))
+   viz_dump_interval           = 0
    viz_dump_dirname            = "viz_adv_diff2d"
    visit_number_procs_per_file = 1
 

--- a/examples/adv_diff/ex1/input3d.test
+++ b/examples/adv_diff/ex1/input3d.test
@@ -197,7 +197,7 @@ Main {
 
 // visualization dump parameters
    viz_writer                  = "VisIt"
-   viz_dump_interval           = int(END_TIME/(3*DT))
+   viz_dump_interval           = 0
    viz_dump_dirname            = "viz_adv_diff3d"
    visit_number_procs_per_file = 1
 


### PR DESCRIPTION
The issue with these tests is that viz_dump_interval depends on DT, which is never defined. We can get around this by simply never writing output.

Part of #290.