### PR TITLE
Fix aborting IBFE tests

### DIFF
--- a/examples/IBFE/explicit/ex5/input2d
+++ b/examples/IBFE/explicit/ex5/input2d
@@ -48,6 +48,13 @@ ENABLE_LOGGING             = TRUE
 KAPPA_S = 2.5*DX/DT^2
 ETA_S = 1.5*DX/DT
 
+// tether penalty data
+C1_S = 1.0e5
+KAPPA_S_BODY = 1.0e6
+ETA_S_BODY = 0.0
+KAPPA_S_SURFACE = 1.0e6
+ETA_S_SURFACE = 0.0
+
 // collocated solver parameters
 PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
 SECOND_ORDER_PRESSURE_UPDATE = TRUE

--- a/examples/IBFE/explicit/ex5/input2d.test
+++ b/examples/IBFE/explicit/ex5/input2d.test
@@ -48,6 +48,14 @@ ENABLE_LOGGING             = TRUE
 KAPPA_S = 2.5*DX/DT^2
 ETA_S = 1.5*DX/DT
 
+// tether penalty data. These values are small enough that we can keep a
+// constant time-step (unlike the values in input2d).
+C1_S = 1.0
+KAPPA_S_BODY = 1.0
+ETA_S_BODY = 1.0
+KAPPA_S_SURFACE = 1.0
+ETA_S_SURFACE = 1.0
+
 // collocated solver parameters
 PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
 SECOND_ORDER_PRESSURE_UPDATE = TRUE

--- a/examples/IBFE/explicit/ex5/input3d
+++ b/examples/IBFE/explicit/ex5/input3d
@@ -48,6 +48,13 @@ ENABLE_LOGGING             = TRUE
 KAPPA_S = 7.5*DX/DT^2
 ETA_S = 1.5*DX/DT
 
+// tether penalty data
+C1_S = 1.0e5
+KAPPA_S_BODY = 1.0e6
+ETA_S_BODY = 0.0
+KAPPA_S_SURFACE = 1.0e6
+ETA_S_SURFACE = 0.0
+
 // collocated solver parameters
 PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
 SECOND_ORDER_PRESSURE_UPDATE = TRUE

--- a/examples/IBFE/explicit/ex5/input3d.test
+++ b/examples/IBFE/explicit/ex5/input3d.test
@@ -48,6 +48,14 @@ ENABLE_LOGGING             = TRUE
 KAPPA_S = 7.5*DX/DT^2
 ETA_S = 1.5*DX/DT
 
+// tether penalty data. These values are small enough that we can keep a
+// constant time-step (unlike the values in input3d).
+C1_S = 1.0
+KAPPA_S_BODY = 1.0
+ETA_S_BODY = 1.0
+KAPPA_S_SURFACE = 1.0
+ETA_S_SURFACE = 1.0
+
 // collocated solver parameters
 PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
 SECOND_ORDER_PRESSURE_UPDATE = TRUE

--- a/examples/IBFE/explicit/ex6/input2d.test
+++ b/examples/IBFE/explicit/ex6/input2d.test
@@ -59,6 +59,9 @@ LAMBDA_S = 2.0*MU_S*NU_S/(1.0 - 2.0*NU_S)
 // penalty parameters
 KAPPA_S = 6.25e4 * DX / DT^2
 
+// first Piola-Kirchoff stress parameter
+C1_S = 1.0
+
 VelocityBcCoefs_0 {
    U_bar = U_BAR
 

--- a/examples/IBFE/explicit/ex6/input2d.test
+++ b/examples/IBFE/explicit/ex6/input2d.test
@@ -58,8 +58,6 @@ LAMBDA_S = 2.0*MU_S*NU_S/(1.0 - 2.0*NU_S)
 
 // penalty parameters
 KAPPA_S = 6.25e4 * DX / DT^2
-
-// first Piola-Kirchoff stress parameter
 C1_S = 1.0
 
 VelocityBcCoefs_0 {


### PR DESCRIPTION
It looks like we defined these tests and examples without adding all physical parameters to the input files. I added them and also cleaned up the implementation a bit: the relevant IBFE objects have nice support for pointers to context objects, so I moved the state there from global statically allocated variables.

This is enough of a fix to make the tests pass (and avoid basic errors, e.g., looking for variables in the database that were not defined in the input file) but the examples still fail with the default values. I will open separate issues for those.