### PR TITLE
Add parentheses suggested by -Wparentheses.

### DIFF
--- a/src/navier_stokes/StaggeredStokesPhysicalBoundaryHelper.cpp
+++ b/src/navier_stokes/StaggeredStokesPhysicalBoundaryHelper.cpp
@@ -210,8 +210,8 @@ StaggeredStokesPhysicalBoundaryHelper::enforceDivergenceFreeConditionAtBoundary(
         for (Box<NDIM>::Iterator it(bc_coef_box); it; it++)
         {
             const Index<NDIM>& i = it();
-            if (bdry_locs_data(i, 0) == 0.0 && (bdry_tag & NORMAL_TRACTION_BDRY) ||
-                bdry_locs_data(i, 0) == 1.0 && (bdry_tag & NORMAL_VELOCITY_BDRY))
+            if ((bdry_locs_data(i, 0) == 0.0 && (bdry_tag & NORMAL_TRACTION_BDRY)) ||
+                (bdry_locs_data(i, 0) == 1.0 && (bdry_tag & NORMAL_VELOCITY_BDRY)))
             {
                 // Place i_g in the ghost cell abutting the boundary.
                 Index<NDIM> i_g = i;


### PR DESCRIPTION
While the present code is correct, the order of operations (`==`, `&&`, then `||`) is a bit esoteric, so GCC reasonably suggests adding parentheses.