### PR TITLE
Add unordered map headers

### DIFF
--- a/ibtk/contrib/boost/boost/core/no_exceptions_support.hpp
+++ b/ibtk/contrib/boost/boost/core/no_exceptions_support.hpp
@@ -1,0 +1,44 @@
+#ifndef BOOST_CORE_NO_EXCEPTIONS_SUPPORT_HPP
+#define BOOST_CORE_NO_EXCEPTIONS_SUPPORT_HPP
+
+#if defined(_MSC_VER)
+#  pragma once
+#endif
+
+//----------------------------------------------------------------------
+// (C) Copyright 2004 Pavel Vozenilek.
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+//
+// This file contains helper macros used when exception support may be
+// disabled (as indicated by macro BOOST_NO_EXCEPTIONS).
+//
+// Before picking up these macros you may consider using RAII techniques
+// to deal with exceptions - their syntax can be always the same with 
+// or without exception support enabled.
+//----------------------------------------------------------------------
+
+#include <boost/config.hpp>
+#include <boost/detail/workaround.hpp>
+
+#if !(defined BOOST_NO_EXCEPTIONS)
+#    define BOOST_TRY { try
+#    define BOOST_CATCH(x) catch(x)
+#    define BOOST_RETHROW throw;
+#    define BOOST_CATCH_END }
+#else
+#    if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#        define BOOST_TRY { if ("")
+#        define BOOST_CATCH(x) else if (!"")
+#    else
+#        define BOOST_TRY { if (true)
+#        define BOOST_CATCH(x) else if (false)
+#    endif
+#    define BOOST_RETHROW
+#    define BOOST_CATCH_END }
+#endif
+
+
+#endif 

--- a/ibtk/contrib/boost/boost/detail/container_fwd.hpp
+++ b/ibtk/contrib/boost/boost/detail/container_fwd.hpp
@@ -1,0 +1,157 @@
+
+// Copyright 2005-2011 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Note: if you change this include guard, you also need to change
+// container_fwd_compile_fail.cpp
+#if !defined(BOOST_DETAIL_CONTAINER_FWD_HPP)
+#define BOOST_DETAIL_CONTAINER_FWD_HPP
+
+#if defined(_MSC_VER) && \
+    !defined(BOOST_DETAIL_TEST_CONFIG_ONLY)
+# pragma once
+#endif
+
+#include <boost/config.hpp>
+#include <boost/detail/workaround.hpp>
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+// Define BOOST_DETAIL_NO_CONTAINER_FWD if you don't want this header to      //
+// forward declare standard containers.                                       //
+//                                                                            //
+// BOOST_DETAIL_CONTAINER_FWD to make it foward declare containers even if it //
+// normally doesn't.                                                          //
+//                                                                            //
+// BOOST_DETAIL_NO_CONTAINER_FWD overrides BOOST_DETAIL_CONTAINER_FWD.        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+#if !defined(BOOST_DETAIL_NO_CONTAINER_FWD)
+#  if defined(BOOST_DETAIL_CONTAINER_FWD)
+     // Force forward declarations.
+#  elif defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)
+     // STLport
+#    define BOOST_DETAIL_NO_CONTAINER_FWD
+#  elif defined(__LIBCOMO__)
+     // Comeau STL:
+#    define BOOST_DETAIL_NO_CONTAINER_FWD
+#  elif defined(__STD_RWCOMPILER_H__) || defined(_RWSTD_VER)
+     // Rogue Wave library:
+#    define BOOST_DETAIL_NO_CONTAINER_FWD
+#  elif defined(_LIBCPP_VERSION)
+     // libc++
+#    define BOOST_DETAIL_NO_CONTAINER_FWD
+#  elif defined(__GLIBCPP__) || defined(__GLIBCXX__)
+     // GNU libstdc++ 3
+     //
+     // Disable forwarding for all recent versions, as the library has a
+     // versioned namespace mode, and I don't know how to detect it.
+#    if __GLIBCXX__ >= 20070513 \
+        || defined(_GLIBCXX_DEBUG) \
+        || defined(_GLIBCXX_PARALLEL) \
+        || defined(_GLIBCXX_PROFILE)
+#      define BOOST_DETAIL_NO_CONTAINER_FWD
+#    else
+#      if defined(__GLIBCXX__) && __GLIBCXX__ >= 20040530
+#        define BOOST_CONTAINER_FWD_COMPLEX_STRUCT
+#      endif
+#    endif
+#  elif defined(__STL_CONFIG_H)
+     // generic SGI STL
+     //
+     // Forward declaration seems to be okay, but it has a couple of odd
+     // implementations.
+#    define BOOST_CONTAINER_FWD_BAD_BITSET
+#    if !defined(__STL_NON_TYPE_TMPL_PARAM_BUG)
+#      define BOOST_CONTAINER_FWD_BAD_DEQUE
+#     endif
+#  elif defined(__MSL_CPP__)
+     // MSL standard lib:
+#    define BOOST_DETAIL_NO_CONTAINER_FWD
+#  elif defined(__IBMCPP__)
+     // The default VACPP std lib, forward declaration seems to be fine.
+#  elif defined(MSIPL_COMPILE_H)
+     // Modena C++ standard library
+#    define BOOST_DETAIL_NO_CONTAINER_FWD
+#  elif (defined(_YVALS) && !defined(__IBMCPP__)) || defined(_CPPLIB_VER)
+     // Dinkumware Library (this has to appear after any possible replacement
+     // libraries)
+#  else
+#    define BOOST_DETAIL_NO_CONTAINER_FWD
+#  endif
+#endif
+
+#if !defined(BOOST_DETAIL_TEST_CONFIG_ONLY)
+
+#if defined(BOOST_DETAIL_NO_CONTAINER_FWD) && \
+    !defined(BOOST_DETAIL_TEST_FORCE_CONTAINER_FWD)
+
+#include <deque>
+#include <list>
+#include <vector>
+#include <map>
+#include <set>
+#include <bitset>
+#include <string>
+#include <complex>
+
+#else
+
+#include <cstddef>
+
+#if defined(BOOST_CONTAINER_FWD_BAD_DEQUE)
+#include <deque>
+#endif
+
+#if defined(BOOST_CONTAINER_FWD_BAD_BITSET)
+#include <bitset>
+#endif
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4099) // struct/class mismatch in fwd declarations
+#endif
+
+namespace std
+{
+    template <class T> class allocator;
+    template <class charT, class traits, class Allocator> class basic_string;
+
+    template <class charT> struct char_traits;
+
+#if defined(BOOST_CONTAINER_FWD_COMPLEX_STRUCT)
+    template <class T> struct complex;
+#else
+    template <class T> class complex;
+#endif
+
+#if !defined(BOOST_CONTAINER_FWD_BAD_DEQUE)
+    template <class T, class Allocator> class deque;
+#endif
+
+    template <class T, class Allocator> class list;
+    template <class T, class Allocator> class vector;
+    template <class Key, class T, class Compare, class Allocator> class map;
+    template <class Key, class T, class Compare, class Allocator>
+    class multimap;
+    template <class Key, class Compare, class Allocator> class set;
+    template <class Key, class Compare, class Allocator> class multiset;
+
+#if !defined(BOOST_CONTAINER_FWD_BAD_BITSET)
+    template <size_t N> class bitset;
+#endif
+    template <class T1, class T2> struct pair;
+}
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+#endif // BOOST_DETAIL_NO_CONTAINER_FWD &&
+       // !defined(BOOST_DETAIL_TEST_FORCE_CONTAINER_FWD)
+
+#endif // BOOST_DETAIL_TEST_CONFIG_ONLY
+
+#endif

--- a/ibtk/contrib/boost/boost/detail/no_exceptions_support.hpp
+++ b/ibtk/contrib/boost/boost/detail/no_exceptions_support.hpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2014 Glen Fernandes
+ *
+ * Distributed under the Boost Software License, Version 1.0. (See
+ * accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#ifndef BOOST_DETAIL_NO_EXCEPTIONS_SUPPORT_HPP
+#define BOOST_DETAIL_NO_EXCEPTIONS_SUPPORT_HPP
+
+// The header file at this path is deprecated;
+// use boost/core/no_exceptions_support.hpp instead.
+
+#include <boost/core/no_exceptions_support.hpp>
+
+#endif

--- a/ibtk/contrib/boost/boost/detail/select_type.hpp
+++ b/ibtk/contrib/boost/boost/detail/select_type.hpp
@@ -1,0 +1,36 @@
+// (C) Copyright David Abrahams 2001.
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org for most recent version including documentation.
+
+// Revision History
+// 09 Feb 01  Applied John Maddock's Borland patch Moving <true>
+//            specialization to unspecialized template (David Abrahams)
+// 06 Feb 01  Created (David Abrahams)
+
+#ifndef SELECT_TYPE_DWA20010206_HPP
+# define SELECT_TYPE_DWA20010206_HPP
+
+namespace boost { namespace detail {
+
+  // Template class if_true -- select among 2 types based on a bool constant expression
+  // Usage:
+  //   typename if_true<(bool_const_expression)>::template then<true_type, false_type>::type
+
+  // HP aCC cannot deal with missing names for template value parameters
+  template <bool b> struct if_true
+  {
+      template <class T, class F>
+      struct then { typedef T type; };
+  };
+
+  template <>
+  struct if_true<false>
+  {
+      template <class T, class F>
+      struct then { typedef F type; };
+  };
+}}
+#endif // SELECT_TYPE_DWA20010206_HPP

--- a/ibtk/contrib/boost/boost/functional/hash.hpp
+++ b/ibtk/contrib/boost/boost/functional/hash.hpp
@@ -1,0 +1,7 @@
+
+// Copyright 2005-2009 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/functional/hash/hash.hpp>
+

--- a/ibtk/contrib/boost/boost/functional/hash/detail/float_functions.hpp
+++ b/ibtk/contrib/boost/boost/functional/hash/detail/float_functions.hpp
@@ -1,0 +1,336 @@
+
+// Copyright 2005-2009 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_FUNCTIONAL_HASH_DETAIL_FLOAT_FUNCTIONS_HPP)
+#define BOOST_FUNCTIONAL_HASH_DETAIL_FLOAT_FUNCTIONS_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/config/no_tr1/cmath.hpp>
+
+// Set BOOST_HASH_CONFORMANT_FLOATS to 1 for libraries known to have
+// sufficiently good floating point support to not require any
+// workarounds.
+//
+// When set to 0, the library tries to automatically
+// use the best available implementation. This normally works well, but
+// breaks when ambiguities are created by odd namespacing of the functions.
+//
+// Note that if this is set to 0, the library should still take full
+// advantage of the platform's floating point support.
+
+#if defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)
+#   define BOOST_HASH_CONFORMANT_FLOATS 0
+#elif defined(__LIBCOMO__)
+#   define BOOST_HASH_CONFORMANT_FLOATS 0
+#elif defined(__STD_RWCOMPILER_H__) || defined(_RWSTD_VER)
+// Rogue Wave library:
+#   define BOOST_HASH_CONFORMANT_FLOATS 0
+#elif defined(_LIBCPP_VERSION)
+// libc++
+#   define BOOST_HASH_CONFORMANT_FLOATS 1
+#elif defined(__GLIBCPP__) || defined(__GLIBCXX__)
+// GNU libstdc++ 3
+#   if defined(__GNUC__) && __GNUC__ >= 4
+#       define BOOST_HASH_CONFORMANT_FLOATS 1
+#   else
+#       define BOOST_HASH_CONFORMANT_FLOATS 0
+#   endif
+#elif defined(__STL_CONFIG_H)
+// generic SGI STL
+#   define BOOST_HASH_CONFORMANT_FLOATS 0
+#elif defined(__MSL_CPP__)
+// MSL standard lib:
+#   define BOOST_HASH_CONFORMANT_FLOATS 0
+#elif defined(__IBMCPP__)
+// VACPP std lib (probably conformant for much earlier version).
+#   if __IBMCPP__ >= 1210
+#       define BOOST_HASH_CONFORMANT_FLOATS 1
+#   else
+#       define BOOST_HASH_CONFORMANT_FLOATS 0
+#   endif
+#elif defined(MSIPL_COMPILE_H)
+// Modena C++ standard library
+#   define BOOST_HASH_CONFORMANT_FLOATS 0
+#elif (defined(_YVALS) && !defined(__IBMCPP__)) || defined(_CPPLIB_VER)
+// Dinkumware Library (this has to appear after any possible replacement libraries):
+#   if _CPPLIB_VER >= 405
+#       define BOOST_HASH_CONFORMANT_FLOATS 1
+#   else
+#       define BOOST_HASH_CONFORMANT_FLOATS 0
+#   endif
+#else
+#   define BOOST_HASH_CONFORMANT_FLOATS 0
+#endif
+
+#if BOOST_HASH_CONFORMANT_FLOATS
+
+// The standard library is known to be compliant, so don't use the
+// configuration mechanism.
+
+namespace boost {
+    namespace hash_detail {
+        template <typename Float>
+        struct call_ldexp {
+            typedef Float float_type;
+            inline Float operator()(Float x, int y) const {
+                return std::ldexp(x, y);
+            }
+        };
+
+        template <typename Float>
+        struct call_frexp {
+            typedef Float float_type;
+            inline Float operator()(Float x, int* y) const {
+                return std::frexp(x, y);
+            }
+        };
+
+        template <typename Float>
+        struct select_hash_type
+        {
+            typedef Float type;
+        };
+    }
+}
+
+#else // BOOST_HASH_CONFORMANT_FLOATS == 0
+
+// The C++ standard requires that the C float functions are overloarded
+// for float, double and long double in the std namespace, but some of the older
+// library implementations don't support this. On some that don't, the C99
+// float functions (frexpf, frexpl, etc.) are available.
+//
+// The following tries to automatically detect which are available.
+
+namespace boost {
+    namespace hash_detail {
+
+        // Returned by dummy versions of the float functions.
+    
+        struct not_found {
+            // Implicitly convertible to float and long double in order to avoid
+            // a compile error when the dummy float functions are used.
+
+            inline operator float() const { return 0; }
+            inline operator long double() const { return 0; }
+        };
+          
+        // A type for detecting the return type of functions.
+
+        template <typename T> struct is;
+        template <> struct is<float> { char x[10]; };
+        template <> struct is<double> { char x[20]; };
+        template <> struct is<long double> { char x[30]; };
+        template <> struct is<boost::hash_detail::not_found> { char x[40]; };
+            
+        // Used to convert the return type of a function to a type for sizeof.
+
+        template <typename T> is<T> float_type(T);
+
+        // call_ldexp
+        //
+        // This will get specialized for float and long double
+        
+        template <typename Float> struct call_ldexp
+        {
+            typedef double float_type;
+            
+            inline double operator()(double a, int b) const
+            {
+                using namespace std;
+                return ldexp(a, b);
+            }
+        };
+
+        // call_frexp
+        //
+        // This will get specialized for float and long double
+
+        template <typename Float> struct call_frexp
+        {
+            typedef double float_type;
+            
+            inline double operator()(double a, int* b) const
+            {
+                using namespace std;
+                return frexp(a, b);
+            }
+        };
+    }
+}
+            
+// A namespace for dummy functions to detect when the actual function we want
+// isn't available. ldexpl, ldexpf etc. might be added tby the macros below.
+//
+// AFAICT these have to be outside of the boost namespace, as if they're in
+// the boost namespace they'll always be preferable to any other function
+// (since the arguments are built in types, ADL can't be used).
+
+namespace boost_hash_detect_float_functions {
+    template <class Float> boost::hash_detail::not_found ldexp(Float, int);
+    template <class Float> boost::hash_detail::not_found frexp(Float, int*);    
+}
+
+// Macros for generating specializations of call_ldexp and call_frexp.
+//
+// check_cpp and check_c99 check if the C++ or C99 functions are available.
+//
+// Then the call_* functions select an appropriate implementation.
+//
+// I used c99_func in a few places just to get a unique name.
+//
+// Important: when using 'using namespace' at namespace level, include as
+// little as possible in that namespace, as Visual C++ has an odd bug which
+// can cause the namespace to be imported at the global level. This seems to
+// happen mainly when there's a template in the same namesapce.
+
+#define BOOST_HASH_CALL_FLOAT_FUNC(cpp_func, c99_func, type1, type2)    \
+namespace boost_hash_detect_float_functions {                           \
+    template <class Float>                                              \
+    boost::hash_detail::not_found c99_func(Float, type2);               \
+}                                                                       \
+                                                                        \
+namespace boost {                                                       \
+    namespace hash_detail {                                             \
+        namespace c99_func##_detect {                                   \
+            using namespace std;                                        \
+            using namespace boost_hash_detect_float_functions;          \
+                                                                        \
+            struct check {                                              \
+                static type1 x;                                         \
+                static type2 y;                                         \
+                BOOST_STATIC_CONSTANT(bool, cpp =                       \
+                    sizeof(float_type(cpp_func(x,y)))                   \
+                        == sizeof(is<type1>));                          \
+                BOOST_STATIC_CONSTANT(bool, c99 =                       \
+                    sizeof(float_type(c99_func(x,y)))                   \
+                        == sizeof(is<type1>));                          \
+            };                                                          \
+        }                                                               \
+                                                                        \
+        template <bool x>                                               \
+        struct call_c99_##c99_func :                                    \
+            boost::hash_detail::call_##cpp_func<double> {};             \
+                                                                        \
+        template <>                                                     \
+        struct call_c99_##c99_func<true> {                              \
+            typedef type1 float_type;                                   \
+                                                                        \
+            template <typename T>                                       \
+            inline type1 operator()(type1 a, T b)  const                \
+            {                                                           \
+                using namespace std;                                    \
+                return c99_func(a, b);                                  \
+            }                                                           \
+        };                                                              \
+                                                                        \
+        template <bool x>                                               \
+        struct call_cpp_##c99_func :                                    \
+            call_c99_##c99_func<                                        \
+                ::boost::hash_detail::c99_func##_detect::check::c99     \
+            > {};                                                       \
+                                                                        \
+        template <>                                                     \
+        struct call_cpp_##c99_func<true> {                              \
+            typedef type1 float_type;                                   \
+                                                                        \
+            template <typename T>                                       \
+            inline type1 operator()(type1 a, T b)  const                \
+            {                                                           \
+                using namespace std;                                    \
+                return cpp_func(a, b);                                  \
+            }                                                           \
+        };                                                              \
+                                                                        \
+        template <>                                                     \
+        struct call_##cpp_func<type1> :                                 \
+            call_cpp_##c99_func<                                        \
+                ::boost::hash_detail::c99_func##_detect::check::cpp     \
+            > {};                                                       \
+    }                                                                   \
+}
+
+#define BOOST_HASH_CALL_FLOAT_MACRO(cpp_func, c99_func, type1, type2)   \
+namespace boost {                                                       \
+    namespace hash_detail {                                             \
+                                                                        \
+        template <>                                                     \
+        struct call_##cpp_func<type1> {                                 \
+            typedef type1 float_type;                                   \
+            inline type1 operator()(type1 x, type2 y) const {           \
+                return c99_func(x, y);                                  \
+            }                                                           \
+        };                                                              \
+    }                                                                   \
+}
+
+#if defined(ldexpf)
+BOOST_HASH_CALL_FLOAT_MACRO(ldexp, ldexpf, float, int)
+#else
+BOOST_HASH_CALL_FLOAT_FUNC(ldexp, ldexpf, float, int)
+#endif
+
+#if defined(ldexpl)
+BOOST_HASH_CALL_FLOAT_MACRO(ldexp, ldexpl, long double, int)
+#else
+BOOST_HASH_CALL_FLOAT_FUNC(ldexp, ldexpl, long double, int)
+#endif
+
+#if defined(frexpf)
+BOOST_HASH_CALL_FLOAT_MACRO(frexp, frexpf, float, int*)
+#else
+BOOST_HASH_CALL_FLOAT_FUNC(frexp, frexpf, float, int*)
+#endif
+
+#if defined(frexpl)
+BOOST_HASH_CALL_FLOAT_MACRO(frexp, frexpl, long double, int*)
+#else
+BOOST_HASH_CALL_FLOAT_FUNC(frexp, frexpl, long double, int*)
+#endif
+
+#undef BOOST_HASH_CALL_FLOAT_MACRO
+#undef BOOST_HASH_CALL_FLOAT_FUNC
+
+
+namespace boost
+{
+    namespace hash_detail
+    {
+        template <typename Float1, typename Float2>
+        struct select_hash_type_impl {
+            typedef double type;
+        };
+
+        template <>
+        struct select_hash_type_impl<float, float> {
+            typedef float type;
+        };
+
+        template <>
+        struct select_hash_type_impl<long double, long double> {
+            typedef long double type;
+        };
+
+
+        // select_hash_type
+        //
+        // If there is support for a particular floating point type, use that
+        // otherwise use double (there's always support for double).
+             
+        template <typename Float>
+        struct select_hash_type : select_hash_type_impl<
+                BOOST_DEDUCED_TYPENAME call_ldexp<Float>::float_type,
+                BOOST_DEDUCED_TYPENAME call_frexp<Float>::float_type
+            > {};            
+    }
+}
+
+#endif // BOOST_HASH_CONFORMANT_FLOATS
+
+#endif

--- a/ibtk/contrib/boost/boost/functional/hash/detail/hash_float.hpp
+++ b/ibtk/contrib/boost/boost/functional/hash/detail/hash_float.hpp
@@ -1,0 +1,271 @@
+
+// Copyright 2005-2012 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_FUNCTIONAL_HASH_DETAIL_HASH_FLOAT_HEADER)
+#define BOOST_FUNCTIONAL_HASH_DETAIL_HASH_FLOAT_HEADER
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/functional/hash/detail/float_functions.hpp>
+#include <boost/functional/hash/detail/limits.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/integer/static_log2.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/assert.hpp>
+#include <boost/limits.hpp>
+#include <cstring>
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+#if BOOST_MSVC >= 1400
+#pragma warning(disable:6294) // Ill-defined for-loop: initial condition does
+                              // not satisfy test. Loop body not executed
+#endif
+#endif
+
+// Can we use fpclassify?
+
+// STLport
+#if defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)
+#define BOOST_HASH_USE_FPCLASSIFY 0
+
+// GNU libstdc++ 3
+#elif defined(__GLIBCPP__) || defined(__GLIBCXX__)
+#  if (defined(__USE_ISOC99) || defined(_GLIBCXX_USE_C99_MATH)) && \
+      !(defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__))
+#    define BOOST_HASH_USE_FPCLASSIFY 1
+#  else
+#    define BOOST_HASH_USE_FPCLASSIFY 0
+#  endif
+
+// Everything else
+#else
+#  define BOOST_HASH_USE_FPCLASSIFY 0
+#endif
+
+namespace boost
+{
+    namespace hash_detail
+    {
+        inline void hash_float_combine(std::size_t& seed, std::size_t value)
+        {
+            seed ^= value + (seed<<6) + (seed>>2);
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Binary hash function
+        //
+        // Only used for floats with known iec559 floats, and certain values in
+        // numeric_limits
+
+        inline std::size_t hash_binary(char* ptr, std::size_t length)
+        {
+            std::size_t seed = 0;
+
+            if (length >= sizeof(std::size_t)) {
+                std::memcpy(&seed, ptr, sizeof(std::size_t));
+                length -= sizeof(std::size_t);
+                ptr += sizeof(std::size_t);
+
+                while(length >= sizeof(std::size_t)) {
+                    std::size_t buffer = 0;
+                    std::memcpy(&buffer, ptr, sizeof(std::size_t));
+                    hash_float_combine(seed, buffer);
+                    length -= sizeof(std::size_t);
+                    ptr += sizeof(std::size_t);
+                }
+            }
+
+            if (length > 0) {
+                std::size_t buffer = 0;
+                std::memcpy(&buffer, ptr, length);
+                hash_float_combine(seed, buffer);
+            }
+
+            return seed;
+        }
+
+        template <typename Float, unsigned digits, unsigned max_exponent>
+        struct enable_binary_hash
+        {
+            BOOST_STATIC_CONSTANT(bool, value =
+                std::numeric_limits<Float>::is_iec559 &&
+                std::numeric_limits<Float>::digits == digits &&
+                std::numeric_limits<Float>::radix == 2 &&
+                std::numeric_limits<Float>::max_exponent == max_exponent);
+        };
+
+        template <typename Float>
+        inline std::size_t float_hash_impl(Float v,
+            BOOST_DEDUCED_TYPENAME boost::enable_if_c<
+                enable_binary_hash<Float, 24, 128>::value,
+                std::size_t>::type)
+        {
+            return hash_binary((char*) &v, 4);
+        }
+
+
+        template <typename Float>
+        inline std::size_t float_hash_impl(Float v,
+            BOOST_DEDUCED_TYPENAME boost::enable_if_c<
+                enable_binary_hash<Float, 53, 1024>::value,
+                std::size_t>::type)
+        {
+            return hash_binary((char*) &v, 8);
+        }
+
+        template <typename Float>
+        inline std::size_t float_hash_impl(Float v,
+            BOOST_DEDUCED_TYPENAME boost::enable_if_c<
+                enable_binary_hash<Float, 64, 16384>::value,
+                std::size_t>::type)
+        {
+            return hash_binary((char*) &v, 10);
+        }
+
+        template <typename Float>
+        inline std::size_t float_hash_impl(Float v,
+            BOOST_DEDUCED_TYPENAME boost::enable_if_c<
+                enable_binary_hash<Float, 113, 16384>::value,
+                std::size_t>::type)
+        {
+            return hash_binary((char*) &v, 16);
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Portable hash function
+        //
+        // Used as a fallback when the binary hash function isn't supported.
+
+        template <class T>
+        inline std::size_t float_hash_impl2(T v)
+        {
+            boost::hash_detail::call_frexp<T> frexp;
+            boost::hash_detail::call_ldexp<T> ldexp;
+
+            int exp = 0;
+
+            v = frexp(v, &exp);
+
+            // A postive value is easier to hash, so combine the
+            // sign with the exponent and use the absolute value.
+            if(v < 0) {
+                v = -v;
+                exp += limits<T>::max_exponent -
+                    limits<T>::min_exponent;
+            }
+
+            v = ldexp(v, limits<std::size_t>::digits);
+            std::size_t seed = static_cast<std::size_t>(v);
+            v -= static_cast<T>(seed);
+
+            // ceiling(digits(T) * log2(radix(T))/ digits(size_t)) - 1;
+            std::size_t const length
+                = (limits<T>::digits *
+                        boost::static_log2<limits<T>::radix>::value
+                        + limits<std::size_t>::digits - 1)
+                / limits<std::size_t>::digits;
+
+            for(std::size_t i = 0; i != length; ++i)
+            {
+                v = ldexp(v, limits<std::size_t>::digits);
+                std::size_t part = static_cast<std::size_t>(v);
+                v -= static_cast<T>(part);
+                hash_float_combine(seed, part);
+            }
+
+            hash_float_combine(seed, exp);
+
+            return seed;
+        }
+
+#if !defined(BOOST_HASH_DETAIL_TEST_WITHOUT_GENERIC)
+        template <class T>
+        inline std::size_t float_hash_impl(T v, ...)
+        {
+            typedef BOOST_DEDUCED_TYPENAME select_hash_type<T>::type type;
+            return float_hash_impl2(static_cast<type>(v));
+        }
+#endif
+    }
+}
+
+#if BOOST_HASH_USE_FPCLASSIFY
+
+#include <boost/config/no_tr1/cmath.hpp>
+
+namespace boost
+{
+    namespace hash_detail
+    {
+        template <class T>
+        inline std::size_t float_hash_value(T v)
+        {
+#if defined(fpclassify)
+            switch (fpclassify(v))
+#elif BOOST_HASH_CONFORMANT_FLOATS
+            switch (std::fpclassify(v))
+#else
+            using namespace std;
+            switch (fpclassify(v))
+#endif
+            {
+            case FP_ZERO:
+                return 0;
+            case FP_INFINITE:
+                return (std::size_t)(v > 0 ? -1 : -2);
+            case FP_NAN:
+                return (std::size_t)(-3);
+            case FP_NORMAL:
+            case FP_SUBNORMAL:
+                return float_hash_impl(v, 0);
+            default:
+                BOOST_ASSERT(0);
+                return 0;
+            }
+        }
+    }
+}
+
+#else // !BOOST_HASH_USE_FPCLASSIFY
+
+namespace boost
+{
+    namespace hash_detail
+    {
+        template <class T>
+        inline bool is_zero(T v)
+        {
+#if !defined(__GNUC__)
+            return v == 0;
+#else
+            // GCC's '-Wfloat-equal' will complain about comparing
+            // v to 0, but because it disables warnings for system
+            // headers it won't complain if you use std::equal_to to
+            // compare with 0. Resulting in this silliness:
+            return std::equal_to<T>()(v, 0);
+#endif
+        }
+
+        template <class T>
+        inline std::size_t float_hash_value(T v)
+        {
+            return boost::hash_detail::is_zero(v) ? 0 : float_hash_impl(v, 0);
+        }
+    }
+}
+
+#endif // BOOST_HASH_USE_FPCLASSIFY
+
+#undef BOOST_HASH_USE_FPCLASSIFY
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+#endif

--- a/ibtk/contrib/boost/boost/functional/hash/detail/limits.hpp
+++ b/ibtk/contrib/boost/boost/functional/hash/detail/limits.hpp
@@ -1,0 +1,62 @@
+
+// Copyright 2005-2009 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// On some platforms std::limits gives incorrect values for long double.
+// This tries to work around them.
+
+#if !defined(BOOST_FUNCTIONAL_HASH_DETAIL_LIMITS_HEADER)
+#define BOOST_FUNCTIONAL_HASH_DETAIL_LIMITS_HEADER
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/limits.hpp>
+
+// On OpenBSD, numeric_limits is not reliable for long doubles, but
+// the macros defined in <float.h> are and support long double when STLport
+// doesn't.
+
+#if defined(__OpenBSD__) || defined(_STLP_NO_LONG_DOUBLE)
+#include <float.h>
+#endif
+
+namespace boost
+{
+    namespace hash_detail
+    {
+        template <class T>
+        struct limits : std::numeric_limits<T> {};
+
+#if defined(__OpenBSD__) || defined(_STLP_NO_LONG_DOUBLE)
+        template <>
+        struct limits<long double>
+             : std::numeric_limits<long double>
+        {
+            static long double epsilon() {
+                return LDBL_EPSILON;
+            }
+
+            static long double (max)() {
+                return LDBL_MAX;
+            }
+
+            static long double (min)() {
+                return LDBL_MIN;
+            }
+
+            BOOST_STATIC_CONSTANT(int, digits = LDBL_MANT_DIG);
+            BOOST_STATIC_CONSTANT(int, max_exponent = LDBL_MAX_EXP);
+            BOOST_STATIC_CONSTANT(int, min_exponent = LDBL_MIN_EXP);
+#if defined(_STLP_NO_LONG_DOUBLE)
+            BOOST_STATIC_CONSTANT(int, radix = FLT_RADIX);
+#endif
+        };
+#endif // __OpenBSD__
+    }
+}
+
+#endif

--- a/ibtk/contrib/boost/boost/functional/hash/extensions.hpp
+++ b/ibtk/contrib/boost/boost/functional/hash/extensions.hpp
@@ -1,0 +1,318 @@
+
+// Copyright 2005-2009 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  Based on Peter Dimov's proposal
+//  http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2005/n1756.pdf
+//  issue 6.18. 
+
+// This implements the extensions to the standard.
+// It's undocumented, so you shouldn't use it....
+
+#if !defined(BOOST_FUNCTIONAL_HASH_EXTENSIONS_HPP)
+#define BOOST_FUNCTIONAL_HASH_EXTENSIONS_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/functional/hash/hash.hpp>
+#include <boost/detail/container_fwd.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+
+#if !defined(BOOST_NO_CXX11_HDR_ARRAY)
+#   include <array>
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+#   include <tuple>
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_MEMORY)
+#   include <memory>
+#endif
+
+#if defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
+#include <boost/type_traits/is_array.hpp>
+#endif
+
+namespace boost
+{
+    template <class A, class B>
+    std::size_t hash_value(std::pair<A, B> const&);
+    template <class T, class A>
+    std::size_t hash_value(std::vector<T, A> const&);
+    template <class T, class A>
+    std::size_t hash_value(std::list<T, A> const& v);
+    template <class T, class A>
+    std::size_t hash_value(std::deque<T, A> const& v);
+    template <class K, class C, class A>
+    std::size_t hash_value(std::set<K, C, A> const& v);
+    template <class K, class C, class A>
+    std::size_t hash_value(std::multiset<K, C, A> const& v);
+    template <class K, class T, class C, class A>
+    std::size_t hash_value(std::map<K, T, C, A> const& v);
+    template <class K, class T, class C, class A>
+    std::size_t hash_value(std::multimap<K, T, C, A> const& v);
+
+    template <class T>
+    std::size_t hash_value(std::complex<T> const&);
+
+    template <class A, class B>
+    std::size_t hash_value(std::pair<A, B> const& v)
+    {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, v.first);
+        boost::hash_combine(seed, v.second);
+        return seed;
+    }
+
+    template <class T, class A>
+    std::size_t hash_value(std::vector<T, A> const& v)
+    {
+        return boost::hash_range(v.begin(), v.end());
+    }
+
+    template <class T, class A>
+    std::size_t hash_value(std::list<T, A> const& v)
+    {
+        return boost::hash_range(v.begin(), v.end());
+    }
+
+    template <class T, class A>
+    std::size_t hash_value(std::deque<T, A> const& v)
+    {
+        return boost::hash_range(v.begin(), v.end());
+    }
+
+    template <class K, class C, class A>
+    std::size_t hash_value(std::set<K, C, A> const& v)
+    {
+        return boost::hash_range(v.begin(), v.end());
+    }
+
+    template <class K, class C, class A>
+    std::size_t hash_value(std::multiset<K, C, A> const& v)
+    {
+        return boost::hash_range(v.begin(), v.end());
+    }
+
+    template <class K, class T, class C, class A>
+    std::size_t hash_value(std::map<K, T, C, A> const& v)
+    {
+        return boost::hash_range(v.begin(), v.end());
+    }
+
+    template <class K, class T, class C, class A>
+    std::size_t hash_value(std::multimap<K, T, C, A> const& v)
+    {
+        return boost::hash_range(v.begin(), v.end());
+    }
+
+    template <class T>
+    std::size_t hash_value(std::complex<T> const& v)
+    {
+        boost::hash<T> hasher;
+        std::size_t seed = hasher(v.imag());
+        seed ^= hasher(v.real()) + (seed<<6) + (seed>>2);
+        return seed;
+    }
+
+#if !defined(BOOST_NO_CXX11_HDR_ARRAY)
+    template <class T, std::size_t N>
+    std::size_t hash_value(std::array<T, N> const& v)
+    {
+        return boost::hash_range(v.begin(), v.end());
+    }
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+    namespace hash_detail {
+        template <std::size_t I, typename T>
+        inline typename boost::enable_if_c<(I == std::tuple_size<T>::value),
+                void>::type
+            hash_combine_tuple(std::size_t&, T const&)
+        {
+        }
+
+        template <std::size_t I, typename T>
+        inline typename boost::enable_if_c<(I < std::tuple_size<T>::value),
+                void>::type
+            hash_combine_tuple(std::size_t& seed, T const& v)
+        {
+            boost::hash_combine(seed, std::get<I>(v));
+            boost::hash_detail::hash_combine_tuple<I + 1>(seed, v);
+        }
+
+        template <typename T>
+        inline std::size_t hash_tuple(T const& v)
+        {
+            std::size_t seed = 0;
+            boost::hash_detail::hash_combine_tuple<0>(seed, v);
+            return seed;
+        }
+    }
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+    template <typename... T>
+    inline std::size_t hash_value(std::tuple<T...> const& v)
+    {
+        return boost::hash_detail::hash_tuple(v);
+    }
+#else
+
+    inline std::size_t hash_value(std::tuple<> const& v)
+    {
+        return boost::hash_detail::hash_tuple(v);
+    }
+
+#   define BOOST_HASH_TUPLE_F(z, n, _)                                      \
+    template<                                                               \
+        BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)                            \
+    >                                                                       \
+    inline std::size_t hash_value(std::tuple<                               \
+        BOOST_PP_ENUM_PARAMS_Z(z, n, A)                                     \
+    > const& v)                                                             \
+    {                                                                       \
+        return boost::hash_detail::hash_tuple(v);                           \
+    }
+
+    BOOST_PP_REPEAT_FROM_TO(1, 11, BOOST_HASH_TUPLE_F, _)
+#   undef BOOST_HASH_TUPLE_F
+#endif
+
+#endif
+
+#if !defined(BOOST_NO_CXX11_SMART_PTR)
+    template <typename T>
+    inline std::size_t hash_value(std::shared_ptr<T> const& x) {
+        return boost::hash_value(x.get());
+    }
+
+    template <typename T, typename Deleter>
+    inline std::size_t hash_value(std::unique_ptr<T, Deleter> const& x) {
+        return boost::hash_value(x.get());
+    }
+#endif
+
+    //
+    // call_hash_impl
+    //
+
+    // On compilers without function template ordering, this deals with arrays.
+
+#if defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
+    namespace hash_detail
+    {
+        template <bool IsArray>
+        struct call_hash_impl
+        {
+            template <class T>
+            struct inner
+            {
+                static std::size_t call(T const& v)
+                {
+                    using namespace boost;
+                    return hash_value(v);
+                }
+            };
+        };
+
+        template <>
+        struct call_hash_impl<true>
+        {
+            template <class Array>
+            struct inner
+            {
+                static std::size_t call(Array const& v)
+                {
+                    const int size = sizeof(v) / sizeof(*v);
+                    return boost::hash_range(v, v + size);
+                }
+            };
+        };
+
+        template <class T>
+        struct call_hash
+            : public call_hash_impl<boost::is_array<T>::value>
+                ::BOOST_NESTED_TEMPLATE inner<T>
+        {
+        };
+    }
+#endif // BOOST_NO_FUNCTION_TEMPLATE_ORDERING
+
+    //
+    // boost::hash
+    //
+
+
+#if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
+
+    template <class T> struct hash
+        : std::unary_function<T, std::size_t>
+    {
+#if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
+        std::size_t operator()(T const& val) const
+        {
+            return hash_value(val);
+        }
+#else
+        std::size_t operator()(T const& val) const
+        {
+            return hash_detail::call_hash<T>::call(val);
+        }
+#endif
+    };
+
+#if BOOST_WORKAROUND(__DMC__, <= 0x848)
+    template <class T, unsigned int n> struct hash<T[n]>
+        : std::unary_function<T[n], std::size_t>
+    {
+        std::size_t operator()(const T* val) const
+        {
+            return boost::hash_range(val, val+n);
+        }
+    };
+#endif
+
+#else // BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION
+
+    // On compilers without partial specialization, boost::hash<T>
+    // has already been declared to deal with pointers, so just
+    // need to supply the non-pointer version of hash_impl.
+
+    namespace hash_detail
+    {
+        template <bool IsPointer>
+        struct hash_impl;
+
+        template <>
+        struct hash_impl<false>
+        {
+            template <class T>
+            struct inner
+                : std::unary_function<T, std::size_t>
+            {
+#if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
+                std::size_t operator()(T const& val) const
+                {
+                    return hash_value(val);
+                }
+#else
+                std::size_t operator()(T const& val) const
+                {
+                    return hash_detail::call_hash<T>::call(val);
+                }
+#endif
+            };
+        };
+    }
+#endif  // BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION
+}
+
+#endif

--- a/ibtk/contrib/boost/boost/functional/hash/hash.hpp
+++ b/ibtk/contrib/boost/boost/functional/hash/hash.hpp
@@ -1,0 +1,559 @@
+
+// Copyright 2005-2014 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  Based on Peter Dimov's proposal
+//  http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2005/n1756.pdf
+//  issue 6.18. 
+//
+//  This also contains public domain code from MurmurHash. From the
+//  MurmurHash header:
+
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+#if !defined(BOOST_FUNCTIONAL_HASH_HASH_HPP)
+#define BOOST_FUNCTIONAL_HASH_HASH_HPP
+
+#include <boost/functional/hash/hash_fwd.hpp>
+#include <functional>
+#include <boost/functional/hash/detail/hash_float.hpp>
+#include <string>
+#include <boost/limits.hpp>
+#include <boost/type_traits/is_enum.hpp>
+#include <boost/type_traits/is_integral.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/cstdint.hpp>
+
+#if defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
+#include <boost/type_traits/is_pointer.hpp>
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPEINDEX)
+#include <typeindex>
+#endif
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+
+#if BOOST_MSVC >= 1400
+#pragma warning(disable:6295) // Ill-defined for-loop : 'unsigned int' values
+                              // are always of range '0' to '4294967295'.
+                              // Loop executes infinitely.
+#endif
+
+#endif
+
+#if BOOST_WORKAROUND(__GNUC__, < 3) \
+    && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
+#define BOOST_HASH_CHAR_TRAITS string_char_traits
+#else
+#define BOOST_HASH_CHAR_TRAITS char_traits
+#endif
+
+#if defined(_MSC_VER)
+#   define BOOST_FUNCTIONAL_HASH_ROTL32(x, r) _rotl(x,r)
+#else
+#   define BOOST_FUNCTIONAL_HASH_ROTL32(x, r) (x << r) | (x >> (32 - r))
+#endif
+
+namespace boost
+{
+    namespace hash_detail
+    {
+        struct enable_hash_value { typedef std::size_t type; };
+
+        template <typename T> struct basic_numbers {};
+        template <typename T> struct long_numbers;
+        template <typename T> struct ulong_numbers;
+        template <typename T> struct float_numbers {};
+
+        template <> struct basic_numbers<bool> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct basic_numbers<char> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct basic_numbers<unsigned char> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct basic_numbers<signed char> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct basic_numbers<short> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct basic_numbers<unsigned short> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct basic_numbers<int> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct basic_numbers<unsigned int> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct basic_numbers<long> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct basic_numbers<unsigned long> :
+            boost::hash_detail::enable_hash_value {};
+
+#if !defined(BOOST_NO_INTRINSIC_WCHAR_T)
+        template <> struct basic_numbers<wchar_t> :
+            boost::hash_detail::enable_hash_value {};
+#endif
+
+        // long_numbers is defined like this to allow for separate
+        // specialization for long_long and int128_type, in case
+        // they conflict.
+        template <typename T> struct long_numbers2 {};
+        template <typename T> struct ulong_numbers2 {};
+        template <typename T> struct long_numbers : long_numbers2<T> {};
+        template <typename T> struct ulong_numbers : ulong_numbers2<T> {};
+
+#if !defined(BOOST_NO_LONG_LONG)
+        template <> struct long_numbers<boost::long_long_type> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct ulong_numbers<boost::ulong_long_type> :
+            boost::hash_detail::enable_hash_value {};
+#endif
+
+#if defined(BOOST_HAS_INT128)
+        template <> struct long_numbers2<boost::int128_type> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct ulong_numbers2<boost::uint128_type> :
+            boost::hash_detail::enable_hash_value {};
+#endif
+
+        template <> struct float_numbers<float> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct float_numbers<double> :
+            boost::hash_detail::enable_hash_value {};
+        template <> struct float_numbers<long double> :
+            boost::hash_detail::enable_hash_value {};
+    }
+
+    template <typename T>
+    typename boost::hash_detail::basic_numbers<T>::type hash_value(T);
+    template <typename T>
+    typename boost::hash_detail::long_numbers<T>::type hash_value(T);
+    template <typename T>
+    typename boost::hash_detail::ulong_numbers<T>::type hash_value(T);
+
+    template <typename T>
+    typename boost::enable_if<boost::is_enum<T>, std::size_t>::type
+        hash_value(T);
+
+#if !BOOST_WORKAROUND(__DMC__, <= 0x848)
+    template <class T> std::size_t hash_value(T* const&);
+#else
+    template <class T> std::size_t hash_value(T*);
+#endif
+
+#if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
+    template< class T, unsigned N >
+    std::size_t hash_value(const T (&x)[N]);
+
+    template< class T, unsigned N >
+    std::size_t hash_value(T (&x)[N]);
+#endif
+
+    template <class Ch, class A>
+    std::size_t hash_value(
+        std::basic_string<Ch, std::BOOST_HASH_CHAR_TRAITS<Ch>, A> const&);
+
+    template <typename T>
+    typename boost::hash_detail::float_numbers<T>::type hash_value(T);
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPEINDEX)
+    std::size_t hash_value(std::type_index);
+#endif
+
+    // Implementation
+
+    namespace hash_detail
+    {
+        template <class T>
+        inline std::size_t hash_value_signed(T val)
+        {
+             const int size_t_bits = std::numeric_limits<std::size_t>::digits;
+             // ceiling(std::numeric_limits<T>::digits / size_t_bits) - 1
+             const int length = (std::numeric_limits<T>::digits - 1)
+                 / size_t_bits;
+
+             std::size_t seed = 0;
+             T positive = val < 0 ? -1 - val : val;
+
+             // Hopefully, this loop can be unrolled.
+             for(unsigned int i = length * size_t_bits; i > 0; i -= size_t_bits)
+             {
+                 seed ^= (std::size_t) (positive >> i) + (seed<<6) + (seed>>2);
+             }
+             seed ^= (std::size_t) val + (seed<<6) + (seed>>2);
+
+             return seed;
+        }
+
+        template <class T>
+        inline std::size_t hash_value_unsigned(T val)
+        {
+             const int size_t_bits = std::numeric_limits<std::size_t>::digits;
+             // ceiling(std::numeric_limits<T>::digits / size_t_bits) - 1
+             const int length = (std::numeric_limits<T>::digits - 1)
+                 / size_t_bits;
+
+             std::size_t seed = 0;
+
+             // Hopefully, this loop can be unrolled.
+             for(unsigned int i = length * size_t_bits; i > 0; i -= size_t_bits)
+             {
+                 seed ^= (std::size_t) (val >> i) + (seed<<6) + (seed>>2);
+             }
+             seed ^= (std::size_t) val + (seed<<6) + (seed>>2);
+
+             return seed;
+        }
+
+        template <typename SizeT>
+        inline void hash_combine_impl(SizeT& seed, SizeT value)
+        {
+            seed ^= value + 0x9e3779b9 + (seed<<6) + (seed>>2);
+        }
+
+        template <typename SizeT>
+        inline void hash_combine_impl(boost::uint32_t& h1,
+                boost::uint32_t k1)
+        {
+            const uint32_t c1 = 0xcc9e2d51;
+            const uint32_t c2 = 0x1b873593;
+
+            k1 *= c1;
+            k1 = BOOST_FUNCTIONAL_HASH_ROTL32(k1,15);
+            k1 *= c2;
+
+            h1 ^= k1;
+            h1 = BOOST_FUNCTIONAL_HASH_ROTL32(h1,13);
+            h1 = h1*5+0xe6546b64;
+        }
+
+
+// Don't define 64-bit hash combine on platforms with 64 bit integers,
+// and also not for 32-bit gcc as it warns about the 64-bit constant.
+#if !defined(BOOST_NO_INT64_T) && \
+        !(defined(__GNUC__) && ULONG_MAX == 0xffffffff)
+
+        template <typename SizeT>
+        inline void hash_combine_impl(boost::uint64_t& h,
+                boost::uint64_t k)
+        {
+            const uint64_t m = UINT64_C(0xc6a4a7935bd1e995);
+            const int r = 47;
+
+            k *= m;
+            k ^= k >> r;
+            k *= m;
+
+            h ^= k;
+            h *= m;
+        }
+
+#endif // BOOST_NO_INT64_T
+    }
+
+    template <typename T>
+    typename boost::hash_detail::basic_numbers<T>::type hash_value(T v)
+    {
+        return static_cast<std::size_t>(v);
+    }
+
+    template <typename T>
+    typename boost::hash_detail::long_numbers<T>::type hash_value(T v)
+    {
+        return hash_detail::hash_value_signed(v);
+    }
+
+    template <typename T>
+    typename boost::hash_detail::ulong_numbers<T>::type hash_value(T v)
+    {
+        return hash_detail::hash_value_unsigned(v);
+    }
+
+    template <typename T>
+    typename boost::enable_if<boost::is_enum<T>, std::size_t>::type
+        hash_value(T v)
+    {
+        return static_cast<std::size_t>(v);
+    }
+
+    // Implementation by Alberto Barbati and Dave Harris.
+#if !BOOST_WORKAROUND(__DMC__, <= 0x848)
+    template <class T> std::size_t hash_value(T* const& v)
+#else
+    template <class T> std::size_t hash_value(T* v)
+#endif
+    {
+#if defined(__VMS) && __INITIAL_POINTER_SIZE == 64
+    // for some reason ptrdiff_t on OpenVMS compiler with
+    // 64 bit is not 64 bit !!!
+        std::size_t x = static_cast<std::size_t>(
+           reinterpret_cast<long long int>(v));
+#else
+        std::size_t x = static_cast<std::size_t>(
+           reinterpret_cast<std::ptrdiff_t>(v));
+#endif
+        return x + (x >> 3);
+    }
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+#if BOOST_MSVC <= 1400
+#pragma warning(disable:4267) // 'argument' : conversion from 'size_t' to
+                              // 'unsigned int', possible loss of data
+                              // A misguided attempt to detect 64-bit
+                              // incompatability.
+#endif
+#endif
+
+    template <class T>
+    inline void hash_combine(std::size_t& seed, T const& v)
+    {
+        boost::hash<T> hasher;
+        return boost::hash_detail::hash_combine_impl(seed, hasher(v));
+    }
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+    template <class It>
+    inline std::size_t hash_range(It first, It last)
+    {
+        std::size_t seed = 0;
+
+        for(; first != last; ++first)
+        {
+            hash_combine(seed, *first);
+        }
+
+        return seed;
+    }
+
+    template <class It>
+    inline void hash_range(std::size_t& seed, It first, It last)
+    {
+        for(; first != last; ++first)
+        {
+            hash_combine(seed, *first);
+        }
+    }
+
+#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))
+    template <class T>
+    inline std::size_t hash_range(T* first, T* last)
+    {
+        std::size_t seed = 0;
+
+        for(; first != last; ++first)
+        {
+            boost::hash<T> hasher;
+            seed ^= hasher(*first) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+        }
+
+        return seed;
+    }
+
+    template <class T>
+    inline void hash_range(std::size_t& seed, T* first, T* last)
+    {
+        for(; first != last; ++first)
+        {
+            boost::hash<T> hasher;
+            seed ^= hasher(*first) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+        }
+    }
+#endif
+
+#if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
+    template< class T, unsigned N >
+    inline std::size_t hash_value(const T (&x)[N])
+    {
+        return hash_range(x, x + N);
+    }
+
+    template< class T, unsigned N >
+    inline std::size_t hash_value(T (&x)[N])
+    {
+        return hash_range(x, x + N);
+    }
+#endif
+
+    template <class Ch, class A>
+    inline std::size_t hash_value(
+        std::basic_string<Ch, std::BOOST_HASH_CHAR_TRAITS<Ch>, A> const& v)
+    {
+        return hash_range(v.begin(), v.end());
+    }
+
+    template <typename T>
+    typename boost::hash_detail::float_numbers<T>::type hash_value(T v)
+    {
+        return boost::hash_detail::float_hash_value(v);
+    }
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPEINDEX)
+    inline std::size_t hash_value(std::type_index v)
+    {
+        return v.hash_code();
+    }
+#endif
+
+    //
+    // boost::hash
+    //
+    
+    // Define the specializations required by the standard. The general purpose
+    // boost::hash is defined later in extensions.hpp if
+    // BOOST_HASH_NO_EXTENSIONS is not defined.
+    
+    // BOOST_HASH_SPECIALIZE - define a specialization for a type which is
+    // passed by copy.
+    //
+    // BOOST_HASH_SPECIALIZE_REF - define a specialization for a type which is
+    // passed by const reference.
+    //
+    // These are undefined later.
+
+#define BOOST_HASH_SPECIALIZE(type) \
+    template <> struct hash<type> \
+         : public std::unary_function<type, std::size_t> \
+    { \
+        std::size_t operator()(type v) const \
+        { \
+            return boost::hash_value(v); \
+        } \
+    };
+
+#define BOOST_HASH_SPECIALIZE_REF(type) \
+    template <> struct hash<type> \
+         : public std::unary_function<type, std::size_t> \
+    { \
+        std::size_t operator()(type const& v) const \
+        { \
+            return boost::hash_value(v); \
+        } \
+    };
+
+    BOOST_HASH_SPECIALIZE(bool)
+    BOOST_HASH_SPECIALIZE(char)
+    BOOST_HASH_SPECIALIZE(signed char)
+    BOOST_HASH_SPECIALIZE(unsigned char)
+#if !defined(BOOST_NO_INTRINSIC_WCHAR_T)
+    BOOST_HASH_SPECIALIZE(wchar_t)
+#endif
+    BOOST_HASH_SPECIALIZE(short)
+    BOOST_HASH_SPECIALIZE(unsigned short)
+    BOOST_HASH_SPECIALIZE(int)
+    BOOST_HASH_SPECIALIZE(unsigned int)
+    BOOST_HASH_SPECIALIZE(long)
+    BOOST_HASH_SPECIALIZE(unsigned long)
+
+    BOOST_HASH_SPECIALIZE(float)
+    BOOST_HASH_SPECIALIZE(double)
+    BOOST_HASH_SPECIALIZE(long double)
+
+    BOOST_HASH_SPECIALIZE_REF(std::string)
+#if !defined(BOOST_NO_STD_WSTRING)
+    BOOST_HASH_SPECIALIZE_REF(std::wstring)
+#endif
+
+#if !defined(BOOST_NO_LONG_LONG)
+    BOOST_HASH_SPECIALIZE(boost::long_long_type)
+    BOOST_HASH_SPECIALIZE(boost::ulong_long_type)
+#endif
+
+#if defined(BOOST_HAS_INT128)
+    BOOST_HASH_SPECIALIZE(boost::int128_type)
+    BOOST_HASH_SPECIALIZE(boost::uint128_type)
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPEINDEX)
+    BOOST_HASH_SPECIALIZE(std::type_index)
+#endif
+
+#undef BOOST_HASH_SPECIALIZE
+#undef BOOST_HASH_SPECIALIZE_REF
+
+// Specializing boost::hash for pointers.
+
+#if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
+
+    template <class T>
+    struct hash<T*>
+        : public std::unary_function<T*, std::size_t>
+    {
+        std::size_t operator()(T* v) const
+        {
+#if !BOOST_WORKAROUND(__SUNPRO_CC, <= 0x590)
+            return boost::hash_value(v);
+#else
+            std::size_t x = static_cast<std::size_t>(
+                reinterpret_cast<std::ptrdiff_t>(v));
+
+            return x + (x >> 3);
+#endif
+        }
+    };
+
+#else
+
+    // For compilers without partial specialization, we define a
+    // boost::hash for all remaining types. But hash_impl is only defined
+    // for pointers in 'extensions.hpp' - so when BOOST_HASH_NO_EXTENSIONS
+    // is defined there will still be a compile error for types not supported
+    // in the standard.
+
+    namespace hash_detail
+    {
+        template <bool IsPointer>
+        struct hash_impl;
+
+        template <>
+        struct hash_impl<true>
+        {
+            template <class T>
+            struct inner
+                : public std::unary_function<T, std::size_t>
+            {
+                std::size_t operator()(T val) const
+                {
+#if !BOOST_WORKAROUND(__SUNPRO_CC, <= 590)
+                    return boost::hash_value(val);
+#else
+                    std::size_t x = static_cast<std::size_t>(
+                        reinterpret_cast<std::ptrdiff_t>(val));
+
+                    return x + (x >> 3);
+#endif
+                }
+            };
+        };
+    }
+
+    template <class T> struct hash
+        : public boost::hash_detail::hash_impl<boost::is_pointer<T>::value>
+            ::BOOST_NESTED_TEMPLATE inner<T>
+    {
+    };
+
+#endif
+}
+
+#undef BOOST_HASH_CHAR_TRAITS
+#undef BOOST_FUNCTIONAL_HASH_ROTL32
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+#endif // BOOST_FUNCTIONAL_HASH_HASH_HPP
+
+// Include this outside of the include guards in case the file is included
+// twice - once with BOOST_HASH_NO_EXTENSIONS defined, and then with it
+// undefined.
+
+#if !defined(BOOST_HASH_NO_EXTENSIONS) \
+    && !defined(BOOST_FUNCTIONAL_HASH_EXTENSIONS_HPP)
+#include <boost/functional/hash/extensions.hpp>
+#endif

--- a/ibtk/contrib/boost/boost/integer/static_log2.hpp
+++ b/ibtk/contrib/boost/boost/integer/static_log2.hpp
@@ -1,0 +1,127 @@
+// -------------- Boost static_log2.hpp header file  ----------------------- //
+//
+//                 Copyright (C) 2001 Daryle Walker.
+//                 Copyright (C) 2003 Vesa Karvonen.
+//                 Copyright (C) 2003 Gennaro Prota.
+//
+//     Distributed under the Boost Software License, Version 1.0.
+//        (See accompanying file LICENSE_1_0.txt or copy at
+//              http://www.boost.org/LICENSE_1_0.txt)
+//
+//         ---------------------------------------------------
+//       See http://www.boost.org/libs/integer for documentation.
+// ------------------------------------------------------------------------- //
+
+
+#ifndef BOOST_INTEGER_STATIC_LOG2_HPP
+#define BOOST_INTEGER_STATIC_LOG2_HPP
+
+#include "boost/integer_fwd.hpp" // for boost::intmax_t
+
+namespace boost {
+
+ namespace detail {
+
+     namespace static_log2_impl {
+
+     // choose_initial_n<>
+     //
+     // Recursively doubles its integer argument, until it
+     // becomes >= of the "width" (C99, 6.2.6.2p4) of
+     // static_log2_argument_type.
+     //
+     // Used to get the maximum power of two less then the width.
+     //
+     // Example: if on your platform argument_type has 48 value
+     //          bits it yields n=32.
+     //
+     // It's easy to prove that, starting from such a value
+     // of n, the core algorithm works correctly for any width
+     // of static_log2_argument_type and that recursion always
+     // terminates with x = 1 and n = 0 (see the algorithm's
+     // invariant).
+
+     typedef boost::static_log2_argument_type argument_type;
+     typedef boost::static_log2_result_type result_type;
+
+     template <result_type n>
+     struct choose_initial_n {
+
+         BOOST_STATIC_CONSTANT(bool, c = (argument_type(1) << n << n) != 0);
+         BOOST_STATIC_CONSTANT(
+             result_type,
+             value = !c*n + choose_initial_n<2*c*n>::value
+         );
+
+     };
+
+     template <>
+     struct choose_initial_n<0> {
+         BOOST_STATIC_CONSTANT(result_type, value = 0);
+     };
+
+
+
+     // start computing from n_zero - must be a power of two
+     const result_type n_zero = 16;
+     const result_type initial_n = choose_initial_n<n_zero>::value;
+
+     // static_log2_impl<>
+     //
+     // * Invariant:
+     //                 2n
+     //  1 <= x && x < 2    at the start of each recursion
+     //                     (see also choose_initial_n<>)
+     //
+     // * Type requirements:
+     //
+     //   argument_type maybe any unsigned type with at least n_zero + 1
+     //   value bits. (Note: If larger types will be standardized -e.g.
+     //   unsigned long long- then the argument_type typedef can be
+     //   changed without affecting the rest of the code.)
+     //
+
+     template <argument_type x, result_type n = initial_n>
+     struct static_log2_impl {
+
+         BOOST_STATIC_CONSTANT(bool, c = (x >> n) > 0); // x >= 2**n ?
+         BOOST_STATIC_CONSTANT(
+             result_type,
+             value = c*n + (static_log2_impl< (x>>c*n), n/2 >::value)
+         );
+
+     };
+
+     template <>
+     struct static_log2_impl<1, 0> {
+        BOOST_STATIC_CONSTANT(result_type, value = 0);
+     };
+
+     }
+ } // detail
+
+
+
+ // --------------------------------------
+ // static_log2<x>
+ // ----------------------------------------
+
+ template <static_log2_argument_type x>
+ struct static_log2 {
+
+     BOOST_STATIC_CONSTANT(
+         static_log2_result_type,
+         value = detail::static_log2_impl::static_log2_impl<x>::value
+     );
+
+ };
+
+
+ template <>
+ struct static_log2<0> { };
+
+}
+
+
+
+#endif // include guard

--- a/ibtk/contrib/boost/boost/integer_fwd.hpp
+++ b/ibtk/contrib/boost/boost/integer_fwd.hpp
@@ -1,0 +1,187 @@
+//  Boost integer_fwd.hpp header file  ---------------------------------------//
+
+//  (C) Copyright Dave Abrahams and Daryle Walker 2001. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/integer for documentation.
+
+#ifndef BOOST_INTEGER_FWD_HPP
+#define BOOST_INTEGER_FWD_HPP
+
+#include <climits>  // for UCHAR_MAX, etc.
+#include <cstddef>  // for std::size_t
+
+#include <boost/config.hpp>  // for BOOST_NO_INTRINSIC_WCHAR_T
+#include <boost/limits.hpp>  // for std::numeric_limits
+#include <boost/cstdint.hpp>  // For intmax_t
+
+
+namespace boost
+{
+
+#ifdef BOOST_NO_INTEGRAL_INT64_T
+     typedef unsigned long static_log2_argument_type;
+     typedef          int  static_log2_result_type;
+     typedef long          static_min_max_signed_type;
+     typedef unsigned long static_min_max_unsigned_type;
+#else
+     typedef boost::uintmax_t static_min_max_unsigned_type;
+     typedef boost::intmax_t  static_min_max_signed_type;
+     typedef boost::uintmax_t static_log2_argument_type;
+     typedef int              static_log2_result_type;
+#endif
+
+//  From <boost/cstdint.hpp>  ------------------------------------------------//
+
+// Only has typedefs or using statements, with #conditionals
+
+
+//  From <boost/integer_traits.hpp>  -----------------------------------------//
+
+template < class T >
+    class integer_traits;
+
+template <  >
+    class integer_traits< bool >;
+
+template <  >
+    class integer_traits< char >;
+
+template <  >
+    class integer_traits< signed char >;
+
+template <  >
+    class integer_traits< unsigned char >;
+
+#ifndef BOOST_NO_INTRINSIC_WCHAR_T
+template <  >
+    class integer_traits< wchar_t >;
+#endif
+
+template <  >
+    class integer_traits< short >;
+
+template <  >
+    class integer_traits< unsigned short >;
+
+template <  >
+    class integer_traits< int >;
+
+template <  >
+    class integer_traits< unsigned int >;
+
+template <  >
+    class integer_traits< long >;
+
+template <  >
+    class integer_traits< unsigned long >;
+
+#if !defined(BOOST_NO_INTEGRAL_INT64_T) && !defined(BOOST_NO_INT64_T) && defined(BOOST_HAS_LONG_LONG)
+template <  >
+class integer_traits<  ::boost::long_long_type>;
+
+template <  >
+class integer_traits<  ::boost::ulong_long_type >;
+#elif !defined(BOOST_NO_INTEGRAL_INT64_T) && !defined(BOOST_NO_INT64_T) && defined(BOOST_HAS_MS_INT64)
+template <  >
+class integer_traits<__int64>;
+
+template <  >
+class integer_traits<unsigned __int64>;
+#endif
+
+
+//  From <boost/integer.hpp>  ------------------------------------------------//
+
+template < typename LeastInt >
+    struct int_fast_t;
+
+template< int Bits >
+    struct int_t;
+
+template< int Bits >
+    struct uint_t;
+
+#if !defined(BOOST_NO_INTEGRAL_INT64_T) && defined(BOOST_HAS_LONG_LONG)
+    template< boost::long_long_type MaxValue >   // maximum value to require support
+#else
+  template< long MaxValue >   // maximum value to require support
+#endif
+    struct int_max_value_t;
+
+#if !defined(BOOST_NO_INTEGRAL_INT64_T) && defined(BOOST_HAS_LONG_LONG)
+  template< boost::long_long_type MinValue >   // minimum value to require support
+#else
+  template< long MinValue >   // minimum value to require support
+#endif
+    struct int_min_value_t;
+
+#if !defined(BOOST_NO_INTEGRAL_INT64_T) && defined(BOOST_HAS_LONG_LONG)
+  template< boost::ulong_long_type MaxValue >   // maximum value to require support
+#else
+  template< unsigned long MaxValue >   // maximum value to require support
+#endif
+    struct uint_value_t;
+
+
+//  From <boost/integer/integer_mask.hpp>  -----------------------------------//
+
+template < std::size_t Bit >
+    struct high_bit_mask_t;
+
+template < std::size_t Bits >
+    struct low_bits_mask_t;
+
+template <  >
+    struct low_bits_mask_t< ::std::numeric_limits<unsigned char>::digits >;
+
+//  From <boost/integer/static_log2.hpp>  ------------------------------------//
+
+template <static_log2_argument_type Value >
+    struct static_log2;
+
+template <> struct static_log2<0u>;
+
+
+//  From <boost/integer/static_min_max.hpp>  ---------------------------------//
+
+template <static_min_max_signed_type Value1, static_min_max_signed_type Value2>
+    struct static_signed_min;
+
+template <static_min_max_signed_type Value1, static_min_max_signed_type Value2>
+    struct static_signed_max;
+
+template <static_min_max_unsigned_type Value1, static_min_max_unsigned_type Value2>
+    struct static_unsigned_min;
+
+template <static_min_max_unsigned_type Value1, static_min_max_unsigned_type Value2>
+    struct static_unsigned_max;
+
+
+//  From <boost/integer/common_factor_ct.hpp>
+
+#ifdef BOOST_NO_INTEGRAL_INT64_T
+     typedef unsigned long static_gcd_type;
+#else
+     typedef boost::uintmax_t static_gcd_type;
+#endif
+
+template < static_gcd_type Value1, static_gcd_type Value2 >
+    struct static_gcd;
+template < static_gcd_type Value1, static_gcd_type Value2 >
+    struct static_lcm;
+
+
+//  From <boost/integer/common_factor_rt.hpp>
+
+template < typename IntegerType >
+    class gcd_evaluator;
+template < typename IntegerType >
+    class lcm_evaluator;
+
+
+}  // namespace boost
+
+
+#endif  // BOOST_INTEGER_FWD_HPP

--- a/ibtk/contrib/boost/boost/move/algorithm.hpp
+++ b/ibtk/contrib/boost/boost/move/algorithm.hpp
@@ -1,0 +1,282 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2012.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+
+#ifndef BOOST_MOVE_ALGORITHM_HPP
+#define BOOST_MOVE_ALGORITHM_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+
+#include <boost/move/utility_core.hpp>
+#include <boost/move/iterator.hpp>
+#include <boost/detail/no_exceptions_support.hpp>
+
+#include <algorithm> //copy, copy_backward
+#include <memory>    //uninitialized_copy
+
+namespace boost {
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                               move
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#if !defined(BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+
+   //! <b>Effects</b>: Moves elements in the range [first,last) into the range [result,result + (last -
+   //!   first)) starting from first and proceeding to last. For each non-negative integer n < (last-first),
+   //!   performs *(result + n) = ::boost::move (*(first + n)).
+   //!
+   //! <b>Effects</b>: result + (last - first).
+   //!
+   //! <b>Requires</b>: result shall not be in the range [first,last).
+   //!
+   //! <b>Complexity</b>: Exactly last - first move assignments.
+   template <typename I, // I models InputIterator
+            typename O> // O models OutputIterator
+   O move(I f, I l, O result)
+   {
+      while (f != l) {
+         *result = ::boost::move(*f);
+         ++f; ++result;
+      }
+      return result;
+   }
+
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                               move_backward
+   //
+   //////////////////////////////////////////////////////////////////////////////
+
+   //! <b>Effects</b>: Moves elements in the range [first,last) into the range
+   //!   [result - (last-first),result) starting from last - 1 and proceeding to
+   //!   first. For each positive integer n <= (last - first),
+   //!   performs *(result - n) = ::boost::move(*(last - n)).
+   //!
+   //! <b>Requires</b>: result shall not be in the range [first,last).
+   //!
+   //! <b>Returns</b>: result - (last - first).
+   //!
+   //! <b>Complexity</b>: Exactly last - first assignments.
+   template <typename I, // I models BidirectionalIterator
+   typename O> // O models BidirectionalIterator
+   O move_backward(I f, I l, O result)
+   {
+      while (f != l) {
+         --l; --result;
+         *result = ::boost::move(*l);
+      }
+      return result;
+   }
+
+#else
+
+   using ::std::move_backward;
+
+#endif   //!defined(BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                               uninitialized_move
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! <b>Effects</b>:
+//!   \code
+//!   for (; first != last; ++result, ++first)
+//!      new (static_cast<void*>(&*result))
+//!         typename iterator_traits<ForwardIterator>::value_type(boost::move(*first));
+//!   \endcode
+//!
+//! <b>Returns</b>: result
+template
+   <typename I, // I models InputIterator
+    typename F> // F models ForwardIterator
+F uninitialized_move(I f, I l, F r
+   /// @cond
+//   ,typename ::boost::move_detail::enable_if<has_move_emulation_enabled<typename std::iterator_traits<I>::value_type> >::type* = 0
+   /// @endcond
+   )
+{
+   typedef typename std::iterator_traits<I>::value_type input_value_type;
+
+   F back = r;
+   BOOST_TRY{
+      while (f != l) {
+         void * const addr = static_cast<void*>(::boost::move_detail::addressof(*r));
+         ::new(addr) input_value_type(::boost::move(*f));
+         ++f; ++r;
+      }
+   }
+   BOOST_CATCH(...){
+	   for (; back != r; ++back){
+         back->~input_value_type();
+      }
+	   BOOST_RETHROW;
+   }
+   BOOST_CATCH_END
+   return r;
+}
+
+/// @cond
+/*
+template
+   <typename I,   // I models InputIterator
+    typename F>   // F models ForwardIterator
+F uninitialized_move(I f, I l, F r,
+   typename ::boost::move_detail::disable_if<has_move_emulation_enabled<typename std::iterator_traits<I>::value_type> >::type* = 0)
+{
+   return std::uninitialized_copy(f, l, r);
+}
+*/
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                            uninitialized_copy_or_move
+//
+//////////////////////////////////////////////////////////////////////////////
+
+namespace move_detail {
+
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F uninitialized_move_move_iterator(I f, I l, F r
+//                             ,typename ::boost::move_detail::enable_if< has_move_emulation_enabled<typename I::value_type> >::type* = 0
+)
+{
+   return ::boost::uninitialized_move(f, l, r);
+}
+/*
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+F uninitialized_move_move_iterator(I f, I l, F r,
+                                   typename ::boost::move_detail::disable_if< has_move_emulation_enabled<typename I::value_type> >::type* = 0)
+{
+   return std::uninitialized_copy(f.base(), l.base(), r);
+}
+*/
+}  //namespace move_detail {
+
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F uninitialized_copy_or_move(I f, I l, F r,
+                             typename ::boost::move_detail::enable_if< move_detail::is_move_iterator<I> >::type* = 0)
+{
+   return ::boost::move_detail::uninitialized_move_move_iterator(f, l, r);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                            copy_or_move
+//
+//////////////////////////////////////////////////////////////////////////////
+
+namespace move_detail {
+
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F move_move_iterator(I f, I l, F r
+//                             ,typename ::boost::move_detail::enable_if< has_move_emulation_enabled<typename I::value_type> >::type* = 0
+)
+{
+   return ::boost::move(f, l, r);
+}
+/*
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+F move_move_iterator(I f, I l, F r,
+                                   typename ::boost::move_detail::disable_if< has_move_emulation_enabled<typename I::value_type> >::type* = 0)
+{
+   return std::copy(f.base(), l.base(), r);
+}
+*/
+
+}  //namespace move_detail {
+
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F copy_or_move(I f, I l, F r,
+                             typename ::boost::move_detail::enable_if< move_detail::is_move_iterator<I> >::type* = 0)
+{
+   return ::boost::move_detail::move_move_iterator(f, l, r);
+}
+
+/// @endcond
+
+//! <b>Effects</b>:
+//!   \code
+//!   for (; first != last; ++result, ++first)
+//!      new (static_cast<void*>(&*result))
+//!         typename iterator_traits<ForwardIterator>::value_type(*first);
+//!   \endcode
+//!
+//! <b>Returns</b>: result
+//!
+//! <b>Note</b>: This function is provided because
+//!   <i>std::uninitialized_copy</i> from some STL implementations
+//!    is not compatible with <i>move_iterator</i>
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F uninitialized_copy_or_move(I f, I l, F r
+   /// @cond
+   ,typename ::boost::move_detail::disable_if< move_detail::is_move_iterator<I> >::type* = 0
+   /// @endcond
+   )
+{
+   return std::uninitialized_copy(f, l, r);
+}
+
+//! <b>Effects</b>:
+//!   \code
+//!   for (; first != last; ++result, ++first)
+//!      *result = *first;
+//!   \endcode
+//!
+//! <b>Returns</b>: result
+//!
+//! <b>Note</b>: This function is provided because
+//!   <i>std::uninitialized_copy</i> from some STL implementations
+//!    is not compatible with <i>move_iterator</i>
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F copy_or_move(I f, I l, F r
+   /// @cond
+   ,typename ::boost::move_detail::disable_if< move_detail::is_move_iterator<I> >::type* = 0
+   /// @endcond
+   )
+{
+   return std::copy(f, l, r);
+}
+
+}  //namespace boost {
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_ALGORITHM_HPP

--- a/ibtk/contrib/boost/boost/move/detail/iterator_traits.hpp
+++ b/ibtk/contrib/boost/boost/move/detail/iterator_traits.hpp
@@ -1,0 +1,73 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2014-2014.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+
+#ifndef BOOST_MOVE_DETAIL_ITERATOR_TRAITS_HPP
+#define BOOST_MOVE_DETAIL_ITERATOR_TRAITS_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <cstddef>
+
+#include <boost/move/detail/std_ns_begin.hpp>
+BOOST_MOVE_STD_NS_BEG
+
+struct input_iterator_tag;
+struct forward_iterator_tag;
+struct bidirectional_iterator_tag;
+struct random_access_iterator_tag;
+struct output_iterator_tag;
+
+BOOST_MOVE_STD_NS_END
+#include <boost/move/detail/std_ns_end.hpp>
+
+namespace boost{  namespace movelib{
+
+template<class Iterator>
+struct iterator_traits
+{
+   typedef typename Iterator::difference_type   difference_type;
+   typedef typename Iterator::value_type        value_type;
+   typedef typename Iterator::pointer           pointer;
+   typedef typename Iterator::reference         reference;
+   typedef typename Iterator::iterator_category iterator_category;
+};
+
+template<class T>
+struct iterator_traits<T*>
+{
+   typedef std::ptrdiff_t                    difference_type;
+   typedef T                                 value_type;
+   typedef T*                                pointer;
+   typedef T&                                reference;
+   typedef std::random_access_iterator_tag   iterator_category;
+};
+
+template<class T>
+struct iterator_traits<const T*>
+{
+   typedef std::ptrdiff_t                    difference_type;
+   typedef T                                 value_type;
+   typedef const T*                          pointer;
+   typedef const T&                          reference;
+   typedef std::random_access_iterator_tag   iterator_category;
+};
+
+}} //namespace boost {  namespace movelib{
+
+#endif //#ifndef BOOST_MOVE_DETAIL_ITERATOR_TRAITS_HPP

--- a/ibtk/contrib/boost/boost/move/detail/std_ns_begin.hpp
+++ b/ibtk/contrib/boost/boost/move/detail/std_ns_begin.hpp
@@ -1,0 +1,30 @@
+#//////////////////////////////////////////////////////////////////////////////
+#//
+#// (C) Copyright Ion Gaztanaga 2015-2015.
+#// Distributed under the Boost Software License, Version 1.0.
+#// (See accompanying file LICENSE_1_0.txt or copy at
+#// http://www.boost.org/LICENSE_1_0.txt)
+#//
+#// See http://www.boost.org/libs/move for documentation.
+#//
+#//////////////////////////////////////////////////////////////////////////////
+#
+#if defined(_LIBCPP_VERSION)
+   #if defined(__clang__)
+      #define BOOST_MOVE_STD_NS_GCC_DIAGNOSTIC_PUSH
+      #pragma GCC diagnostic push
+      #pragma GCC diagnostic ignored "-Wc++11-extensions"
+   #endif
+   #define BOOST_MOVE_STD_NS_BEG _LIBCPP_BEGIN_NAMESPACE_STD
+   #define BOOST_MOVE_STD_NS_END _LIBCPP_END_NAMESPACE_STD
+#elif defined(BOOST_GNU_STDLIB) && defined(_GLIBCXX_BEGIN_NAMESPACE_VERSION)  //GCC >= 4.6
+   #define BOOST_MOVE_STD_NS_BEG namespace std _GLIBCXX_VISIBILITY(default) { _GLIBCXX_BEGIN_NAMESPACE_VERSION
+   #define BOOST_MOVE_STD_NS_END _GLIBCXX_END_NAMESPACE_VERSION  } // namespace
+#elif defined(BOOST_GNU_STDLIB) && defined(_GLIBCXX_BEGIN_NAMESPACE)  //GCC >= 4.2
+   #define BOOST_MOVE_STD_NS_BEG _GLIBCXX_BEGIN_NAMESPACE(std)
+   #define BOOST_MOVE_STD_NS_END _GLIBCXX_END_NAMESPACE
+#else
+   #define BOOST_MOVE_STD_NS_BEG namespace std{
+   #define BOOST_MOVE_STD_NS_END }
+#endif
+

--- a/ibtk/contrib/boost/boost/move/detail/std_ns_end.hpp
+++ b/ibtk/contrib/boost/boost/move/detail/std_ns_end.hpp
@@ -1,0 +1,14 @@
+#//////////////////////////////////////////////////////////////////////////////
+#//
+#// (C) Copyright Ion Gaztanaga 2015-2015.
+#// Distributed under the Boost Software License, Version 1.0.
+#// (See accompanying file LICENSE_1_0.txt or copy at
+#// http://www.boost.org/LICENSE_1_0.txt)
+#//
+#// See http://www.boost.org/libs/move for documentation.
+#//
+#//////////////////////////////////////////////////////////////////////////////
+#ifdef BOOST_MOVE_STD_NS_GCC_DIAGNOSTIC_PUSH
+   #pragma GCC diagnostic pop
+   #undef BOOST_MOVE_STD_NS_GCC_DIAGNOSTIC_PUSH
+#endif   //BOOST_MOVE_STD_NS_GCC_DIAGNOSTIC_PUSH

--- a/ibtk/contrib/boost/boost/move/iterator.hpp
+++ b/ibtk/contrib/boost/boost/move/iterator.hpp
@@ -1,0 +1,312 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2012.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+
+#ifndef BOOST_MOVE_ITERATOR_HPP
+#define BOOST_MOVE_ITERATOR_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+#include <boost/move/detail/iterator_traits.hpp>
+#include <boost/move/utility_core.hpp>
+
+namespace boost {
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                            move_iterator
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! Class template move_iterator is an iterator adaptor with the same behavior
+//! as the underlying iterator except that its dereference operator implicitly
+//! converts the value returned by the underlying iterator's dereference operator
+//! to an rvalue reference. Some generic algorithms can be called with move
+//! iterators to replace copying with moving.
+template <class It>
+class move_iterator
+{
+   public:
+   typedef It                                                              iterator_type;
+   typedef typename boost::movelib::iterator_traits<iterator_type>::value_type        value_type;
+   #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_MOVE_DOXYGEN_INVOKED)
+   typedef value_type &&                                                   reference;
+   #else
+   typedef typename ::boost::move_detail::if_
+      < ::boost::has_move_emulation_enabled<value_type>
+      , ::boost::rv<value_type>&
+      , value_type & >::type                                               reference;
+   #endif
+   typedef It                                                              pointer;
+   typedef typename boost::movelib::iterator_traits<iterator_type>::difference_type   difference_type;
+   typedef typename boost::movelib::iterator_traits<iterator_type>::iterator_category iterator_category;
+
+   move_iterator()
+   {}
+
+   explicit move_iterator(It i)
+      :  m_it(i)
+   {}
+
+   template <class U>
+   move_iterator(const move_iterator<U>& u)
+      :  m_it(u.base())
+   {}
+
+   iterator_type base() const
+   {  return m_it;   }
+
+   reference operator*() const
+   {
+      #if defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES)
+      return *m_it;
+      #else
+      return ::boost::move(*m_it);
+      #endif
+   }
+
+   pointer   operator->() const
+   {  return m_it;   }
+
+   move_iterator& operator++()
+   {  ++m_it; return *this;   }
+
+   move_iterator<iterator_type>  operator++(int)
+   {  move_iterator<iterator_type> tmp(*this); ++(*this); return tmp;   }
+
+   move_iterator& operator--()
+   {  --m_it; return *this;   }
+
+   move_iterator<iterator_type>  operator--(int)
+   {  move_iterator<iterator_type> tmp(*this); --(*this); return tmp;   }
+
+   move_iterator<iterator_type>  operator+ (difference_type n) const
+   {  return move_iterator<iterator_type>(m_it + n);  }
+
+   move_iterator& operator+=(difference_type n)
+   {  m_it += n; return *this;   }
+
+   move_iterator<iterator_type>  operator- (difference_type n) const
+   {  return move_iterator<iterator_type>(m_it - n);  }
+
+   move_iterator& operator-=(difference_type n)
+   {  m_it -= n; return *this;   }
+
+   reference operator[](difference_type n) const
+   {
+      #if defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES)
+      return m_it[n];
+      #else
+      return ::boost::move(m_it[n]);
+      #endif
+   }
+
+   friend bool operator==(const move_iterator& x, const move_iterator& y)
+   {  return x.base() == y.base();  }
+
+   friend bool operator!=(const move_iterator& x, const move_iterator& y)
+   {  return x.base() != y.base();  }
+
+   friend bool operator< (const move_iterator& x, const move_iterator& y)
+   {  return x.base() < y.base();   }
+
+   friend bool operator<=(const move_iterator& x, const move_iterator& y)
+   {  return x.base() <= y.base();  }
+
+   friend bool operator> (const move_iterator& x, const move_iterator& y)
+   {  return x.base() > y.base();  }
+
+   friend bool operator>=(const move_iterator& x, const move_iterator& y)
+   {  return x.base() >= y.base();  }
+
+   friend difference_type operator-(const move_iterator& x, const move_iterator& y)
+   {  return x.base() - y.base();   }
+
+   friend move_iterator operator+(difference_type n, const move_iterator& x)
+   {  return move_iterator(x.base() + n);   }
+
+   private:
+   It m_it;
+};
+
+//is_move_iterator
+namespace move_detail {
+
+template <class I>
+struct is_move_iterator
+{
+   static const bool value = false;
+};
+
+template <class I>
+struct is_move_iterator< ::boost::move_iterator<I> >
+{
+   static const bool value = true;
+};
+
+}  //namespace move_detail {
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                            move_iterator
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//!
+//! <b>Returns</b>: move_iterator<It>(i).
+template<class It>
+inline move_iterator<It> make_move_iterator(const It &it)
+{  return move_iterator<It>(it); }
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                         back_move_insert_iterator
+//
+//////////////////////////////////////////////////////////////////////////////
+
+
+//! A move insert iterator that move constructs elements at the
+//! back of a container
+template <typename C> // C models Container
+class back_move_insert_iterator
+{
+   C* container_m;
+
+   public:
+   typedef C                           container_type;
+   typedef typename C::value_type      value_type;
+   typedef typename C::reference       reference;
+   typedef typename C::pointer         pointer;
+   typedef typename C::difference_type difference_type;
+   typedef std::output_iterator_tag    iterator_category;
+
+   explicit back_move_insert_iterator(C& x) : container_m(&x) { }
+
+   back_move_insert_iterator& operator=(reference x)
+   { container_m->push_back(boost::move(x)); return *this; }
+
+   back_move_insert_iterator& operator=(BOOST_RV_REF(value_type) x)
+   {  reference rx = x; return this->operator=(rx);  }
+
+   back_move_insert_iterator& operator*()     { return *this; }
+   back_move_insert_iterator& operator++()    { return *this; }
+   back_move_insert_iterator& operator++(int) { return *this; }
+};
+
+//!
+//! <b>Returns</b>: back_move_insert_iterator<C>(x).
+template <typename C> // C models Container
+inline back_move_insert_iterator<C> back_move_inserter(C& x)
+{
+   return back_move_insert_iterator<C>(x);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                         front_move_insert_iterator
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! A move insert iterator that move constructs elements int the
+//! front of a container
+template <typename C> // C models Container
+class front_move_insert_iterator
+{
+   C* container_m;
+
+public:
+   typedef C                           container_type;
+   typedef typename C::value_type      value_type;
+   typedef typename C::reference       reference;
+   typedef typename C::pointer         pointer;
+   typedef typename C::difference_type difference_type;
+   typedef std::output_iterator_tag    iterator_category;
+
+   explicit front_move_insert_iterator(C& x) : container_m(&x) { }
+
+   front_move_insert_iterator& operator=(reference x)
+   { container_m->push_front(boost::move(x)); return *this; }
+
+   front_move_insert_iterator& operator=(BOOST_RV_REF(value_type) x)
+   {  reference rx = x; return this->operator=(rx);  }
+
+   front_move_insert_iterator& operator*()     { return *this; }
+   front_move_insert_iterator& operator++()    { return *this; }
+   front_move_insert_iterator& operator++(int) { return *this; }
+};
+
+//!
+//! <b>Returns</b>: front_move_insert_iterator<C>(x).
+template <typename C> // C models Container
+inline front_move_insert_iterator<C> front_move_inserter(C& x)
+{
+   return front_move_insert_iterator<C>(x);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                         insert_move_iterator
+//
+//////////////////////////////////////////////////////////////////////////////
+template <typename C> // C models Container
+class move_insert_iterator
+{
+   C* container_m;
+   typename C::iterator pos_;
+
+   public:
+   typedef C                           container_type;
+   typedef typename C::value_type      value_type;
+   typedef typename C::reference       reference;
+   typedef typename C::pointer         pointer;
+   typedef typename C::difference_type difference_type;
+   typedef std::output_iterator_tag    iterator_category;
+
+   explicit move_insert_iterator(C& x, typename C::iterator pos)
+      : container_m(&x), pos_(pos)
+   {}
+
+   move_insert_iterator& operator=(reference x)
+   {
+      pos_ = container_m->insert(pos_, ::boost::move(x));
+      ++pos_;
+      return *this;
+   }
+
+   move_insert_iterator& operator=(BOOST_RV_REF(value_type) x)
+   {  reference rx = x; return this->operator=(rx);  }
+
+   move_insert_iterator& operator*()     { return *this; }
+   move_insert_iterator& operator++()    { return *this; }
+   move_insert_iterator& operator++(int) { return *this; }
+};
+
+//!
+//! <b>Returns</b>: move_insert_iterator<C>(x, it).
+template <typename C> // C models Container
+inline move_insert_iterator<C> move_inserter(C& x, typename C::iterator it)
+{
+   return move_insert_iterator<C>(x, it);
+}
+
+}  //namespace boost {
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_ITERATOR_HPP

--- a/ibtk/contrib/boost/boost/move/move.hpp
+++ b/ibtk/contrib/boost/boost/move/move.hpp
@@ -1,0 +1,35 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright David Abrahams, Vicente Botet 2009.
+// (C) Copyright Ion Gaztanaga 2009-2012.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+//! A general library header that includes
+//! the rest of top-level headers.
+
+#ifndef BOOST_MOVE_MOVE_HPP
+#define BOOST_MOVE_MOVE_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+#include <boost/move/utility.hpp>
+#include <boost/move/iterator.hpp>
+#include <boost/move/traits.hpp>
+#include <boost/move/algorithm.hpp>
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_MOVE_HPP

--- a/ibtk/contrib/boost/boost/pointer_to_other.hpp
+++ b/ibtk/contrib/boost/boost/pointer_to_other.hpp
@@ -1,0 +1,55 @@
+#ifndef BOOST_POINTER_TO_OTHER_HPP_INCLUDED
+#define BOOST_POINTER_TO_OTHER_HPP_INCLUDED
+
+//
+//  pointer_to_other.hpp
+//
+//  (C) Copyright Ion Gaztanaga 2005.
+//  Copyright (c) 2005 Peter Dimov.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//
+//  (See accompanying file LICENSE_1_0.txt or copy at 
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+//  See http://www.boost.org/libs/smart_ptr/pointer_to_other.html
+//
+
+namespace boost
+{
+
+// Defines the same pointer type (raw or smart) to another pointee type
+
+template<class T, class U>
+struct pointer_to_other;
+
+template<class T, class U, 
+         template<class> class Sp>
+struct pointer_to_other< Sp<T>, U >
+{
+   typedef Sp<U> type;
+};
+
+template<class T, class T2, class U, 
+         template<class, class> class Sp>
+struct pointer_to_other< Sp<T, T2>, U >
+{
+   typedef Sp<U, T2> type;
+};
+
+template<class T, class T2, class T3, class U, 
+         template<class, class, class> class Sp>
+struct pointer_to_other< Sp<T, T2, T3>, U >
+{
+   typedef Sp<U, T2, T3> type;
+};
+
+template<class T, class U>
+struct pointer_to_other< T*, U >
+{
+   typedef U* type;
+};
+
+} // namespace boost
+
+#endif // #ifndef BOOST_POINTER_TO_OTHER_HPP_INCLUDED

--- a/ibtk/contrib/boost/boost/unordered/detail/allocate.hpp
+++ b/ibtk/contrib/boost/boost/unordered/detail/allocate.hpp
@@ -1,0 +1,1128 @@
+
+// Copyright 2005-2011 Daniel James.
+// Copyright 2009 Pablo Halpern.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/unordered for documentation
+
+#ifndef BOOST_UNORDERED_ALLOCATE_HPP
+#define BOOST_UNORDERED_ALLOCATE_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/unordered/detail/fwd.hpp>
+#include <boost/move/move.hpp>
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/inc.hpp>
+#include <boost/preprocessor/dec.hpp>
+#include <boost/preprocessor/repetition/enum.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+#include <boost/type_traits/is_class.hpp>
+#include <boost/type_traits/add_lvalue_reference.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/utility/addressof.hpp>
+#include <boost/detail/select_type.hpp>
+#include <boost/assert.hpp>
+#include <utility>
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+#include <tuple>
+#endif
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4512) // assignment operator could not be generated.
+#pragma warning(disable:4345) // behavior change: an object of POD type
+                              // constructed with an initializer of the form ()
+                              // will be default-initialized.
+#endif
+
+#define BOOST_UNORDERED_EMPLACE_LIMIT 10
+
+namespace boost { namespace unordered { namespace detail {
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Bits and pieces for implementing traits
+
+    template <typename T> typename boost::add_lvalue_reference<T>::type make();
+    struct choice9 { typedef char (&type)[9]; };
+    struct choice8 : choice9 { typedef char (&type)[8]; };
+    struct choice7 : choice8 { typedef char (&type)[7]; };
+    struct choice6 : choice7 { typedef char (&type)[6]; };
+    struct choice5 : choice6 { typedef char (&type)[5]; };
+    struct choice4 : choice5 { typedef char (&type)[4]; };
+    struct choice3 : choice4 { typedef char (&type)[3]; };
+    struct choice2 : choice3 { typedef char (&type)[2]; };
+    struct choice1 : choice2 { typedef char (&type)[1]; };
+    choice1 choose();
+
+    typedef choice1::type yes_type;
+    typedef choice2::type no_type;
+
+    struct private_type
+    {
+       private_type const &operator,(int) const;
+    };
+
+    template <typename T>
+    no_type is_private_type(T const&);
+    yes_type is_private_type(private_type const&);
+
+    struct convert_from_anything {
+        template <typename T>
+        convert_from_anything(T const&);
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    // emplace_args
+    //
+    // Either forwarding variadic arguments, or storing the arguments in
+    // emplace_args##n
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+
+#define BOOST_UNORDERED_EMPLACE_TEMPLATE typename... Args
+#define BOOST_UNORDERED_EMPLACE_ARGS BOOST_FWD_REF(Args)... args
+#define BOOST_UNORDERED_EMPLACE_FORWARD boost::forward<Args>(args)...
+
+#define BOOST_UNORDERED_EMPLACE_ARGS1(a0) a0
+#define BOOST_UNORDERED_EMPLACE_ARGS2(a0, a1) a0, a1
+#define BOOST_UNORDERED_EMPLACE_ARGS3(a0, a1, a2) a0, a1, a2
+
+#else
+
+#define BOOST_UNORDERED_EMPLACE_TEMPLATE typename Args
+#define BOOST_UNORDERED_EMPLACE_ARGS Args const& args
+#define BOOST_UNORDERED_EMPLACE_FORWARD args
+
+#define BOOST_UNORDERED_FWD_PARAM(z, n, a) \
+    BOOST_FWD_REF(BOOST_PP_CAT(A, n)) BOOST_PP_CAT(a, n)
+
+#define BOOST_UNORDERED_CALL_FORWARD(z, i, a) \
+    boost::forward<BOOST_PP_CAT(A,i)>(BOOST_PP_CAT(a,i))
+
+#define BOOST_UNORDERED_EARGS(z, n, _)                                      \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)>                     \
+    struct BOOST_PP_CAT(emplace_args, n)                                    \
+    {                                                                       \
+        BOOST_PP_REPEAT_##z(n, BOOST_UNORDERED_EARGS_MEMBER, _)             \
+        BOOST_PP_CAT(emplace_args, n) (                                     \
+            BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, Arg, b)                     \
+        ) : BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_EARGS_INIT, _)             \
+        {}                                                                  \
+                                                                            \
+    };                                                                      \
+                                                                            \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)>                     \
+    inline BOOST_PP_CAT(emplace_args, n) <                                  \
+        BOOST_PP_ENUM_PARAMS_Z(z, n, A)                                     \
+    > create_emplace_args(                                                  \
+        BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_FWD_PARAM, b)                  \
+    )                                                                       \
+    {                                                                       \
+        BOOST_PP_CAT(emplace_args, n) <                                     \
+            BOOST_PP_ENUM_PARAMS_Z(z, n, A)                                 \
+        > e(BOOST_PP_ENUM_PARAMS_Z(z, n, b));                               \
+        return e;                                                           \
+    }
+
+#define BOOST_UNORDERED_EMPLACE_ARGS1 create_emplace_args
+#define BOOST_UNORDERED_EMPLACE_ARGS2 create_emplace_args
+#define BOOST_UNORDERED_EMPLACE_ARGS3 create_emplace_args
+
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+#define BOOST_UNORDERED_EARGS_MEMBER(z, n, _)                               \
+    typedef BOOST_FWD_REF(BOOST_PP_CAT(A, n)) BOOST_PP_CAT(Arg, n);         \
+    BOOST_PP_CAT(Arg, n) BOOST_PP_CAT(a, n);
+
+#define BOOST_UNORDERED_EARGS_INIT(z, n, _)                                 \
+    BOOST_PP_CAT(a, n)(                                                     \
+        boost::forward<BOOST_PP_CAT(A,n)>(BOOST_PP_CAT(b, n)))
+
+#else
+
+#define BOOST_UNORDERED_EARGS_MEMBER(z, n, _)                               \
+    typedef typename boost::add_lvalue_reference<BOOST_PP_CAT(A, n)>::type  \
+        BOOST_PP_CAT(Arg, n);                                               \
+    BOOST_PP_CAT(Arg, n) BOOST_PP_CAT(a, n);
+
+#define BOOST_UNORDERED_EARGS_INIT(z, n, _)                                 \
+    BOOST_PP_CAT(a, n)(BOOST_PP_CAT(b, n))
+
+#endif
+
+BOOST_PP_REPEAT_FROM_TO(1, BOOST_UNORDERED_EMPLACE_LIMIT, BOOST_UNORDERED_EARGS,
+    _)
+
+#undef BOOST_UNORDERED_DEFINE_EMPLACE_ARGS
+#undef BOOST_UNORDERED_EARGS_MEMBER
+#undef BOOST_UNORDERED_EARGS_INIT
+
+#endif
+
+}}}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Pick which version of allocator_traits to use
+//
+// 0 = Own partial implementation
+// 1 = std::allocator_traits
+// 2 = boost::container::allocator_traits
+
+#if !defined(BOOST_UNORDERED_USE_ALLOCATOR_TRAITS)
+#   if defined(__GXX_EXPERIMENTAL_CXX0X__) && \
+            (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7))
+#       define BOOST_UNORDERED_USE_ALLOCATOR_TRAITS 0
+#   elif defined(BOOST_MSVC)
+#       if BOOST_MSVC < 1400
+            // Use container's allocator_traits for older versions of Visual
+            // C++ as I don't test with them.
+#           define BOOST_UNORDERED_USE_ALLOCATOR_TRAITS 2
+#       endif
+#   endif
+#endif
+
+#if !defined(BOOST_UNORDERED_USE_ALLOCATOR_TRAITS)
+#   define BOOST_UNORDERED_USE_ALLOCATOR_TRAITS 0
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Some utilities for implementing allocator_traits, but useful elsewhere so
+// they're always defined.
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+#  include <type_traits>
+#endif
+
+namespace boost { namespace unordered { namespace detail {
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Integral_constrant, true_type, false_type
+    //
+    // Uses the standard versions if available.
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+
+    using std::integral_constant;
+    using std::true_type;
+    using std::false_type;
+
+#else
+
+    template <typename T, T Value>
+    struct integral_constant { enum { value = Value }; };
+
+    typedef boost::unordered::detail::integral_constant<bool, true> true_type;
+    typedef boost::unordered::detail::integral_constant<bool, false> false_type;
+
+#endif
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Explicitly call a destructor
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4100) // unreferenced formal parameter
+#endif
+
+    namespace func {
+        template <class T>
+        inline void destroy(T* x) {
+            x->~T();
+        }
+    }
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Expression test mechanism
+    //
+    // When SFINAE expressions are available, define
+    // BOOST_UNORDERED_HAS_FUNCTION which can check if a function call is
+    // supported by a class, otherwise define BOOST_UNORDERED_HAS_MEMBER which
+    // can detect if a class has the specified member, but not that it has the
+    // correct type, this is good enough for a passable impression of
+    // allocator_traits.
+
+#if !defined(BOOST_NO_SFINAE_EXPR)
+
+    template <typename T, unsigned int> struct expr_test;
+    template <typename T> struct expr_test<T, sizeof(char)> : T {};
+
+#   define BOOST_UNORDERED_CHECK_EXPRESSION(count, result, expression)      \
+        template <typename U>                                               \
+        static typename boost::unordered::detail::expr_test<                \
+            BOOST_PP_CAT(choice, result),                                   \
+            sizeof(for_expr_test((                                          \
+                (expression),                                               \
+            0)))>::type test(                                               \
+            BOOST_PP_CAT(choice, count))
+
+#   define BOOST_UNORDERED_DEFAULT_EXPRESSION(count, result)                \
+        template <typename U>                                               \
+        static BOOST_PP_CAT(choice, result)::type test(                     \
+            BOOST_PP_CAT(choice, count))
+
+#   define BOOST_UNORDERED_HAS_FUNCTION(name, thing, args, _)               \
+    struct BOOST_PP_CAT(has_, name)                                         \
+    {                                                                       \
+        template <typename U> static char for_expr_test(U const&);          \
+        BOOST_UNORDERED_CHECK_EXPRESSION(1, 1,                              \
+            boost::unordered::detail::make< thing >().name args);           \
+        BOOST_UNORDERED_DEFAULT_EXPRESSION(2, 2);                           \
+                                                                            \
+        enum { value = sizeof(test<T>(choose())) == sizeof(choice1::type) };\
+    }
+
+#else
+
+    template <typename T> struct identity { typedef T type; };
+
+#   define BOOST_UNORDERED_CHECK_MEMBER(count, result, name, member)        \
+                                                                            \
+    typedef typename boost::unordered::detail::identity<member>::type       \
+        BOOST_PP_CAT(check, count);                                         \
+                                                                            \
+    template <BOOST_PP_CAT(check, count) e>                                 \
+    struct BOOST_PP_CAT(test, count) {                                      \
+        typedef BOOST_PP_CAT(choice, result) type;                          \
+    };                                                                      \
+                                                                            \
+    template <class U> static typename                                      \
+        BOOST_PP_CAT(test, count)<&U::name>::type                           \
+        test(BOOST_PP_CAT(choice, count))
+
+#   define BOOST_UNORDERED_DEFAULT_MEMBER(count, result)                    \
+    template <class U> static BOOST_PP_CAT(choice, result)::type            \
+        test(BOOST_PP_CAT(choice, count))
+
+#   define BOOST_UNORDERED_HAS_MEMBER(name)                                 \
+    struct BOOST_PP_CAT(has_, name)                                         \
+    {                                                                       \
+        struct impl {                                                       \
+            struct base_mixin { int name; };                                \
+            struct base : public T, public base_mixin {};                   \
+                                                                            \
+            BOOST_UNORDERED_CHECK_MEMBER(1, 1, name, int base_mixin::*);    \
+            BOOST_UNORDERED_DEFAULT_MEMBER(2, 2);                           \
+                                                                            \
+            enum { value = sizeof(choice2::type) ==                         \
+                sizeof(test<base>(choose()))                                \
+            };                                                              \
+        };                                                                  \
+                                                                            \
+        enum { value = impl::value };                                       \
+    }
+
+#endif
+
+}}}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Allocator traits
+//
+// First our implementation, then later light wrappers around the alternatives
+
+#if BOOST_UNORDERED_USE_ALLOCATOR_TRAITS == 0
+
+#   include <boost/limits.hpp>
+#   include <boost/utility/enable_if.hpp>
+#   include <boost/pointer_to_other.hpp>
+#   if defined(BOOST_NO_SFINAE_EXPR)
+#       include <boost/type_traits/is_same.hpp>
+#   endif
+
+#   if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && \
+        !defined(BOOST_NO_SFINAE_EXPR)
+#       define BOOST_UNORDERED_DETAIL_FULL_CONSTRUCT 1
+#   else
+#       define BOOST_UNORDERED_DETAIL_FULL_CONSTRUCT 0
+#   endif
+
+namespace boost { namespace unordered { namespace detail {
+
+    // TODO: Does this match std::allocator_traits<Alloc>::rebind_alloc<T>?
+    template <typename Alloc, typename T>
+    struct rebind_wrap
+    {
+        typedef typename Alloc::BOOST_NESTED_TEMPLATE rebind<T>::other type;
+    };
+
+#   if defined(BOOST_MSVC) && BOOST_MSVC <= 1400
+
+#       define BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(tname)                    \
+    template <typename Tp, typename Default>                                \
+    struct default_type_ ## tname {                                         \
+                                                                            \
+        template <typename X>                                               \
+        static choice1::type test(choice1, typename X::tname* = 0);         \
+                                                                            \
+        template <typename X>                                               \
+        static choice2::type test(choice2, void* = 0);                      \
+                                                                            \
+        struct DefaultWrap { typedef Default tname; };                      \
+                                                                            \
+        enum { value = (1 == sizeof(test<Tp>(choose()))) };                 \
+                                                                            \
+        typedef typename boost::detail::if_true<value>::                    \
+            BOOST_NESTED_TEMPLATE then<Tp, DefaultWrap>                     \
+            ::type::tname type;                                             \
+    }
+
+#   else
+
+    template <typename T, typename T2>
+    struct sfinae : T2 {};
+
+#       define BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(tname)                    \
+    template <typename Tp, typename Default>                                \
+    struct default_type_ ## tname {                                         \
+                                                                            \
+        template <typename X>                                               \
+        static typename boost::unordered::detail::sfinae<                   \
+                typename X::tname, choice1>::type                           \
+            test(choice1);                                                  \
+                                                                            \
+        template <typename X>                                               \
+        static choice2::type test(choice2);                                 \
+                                                                            \
+        struct DefaultWrap { typedef Default tname; };                      \
+                                                                            \
+        enum { value = (1 == sizeof(test<Tp>(choose()))) };                 \
+                                                                            \
+        typedef typename boost::detail::if_true<value>::                    \
+            BOOST_NESTED_TEMPLATE then<Tp, DefaultWrap>                     \
+            ::type::tname type;                                             \
+    }
+
+#   endif
+
+#   define BOOST_UNORDERED_DEFAULT_TYPE(T,tname, arg)                   \
+    typename default_type_ ## tname<T, arg>::type
+
+    BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(pointer);
+    BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(const_pointer);
+    BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(void_pointer);
+    BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(const_void_pointer);
+    BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(difference_type);
+    BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(size_type);
+    BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(propagate_on_container_copy_assignment);
+    BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(propagate_on_container_move_assignment);
+    BOOST_UNORDERED_DEFAULT_TYPE_TMPLT(propagate_on_container_swap);
+
+#   if !defined(BOOST_NO_SFINAE_EXPR)
+
+    template <typename T>
+    BOOST_UNORDERED_HAS_FUNCTION(
+        select_on_container_copy_construction, U const, (), 0
+    );
+
+    template <typename T>
+    BOOST_UNORDERED_HAS_FUNCTION(
+        max_size, U const, (), 0
+    );
+
+#       if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+
+    template <typename T, typename ValueType, typename... Args>
+    BOOST_UNORDERED_HAS_FUNCTION(
+    construct, U, (
+        boost::unordered::detail::make<ValueType*>(),
+        boost::unordered::detail::make<Args const>()...), 2
+    );
+
+#       else
+
+    template <typename T, typename ValueType>
+    BOOST_UNORDERED_HAS_FUNCTION(
+    construct, U, (
+        boost::unordered::detail::make<ValueType*>(),
+        boost::unordered::detail::make<ValueType const>()), 2
+    );
+
+#       endif
+
+    template <typename T, typename ValueType>
+    BOOST_UNORDERED_HAS_FUNCTION(
+        destroy, U, (boost::unordered::detail::make<ValueType*>()), 1
+    );
+
+#   else
+
+    template <typename T>
+    BOOST_UNORDERED_HAS_MEMBER(select_on_container_copy_construction);
+
+    template <typename T>
+    BOOST_UNORDERED_HAS_MEMBER(max_size);
+
+    template <typename T, typename ValueType>
+    BOOST_UNORDERED_HAS_MEMBER(construct);
+
+    template <typename T, typename ValueType>
+    BOOST_UNORDERED_HAS_MEMBER(destroy);
+
+#   endif
+
+    namespace func
+    {
+
+    template <typename Alloc>
+    inline Alloc call_select_on_container_copy_construction(const Alloc& rhs,
+        typename boost::enable_if_c<
+            boost::unordered::detail::
+            has_select_on_container_copy_construction<Alloc>::value, void*
+        >::type = 0)
+    {
+        return rhs.select_on_container_copy_construction();
+    }
+
+    template <typename Alloc>
+    inline Alloc call_select_on_container_copy_construction(const Alloc& rhs,
+        typename boost::disable_if_c<
+            boost::unordered::detail::
+            has_select_on_container_copy_construction<Alloc>::value, void*
+        >::type = 0)
+    {
+        return rhs;
+    }
+
+    template <typename SizeType, typename Alloc>
+    inline SizeType call_max_size(const Alloc& a,
+        typename boost::enable_if_c<
+            boost::unordered::detail::has_max_size<Alloc>::value, void*
+        >::type = 0)
+    {
+        return a.max_size();
+    }
+
+    template <typename SizeType, typename Alloc>
+    inline SizeType call_max_size(const Alloc&, typename boost::disable_if_c<
+            boost::unordered::detail::has_max_size<Alloc>::value, void*
+        >::type = 0)
+    {
+        return (std::numeric_limits<SizeType>::max)();
+    }
+
+    } // namespace func.
+
+    template <typename Alloc>
+    struct allocator_traits
+    {
+        typedef Alloc allocator_type;
+        typedef typename Alloc::value_type value_type;
+
+        typedef BOOST_UNORDERED_DEFAULT_TYPE(Alloc, pointer, value_type*)
+            pointer;
+
+        template <typename T>
+        struct pointer_to_other : boost::pointer_to_other<pointer, T> {};
+
+        typedef BOOST_UNORDERED_DEFAULT_TYPE(Alloc, const_pointer,
+            typename pointer_to_other<const value_type>::type)
+            const_pointer;
+
+        //typedef BOOST_UNORDERED_DEFAULT_TYPE(Alloc, void_pointer,
+        //    typename pointer_to_other<void>::type)
+        //    void_pointer;
+        //
+        //typedef BOOST_UNORDERED_DEFAULT_TYPE(Alloc, const_void_pointer,
+        //    typename pointer_to_other<const void>::type)
+        //    const_void_pointer;
+
+        typedef BOOST_UNORDERED_DEFAULT_TYPE(Alloc, difference_type,
+            std::ptrdiff_t) difference_type;
+
+        typedef BOOST_UNORDERED_DEFAULT_TYPE(Alloc, size_type, std::size_t)
+            size_type;
+
+        // TODO: rebind_alloc and rebind_traits
+
+        static pointer allocate(Alloc& a, size_type n)
+            { return a.allocate(n); }
+
+        // I never use this, so I'll just comment it out for now.
+        //
+        //static pointer allocate(Alloc& a, size_type n,
+        //        const_void_pointer hint)
+        //    { return DEFAULT_FUNC(allocate, pointer)(a, n, hint); }
+
+        static void deallocate(Alloc& a, pointer p, size_type n)
+            { a.deallocate(p, n); }
+
+    public:
+
+#   if BOOST_UNORDERED_DETAIL_FULL_CONSTRUCT
+
+        template <typename T, typename... Args>
+        static typename boost::enable_if_c<
+                boost::unordered::detail::has_construct<Alloc, T, Args...>
+                ::value>::type
+            construct(Alloc& a, T* p, BOOST_FWD_REF(Args)... x)
+        {
+            a.construct(p, boost::forward<Args>(x)...);
+        }
+
+        template <typename T, typename... Args>
+        static typename boost::disable_if_c<
+                boost::unordered::detail::has_construct<Alloc, T, Args...>
+                ::value>::type
+            construct(Alloc&, T* p, BOOST_FWD_REF(Args)... x)
+        {
+            new ((void*) p) T(boost::forward<Args>(x)...);
+        }
+
+        template <typename T>
+        static typename boost::enable_if_c<
+                boost::unordered::detail::has_destroy<Alloc, T>::value>::type
+            destroy(Alloc& a, T* p)
+        {
+            a.destroy(p);
+        }
+
+        template <typename T>
+        static typename boost::disable_if_c<
+                boost::unordered::detail::has_destroy<Alloc, T>::value>::type
+            destroy(Alloc&, T* p)
+        {
+            boost::unordered::detail::func::destroy(p);
+        }
+
+#   elif !defined(BOOST_NO_SFINAE_EXPR)
+
+        template <typename T>
+        static typename boost::enable_if_c<
+                boost::unordered::detail::has_construct<Alloc, T>::value>::type
+            construct(Alloc& a, T* p, T const& x)
+        {
+            a.construct(p, x);
+        }
+
+        template <typename T>
+        static typename boost::disable_if_c<
+                boost::unordered::detail::has_construct<Alloc, T>::value>::type
+            construct(Alloc&, T* p, T const& x)
+        {
+            new ((void*) p) T(x);
+        }
+
+        template <typename T>
+        static typename boost::enable_if_c<
+                boost::unordered::detail::has_destroy<Alloc, T>::value>::type
+            destroy(Alloc& a, T* p)
+        {
+            a.destroy(p);
+        }
+
+        template <typename T>
+        static typename boost::disable_if_c<
+                boost::unordered::detail::has_destroy<Alloc, T>::value>::type
+            destroy(Alloc&, T* p)
+        {
+            boost::unordered::detail::func::destroy(p);
+        }
+
+#   else
+
+        // If we don't have SFINAE expressions, only call construct for the
+        // copy constructor for the allocator's value_type - as that's
+        // the only construct method that old fashioned allocators support.
+
+        template <typename T>
+        static void construct(Alloc& a, T* p, T const& x,
+            typename boost::enable_if_c<
+                    boost::unordered::detail::has_construct<Alloc, T>::value &&
+                    boost::is_same<T, value_type>::value,
+                    void*>::type = 0)
+        {
+            a.construct(p, x);
+        }
+
+        template <typename T>
+        static void construct(Alloc&, T* p, T const& x,
+            typename boost::disable_if_c<
+                boost::unordered::detail::has_construct<Alloc, T>::value &&
+                boost::is_same<T, value_type>::value,
+                void*>::type = 0)
+        {
+            new ((void*) p) T(x);
+        }
+
+        template <typename T>
+        static void destroy(Alloc& a, T* p,
+            typename boost::enable_if_c<
+                boost::unordered::detail::has_destroy<Alloc, T>::value &&
+                boost::is_same<T, value_type>::value,
+                void*>::type = 0)
+        {
+            a.destroy(p);
+        }
+
+        template <typename T>
+        static void destroy(Alloc&, T* p,
+            typename boost::disable_if_c<
+                boost::unordered::detail::has_destroy<Alloc, T>::value &&
+                boost::is_same<T, value_type>::value,
+                void*>::type = 0)
+        {
+            boost::unordered::detail::func::destroy(p);
+        }
+
+#   endif
+
+        static size_type max_size(const Alloc& a)
+        {
+            return boost::unordered::detail::func::
+                call_max_size<size_type>(a);
+        }
+
+        // Allocator propagation on construction
+
+        static Alloc select_on_container_copy_construction(Alloc const& rhs)
+        {
+            return boost::unordered::detail::func::
+                call_select_on_container_copy_construction(rhs);
+        }
+
+        // Allocator propagation on assignment and swap.
+        // Return true if lhs is modified.
+        typedef BOOST_UNORDERED_DEFAULT_TYPE(
+            Alloc, propagate_on_container_copy_assignment, false_type)
+            propagate_on_container_copy_assignment;
+        typedef BOOST_UNORDERED_DEFAULT_TYPE(
+            Alloc,propagate_on_container_move_assignment, false_type)
+            propagate_on_container_move_assignment;
+        typedef BOOST_UNORDERED_DEFAULT_TYPE(
+            Alloc,propagate_on_container_swap,false_type)
+            propagate_on_container_swap;
+    };
+}}}
+
+#   undef BOOST_UNORDERED_DEFAULT_TYPE_TMPLT
+#   undef BOOST_UNORDERED_DEFAULT_TYPE
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// std::allocator_traits
+
+#elif BOOST_UNORDERED_USE_ALLOCATOR_TRAITS == 1
+
+#   include <memory>
+
+#   define BOOST_UNORDERED_DETAIL_FULL_CONSTRUCT 1
+
+namespace boost { namespace unordered { namespace detail {
+
+    template <typename Alloc>
+    struct allocator_traits : std::allocator_traits<Alloc> {};
+
+    template <typename Alloc, typename T>
+    struct rebind_wrap
+    {
+        typedef typename std::allocator_traits<Alloc>::
+            template rebind_alloc<T> type;
+    };
+}}}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// boost::container::allocator_traits
+
+#elif BOOST_UNORDERED_USE_ALLOCATOR_TRAITS == 2
+
+#   include <boost/container/allocator_traits.hpp>
+
+#   define BOOST_UNORDERED_DETAIL_FULL_CONSTRUCT 0
+
+namespace boost { namespace unordered { namespace detail {
+
+    template <typename Alloc>
+    struct allocator_traits :
+        boost::container::allocator_traits<Alloc> {};
+
+    template <typename Alloc, typename T>
+    struct rebind_wrap :
+        boost::container::allocator_traits<Alloc>::
+            template portable_rebind_alloc<T>
+    {};
+
+}}}
+
+#else
+
+#error "Invalid BOOST_UNORDERED_USE_ALLOCATOR_TRAITS value."
+
+#endif
+
+
+namespace boost { namespace unordered { namespace detail { namespace func {
+
+    ////////////////////////////////////////////////////////////////////////////
+    // call_construct
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+
+#   if BOOST_UNORDERED_DETAIL_FULL_CONSTRUCT
+
+    template <typename Alloc, typename T, typename... Args>
+    inline void call_construct(Alloc& alloc, T* address,
+        BOOST_FWD_REF(Args)... args)
+    {
+        boost::unordered::detail::allocator_traits<Alloc>::construct(alloc,
+            address, boost::forward<Args>(args)...);
+    }
+
+    template <typename Alloc, typename T>
+    inline void destroy_value_impl(Alloc& alloc, T* x) {
+        boost::unordered::detail::allocator_traits<Alloc>::destroy(alloc, x);
+    }
+
+
+#   else
+
+    template <typename Alloc, typename T, typename... Args>
+    inline void call_construct(Alloc&, T* address,
+        BOOST_FWD_REF(Args)... args)
+    {
+        new((void*) address) T(boost::forward<Args>(args)...);
+    }
+
+    template <typename Alloc, typename T>
+    inline void destroy_value_impl(Alloc&, T* x) {
+        boost::unordered::detail::func::destroy(x);
+    }
+
+
+#   endif
+
+#else
+
+    template <typename Alloc, typename T>
+    inline void destroy_value_impl(Alloc&, T* x) {
+        boost::unordered::detail::func::destroy(x);
+    }
+
+#endif
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Construct from tuple
+    //
+    // Used for piecewise construction.
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+
+#   define BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE(n, namespace_)              \
+    template<typename Alloc, typename T>                                    \
+    void construct_from_tuple(Alloc& alloc, T* ptr, namespace_ tuple<>)     \
+    {                                                                       \
+        boost::unordered::detail::func::call_construct(alloc, ptr);         \
+    }                                                                       \
+                                                                            \
+    BOOST_PP_REPEAT_FROM_TO(1, n,                                           \
+        BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE_IMPL, namespace_)
+
+#   define BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE_IMPL(z, n, namespace_)      \
+    template<typename Alloc, typename T,                                    \
+        BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)>                           \
+    void construct_from_tuple(Alloc& alloc, T* ptr,                         \
+            namespace_ tuple<BOOST_PP_ENUM_PARAMS_Z(z, n, A)> const& x)     \
+    {                                                                       \
+        boost::unordered::detail::func::call_construct(alloc, ptr,          \
+            BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_GET_TUPLE_ARG, namespace_) \
+        );                                                                  \
+    }
+
+#   define BOOST_UNORDERED_GET_TUPLE_ARG(z, n, namespace_)                  \
+    namespace_ get<n>(x)
+
+#elif !defined(__SUNPRO_CC)
+
+#   define BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE(n, namespace_)              \
+    template<typename Alloc, typename T>                                    \
+    void construct_from_tuple(Alloc&, T* ptr, namespace_ tuple<>)           \
+    {                                                                       \
+        new ((void*) ptr) T();                                              \
+    }                                                                       \
+                                                                            \
+    BOOST_PP_REPEAT_FROM_TO(1, n,                                           \
+        BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE_IMPL, namespace_)
+
+#   define BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE_IMPL(z, n, namespace_)      \
+    template<typename Alloc, typename T,                                    \
+        BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)>                           \
+    void construct_from_tuple(Alloc&, T* ptr,                               \
+            namespace_ tuple<BOOST_PP_ENUM_PARAMS_Z(z, n, A)> const& x)     \
+    {                                                                       \
+        new ((void*) ptr) T(                                                \
+            BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_GET_TUPLE_ARG, namespace_) \
+        );                                                                  \
+    }
+
+#   define BOOST_UNORDERED_GET_TUPLE_ARG(z, n, namespace_)                  \
+    namespace_ get<n>(x)
+
+#else
+
+    template <int N> struct length {};
+
+#   define BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE(n, namespace_)              \
+    template<typename Alloc, typename T>                                    \
+    void construct_from_tuple_impl(                                         \
+            boost::unordered::detail::func::length<0>, Alloc&, T* ptr,      \
+            namespace_ tuple<>)                                             \
+    {                                                                       \
+        new ((void*) ptr) T();                                              \
+    }                                                                       \
+                                                                            \
+    BOOST_PP_REPEAT_FROM_TO(1, n,                                           \
+        BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE_IMPL, namespace_)
+
+#   define BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE_IMPL(z, n, namespace_)      \
+    template<typename Alloc, typename T,                                    \
+        BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)>                           \
+    void construct_from_tuple_impl(                                         \
+            boost::unordered::detail::func::length<n>, Alloc&, T* ptr,      \
+            namespace_ tuple<BOOST_PP_ENUM_PARAMS_Z(z, n, A)> const& x)     \
+    {                                                                       \
+        new ((void*) ptr) T(                                                \
+            BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_GET_TUPLE_ARG, namespace_) \
+        );                                                                  \
+    }
+
+#   define BOOST_UNORDERED_GET_TUPLE_ARG(z, n, namespace_)                  \
+    namespace_ get<n>(x)
+
+#endif
+
+BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE(10, boost::)
+
+#if !defined(__SUNPRO_CC) && !defined(BOOST_NO_CXX11_HDR_TUPLE)
+   BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE(10, std::)
+#endif
+
+#undef BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE
+#undef BOOST_UNORDERED_CONSTRUCT_FROM_TUPLE_IMPL
+#undef BOOST_UNORDERED_GET_TUPLE_ARG
+
+#if defined(__SUNPRO_CC)
+
+    template <typename Alloc, typename T, typename Tuple>
+    void construct_from_tuple(Alloc& alloc, T* ptr, Tuple const& x)
+    {
+        construct_from_tuple_impl(
+            boost::unordered::detail::func::length<
+                boost::tuples::length<Tuple>::value>(),
+            alloc, ptr, x);
+    }
+
+#endif
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Trait to check for piecewise construction.
+
+    template <typename A0>
+    struct use_piecewise {
+        static choice1::type test(choice1,
+            boost::unordered::piecewise_construct_t);
+
+        static choice2::type test(choice2, ...);
+
+        enum { value = sizeof(choice1::type) ==
+            sizeof(test(choose(), boost::unordered::detail::make<A0>())) };
+    };
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Construct from variadic parameters
+
+    // For the standard pair constructor.
+
+    template <typename Alloc, typename T, typename... Args>
+    inline void construct_value_impl(Alloc& alloc, T* address,
+        BOOST_FWD_REF(Args)... args)
+    {
+        boost::unordered::detail::func::call_construct(alloc,
+            address, boost::forward<Args>(args)...);
+    }
+
+    // Special case for piece_construct
+    //
+    // TODO: When possible, it might be better to use std::pair's
+    // constructor for std::piece_construct with std::tuple.
+
+    template <typename Alloc, typename A, typename B,
+        typename A0, typename A1, typename A2>
+    inline typename enable_if<use_piecewise<A0>, void>::type
+        construct_value_impl(Alloc& alloc, std::pair<A, B>* address,
+            BOOST_FWD_REF(A0), BOOST_FWD_REF(A1) a1, BOOST_FWD_REF(A2) a2)
+    {
+        boost::unordered::detail::func::construct_from_tuple(alloc,
+            boost::addressof(address->first), boost::forward<A1>(a1));
+        boost::unordered::detail::func::construct_from_tuple(alloc,
+            boost::addressof(address->second), boost::forward<A2>(a2));
+    }
+
+#else // BOOST_NO_CXX11_VARIADIC_TEMPLATES
+
+////////////////////////////////////////////////////////////////////////////////
+// Construct from emplace_args
+
+    // Explicitly write out first three overloads for the sake of sane
+    // error messages.
+
+    template <typename Alloc, typename T, typename A0>
+    inline void construct_value_impl(Alloc&, T* address,
+            emplace_args1<A0> const& args)
+    {
+        new((void*) address) T(boost::forward<A0>(args.a0));
+    }
+
+    template <typename Alloc, typename T, typename A0, typename A1>
+    inline void construct_value_impl(Alloc&, T* address,
+            emplace_args2<A0, A1> const& args)
+    {
+        new((void*) address) T(
+            boost::forward<A0>(args.a0),
+            boost::forward<A1>(args.a1)
+        );
+    }
+
+    template <typename Alloc, typename T, typename A0, typename A1, typename A2>
+    inline void construct_value_impl(Alloc&, T* address,
+            emplace_args3<A0, A1, A2> const& args)
+    {
+        new((void*) address) T(
+            boost::forward<A0>(args.a0),
+            boost::forward<A1>(args.a1),
+            boost::forward<A2>(args.a2)
+        );
+    }
+
+    // Use a macro for the rest.
+
+#define BOOST_UNORDERED_CONSTRUCT_IMPL(z, num_params, _)                    \
+    template <                                                              \
+        typename Alloc, typename T,                                         \
+        BOOST_PP_ENUM_PARAMS_Z(z, num_params, typename A)                   \
+    >                                                                       \
+    inline void construct_value_impl(Alloc&, T* address,                    \
+        boost::unordered::detail::BOOST_PP_CAT(emplace_args,num_params) <   \
+            BOOST_PP_ENUM_PARAMS_Z(z, num_params, A)                        \
+        > const& args)                                                      \
+    {                                                                       \
+        new((void*) address) T(                                             \
+            BOOST_PP_ENUM_##z(num_params, BOOST_UNORDERED_CALL_FORWARD,     \
+                args.a));                                                   \
+    }
+
+    BOOST_PP_REPEAT_FROM_TO(4, BOOST_UNORDERED_EMPLACE_LIMIT,
+        BOOST_UNORDERED_CONSTRUCT_IMPL, _)
+
+#undef BOOST_UNORDERED_CONSTRUCT_IMPL
+
+    // Construct with piece_construct
+
+    template <typename Alloc, typename A, typename B,
+        typename A0, typename A1, typename A2>
+    inline void construct_value_impl(Alloc& alloc, std::pair<A, B>* address,
+            boost::unordered::detail::emplace_args3<A0, A1, A2> const& args,
+            typename enable_if<use_piecewise<A0>, void*>::type = 0)
+    {
+        boost::unordered::detail::func::construct_from_tuple(alloc,
+            boost::addressof(address->first), args.a1);
+        boost::unordered::detail::func::construct_from_tuple(alloc,
+            boost::addressof(address->second), args.a2);
+    }
+
+#endif // BOOST_NO_CXX11_VARIADIC_TEMPLATES
+
+}}}}
+
+namespace boost { namespace unordered { namespace detail {
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    // array_constructor
+    //
+    // Allocate and construct an array in an exception safe manner, and
+    // clean up if an exception is thrown before the container takes charge
+    // of it.
+
+    template <typename Allocator>
+    struct array_constructor
+    {
+        typedef boost::unordered::detail::allocator_traits<Allocator> traits;
+        typedef typename traits::pointer pointer;
+
+        Allocator& alloc_;
+        pointer ptr_;
+        pointer constructed_;
+        std::size_t length_;
+
+        array_constructor(Allocator& a)
+            : alloc_(a), ptr_(), constructed_(), length_(0)
+        {
+            constructed_ = pointer();
+            ptr_ = pointer();
+        }
+
+        ~array_constructor() {
+            if (ptr_) {
+                for(pointer p = ptr_; p != constructed_; ++p) {
+                    boost::unordered::detail::func::destroy(
+                            boost::addressof(*p));
+                }
+
+                traits::deallocate(alloc_, ptr_, length_);
+            }
+        }
+
+        template <typename V>
+        void construct(V const& v, std::size_t l)
+        {
+            BOOST_ASSERT(!ptr_);
+            length_ = l;
+            ptr_ = traits::allocate(alloc_, length_);
+            pointer end = ptr_ + static_cast<std::ptrdiff_t>(length_);
+            for(constructed_ = ptr_; constructed_ != end; ++constructed_) {
+                new ((void*) boost::addressof(*constructed_)) V(v);
+            }
+        }
+
+        pointer get() const
+        {
+            return ptr_;
+        }
+
+        pointer release()
+        {
+            pointer p(ptr_);
+            ptr_ = pointer();
+            return p;
+        }
+
+    private:
+
+        array_constructor(array_constructor const&);
+        array_constructor& operator=(array_constructor const&);
+    };
+}}}
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+#endif

--- a/ibtk/contrib/boost/boost/unordered/detail/buckets.hpp
+++ b/ibtk/contrib/boost/boost/unordered/detail/buckets.hpp
@@ -1,0 +1,928 @@
+
+// Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
+// Copyright (C) 2005-2011 Daniel James
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_UNORDERED_DETAIL_MANAGER_HPP_INCLUDED
+#define BOOST_UNORDERED_DETAIL_MANAGER_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/unordered/detail/util.hpp>
+#include <boost/unordered/detail/allocate.hpp>
+#include <boost/type_traits/aligned_storage.hpp>
+#include <boost/type_traits/alignment_of.hpp>
+#include <boost/type_traits/is_nothrow_move_constructible.hpp>
+#include <boost/type_traits/is_nothrow_move_assignable.hpp>
+#include <boost/swap.hpp>
+#include <boost/assert.hpp>
+#include <boost/limits.hpp>
+#include <boost/iterator.hpp>
+
+namespace boost { namespace unordered { namespace detail {
+
+    template <typename Types> struct table;
+    template <typename NodePointer> struct bucket;
+    struct ptr_bucket;
+    template <typename Types> struct table_impl;
+    template <typename Types> struct grouped_table_impl;
+
+}}}
+
+// The 'iterator_detail' namespace was a misguided attempt at avoiding ADL
+// in the detail namespace. It didn't work because the template parameters
+// were in detail. I'm not changing it at the moment to be safe. I might
+// do in the future if I change the iterator types.
+namespace boost { namespace unordered { namespace iterator_detail {
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Iterators
+    //
+    // all no throw
+
+    template <typename Node> struct iterator;
+    template <typename Node> struct c_iterator;
+    template <typename Node, typename Policy> struct l_iterator;
+    template <typename Node, typename Policy>
+        struct cl_iterator;
+
+    // Local Iterators
+    //
+    // all no throw
+
+    template <typename Node, typename Policy>
+    struct l_iterator
+        : public boost::iterator<
+            std::forward_iterator_tag,
+            typename Node::value_type,
+            std::ptrdiff_t,
+            typename Node::value_type*,
+            typename Node::value_type&>
+    {
+#if !defined(BOOST_NO_MEMBER_TEMPLATE_FRIENDS)
+        template <typename Node2, typename Policy2>
+        friend struct boost::unordered::iterator_detail::cl_iterator;
+    private:
+#endif
+        typedef typename Node::node_pointer node_pointer;
+        typedef boost::unordered::iterator_detail::iterator<Node> n_iterator;
+        node_pointer ptr_;
+        std::size_t bucket_;
+        std::size_t bucket_count_;
+
+    public:
+
+        typedef typename Node::value_type value_type;
+
+        l_iterator() BOOST_NOEXCEPT : ptr_() {}
+
+        l_iterator(n_iterator x, std::size_t b, std::size_t c) BOOST_NOEXCEPT
+            : ptr_(x.node_), bucket_(b), bucket_count_(c) {}
+
+        value_type& operator*() const {
+            return ptr_->value();
+        }
+
+        value_type* operator->() const {
+            return ptr_->value_ptr();
+        }
+
+        l_iterator& operator++() {
+            ptr_ = static_cast<node_pointer>(ptr_->next_);
+            if (ptr_ && Policy::to_bucket(bucket_count_, ptr_->hash_)
+                    != bucket_)
+                ptr_ = node_pointer();
+            return *this;
+        }
+
+        l_iterator operator++(int) {
+            l_iterator tmp(*this);
+            ++(*this);
+            return tmp;
+        }
+
+        bool operator==(l_iterator x) const BOOST_NOEXCEPT {
+            return ptr_ == x.ptr_;
+        }
+
+        bool operator!=(l_iterator x) const BOOST_NOEXCEPT {
+            return ptr_ != x.ptr_;
+        }
+    };
+
+    template <typename Node, typename Policy>
+    struct cl_iterator
+        : public boost::iterator<
+            std::forward_iterator_tag,
+            typename Node::value_type,
+            std::ptrdiff_t,
+            typename Node::value_type const*,
+            typename Node::value_type const&>
+    {
+        friend struct boost::unordered::iterator_detail::l_iterator
+            <Node, Policy>;
+    private:
+
+        typedef typename Node::node_pointer node_pointer;
+        typedef boost::unordered::iterator_detail::iterator<Node> n_iterator;
+        node_pointer ptr_;
+        std::size_t bucket_;
+        std::size_t bucket_count_;
+
+    public:
+
+        typedef typename Node::value_type value_type;
+
+        cl_iterator() BOOST_NOEXCEPT : ptr_() {}
+
+        cl_iterator(n_iterator x, std::size_t b, std::size_t c) BOOST_NOEXCEPT :
+            ptr_(x.node_), bucket_(b), bucket_count_(c) {}
+
+        cl_iterator(boost::unordered::iterator_detail::l_iterator<
+                Node, Policy> const& x) BOOST_NOEXCEPT :
+            ptr_(x.ptr_), bucket_(x.bucket_), bucket_count_(x.bucket_count_)
+        {}
+
+        value_type const& operator*() const {
+            return ptr_->value();
+        }
+
+        value_type const* operator->() const {
+            return ptr_->value_ptr();
+        }
+
+        cl_iterator& operator++() {
+            ptr_ = static_cast<node_pointer>(ptr_->next_);
+            if (ptr_ && Policy::to_bucket(bucket_count_, ptr_->hash_)
+                    != bucket_)
+                ptr_ = node_pointer();
+            return *this;
+        }
+
+        cl_iterator operator++(int) {
+            cl_iterator tmp(*this);
+            ++(*this);
+            return tmp;
+        }
+
+        friend bool operator==(cl_iterator const& x, cl_iterator const& y)
+            BOOST_NOEXCEPT
+        {
+            return x.ptr_ == y.ptr_;
+        }
+
+        friend bool operator!=(cl_iterator const& x, cl_iterator const& y)
+            BOOST_NOEXCEPT
+        {
+            return x.ptr_ != y.ptr_;
+        }
+    };
+
+    template <typename Node>
+    struct iterator
+        : public boost::iterator<
+            std::forward_iterator_tag,
+            typename Node::value_type,
+            std::ptrdiff_t,
+            typename Node::value_type*,
+            typename Node::value_type&>
+    {
+#if !defined(BOOST_NO_MEMBER_TEMPLATE_FRIENDS)
+        template <typename>
+        friend struct boost::unordered::iterator_detail::c_iterator;
+        template <typename, typename>
+        friend struct boost::unordered::iterator_detail::l_iterator;
+        template <typename, typename>
+        friend struct boost::unordered::iterator_detail::cl_iterator;
+        template <typename>
+        friend struct boost::unordered::detail::table;
+        template <typename>
+        friend struct boost::unordered::detail::table_impl;
+        template <typename>
+        friend struct boost::unordered::detail::grouped_table_impl;
+    private:
+#endif
+        typedef typename Node::node_pointer node_pointer;
+        node_pointer node_;
+
+    public:
+
+        typedef typename Node::value_type value_type;
+
+        iterator() BOOST_NOEXCEPT : node_() {}
+
+        explicit iterator(typename Node::link_pointer x) BOOST_NOEXCEPT :
+            node_(static_cast<node_pointer>(x)) {}
+
+        value_type& operator*() const {
+            return node_->value();
+        }
+
+        value_type* operator->() const {
+            return node_->value_ptr();
+        }
+
+        iterator& operator++() {
+            node_ = static_cast<node_pointer>(node_->next_);
+            return *this;
+        }
+
+        iterator operator++(int) {
+            iterator tmp(node_);
+            node_ = static_cast<node_pointer>(node_->next_);
+            return tmp;
+        }
+
+        bool operator==(iterator const& x) const BOOST_NOEXCEPT {
+            return node_ == x.node_;
+        }
+
+        bool operator!=(iterator const& x) const BOOST_NOEXCEPT {
+            return node_ != x.node_;
+        }
+    };
+
+    template <typename Node>
+    struct c_iterator
+        : public boost::iterator<
+            std::forward_iterator_tag,
+            typename Node::value_type,
+            std::ptrdiff_t,
+            typename Node::value_type const*,
+            typename Node::value_type const&>
+    {
+        friend struct boost::unordered::iterator_detail::iterator<Node>;
+
+#if !defined(BOOST_NO_MEMBER_TEMPLATE_FRIENDS)
+        template <typename>
+        friend struct boost::unordered::detail::table;
+        template <typename>
+        friend struct boost::unordered::detail::table_impl;
+        template <typename>
+        friend struct boost::unordered::detail::grouped_table_impl;
+
+    private:
+#endif
+        typedef typename Node::node_pointer node_pointer;
+        typedef boost::unordered::iterator_detail::iterator<Node> n_iterator;
+        node_pointer node_;
+
+    public:
+
+        typedef typename Node::value_type value_type;
+
+        c_iterator() BOOST_NOEXCEPT : node_() {}
+
+        explicit c_iterator(typename Node::link_pointer x) BOOST_NOEXCEPT :
+            node_(static_cast<node_pointer>(x)) {}
+
+        c_iterator(n_iterator const& x) BOOST_NOEXCEPT : node_(x.node_) {}
+
+        value_type const& operator*() const {
+            return node_->value();
+        }
+
+        value_type const* operator->() const {
+            return node_->value_ptr();
+        }
+
+        c_iterator& operator++() {
+            node_ = static_cast<node_pointer>(node_->next_);
+            return *this;
+        }
+
+        c_iterator operator++(int) {
+            c_iterator tmp(node_);
+            node_ = static_cast<node_pointer>(node_->next_);
+            return tmp;
+        }
+
+        friend bool operator==(c_iterator const& x, c_iterator const& y)
+            BOOST_NOEXCEPT
+        {
+            return x.node_ == y.node_;
+        }
+
+        friend bool operator!=(c_iterator const& x, c_iterator const& y)
+            BOOST_NOEXCEPT
+        {
+            return x.node_ != y.node_;
+        }
+    };
+}}}
+
+namespace boost { namespace unordered { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////
+    //
+    // Node construction
+
+    template <typename NodeAlloc>
+    struct node_constructor
+    {
+    private:
+
+        typedef NodeAlloc node_allocator;
+        typedef boost::unordered::detail::allocator_traits<NodeAlloc>
+            node_allocator_traits;
+        typedef typename node_allocator_traits::value_type node;
+        typedef typename node_allocator_traits::pointer node_pointer;
+        typedef typename node::value_type value_type;
+
+    protected:
+
+        node_allocator& alloc_;
+        node_pointer node_;
+        bool node_constructed_;
+        bool value_constructed_;
+
+    public:
+
+        node_constructor(node_allocator& n) :
+            alloc_(n),
+            node_(),
+            node_constructed_(false),
+            value_constructed_(false)
+        {
+        }
+
+        ~node_constructor();
+
+        void construct();
+
+        template <BOOST_UNORDERED_EMPLACE_TEMPLATE>
+        void construct_with_value(BOOST_UNORDERED_EMPLACE_ARGS)
+        {
+            construct();
+            boost::unordered::detail::func::construct_value_impl(
+                alloc_, node_->value_ptr(), BOOST_UNORDERED_EMPLACE_FORWARD);
+            value_constructed_ = true;
+        }
+
+        template <typename A0>
+        void construct_with_value2(BOOST_FWD_REF(A0) a0)
+        {
+            construct();
+            boost::unordered::detail::func::construct_value_impl(
+                alloc_, node_->value_ptr(),
+                BOOST_UNORDERED_EMPLACE_ARGS1(boost::forward<A0>(a0)));
+            value_constructed_ = true;
+        }
+
+        value_type const& value() const {
+            BOOST_ASSERT(node_ && node_constructed_ && value_constructed_);
+            return node_->value();
+        }
+
+        // no throw
+        node_pointer release()
+        {
+            BOOST_ASSERT(node_ && node_constructed_);
+            node_pointer p = node_;
+            node_ = node_pointer();
+            return p;
+        }
+
+    private:
+        node_constructor(node_constructor const&);
+        node_constructor& operator=(node_constructor const&);
+    };
+
+    template <typename Alloc>
+    node_constructor<Alloc>::~node_constructor()
+    {
+        if (node_) {
+            if (value_constructed_) {
+                boost::unordered::detail::func::destroy_value_impl(alloc_,
+                    node_->value_ptr());
+            }
+
+            if (node_constructed_) {
+                boost::unordered::detail::func::destroy(
+                    boost::addressof(*node_));
+            }
+
+            node_allocator_traits::deallocate(alloc_, node_, 1);
+        }
+    }
+
+    template <typename Alloc>
+    void node_constructor<Alloc>::construct()
+    {
+        if(!node_) {
+            node_constructed_ = false;
+            value_constructed_ = false;
+
+            node_ = node_allocator_traits::allocate(alloc_, 1);
+
+            new ((void*) boost::addressof(*node_)) node();
+            node_->init(node_);
+            node_constructed_ = true;
+        }
+        else {
+            BOOST_ASSERT(node_constructed_);
+
+            if (value_constructed_)
+            {
+                boost::unordered::detail::func::destroy_value_impl(alloc_,
+                    node_->value_ptr());
+                value_constructed_ = false;
+            }
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////
+    //
+    // Node Holder
+    //
+    // Temporary store for nodes. Deletes any that aren't used.
+
+    template <typename NodeAlloc>
+    struct node_holder : private node_constructor<NodeAlloc>
+    {
+    private:
+        typedef node_constructor<NodeAlloc> base;
+
+        typedef NodeAlloc node_allocator;
+        typedef boost::unordered::detail::allocator_traits<NodeAlloc>
+            node_allocator_traits;
+        typedef typename node_allocator_traits::value_type node;
+        typedef typename node_allocator_traits::pointer node_pointer;
+        typedef typename node::value_type value_type;
+        typedef typename node::link_pointer link_pointer;
+        typedef boost::unordered::iterator_detail::iterator<node> iterator;
+
+        node_pointer nodes_;
+
+    public:
+
+        template <typename Table>
+        explicit node_holder(Table& b) :
+            base(b.node_alloc()),
+            nodes_()
+        {
+            if (b.size_) {
+                typename Table::link_pointer prev = b.get_previous_start();
+                nodes_ = static_cast<node_pointer>(prev->next_);
+                prev->next_ = link_pointer();
+                b.size_ = 0;
+            }
+        }
+
+        ~node_holder();
+
+        void node_for_assignment()
+        {
+            if (!this->node_ && nodes_) {
+                this->node_ = nodes_;
+                nodes_ = static_cast<node_pointer>(nodes_->next_);
+                this->node_->init(this->node_);
+                this->node_->next_ = link_pointer();
+
+                this->node_constructed_ = true;
+                this->value_constructed_ = true;
+            }
+        }
+
+        template <typename T>
+        inline void assign_impl(T const& v) {
+            if (this->node_ && this->value_constructed_) {
+                this->node_->value() = v;
+            }
+            else {
+                this->construct_with_value2(v);
+            }
+        }
+
+        template <typename T1, typename T2>
+        inline void assign_impl(std::pair<T1 const, T2> const& v) {
+            this->construct_with_value2(v);
+        }
+
+        template <typename T>
+        inline void move_assign_impl(T& v) {
+            if (this->node_ && this->value_constructed_) {
+                this->node_->value() = boost::move(v);
+            }
+            else {
+                this->construct_with_value2(boost::move(v));
+            }
+        }
+
+        template <typename T1, typename T2>
+        inline void move_assign_impl(std::pair<T1 const, T2>& v) {
+            this->construct_with_value2(boost::move(v));
+        }
+
+        node_pointer copy_of(value_type const& v)
+        {
+            node_for_assignment();
+            assign_impl(v);
+            return base::release();
+        }
+
+        node_pointer move_copy_of(value_type& v)
+        {
+            node_for_assignment();
+            move_assign_impl(v);
+            return base::release();
+        }
+
+        iterator begin() const
+        {
+            return iterator(nodes_);
+        }
+    };
+
+    template <typename Alloc>
+    node_holder<Alloc>::~node_holder()
+    {
+        while (nodes_) {
+            node_pointer p = nodes_;
+            nodes_ = static_cast<node_pointer>(p->next_);
+
+            boost::unordered::detail::func::destroy_value_impl(this->alloc_,
+                p->value_ptr());
+            boost::unordered::detail::func::destroy(boost::addressof(*p));
+            node_allocator_traits::deallocate(this->alloc_, p, 1);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////
+    //
+    // Bucket
+
+    template <typename NodePointer>
+    struct bucket
+    {
+        typedef NodePointer link_pointer;
+        link_pointer next_;
+
+        bucket() : next_() {}
+
+        link_pointer first_from_start()
+        {
+            return next_;
+        }
+
+        enum { extra_node = true };
+    };
+
+    struct ptr_bucket
+    {
+        typedef ptr_bucket* link_pointer;
+        link_pointer next_;
+
+        ptr_bucket() : next_(0) {}
+
+        link_pointer first_from_start()
+        {
+            return this;
+        }
+
+        enum { extra_node = false };
+    };
+
+    ///////////////////////////////////////////////////////////////////
+    //
+    // Hash Policy
+
+    template <typename SizeT>
+    struct prime_policy
+    {
+        template <typename Hash, typename T>
+        static inline SizeT apply_hash(Hash const& hf, T const& x) {
+            return hf(x);
+        }
+
+        static inline SizeT to_bucket(SizeT bucket_count, SizeT hash) {
+            return hash % bucket_count;
+        }
+
+        static inline SizeT new_bucket_count(SizeT min) {
+            return boost::unordered::detail::next_prime(min);
+        }
+
+        static inline SizeT prev_bucket_count(SizeT max) {
+            return boost::unordered::detail::prev_prime(max);
+        }
+    };
+
+    template <typename SizeT>
+    struct mix64_policy
+    {
+        template <typename Hash, typename T>
+        static inline SizeT apply_hash(Hash const& hf, T const& x) {
+            SizeT key = hf(x);
+            key = (~key) + (key << 21); // key = (key << 21) - key - 1;
+            key = key ^ (key >> 24);
+            key = (key + (key << 3)) + (key << 8); // key * 265
+            key = key ^ (key >> 14);
+            key = (key + (key << 2)) + (key << 4); // key * 21
+            key = key ^ (key >> 28);
+            key = key + (key << 31);
+            return key;
+        }
+
+        static inline SizeT to_bucket(SizeT bucket_count, SizeT hash) {
+            return hash & (bucket_count - 1);
+        }
+
+        static inline SizeT new_bucket_count(SizeT min) {
+            if (min <= 4) return 4;
+            --min;
+            min |= min >> 1;
+            min |= min >> 2;
+            min |= min >> 4;
+            min |= min >> 8;
+            min |= min >> 16;
+            min |= min >> 32;
+            return min + 1;
+        }
+
+        static inline SizeT prev_bucket_count(SizeT max) {
+            max |= max >> 1;
+            max |= max >> 2;
+            max |= max >> 4;
+            max |= max >> 8;
+            max |= max >> 16;
+            max |= max >> 32;
+            return (max >> 1) + 1;
+        }
+    };
+
+    template <int digits, int radix>
+    struct pick_policy_impl {
+        typedef prime_policy<std::size_t> type;
+    };
+
+    template <>
+    struct pick_policy_impl<64, 2> {
+        typedef mix64_policy<std::size_t> type;
+    };
+
+    template <typename T>
+    struct pick_policy :
+        pick_policy_impl<
+            std::numeric_limits<std::size_t>::digits,
+            std::numeric_limits<std::size_t>::radix> {};
+
+    // While the mix policy is generally faster, the prime policy is a lot
+    // faster when a large number consecutive integers are used, because
+    // there are no collisions. Since that is probably quite common, use
+    // prime policy for integeral types. But not the smaller ones, as they
+    // don't have enough unique values for this to be an issue.
+
+    template <>
+    struct pick_policy<int> {
+        typedef prime_policy<std::size_t> type;
+    };
+
+    template <>
+    struct pick_policy<unsigned int> {
+        typedef prime_policy<std::size_t> type;
+    };
+
+    template <>
+    struct pick_policy<long> {
+        typedef prime_policy<std::size_t> type;
+    };
+
+    template <>
+    struct pick_policy<unsigned long> {
+        typedef prime_policy<std::size_t> type;
+    };
+
+    // TODO: Maybe not if std::size_t is smaller than long long.
+#if !defined(BOOST_NO_LONG_LONG)
+    template <>
+    struct pick_policy<long long> {
+        typedef prime_policy<std::size_t> type;
+    };
+
+    template <>
+    struct pick_policy<unsigned long long> {
+        typedef prime_policy<std::size_t> type;
+    };
+#endif
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Functions
+
+    // Assigning and swapping the equality and hash function objects
+    // needs strong exception safety. To implement that normally we'd
+    // require one of them to be known to not throw and the other to
+    // guarantee strong exception safety. Unfortunately they both only
+    // have basic exception safety. So to acheive strong exception
+    // safety we have storage space for two copies, and assign the new
+    // copies to the unused space. Then switch to using that to use
+    // them. This is implemented in 'set_hash_functions' which
+    // atomically assigns the new function objects in a strongly
+    // exception safe manner.
+
+    template <class H, class P, bool NoThrowMoveAssign>
+    class set_hash_functions;
+
+    template <class H, class P>
+    class functions
+    {
+    public:
+        static const bool nothrow_move_assignable =
+                boost::is_nothrow_move_assignable<H>::value &&
+                boost::is_nothrow_move_assignable<P>::value;
+        static const bool nothrow_move_constructible =
+                boost::is_nothrow_move_constructible<H>::value &&
+                boost::is_nothrow_move_constructible<P>::value;
+
+    private:
+        friend class boost::unordered::detail::set_hash_functions<H, P,
+               nothrow_move_assignable>;
+        functions& operator=(functions const&);
+
+        typedef compressed<H, P> function_pair;
+
+        typedef typename boost::aligned_storage<
+            sizeof(function_pair),
+            boost::alignment_of<function_pair>::value>::type aligned_function;
+
+        bool current_; // The currently active functions.
+        aligned_function funcs_[2];
+
+        function_pair const& current() const {
+            return *static_cast<function_pair const*>(
+                static_cast<void const*>(&funcs_[current_]));
+        }
+
+        function_pair& current() {
+            return *static_cast<function_pair*>(
+                static_cast<void*>(&funcs_[current_]));
+        }
+
+        void construct(bool which, H const& hf, P const& eq)
+        {
+            new((void*) &funcs_[which]) function_pair(hf, eq);
+        }
+
+        void construct(bool which, function_pair const& f,
+                boost::unordered::detail::false_type =
+                    boost::unordered::detail::false_type())
+        {
+            new((void*) &funcs_[which]) function_pair(f);
+        }
+        
+        void construct(bool which, function_pair& f,
+                boost::unordered::detail::true_type)
+        {
+            new((void*) &funcs_[which]) function_pair(f,
+                boost::unordered::detail::move_tag());
+        }
+
+        void destroy(bool which)
+        {
+            boost::unordered::detail::func::destroy((function_pair*)(&funcs_[which]));
+        }
+        
+    public:
+
+        typedef boost::unordered::detail::set_hash_functions<H, P,
+                nothrow_move_assignable> set_hash_functions;
+
+        functions(H const& hf, P const& eq)
+            : current_(false)
+        {
+            construct(current_, hf, eq);
+        }
+
+        functions(functions const& bf)
+            : current_(false)
+        {
+            construct(current_, bf.current());
+        }
+
+        functions(functions& bf, boost::unordered::detail::move_tag)
+            : current_(false)
+        {
+            construct(current_, bf.current(),
+                boost::unordered::detail::integral_constant<bool,
+                    nothrow_move_constructible>());
+        }
+
+        ~functions() {
+            this->destroy(current_);
+        }
+
+        H const& hash_function() const {
+            return current().first();
+        }
+
+        P const& key_eq() const {
+            return current().second();
+        }
+    };
+
+    template <class H, class P>
+    class set_hash_functions<H, P, false>
+    {
+        set_hash_functions(set_hash_functions const&);
+        set_hash_functions& operator=(set_hash_functions const&);
+
+        typedef functions<H, P> functions_type;
+    
+        functions_type& functions_;
+        bool tmp_functions_;
+
+    public:
+
+        set_hash_functions(functions_type& f, H const& h, P const& p)
+          : functions_(f),
+            tmp_functions_(!f.current_)
+        {
+            f.construct(tmp_functions_, h, p);
+        }
+
+        set_hash_functions(functions_type& f, functions_type const& other)
+          : functions_(f),
+            tmp_functions_(!f.current_)
+        {
+            f.construct(tmp_functions_, other.current());
+        }
+
+        ~set_hash_functions()
+        {
+            functions_.destroy(tmp_functions_);
+        }
+
+        void commit()
+        {
+            functions_.current_ = tmp_functions_;
+            tmp_functions_ = !tmp_functions_;
+        }
+    };
+
+    template <class H, class P>
+    class set_hash_functions<H, P, true>
+    {
+        set_hash_functions(set_hash_functions const&);
+        set_hash_functions& operator=(set_hash_functions const&);
+
+        typedef functions<H, P> functions_type;
+
+        functions_type& functions_;
+        H hash_;
+        P pred_;
+    
+    public:
+
+        set_hash_functions(functions_type& f, H const& h, P const& p) :
+            functions_(f),
+            hash_(h),
+            pred_(p) {}
+
+        set_hash_functions(functions_type& f, functions_type const& other) :
+            functions_(f),
+            hash_(other.hash_function()),
+            pred_(other.key_eq()) {}
+
+        void commit()
+        {
+            functions_.current().first() = boost::move(hash_);
+            functions_.current().second() = boost::move(pred_);
+        }
+    };
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // rvalue parameters when type can't be a BOOST_RV_REF(T) parameter
+    // e.g. for int
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#   define BOOST_UNORDERED_RV_REF(T) BOOST_RV_REF(T)
+#else
+    struct please_ignore_this_overload {
+        typedef please_ignore_this_overload type;
+    };
+
+    template <typename T>
+    struct rv_ref_impl {
+        typedef BOOST_RV_REF(T) type;
+    };
+
+    template <typename T>
+    struct rv_ref :
+        boost::detail::if_true<
+            boost::is_class<T>::value
+        >::BOOST_NESTED_TEMPLATE then <
+            boost::unordered::detail::rv_ref_impl<T>,
+            please_ignore_this_overload
+        >::type
+    {};
+
+#   define BOOST_UNORDERED_RV_REF(T) \
+        typename boost::unordered::detail::rv_ref<T>::type
+#endif
+}}}
+
+#endif

--- a/ibtk/contrib/boost/boost/unordered/detail/equivalent.hpp
+++ b/ibtk/contrib/boost/boost/unordered/detail/equivalent.hpp
@@ -1,0 +1,686 @@
+
+// Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
+// Copyright (C) 2005-2011 Daniel James
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_UNORDERED_DETAIL_EQUIVALENT_HPP_INCLUDED
+#define BOOST_UNORDERED_DETAIL_EQUIVALENT_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/unordered/detail/table.hpp>
+#include <boost/unordered/detail/extract_key.hpp>
+
+namespace boost { namespace unordered { namespace detail {
+
+    template <typename A, typename T> struct grouped_node;
+    template <typename T> struct grouped_ptr_node;
+    template <typename Types> struct grouped_table_impl;
+
+    template <typename A, typename T>
+    struct grouped_node :
+        boost::unordered::detail::value_base<T>
+    {
+        typedef typename ::boost::unordered::detail::rebind_wrap<
+            A, grouped_node<A, T> >::type allocator;
+        typedef typename ::boost::unordered::detail::
+            allocator_traits<allocator>::pointer node_pointer;
+        typedef node_pointer link_pointer;
+
+        link_pointer next_;
+        node_pointer group_prev_;
+        std::size_t hash_;
+
+        grouped_node() :
+            next_(),
+            group_prev_(),
+            hash_(0)
+        {}
+
+        void init(node_pointer self)
+        {
+            group_prev_ = self;
+        }
+
+    private:
+        grouped_node& operator=(grouped_node const&);
+    };
+
+    template <typename T>
+    struct grouped_ptr_node :
+        boost::unordered::detail::ptr_bucket
+    {
+        typedef T value_type;
+        typedef boost::unordered::detail::ptr_bucket bucket_base;
+        typedef grouped_ptr_node<T>* node_pointer;
+        typedef ptr_bucket* link_pointer;
+
+        node_pointer group_prev_;
+        std::size_t hash_;
+        boost::unordered::detail::value_base<T> value_base_;
+
+        grouped_ptr_node() :
+            bucket_base(),
+            group_prev_(0),
+            hash_(0)
+        {}
+
+        void init(node_pointer self)
+        {
+            group_prev_ = self;
+        }
+
+        void* address() { return value_base_.address(); }
+        value_type& value() { return value_base_.value(); }
+        value_type* value_ptr() { return value_base_.value_ptr(); }
+
+    private:
+        grouped_ptr_node& operator=(grouped_ptr_node const&);
+    };
+
+    // If the allocator uses raw pointers use grouped_ptr_node
+    // Otherwise use grouped_node.
+
+    template <typename A, typename T, typename NodePtr, typename BucketPtr>
+    struct pick_grouped_node2
+    {
+        typedef boost::unordered::detail::grouped_node<A, T> node;
+
+        typedef typename boost::unordered::detail::allocator_traits<
+            typename boost::unordered::detail::rebind_wrap<A, node>::type
+        >::pointer node_pointer;
+
+        typedef boost::unordered::detail::bucket<node_pointer> bucket;
+        typedef node_pointer link_pointer;
+    };
+
+    template <typename A, typename T>
+    struct pick_grouped_node2<A, T,
+        boost::unordered::detail::grouped_ptr_node<T>*,
+        boost::unordered::detail::ptr_bucket*>
+    {
+        typedef boost::unordered::detail::grouped_ptr_node<T> node;
+        typedef boost::unordered::detail::ptr_bucket bucket;
+        typedef bucket* link_pointer;
+    };
+
+    template <typename A, typename T>
+    struct pick_grouped_node
+    {
+        typedef boost::unordered::detail::allocator_traits<
+            typename boost::unordered::detail::rebind_wrap<A,
+                boost::unordered::detail::grouped_ptr_node<T> >::type
+        > tentative_node_traits;
+
+        typedef boost::unordered::detail::allocator_traits<
+            typename boost::unordered::detail::rebind_wrap<A,
+                boost::unordered::detail::ptr_bucket >::type
+        > tentative_bucket_traits;
+
+        typedef pick_grouped_node2<A, T,
+            typename tentative_node_traits::pointer,
+            typename tentative_bucket_traits::pointer> pick;
+
+        typedef typename pick::node node;
+        typedef typename pick::bucket bucket;
+        typedef typename pick::link_pointer link_pointer;
+    };
+
+    template <typename A, typename T, typename H, typename P>
+    struct multiset
+    {
+        typedef boost::unordered::detail::multiset<A, T, H, P> types;
+
+        typedef A allocator;
+        typedef T value_type;
+        typedef H hasher;
+        typedef P key_equal;
+        typedef T key_type;
+
+        typedef boost::unordered::detail::allocator_traits<allocator> traits;
+        typedef boost::unordered::detail::pick_grouped_node<allocator,
+            value_type> pick;
+        typedef typename pick::node node;
+        typedef typename pick::bucket bucket;
+        typedef typename pick::link_pointer link_pointer;
+
+        typedef boost::unordered::detail::grouped_table_impl<types> table;
+        typedef boost::unordered::detail::set_extractor<value_type> extractor;
+
+        typedef typename boost::unordered::detail::pick_policy<T>::type policy;
+    };
+
+    template <typename A, typename K, typename M, typename H, typename P>
+    struct multimap
+    {
+        typedef boost::unordered::detail::multimap<A, K, M, H, P> types;
+
+        typedef A allocator;
+        typedef std::pair<K const, M> value_type;
+        typedef H hasher;
+        typedef P key_equal;
+        typedef K key_type;
+
+        typedef boost::unordered::detail::allocator_traits<allocator> traits;
+        typedef boost::unordered::detail::pick_grouped_node<allocator,
+                value_type> pick;
+        typedef typename pick::node node;
+        typedef typename pick::bucket bucket;
+        typedef typename pick::link_pointer link_pointer;
+
+        typedef boost::unordered::detail::grouped_table_impl<types> table;
+        typedef boost::unordered::detail::map_extractor<key_type, value_type>
+            extractor;
+
+        typedef typename boost::unordered::detail::pick_policy<K>::type policy;
+    };
+
+    template <typename Types>
+    struct grouped_table_impl : boost::unordered::detail::table<Types>
+    {
+        typedef boost::unordered::detail::table<Types> table;
+        typedef typename table::value_type value_type;
+        typedef typename table::bucket bucket;
+        typedef typename table::policy policy;
+        typedef typename table::node_pointer node_pointer;
+        typedef typename table::node_allocator node_allocator;
+        typedef typename table::node_allocator_traits node_allocator_traits;
+        typedef typename table::bucket_pointer bucket_pointer;
+        typedef typename table::link_pointer link_pointer;
+        typedef typename table::hasher hasher;
+        typedef typename table::key_equal key_equal;
+        typedef typename table::key_type key_type;
+        typedef typename table::node_constructor node_constructor;
+        typedef typename table::extractor extractor;
+        typedef typename table::iterator iterator;
+        typedef typename table::c_iterator c_iterator;
+
+        // Constructors
+
+        grouped_table_impl(std::size_t n,
+                hasher const& hf,
+                key_equal const& eq,
+                node_allocator const& a)
+          : table(n, hf, eq, a)
+        {}
+
+        grouped_table_impl(grouped_table_impl const& x)
+          : table(x, node_allocator_traits::
+                select_on_container_copy_construction(x.node_alloc()))
+        {
+            this->init(x);
+        }
+
+        grouped_table_impl(grouped_table_impl const& x,
+                node_allocator const& a)
+          : table(x, a)
+        {
+            this->init(x);
+        }
+
+        grouped_table_impl(grouped_table_impl& x,
+                boost::unordered::detail::move_tag m)
+          : table(x, m)
+        {}
+
+        grouped_table_impl(grouped_table_impl& x,
+                node_allocator const& a,
+                boost::unordered::detail::move_tag m)
+          : table(x, a, m)
+        {
+            this->move_init(x);
+        }
+
+        // Accessors
+
+        template <class Key, class Pred>
+        iterator find_node_impl(
+                std::size_t key_hash,
+                Key const& k,
+                Pred const& eq) const
+        {
+            std::size_t bucket_index = this->hash_to_bucket(key_hash);
+            iterator n = this->begin(bucket_index);
+
+            for (;;)
+            {
+                if (!n.node_) return n;
+
+                std::size_t node_hash = n.node_->hash_;
+                if (key_hash == node_hash)
+                {
+                    if (eq(k, this->get_key(*n)))
+                        return n;
+                }
+                else
+                {
+                    if (this->hash_to_bucket(node_hash) != bucket_index)
+                        return iterator();
+                }
+
+                n = iterator(n.node_->group_prev_->next_);
+            }
+        }
+
+        std::size_t count(key_type const& k) const
+        {
+            iterator n = this->find_node(k);
+            if (!n.node_) return 0;
+
+            std::size_t x = 0;
+            node_pointer it = n.node_;
+            do {
+                it = it->group_prev_;
+                ++x;
+            } while(it != n.node_);
+
+            return x;
+        }
+
+        std::pair<iterator, iterator>
+            equal_range(key_type const& k) const
+        {
+            iterator n = this->find_node(k);
+            return std::make_pair(
+                n, n.node_ ? iterator(n.node_->group_prev_->next_) : n);
+        }
+
+        // Equality
+
+        bool equals(grouped_table_impl const& other) const
+        {
+            if(this->size_ != other.size_) return false;
+    
+            for(iterator n1 = this->begin(); n1.node_;)
+            {
+                iterator n2 = other.find_matching_node(n1);
+                if (!n2.node_) return false;
+                iterator end1(n1.node_->group_prev_->next_);
+                iterator end2(n2.node_->group_prev_->next_);
+                if (!group_equals(n1, end1, n2, end2)) return false;
+                n1 = end1;    
+            }
+    
+            return true;
+        }
+
+        static bool group_equals(iterator n1, iterator end1,
+                iterator n2, iterator end2)
+        {
+            for(;;)
+            {
+                if (*n1 != *n2) break;
+
+                ++n1;
+                ++n2;
+            
+                if (n1 == end1) return n2 == end2;
+                if (n2 == end2) return false;
+            }
+            
+            for(iterator n1a = n1, n2a = n2;;)
+            {
+                ++n1a;
+                ++n2a;
+
+                if (n1a == end1)
+                {
+                    if (n2a == end2) break;
+                    else return false;
+                }
+
+                if (n2a == end2) return false;
+            }
+
+            iterator start = n1;
+            for(;n1 != end1; ++n1)
+            {
+                value_type const& v = *n1;
+                if (find(start, n1, v)) continue;
+                std::size_t matches = count_equal(n2, end2, v);
+                if (!matches) return false;
+                iterator next = n1;
+                ++next;
+                if (matches != 1 + count_equal(next, end1, v)) return false;
+            }
+            
+            return true;
+        }
+
+        static bool find(iterator n, iterator end, value_type const& v)
+        {
+            for(;n != end; ++n)
+                if (*n == v)
+                    return true;
+            return false;
+        }
+
+        static std::size_t count_equal(iterator n, iterator end,
+            value_type const& v)
+        {
+            std::size_t count = 0;
+            for(;n != end; ++n)
+                if (*n == v) ++count;
+            return count;
+        }
+
+        // Emplace/Insert
+
+        static inline void add_after_node(
+                node_pointer n,
+                node_pointer pos)
+        {
+            n->next_ = pos->group_prev_->next_;
+            n->group_prev_ = pos->group_prev_;
+            pos->group_prev_->next_ = n;
+            pos->group_prev_ = n;
+        }
+
+        inline iterator add_node(
+                node_constructor& a,
+                std::size_t key_hash,
+                iterator pos)
+        {
+            node_pointer n = a.release();
+            n->hash_ = key_hash;
+            if (pos.node_) {
+                this->add_after_node(n, pos.node_);
+                if (n->next_) {
+                    std::size_t next_bucket = this->hash_to_bucket(
+                        static_cast<node_pointer>(n->next_)->hash_);
+                    if (next_bucket != this->hash_to_bucket(key_hash)) {
+                        this->get_bucket(next_bucket)->next_ = n;
+                    }
+                }
+            }
+            else {
+                bucket_pointer b = this->get_bucket(
+                    this->hash_to_bucket(key_hash));
+
+                if (!b->next_)
+                {
+                    link_pointer start_node = this->get_previous_start();
+                    
+                    if (start_node->next_) {
+                        this->get_bucket(this->hash_to_bucket(
+                            static_cast<node_pointer>(start_node->next_)->hash_
+                        ))->next_ = n;
+                    }
+    
+                    b->next_ = start_node;
+                    n->next_ = start_node->next_;
+                    start_node->next_ = n;
+                }
+                else
+                {
+                    n->next_ = b->next_->next_;
+                    b->next_->next_ = n;
+                }
+            }
+            ++this->size_;
+            return iterator(n);
+        }
+
+        iterator emplace_impl(node_constructor& a)
+        {
+            key_type const& k = this->get_key(a.value());
+            std::size_t key_hash = this->hash(k);
+            iterator position = this->find_node(key_hash, k);
+
+            // reserve has basic exception safety if the hash function
+            // throws, strong otherwise.
+            this->reserve_for_insert(this->size_ + 1);
+            return this->add_node(a, key_hash, position);
+        }
+
+        void emplace_impl_no_rehash(node_constructor& a)
+        {
+            key_type const& k = this->get_key(a.value());
+            std::size_t key_hash = this->hash(k);
+            this->add_node(a, key_hash, this->find_node(key_hash, k));
+        }
+
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#   if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+        iterator emplace(boost::unordered::detail::emplace_args1<
+                boost::unordered::detail::please_ignore_this_overload> const&)
+        {
+            BOOST_ASSERT(false);
+            return iterator();
+        }
+#   else
+        iterator emplace(
+                boost::unordered::detail::please_ignore_this_overload const&)
+        {
+            BOOST_ASSERT(false);
+            return iterator();
+        }
+#   endif
+#endif
+
+        template <BOOST_UNORDERED_EMPLACE_TEMPLATE>
+        iterator emplace(BOOST_UNORDERED_EMPLACE_ARGS)
+        {
+            node_constructor a(this->node_alloc());
+            a.construct_with_value(BOOST_UNORDERED_EMPLACE_FORWARD);
+
+            return iterator(emplace_impl(a));
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Insert range methods
+
+        // if hash function throws, or inserting > 1 element, basic exception
+        // safety. Strong otherwise
+        template <class I>
+        typename boost::unordered::detail::enable_if_forward<I, void>::type
+            insert_range(I i, I j)
+        {
+            if(i == j) return;
+
+            std::size_t distance = boost::unordered::detail::distance(i, j);
+            if(distance == 1) {
+                node_constructor a(this->node_alloc());
+                a.construct_with_value2(*i);
+                emplace_impl(a);
+            }
+            else {
+                // Only require basic exception safety here
+                this->reserve_for_insert(this->size_ + distance);
+
+                node_constructor a(this->node_alloc());
+                for (; i != j; ++i) {
+                    a.construct_with_value2(*i);
+                    emplace_impl_no_rehash(a);
+                }
+            }
+        }
+
+        template <class I>
+        typename boost::unordered::detail::disable_if_forward<I, void>::type
+            insert_range(I i, I j)
+        {
+            node_constructor a(this->node_alloc());
+            for (; i != j; ++i) {
+                a.construct_with_value2(*i);
+                emplace_impl(a);
+            }
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Erase
+        //
+        // no throw
+
+        std::size_t erase_key(key_type const& k)
+        {
+            if(!this->size_) return 0;
+
+            std::size_t key_hash = this->hash(k);
+            std::size_t bucket_index = this->hash_to_bucket(key_hash);
+            link_pointer prev = this->get_previous_start(bucket_index);
+            if (!prev) return 0;
+
+            for (;;)
+            {
+                if (!prev->next_) return 0;
+                std::size_t node_hash =
+                    static_cast<node_pointer>(prev->next_)->hash_;
+                if (this->hash_to_bucket(node_hash) != bucket_index)
+                    return 0;
+                if (node_hash == key_hash &&
+                    this->key_eq()(k, this->get_key(
+                        static_cast<node_pointer>(prev->next_)->value())))
+                    break;
+                prev = static_cast<node_pointer>(prev->next_)->group_prev_;
+            }
+
+            node_pointer first_node = static_cast<node_pointer>(prev->next_);
+            link_pointer end = first_node->group_prev_->next_;
+
+            std::size_t deleted_count = this->delete_nodes(prev, end);
+            this->fix_bucket(bucket_index, prev);
+            return deleted_count;
+        }
+
+        iterator erase(c_iterator r)
+        {
+            BOOST_ASSERT(r.node_);
+            iterator next(r.node_);
+            ++next;
+            erase_nodes(r.node_, next.node_);
+            return next;
+        }
+
+        iterator erase_range(c_iterator r1, c_iterator r2)
+        {
+            if (r1 == r2) return iterator(r2.node_);
+            erase_nodes(r1.node_, r2.node_);
+            return iterator(r2.node_);
+        }
+
+        link_pointer erase_nodes(node_pointer i, node_pointer j)
+        {
+            std::size_t bucket_index = this->hash_to_bucket(i->hash_);
+
+            // Split the groups containing 'i' and 'j'.
+            // And get the pointer to the node before i while
+            // we're at it.
+            link_pointer prev = split_groups(i, j);
+
+            // If we don't have a 'prev' it means that i is at the
+            // beginning of a block, so search through the blocks in the
+            // same bucket.
+            if (!prev) {
+                prev = this->get_previous_start(bucket_index);
+                while (prev->next_ != i)
+                    prev = static_cast<node_pointer>(prev->next_)->group_prev_;
+            }
+
+            // Delete the nodes.
+            do {
+                link_pointer group_end =
+                    static_cast<node_pointer>(prev->next_)->group_prev_->next_;
+                this->delete_nodes(prev, group_end);
+                bucket_index = this->fix_bucket(bucket_index, prev);
+            } while(prev->next_ != j);
+
+            return prev;
+        }
+
+        static link_pointer split_groups(node_pointer i, node_pointer j)
+        {
+            node_pointer prev = i->group_prev_;
+            if (prev->next_ != i) prev = node_pointer();
+
+            if (j) {
+                node_pointer first = j;
+                while (first != i && first->group_prev_->next_ == first) {
+                    first = first->group_prev_;
+                }
+
+                boost::swap(first->group_prev_, j->group_prev_);
+                if (first == i) return prev;
+            }
+
+            if (prev) {
+                node_pointer first = prev;
+                while (first->group_prev_->next_ == first) {
+                    first = first->group_prev_;
+                }
+                boost::swap(first->group_prev_, i->group_prev_);
+            }
+
+            return prev;
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // fill_buckets
+
+        template <class NodeCreator>
+        static void fill_buckets(iterator n, table& dst,
+            NodeCreator& creator)
+        {
+            link_pointer prev = dst.get_previous_start();
+
+            while (n.node_) {
+                std::size_t key_hash = n.node_->hash_;
+                iterator group_end(n.node_->group_prev_->next_);
+
+                node_pointer first_node = creator.create(*n);
+                node_pointer end = first_node;
+                first_node->hash_ = key_hash;
+                prev->next_ = first_node;
+                ++dst.size_;
+
+                for (++n; n != group_end; ++n)
+                {
+                    end = creator.create(*n);
+                    end->hash_ = key_hash;
+                    add_after_node(end, first_node);
+                    ++dst.size_;
+                }
+
+                prev = place_in_bucket(dst, prev, end);
+            }
+        }
+
+        // strong otherwise exception safety
+        void rehash_impl(std::size_t num_buckets)
+        {
+            BOOST_ASSERT(this->buckets_);
+
+            this->create_buckets(num_buckets);
+            link_pointer prev = this->get_previous_start();
+            while (prev->next_)
+                prev = place_in_bucket(*this, prev,
+                    static_cast<node_pointer>(prev->next_)->group_prev_);
+        }
+
+        // Iterate through the nodes placing them in the correct buckets.
+        // pre: prev->next_ is not null.
+        static link_pointer place_in_bucket(table& dst,
+                link_pointer prev, node_pointer end)
+        {
+            bucket_pointer b = dst.get_bucket(dst.hash_to_bucket(end->hash_));
+
+            if (!b->next_) {
+                b->next_ = prev;
+                return end;
+            }
+            else {
+                link_pointer next = end->next_;
+                end->next_ = b->next_->next_;
+                b->next_->next_ = prev->next_;
+                prev->next_ = next;
+                return prev;
+            }
+        }
+    };
+}}}
+
+#endif

--- a/ibtk/contrib/boost/boost/unordered/detail/extract_key.hpp
+++ b/ibtk/contrib/boost/boost/unordered/detail/extract_key.hpp
@@ -1,0 +1,188 @@
+
+// Copyright (C) 2005-2011 Daniel James
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_UNORDERED_DETAIL_EXTRACT_KEY_HPP_INCLUDED
+#define BOOST_UNORDERED_DETAIL_EXTRACT_KEY_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/unordered/detail/table.hpp>
+
+namespace boost {
+namespace unordered {
+namespace detail {
+
+    // key extractors
+    //
+    // no throw
+    //
+    // 'extract_key' is called with the emplace parameters to return a
+    // key if available or 'no_key' is one isn't and will need to be
+    // constructed. This could be done by overloading the emplace implementation
+    // for the different cases, but that's a bit tricky on compilers without
+    // variadic templates.
+
+    struct no_key {
+        no_key() {}
+        template <class T> no_key(T const&) {}
+    };
+
+    template <typename Key, typename T>
+    struct is_key {
+        template <typename T2>
+        static choice1::type test(T2 const&);
+        static choice2::type test(Key const&);
+        
+        enum { value = sizeof(test(boost::unordered::detail::make<T>())) ==
+            sizeof(choice2::type) };
+        
+        typedef typename boost::detail::if_true<value>::
+            BOOST_NESTED_TEMPLATE then<Key const&, no_key>::type type;
+    };
+
+    template <class ValueType>
+    struct set_extractor
+    {
+        typedef ValueType value_type;
+        typedef ValueType key_type;
+
+        static key_type const& extract(key_type const& v)
+        {
+            return v;
+        }
+
+        static no_key extract()
+        {
+            return no_key();
+        }
+        
+        template <class Arg>
+        static no_key extract(Arg const&)
+        {
+            return no_key();
+        }
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+        template <class Arg1, class Arg2, class... Args>
+        static no_key extract(Arg1 const&, Arg2 const&, Args const&...)
+        {
+            return no_key();
+        }
+#else
+        template <class Arg1, class Arg2>
+        static no_key extract(Arg1 const&, Arg2 const&)
+        {
+            return no_key();
+        }
+#endif
+    };
+
+    template <class Key, class ValueType>
+    struct map_extractor
+    {
+        typedef ValueType value_type;
+        typedef typename boost::remove_const<Key>::type key_type;
+
+        static key_type const& extract(value_type const& v)
+        {
+            return v.first;
+        }
+            
+        template <class Second>
+        static key_type const& extract(std::pair<key_type, Second> const& v)
+        {
+            return v.first;
+        }
+
+        template <class Second>
+        static key_type const& extract(
+            std::pair<key_type const, Second> const& v)
+        {
+            return v.first;
+        }
+
+        template <class Arg1>
+        static key_type const& extract(key_type const& k, Arg1 const&)
+        {
+            return k;
+        }
+
+        static no_key extract()
+        {
+            return no_key();
+        }
+
+        template <class Arg>
+        static no_key extract(Arg const&)
+        {
+            return no_key();
+        }
+
+        template <class Arg1, class Arg2>
+        static no_key extract(Arg1 const&, Arg2 const&)
+        {
+            return no_key();
+        }
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+        template <class Arg1, class Arg2, class Arg3, class... Args>
+        static no_key extract(Arg1 const&, Arg2 const&, Arg3 const&,
+                Args const&...)
+        {
+            return no_key();
+        }
+#endif
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+
+#define BOOST_UNORDERED_KEY_FROM_TUPLE(namespace_)                          \
+        template <typename T2>                                              \
+        static no_key extract(boost::unordered::piecewise_construct_t,      \
+                namespace_ tuple<> const&, T2 const&)                       \
+        {                                                                   \
+            return no_key();                                                \
+        }                                                                   \
+                                                                            \
+        template <typename T, typename T2>                                  \
+        static typename is_key<key_type, T>::type                           \
+            extract(boost::unordered::piecewise_construct_t,                \
+                namespace_ tuple<T> const& k, T2 const&)                    \
+        {                                                                   \
+            return typename is_key<key_type, T>::type(                      \
+                namespace_ get<0>(k));                                      \
+        }
+
+#else
+
+#define BOOST_UNORDERED_KEY_FROM_TUPLE(namespace_)                          \
+        static no_key extract(boost::unordered::piecewise_construct_t,      \
+                namespace_ tuple<> const&)                                  \
+        {                                                                   \
+            return no_key();                                                \
+        }                                                                   \
+                                                                            \
+        template <typename T>                                               \
+        static typename is_key<key_type, T>::type                           \
+            extract(boost::unordered::piecewise_construct_t,                \
+                namespace_ tuple<T> const& k)                               \
+        {                                                                   \
+            return typename is_key<key_type, T>::type(                      \
+                namespace_ get<0>(k));                                      \
+        }
+
+#endif
+
+BOOST_UNORDERED_KEY_FROM_TUPLE(boost::)
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+BOOST_UNORDERED_KEY_FROM_TUPLE(std::)
+#endif
+    };
+}}}
+
+#endif

--- a/ibtk/contrib/boost/boost/unordered/detail/fwd.hpp
+++ b/ibtk/contrib/boost/boost/unordered/detail/fwd.hpp
@@ -1,0 +1,23 @@
+
+// Copyright (C) 2008-2011 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_UNORDERED_FWD_HPP_INCLUDED
+#define BOOST_UNORDERED_FWD_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+namespace boost
+{
+namespace unordered
+{
+    struct piecewise_construct_t {};
+    const piecewise_construct_t piecewise_construct = piecewise_construct_t();
+}
+}
+
+#endif

--- a/ibtk/contrib/boost/boost/unordered/detail/table.hpp
+++ b/ibtk/contrib/boost/boost/unordered/detail/table.hpp
@@ -1,0 +1,873 @@
+
+// Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
+// Copyright (C) 2005-2011 Daniel James
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_UNORDERED_DETAIL_ALL_HPP_INCLUDED
+#define BOOST_UNORDERED_DETAIL_ALL_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/unordered/detail/buckets.hpp>
+#include <boost/unordered/detail/util.hpp>
+#include <boost/type_traits/aligned_storage.hpp>
+#include <boost/type_traits/alignment_of.hpp>
+#include <cmath>
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4127) // conditional expression is constant
+#endif
+
+#if defined(BOOST_UNORDERED_DEPRECATED_EQUALITY)
+
+#if defined(__EDG__)
+#elif defined(_MSC_VER) || defined(__BORLANDC__) || defined(__DMC__)
+#pragma message("Warning: BOOST_UNORDERED_DEPRECATED_EQUALITY is no longer supported.")
+#elif defined(__GNUC__) || defined(__HP_aCC) || \
+    defined(__SUNPRO_CC) || defined(__IBMCPP__)
+#warning "BOOST_UNORDERED_DEPRECATED_EQUALITY is no longer supported."
+#endif
+
+#endif
+
+namespace boost { namespace unordered { namespace detail {
+
+    ////////////////////////////////////////////////////////////////////////////
+    // convert double to std::size_t
+
+    inline std::size_t double_to_size(double f)
+    {
+        return f >= static_cast<double>(
+            (std::numeric_limits<std::size_t>::max)()) ?
+            (std::numeric_limits<std::size_t>::max)() :
+            static_cast<std::size_t>(f);
+    }
+
+    // The space used to store values in a node.
+
+    template <typename ValueType>
+    struct value_base
+    {
+        typedef ValueType value_type;
+
+        typename boost::aligned_storage<
+            sizeof(value_type),
+            boost::alignment_of<value_type>::value>::type data_;
+
+        value_base() :
+            data_()
+        {}
+
+        void* address() {
+            return this;
+        }
+
+        value_type& value() {
+            return *(ValueType*) this;
+        }
+
+        value_type* value_ptr() {
+            return (ValueType*) this;
+        }
+
+    private:
+
+        value_base& operator=(value_base const&);
+    };
+
+    template <typename NodeAlloc>
+    struct copy_nodes
+    {
+        typedef boost::unordered::detail::allocator_traits<NodeAlloc>
+            node_allocator_traits;
+
+        node_constructor<NodeAlloc> constructor;
+
+        explicit copy_nodes(NodeAlloc& a) : constructor(a) {}
+
+        typename node_allocator_traits::pointer create(
+                typename node_allocator_traits::value_type::value_type const& v)
+        {
+            constructor.construct_with_value2(v);
+            return constructor.release();
+        }
+    };
+
+    template <typename NodeAlloc>
+    struct move_nodes
+    {
+        typedef boost::unordered::detail::allocator_traits<NodeAlloc>
+            node_allocator_traits;
+
+        node_constructor<NodeAlloc> constructor;
+
+        explicit move_nodes(NodeAlloc& a) : constructor(a) {}
+
+        typename node_allocator_traits::pointer create(
+                typename node_allocator_traits::value_type::value_type& v)
+        {
+            constructor.construct_with_value2(boost::move(v));
+            return constructor.release();
+        }
+    };
+
+    template <typename Buckets>
+    struct assign_nodes
+    {
+        node_holder<typename Buckets::node_allocator> holder;
+
+        explicit assign_nodes(Buckets& b) : holder(b) {}
+
+        typename Buckets::node_pointer create(
+                typename Buckets::value_type const& v)
+        {
+            return holder.copy_of(v);
+        }
+    };
+
+    template <typename Buckets>
+    struct move_assign_nodes
+    {
+        node_holder<typename Buckets::node_allocator> holder;
+
+        explicit move_assign_nodes(Buckets& b) : holder(b) {}
+
+        typename Buckets::node_pointer create(
+                typename Buckets::value_type& v)
+        {
+            return holder.move_copy_of(v);
+        }
+    };
+
+    template <typename Types>
+    struct table :
+        boost::unordered::detail::functions<
+            typename Types::hasher,
+            typename Types::key_equal>
+    {
+    private:
+        table(table const&);
+        table& operator=(table const&);
+    public:
+        typedef typename Types::node node;
+        typedef typename Types::bucket bucket;
+        typedef typename Types::hasher hasher;
+        typedef typename Types::key_equal key_equal;
+        typedef typename Types::key_type key_type;
+        typedef typename Types::extractor extractor;
+        typedef typename Types::value_type value_type;
+        typedef typename Types::table table_impl;
+        typedef typename Types::link_pointer link_pointer;
+        typedef typename Types::policy policy;
+
+        typedef boost::unordered::detail::functions<
+            typename Types::hasher,
+            typename Types::key_equal> functions;
+        typedef typename functions::set_hash_functions set_hash_functions;
+
+        typedef typename Types::allocator allocator;
+        typedef typename boost::unordered::detail::
+            rebind_wrap<allocator, node>::type node_allocator;
+        typedef typename boost::unordered::detail::
+            rebind_wrap<allocator, bucket>::type bucket_allocator;
+        typedef boost::unordered::detail::allocator_traits<node_allocator>
+            node_allocator_traits;
+        typedef boost::unordered::detail::allocator_traits<bucket_allocator>
+            bucket_allocator_traits;
+        typedef typename node_allocator_traits::pointer
+            node_pointer;
+        typedef typename node_allocator_traits::const_pointer
+            const_node_pointer;
+        typedef typename bucket_allocator_traits::pointer
+            bucket_pointer;
+        typedef boost::unordered::detail::node_constructor<node_allocator>
+            node_constructor;
+
+        typedef boost::unordered::iterator_detail::
+            iterator<node> iterator;
+        typedef boost::unordered::iterator_detail::
+            c_iterator<node> c_iterator;
+        typedef boost::unordered::iterator_detail::
+            l_iterator<node, policy> l_iterator;
+        typedef boost::unordered::iterator_detail::
+            cl_iterator<node, policy> cl_iterator;
+
+        ////////////////////////////////////////////////////////////////////////
+        // Members
+
+        boost::unordered::detail::compressed<bucket_allocator, node_allocator>
+            allocators_;
+        std::size_t bucket_count_;
+        std::size_t size_;
+        float mlf_;
+        std::size_t max_load_;
+        bucket_pointer buckets_;
+
+        ////////////////////////////////////////////////////////////////////////
+        // Data access
+
+        bucket_allocator const& bucket_alloc() const
+        {
+            return allocators_.first();
+        }
+
+        node_allocator const& node_alloc() const
+        {
+            return allocators_.second();
+        }
+
+        bucket_allocator& bucket_alloc()
+        {
+            return allocators_.first();
+        }
+
+        node_allocator& node_alloc()
+        {
+            return allocators_.second();
+        }
+
+        std::size_t max_bucket_count() const
+        {
+            // -1 to account for the start bucket.
+            return policy::prev_bucket_count(
+                bucket_allocator_traits::max_size(bucket_alloc()) - 1);
+        }
+
+        bucket_pointer get_bucket(std::size_t bucket_index) const
+        {
+            BOOST_ASSERT(buckets_);
+            return buckets_ + static_cast<std::ptrdiff_t>(bucket_index);
+        }
+
+        link_pointer get_previous_start() const
+        {
+            return get_bucket(bucket_count_)->first_from_start();
+        }
+
+        link_pointer get_previous_start(std::size_t bucket_index) const
+        {
+            return get_bucket(bucket_index)->next_;
+        }
+
+        iterator begin() const
+        {
+            return size_ ? iterator(get_previous_start()->next_) : iterator();
+        }
+
+        iterator begin(std::size_t bucket_index) const
+        {
+            if (!size_) return iterator();
+            link_pointer prev = get_previous_start(bucket_index);
+            return prev ? iterator(prev->next_) : iterator();
+        }
+        
+        std::size_t hash_to_bucket(std::size_t hash_value) const
+        {
+            return policy::to_bucket(bucket_count_, hash_value);
+        }
+
+        float load_factor() const
+        {
+            BOOST_ASSERT(bucket_count_ != 0);
+            return static_cast<float>(size_)
+                / static_cast<float>(bucket_count_);
+        }
+
+        std::size_t bucket_size(std::size_t index) const
+        {
+            iterator it = begin(index);
+            if (!it.node_) return 0;
+
+            std::size_t count = 0;
+            while(it.node_ && hash_to_bucket(it.node_->hash_) == index)
+            {
+                ++count;
+                ++it;
+            }
+
+            return count;
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Load methods
+
+        std::size_t max_size() const
+        {
+            using namespace std;
+    
+            // size < mlf_ * count
+            return boost::unordered::detail::double_to_size(ceil(
+                    static_cast<double>(mlf_) *
+                    static_cast<double>(max_bucket_count())
+                )) - 1;
+        }
+
+        void recalculate_max_load()
+        {
+            using namespace std;
+    
+            // From 6.3.1/13:
+            // Only resize when size >= mlf_ * count
+            max_load_ = buckets_ ? boost::unordered::detail::double_to_size(ceil(
+                    static_cast<double>(mlf_) *
+                    static_cast<double>(bucket_count_)
+                )) : 0;
+
+        }
+
+        void max_load_factor(float z)
+        {
+            BOOST_ASSERT(z > 0);
+            mlf_ = (std::max)(z, minimum_max_load_factor);
+            recalculate_max_load();
+        }
+
+        std::size_t min_buckets_for_size(std::size_t size) const
+        {
+            BOOST_ASSERT(mlf_ >= minimum_max_load_factor);
+    
+            using namespace std;
+    
+            // From 6.3.1/13:
+            // size < mlf_ * count
+            // => count > size / mlf_
+            //
+            // Or from rehash post-condition:
+            // count > size / mlf_
+
+            return policy::new_bucket_count(
+                boost::unordered::detail::double_to_size(floor(
+                    static_cast<double>(size) /
+                    static_cast<double>(mlf_)) + 1));
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Constructors
+
+        table(std::size_t num_buckets,
+                hasher const& hf,
+                key_equal const& eq,
+                node_allocator const& a) :
+            functions(hf, eq),
+            allocators_(a,a),
+            bucket_count_(policy::new_bucket_count(num_buckets)),
+            size_(0),
+            mlf_(1.0f),
+            max_load_(0),
+            buckets_()
+        {}
+
+        table(table const& x, node_allocator const& a) :
+            functions(x),
+            allocators_(a,a),
+            bucket_count_(x.min_buckets_for_size(x.size_)),
+            size_(0),
+            mlf_(x.mlf_),
+            max_load_(0),
+            buckets_()
+        {}
+
+        table(table& x, boost::unordered::detail::move_tag m) :
+            functions(x, m),
+            allocators_(x.allocators_, m),
+            bucket_count_(x.bucket_count_),
+            size_(x.size_),
+            mlf_(x.mlf_),
+            max_load_(x.max_load_),
+            buckets_(x.buckets_)
+        {
+            x.buckets_ = bucket_pointer();
+            x.size_ = 0;
+            x.max_load_ = 0;
+        }
+
+        table(table& x, node_allocator const& a,
+                boost::unordered::detail::move_tag m) :
+            functions(x, m),
+            allocators_(a, a),
+            bucket_count_(x.bucket_count_),
+            size_(0),
+            mlf_(x.mlf_),
+            max_load_(x.max_load_),
+            buckets_()
+        {}
+
+        ////////////////////////////////////////////////////////////////////////
+        // Initialisation.
+
+        void init(table const& x)
+        {
+            if (x.size_) {
+                create_buckets(bucket_count_);
+                copy_nodes<node_allocator> node_creator(node_alloc());
+                table_impl::fill_buckets(x.begin(), *this, node_creator);
+            }
+        }
+
+        void move_init(table& x)
+        {
+            if(node_alloc() == x.node_alloc()) {
+                move_buckets_from(x);
+            }
+            else if(x.size_) {
+                // TODO: Could pick new bucket size?
+                create_buckets(bucket_count_);
+
+                move_nodes<node_allocator> node_creator(node_alloc());
+                node_holder<node_allocator> nodes(x);
+                table_impl::fill_buckets(nodes.begin(), *this, node_creator);
+            }
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Create buckets
+
+        void create_buckets(std::size_t new_count)
+        {
+            boost::unordered::detail::array_constructor<bucket_allocator>
+                constructor(bucket_alloc());
+    
+            // Creates an extra bucket to act as the start node.
+            constructor.construct(bucket(), new_count + 1);
+
+            if (buckets_)
+            {
+                // Copy the nodes to the new buckets, including the dummy
+                // node if there is one.
+                (constructor.get() +
+                    static_cast<std::ptrdiff_t>(new_count))->next_ =
+                        (buckets_ + static_cast<std::ptrdiff_t>(
+                            bucket_count_))->next_;
+                destroy_buckets();
+            }
+            else if (bucket::extra_node)
+            {
+                node_constructor a(node_alloc());
+                a.construct();
+
+                (constructor.get() +
+                    static_cast<std::ptrdiff_t>(new_count))->next_ =
+                        a.release();
+            }
+
+            bucket_count_ = new_count;
+            buckets_ = constructor.release();
+            recalculate_max_load();
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Swap and Move
+
+        void swap_allocators(table& other, false_type)
+        {
+            boost::unordered::detail::func::ignore_unused_variable_warning(other);
+
+            // According to 23.2.1.8, if propagate_on_container_swap is
+            // false the behaviour is undefined unless the allocators
+            // are equal.
+            BOOST_ASSERT(node_alloc() == other.node_alloc());
+        }
+
+        void swap_allocators(table& other, true_type)
+        {
+            allocators_.swap(other.allocators_);
+        }
+
+        // Only swaps the allocators if propagate_on_container_swap
+        void swap(table& x)
+        {
+            set_hash_functions op1(*this, x);
+            set_hash_functions op2(x, *this);
+
+            // I think swap can throw if Propagate::value,
+            // since the allocators' swap can throw. Not sure though.
+            swap_allocators(x,
+                boost::unordered::detail::integral_constant<bool,
+                    allocator_traits<node_allocator>::
+                    propagate_on_container_swap::value>());
+
+            boost::swap(buckets_, x.buckets_);
+            boost::swap(bucket_count_, x.bucket_count_);
+            boost::swap(size_, x.size_);
+            std::swap(mlf_, x.mlf_);
+            std::swap(max_load_, x.max_load_);
+            op1.commit();
+            op2.commit();
+        }
+
+        // Only call with nodes allocated with the currect allocator, or
+        // one that is equal to it. (Can't assert because other's
+        // allocators might have already been moved).
+        void move_buckets_from(table& other)
+        {
+            BOOST_ASSERT(!buckets_);
+            buckets_ = other.buckets_;
+            bucket_count_ = other.bucket_count_;
+            size_ = other.size_;
+            other.buckets_ = bucket_pointer();
+            other.size_ = 0;
+            other.max_load_ = 0;
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Delete/destruct
+
+        ~table()
+        {
+            delete_buckets();
+        }
+
+        void delete_node(link_pointer prev)
+        {
+            node_pointer n = static_cast<node_pointer>(prev->next_);
+            prev->next_ = n->next_;
+
+            boost::unordered::detail::func::destroy_value_impl(node_alloc(),
+                n->value_ptr());
+            boost::unordered::detail::func::destroy(boost::addressof(*n));
+            node_allocator_traits::deallocate(node_alloc(), n, 1);
+            --size_;
+        }
+
+        std::size_t delete_nodes(link_pointer prev, link_pointer end)
+        {
+            BOOST_ASSERT(prev->next_ != end);
+
+            std::size_t count = 0;
+
+            do {
+                delete_node(prev);
+                ++count;
+            } while (prev->next_ != end);
+
+            return count;
+        }
+
+        void delete_buckets()
+        {
+            if(buckets_) {
+                if (size_) delete_nodes(get_previous_start(), link_pointer());
+
+                if (bucket::extra_node) {
+                    node_pointer n = static_cast<node_pointer>(
+                            get_bucket(bucket_count_)->next_);
+                    boost::unordered::detail::func::destroy(
+                            boost::addressof(*n));
+                    node_allocator_traits::deallocate(node_alloc(), n, 1);
+                }
+
+                destroy_buckets();
+                buckets_ = bucket_pointer();
+                max_load_ = 0;
+            }
+
+            BOOST_ASSERT(!size_);
+        }
+
+        void clear()
+        {
+            if (!size_) return;
+
+            delete_nodes(get_previous_start(), link_pointer());
+            clear_buckets();
+
+            BOOST_ASSERT(!size_);
+        }
+
+        void clear_buckets()
+        {
+            bucket_pointer end = get_bucket(bucket_count_);
+            for(bucket_pointer it = buckets_; it != end; ++it)
+            {
+                it->next_ = node_pointer();
+            }
+        }
+
+        void destroy_buckets()
+        {
+            bucket_pointer end = get_bucket(bucket_count_ + 1);
+            for(bucket_pointer it = buckets_; it != end; ++it)
+            {
+                boost::unordered::detail::func::destroy(
+                    boost::addressof(*it));
+            }
+
+            bucket_allocator_traits::deallocate(bucket_alloc(),
+                buckets_, bucket_count_ + 1);
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Fix buckets after delete
+        //
+
+        std::size_t fix_bucket(std::size_t bucket_index, link_pointer prev)
+        {
+            link_pointer end = prev->next_;
+            std::size_t bucket_index2 = bucket_index;
+
+            if (end)
+            {
+                bucket_index2 = hash_to_bucket(
+                    static_cast<node_pointer>(end)->hash_);
+
+                // If begin and end are in the same bucket, then
+                // there's nothing to do.
+                if (bucket_index == bucket_index2) return bucket_index2;
+
+                // Update the bucket containing end.
+                get_bucket(bucket_index2)->next_ = prev;
+            }
+
+            // Check if this bucket is now empty.
+            bucket_pointer this_bucket = get_bucket(bucket_index);
+            if (this_bucket->next_ == prev)
+                this_bucket->next_ = link_pointer();
+
+            return bucket_index2;
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Assignment
+
+        void assign(table const& x)
+        {
+            if (this != boost::addressof(x))
+            {
+                assign(x,
+                    boost::unordered::detail::integral_constant<bool,
+                        allocator_traits<node_allocator>::
+                        propagate_on_container_copy_assignment::value>());
+            }
+        }
+
+        void assign(table const& x, false_type)
+        {
+            // Strong exception safety.
+            set_hash_functions new_func_this(*this, x);
+            new_func_this.commit();
+            mlf_ = x.mlf_;
+            recalculate_max_load();
+
+            if (!size_ && !x.size_) return;
+
+            if (x.size_ >= max_load_) {
+                create_buckets(min_buckets_for_size(x.size_));
+            }
+            else {
+                clear_buckets();
+            }
+
+            // assign_nodes takes ownership of the container's elements,
+            // assigning to them if possible, and deleting any that are
+            // left over.
+            assign_nodes<table> node_creator(*this);
+            table_impl::fill_buckets(x.begin(), *this, node_creator);
+        }
+
+        void assign(table const& x, true_type)
+        {
+            if (node_alloc() == x.node_alloc()) {
+                allocators_.assign(x.allocators_);
+                assign(x, false_type());
+            }
+            else {
+                set_hash_functions new_func_this(*this, x);
+
+                // Delete everything with current allocators before assigning
+                // the new ones.
+                delete_buckets();
+                allocators_.assign(x.allocators_);
+
+                // Copy over other data, all no throw.
+                new_func_this.commit();
+                mlf_ = x.mlf_;
+                bucket_count_ = min_buckets_for_size(x.size_);
+                max_load_ = 0;
+
+                // Finally copy the elements.
+                if (x.size_) {
+                    create_buckets(bucket_count_);
+                    copy_nodes<node_allocator> node_creator(node_alloc());
+                    table_impl::fill_buckets(x.begin(), *this, node_creator);
+                }
+            }
+        }
+
+        void move_assign(table& x)
+        {
+            if (this != boost::addressof(x))
+            {
+                move_assign(x,
+                    boost::unordered::detail::integral_constant<bool,
+                        allocator_traits<node_allocator>::
+                        propagate_on_container_move_assignment::value>());
+            }
+        }
+
+        void move_assign(table& x, true_type)
+        {
+            delete_buckets();
+            set_hash_functions new_func_this(*this, x);
+            allocators_.move_assign(x.allocators_);
+            // No throw from here.
+            mlf_ = x.mlf_;
+            max_load_ = x.max_load_;
+            move_buckets_from(x);
+            new_func_this.commit();
+        }
+
+        void move_assign(table& x, false_type)
+        {
+            if (node_alloc() == x.node_alloc()) {
+                delete_buckets();
+                set_hash_functions new_func_this(*this, x);
+                // No throw from here.
+                mlf_ = x.mlf_;
+                max_load_ = x.max_load_;
+                move_buckets_from(x);
+                new_func_this.commit();
+            }
+            else {
+                set_hash_functions new_func_this(*this, x);
+                new_func_this.commit();
+                mlf_ = x.mlf_;
+                recalculate_max_load();
+
+                if (!size_ && !x.size_) return;
+
+                if (x.size_ >= max_load_) {
+                    create_buckets(min_buckets_for_size(x.size_));
+                }
+                else {
+                    clear_buckets();
+                }
+
+                // move_assign_nodes takes ownership of the container's
+                // elements, assigning to them if possible, and deleting
+                // any that are left over.
+                move_assign_nodes<table> node_creator(*this);
+                node_holder<node_allocator> nodes(x);
+                table_impl::fill_buckets(nodes.begin(), *this, node_creator);
+            }
+        }
+
+        // Accessors
+
+        key_type const& get_key(value_type const& x) const
+        {
+            return extractor::extract(x);
+        }
+
+        std::size_t hash(key_type const& k) const
+        {
+            return policy::apply_hash(this->hash_function(), k);
+        }
+
+        // Find Node
+
+        template <typename Key, typename Hash, typename Pred>
+        iterator generic_find_node(
+                Key const& k,
+                Hash const& hf,
+                Pred const& eq) const
+        {
+            return static_cast<table_impl const*>(this)->
+                find_node_impl(policy::apply_hash(hf, k), k, eq);
+        }
+
+        iterator find_node(
+                std::size_t key_hash,
+                key_type const& k) const
+        {
+            return static_cast<table_impl const*>(this)->
+                find_node_impl(key_hash, k, this->key_eq());
+        }
+
+        iterator find_node(key_type const& k) const
+        {
+            return static_cast<table_impl const*>(this)->
+                find_node_impl(hash(k), k, this->key_eq());
+        }
+
+        iterator find_matching_node(iterator n) const
+        {
+            // TODO: Does this apply to C++11?
+            //
+            // For some stupid reason, I decided to support equality comparison
+            // when different hash functions are used. So I can't use the hash
+            // value from the node here.
+    
+            return find_node(get_key(*n));
+        }
+
+        // Reserve and rehash
+
+        void reserve_for_insert(std::size_t);
+        void rehash(std::size_t);
+        void reserve(std::size_t);
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Reserve & Rehash
+
+    // basic exception safety
+    template <typename Types>
+    inline void table<Types>::reserve_for_insert(std::size_t size)
+    {
+        if (!buckets_) {
+            create_buckets((std::max)(bucket_count_,
+                min_buckets_for_size(size)));
+        }
+        // According to the standard this should be 'size >= max_load_',
+        // but I think this is better, defect report filed.
+        else if(size > max_load_) {
+            std::size_t num_buckets
+                = min_buckets_for_size((std::max)(size,
+                    size_ + (size_ >> 1)));
+
+            if (num_buckets != bucket_count_)
+                static_cast<table_impl*>(this)->rehash_impl(num_buckets);
+        }
+    }
+
+    // if hash function throws, basic exception safety
+    // strong otherwise.
+
+    template <typename Types>
+    inline void table<Types>::rehash(std::size_t min_buckets)
+    {
+        using namespace std;
+
+        if(!size_) {
+            delete_buckets();
+            bucket_count_ = policy::new_bucket_count(min_buckets);
+        }
+        else {
+            min_buckets = policy::new_bucket_count((std::max)(min_buckets,
+                boost::unordered::detail::double_to_size(floor(
+                    static_cast<double>(size_) /
+                    static_cast<double>(mlf_))) + 1));
+
+            if(min_buckets != bucket_count_)
+                static_cast<table_impl*>(this)->rehash_impl(min_buckets);
+        }
+    }
+
+    template <typename Types>
+    inline void table<Types>::reserve(std::size_t num_elements)
+    {
+        rehash(static_cast<std::size_t>(
+            std::ceil(static_cast<double>(num_elements) / mlf_)));
+    }
+}}}
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+#endif

--- a/ibtk/contrib/boost/boost/unordered/detail/unique.hpp
+++ b/ibtk/contrib/boost/boost/unordered/detail/unique.hpp
@@ -1,0 +1,628 @@
+
+// Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
+// Copyright (C) 2005-2011 Daniel James
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_UNORDERED_DETAIL_UNIQUE_HPP_INCLUDED
+#define BOOST_UNORDERED_DETAIL_UNIQUE_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/unordered/detail/table.hpp>
+#include <boost/unordered/detail/extract_key.hpp>
+#include <boost/throw_exception.hpp>
+#include <stdexcept>
+
+namespace boost { namespace unordered { namespace detail {
+
+    template <typename A, typename T> struct unique_node;
+    template <typename T> struct ptr_node;
+    template <typename Types> struct table_impl;
+
+    template <typename A, typename T>
+    struct unique_node :
+        boost::unordered::detail::value_base<T>
+    {
+        typedef typename ::boost::unordered::detail::rebind_wrap<
+            A, unique_node<A, T> >::type allocator;
+        typedef typename ::boost::unordered::detail::
+            allocator_traits<allocator>::pointer node_pointer;
+        typedef node_pointer link_pointer;
+
+        link_pointer next_;
+        std::size_t hash_;
+
+        unique_node() :
+            next_(),
+            hash_(0)
+        {}
+
+        void init(node_pointer)
+        {
+        }
+
+    private:
+        unique_node& operator=(unique_node const&);
+    };
+
+    template <typename T>
+    struct ptr_node :
+        boost::unordered::detail::ptr_bucket
+    {
+        typedef T value_type;
+        typedef boost::unordered::detail::ptr_bucket bucket_base;
+        typedef ptr_node<T>* node_pointer;
+        typedef ptr_bucket* link_pointer;
+
+        std::size_t hash_;
+        boost::unordered::detail::value_base<T> value_base_;
+
+        ptr_node() :
+            bucket_base(),
+            hash_(0)
+        {}
+
+        void init(node_pointer)
+        {
+        }
+
+        void* address() { return value_base_.address(); }
+        value_type& value() { return value_base_.value(); }
+        value_type* value_ptr() { return value_base_.value_ptr(); }
+
+    private:
+        ptr_node& operator=(ptr_node const&);
+    };
+
+    // If the allocator uses raw pointers use ptr_node
+    // Otherwise use node.
+
+    template <typename A, typename T, typename NodePtr, typename BucketPtr>
+    struct pick_node2
+    {
+        typedef boost::unordered::detail::unique_node<A, T> node;
+
+        typedef typename boost::unordered::detail::allocator_traits<
+            typename boost::unordered::detail::rebind_wrap<A, node>::type
+        >::pointer node_pointer;
+
+        typedef boost::unordered::detail::bucket<node_pointer> bucket;
+        typedef node_pointer link_pointer;
+    };
+
+    template <typename A, typename T>
+    struct pick_node2<A, T,
+        boost::unordered::detail::ptr_node<T>*,
+        boost::unordered::detail::ptr_bucket*>
+    {
+        typedef boost::unordered::detail::ptr_node<T> node;
+        typedef boost::unordered::detail::ptr_bucket bucket;
+        typedef bucket* link_pointer;
+    };
+
+    template <typename A, typename T>
+    struct pick_node
+    {
+        typedef boost::unordered::detail::allocator_traits<
+            typename boost::unordered::detail::rebind_wrap<A,
+                boost::unordered::detail::ptr_node<T> >::type
+        > tentative_node_traits;
+
+        typedef boost::unordered::detail::allocator_traits<
+            typename boost::unordered::detail::rebind_wrap<A,
+                boost::unordered::detail::ptr_bucket >::type
+        > tentative_bucket_traits;
+
+        typedef pick_node2<A, T,
+            typename tentative_node_traits::pointer,
+            typename tentative_bucket_traits::pointer> pick;
+
+        typedef typename pick::node node;
+        typedef typename pick::bucket bucket;
+        typedef typename pick::link_pointer link_pointer;
+    };
+
+    template <typename A, typename T, typename H, typename P>
+    struct set
+    {
+        typedef boost::unordered::detail::set<A, T, H, P> types;
+
+        typedef A allocator;
+        typedef T value_type;
+        typedef H hasher;
+        typedef P key_equal;
+        typedef T key_type;
+
+        typedef boost::unordered::detail::allocator_traits<allocator> traits;
+        typedef boost::unordered::detail::pick_node<allocator, value_type> pick;
+        typedef typename pick::node node;
+        typedef typename pick::bucket bucket;
+        typedef typename pick::link_pointer link_pointer;
+
+        typedef boost::unordered::detail::table_impl<types> table;
+        typedef boost::unordered::detail::set_extractor<value_type> extractor;
+
+        typedef typename boost::unordered::detail::pick_policy<T>::type policy;
+    };
+
+    template <typename A, typename K, typename M, typename H, typename P>
+    struct map
+    {
+        typedef boost::unordered::detail::map<A, K, M, H, P> types;
+
+        typedef A allocator;
+        typedef std::pair<K const, M> value_type;
+        typedef H hasher;
+        typedef P key_equal;
+        typedef K key_type;
+
+        typedef boost::unordered::detail::allocator_traits<allocator>
+            traits;
+        typedef boost::unordered::detail::pick_node<allocator, value_type> pick;
+        typedef typename pick::node node;
+        typedef typename pick::bucket bucket;
+        typedef typename pick::link_pointer link_pointer;
+
+        typedef boost::unordered::detail::table_impl<types> table;
+        typedef boost::unordered::detail::map_extractor<key_type, value_type>
+            extractor;
+
+        typedef typename boost::unordered::detail::pick_policy<K>::type policy;
+    };
+
+    template <typename Types>
+    struct table_impl : boost::unordered::detail::table<Types>
+    {
+        typedef boost::unordered::detail::table<Types> table;
+        typedef typename table::value_type value_type;
+        typedef typename table::bucket bucket;
+        typedef typename table::policy policy;
+        typedef typename table::node_pointer node_pointer;
+        typedef typename table::node_allocator node_allocator;
+        typedef typename table::node_allocator_traits node_allocator_traits;
+        typedef typename table::bucket_pointer bucket_pointer;
+        typedef typename table::link_pointer link_pointer;
+        typedef typename table::hasher hasher;
+        typedef typename table::key_equal key_equal;
+        typedef typename table::key_type key_type;
+        typedef typename table::node_constructor node_constructor;
+        typedef typename table::extractor extractor;
+        typedef typename table::iterator iterator;
+        typedef typename table::c_iterator c_iterator;
+
+        typedef std::pair<iterator, bool> emplace_return;
+
+        // Constructors
+
+        table_impl(std::size_t n,
+                hasher const& hf,
+                key_equal const& eq,
+                node_allocator const& a)
+          : table(n, hf, eq, a)
+        {}
+
+        table_impl(table_impl const& x)
+          : table(x, node_allocator_traits::
+                select_on_container_copy_construction(x.node_alloc()))
+        {
+            this->init(x);
+        }
+
+        table_impl(table_impl const& x,
+                node_allocator const& a)
+          : table(x, a)
+        {
+            this->init(x);
+        }
+
+        table_impl(table_impl& x,
+                boost::unordered::detail::move_tag m)
+          : table(x, m)
+        {}
+
+        table_impl(table_impl& x,
+                node_allocator const& a,
+                boost::unordered::detail::move_tag m)
+          : table(x, a, m)
+        {
+            this->move_init(x);
+        }
+
+        // Accessors
+
+        template <class Key, class Pred>
+        iterator find_node_impl(
+                std::size_t key_hash,
+                Key const& k,
+                Pred const& eq) const
+        {
+            std::size_t bucket_index = this->hash_to_bucket(key_hash);
+            iterator n = this->begin(bucket_index);
+
+            for (;;)
+            {
+                if (!n.node_) return n;
+
+                std::size_t node_hash = n.node_->hash_;
+                if (key_hash == node_hash)
+                {
+                    if (eq(k, this->get_key(*n)))
+                        return n;
+                }
+                else
+                {
+                    if (this->hash_to_bucket(node_hash) != bucket_index)
+                        return iterator();
+                }
+
+                ++n;
+            }
+        }
+
+        std::size_t count(key_type const& k) const
+        {
+            return this->find_node(k).node_ ? 1 : 0;
+        }
+
+        value_type& at(key_type const& k) const
+        {
+            if (this->size_) {
+                iterator it = this->find_node(k);
+                if (it.node_) return *it;
+            }
+
+            boost::throw_exception(
+                std::out_of_range("Unable to find key in unordered_map."));
+        }
+
+        std::pair<iterator, iterator>
+            equal_range(key_type const& k) const
+        {
+            iterator n = this->find_node(k);
+            iterator n2 = n;
+            if (n2.node_) ++n2;
+            return std::make_pair(n, n2);
+        }
+
+        // equals
+
+        bool equals(table_impl const& other) const
+        {
+            if(this->size_ != other.size_) return false;
+    
+            for(iterator n1 = this->begin(); n1.node_; ++n1)
+            {
+                iterator n2 = other.find_matching_node(n1);
+
+                if (!n2.node_ || *n1 != *n2)
+                    return false;
+            }
+    
+            return true;
+        }
+
+        // Emplace/Insert
+
+        inline iterator add_node(
+                node_constructor& a,
+                std::size_t key_hash)
+        {
+            node_pointer n = a.release();
+            n->hash_ = key_hash;
+    
+            bucket_pointer b = this->get_bucket(this->hash_to_bucket(key_hash));
+
+            if (!b->next_)
+            {
+                link_pointer start_node = this->get_previous_start();
+                
+                if (start_node->next_) {
+                    this->get_bucket(this->hash_to_bucket(
+                        static_cast<node_pointer>(start_node->next_)->hash_)
+                    )->next_ = n;
+                }
+
+                b->next_ = start_node;
+                n->next_ = start_node->next_;
+                start_node->next_ = n;
+            }
+            else
+            {
+                n->next_ = b->next_->next_;
+                b->next_->next_ = n;
+            }
+
+            ++this->size_;
+            return iterator(n);
+        }
+
+        value_type& operator[](key_type const& k)
+        {
+            std::size_t key_hash = this->hash(k);
+            iterator pos = this->find_node(key_hash, k);
+    
+            if (pos.node_) return *pos;
+    
+            // Create the node before rehashing in case it throws an
+            // exception (need strong safety in such a case).
+            node_constructor a(this->node_alloc());
+            a.construct_with_value(BOOST_UNORDERED_EMPLACE_ARGS3(
+                boost::unordered::piecewise_construct,
+                boost::make_tuple(k),
+                boost::make_tuple()));
+    
+            this->reserve_for_insert(this->size_ + 1);
+            return *add_node(a, key_hash);
+        }
+
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#   if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+        emplace_return emplace(boost::unordered::detail::emplace_args1<
+                boost::unordered::detail::please_ignore_this_overload> const&)
+        {
+            BOOST_ASSERT(false);
+            return emplace_return(this->begin(), false);
+        }
+#   else
+        emplace_return emplace(
+                boost::unordered::detail::please_ignore_this_overload const&)
+        {
+            BOOST_ASSERT(false);
+            return emplace_return(this->begin(), false);
+        }
+#   endif
+#endif
+
+        template <BOOST_UNORDERED_EMPLACE_TEMPLATE>
+        emplace_return emplace(BOOST_UNORDERED_EMPLACE_ARGS)
+        {
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+            return emplace_impl(
+                extractor::extract(BOOST_UNORDERED_EMPLACE_FORWARD),
+                BOOST_UNORDERED_EMPLACE_FORWARD);
+#else
+            return emplace_impl(
+                extractor::extract(args.a0, args.a1),
+                BOOST_UNORDERED_EMPLACE_FORWARD);
+#endif
+        }
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+        template <typename A0>
+        emplace_return emplace(
+                boost::unordered::detail::emplace_args1<A0> const& args)
+        {
+            return emplace_impl(extractor::extract(args.a0), args);
+        }
+#endif
+
+        template <BOOST_UNORDERED_EMPLACE_TEMPLATE>
+        emplace_return emplace_impl(key_type const& k,
+            BOOST_UNORDERED_EMPLACE_ARGS)
+        {
+            std::size_t key_hash = this->hash(k);
+            iterator pos = this->find_node(key_hash, k);
+    
+            if (pos.node_) return emplace_return(pos, false);
+    
+            // Create the node before rehashing in case it throws an
+            // exception (need strong safety in such a case).
+            node_constructor a(this->node_alloc());
+            a.construct_with_value(BOOST_UNORDERED_EMPLACE_FORWARD);
+    
+            // reserve has basic exception safety if the hash function
+            // throws, strong otherwise.
+            this->reserve_for_insert(this->size_ + 1);
+            return emplace_return(this->add_node(a, key_hash), true);
+        }
+
+        emplace_return emplace_impl_with_node(node_constructor& a)
+        {
+            key_type const& k = this->get_key(a.value());
+            std::size_t key_hash = this->hash(k);
+            iterator pos = this->find_node(key_hash, k);
+
+            if (pos.node_) return emplace_return(pos, false);
+
+            // reserve has basic exception safety if the hash function
+            // throws, strong otherwise.
+            this->reserve_for_insert(this->size_ + 1);
+            return emplace_return(this->add_node(a, key_hash), true);
+        }
+
+        template <BOOST_UNORDERED_EMPLACE_TEMPLATE>
+        emplace_return emplace_impl(no_key, BOOST_UNORDERED_EMPLACE_ARGS)
+        {
+            // Don't have a key, so construct the node first in order
+            // to be able to lookup the position.
+            node_constructor a(this->node_alloc());
+            a.construct_with_value(BOOST_UNORDERED_EMPLACE_FORWARD);
+            return emplace_impl_with_node(a);
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Insert range methods
+        //
+        // if hash function throws, or inserting > 1 element, basic exception
+        // safety strong otherwise
+
+        template <class InputIt>
+        void insert_range(InputIt i, InputIt j)
+        {
+            if(i != j)
+                return insert_range_impl(extractor::extract(*i), i, j);
+        }
+
+        template <class InputIt>
+        void insert_range_impl(key_type const& k, InputIt i, InputIt j)
+        {
+            node_constructor a(this->node_alloc());
+
+            insert_range_impl2(a, k, i, j);
+
+            while(++i != j) {
+                // Note: can't use get_key as '*i' might not be value_type - it
+                // could be a pair with first_types as key_type without const or
+                // a different second_type.
+                //
+                // TODO: Might be worth storing the value_type instead of the
+                // key here. Could be more efficient if '*i' is expensive. Could
+                // be less efficient if copying the full value_type is
+                // expensive.
+                insert_range_impl2(a, extractor::extract(*i), i, j);
+            }
+        }
+
+        template <class InputIt>
+        void insert_range_impl2(node_constructor& a, key_type const& k,
+            InputIt i, InputIt j)
+        {
+            // No side effects in this initial code
+            std::size_t key_hash = this->hash(k);
+            iterator pos = this->find_node(key_hash, k);
+    
+            if (!pos.node_) {
+                a.construct_with_value2(*i);
+                if(this->size_ + 1 > this->max_load_)
+                    this->reserve_for_insert(this->size_ +
+                        boost::unordered::detail::insert_size(i, j));
+    
+                // Nothing after this point can throw.
+                this->add_node(a, key_hash);
+            }
+        }
+
+        template <class InputIt>
+        void insert_range_impl(no_key, InputIt i, InputIt j)
+        {
+            node_constructor a(this->node_alloc());
+
+            do {
+                a.construct_with_value2(*i);
+                emplace_impl_with_node(a);
+            } while(++i != j);
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // Erase
+        //
+        // no throw
+
+        std::size_t erase_key(key_type const& k)
+        {
+            if(!this->size_) return 0;
+
+            std::size_t key_hash = this->hash(k);
+            std::size_t bucket_index = this->hash_to_bucket(key_hash);
+            link_pointer prev = this->get_previous_start(bucket_index);
+            if (!prev) return 0;
+
+            for (;;)
+            {
+                if (!prev->next_) return 0;
+                std::size_t node_hash =
+                    static_cast<node_pointer>(prev->next_)->hash_;
+                if (this->hash_to_bucket(node_hash) != bucket_index)
+                    return 0;
+                if (node_hash == key_hash &&
+                        this->key_eq()(k, this->get_key(
+                        static_cast<node_pointer>(prev->next_)->value())))
+                    break;
+                prev = prev->next_;
+            }
+
+            link_pointer end = static_cast<node_pointer>(prev->next_)->next_;
+
+            std::size_t deleted_count = this->delete_nodes(prev, end);
+            this->fix_bucket(bucket_index, prev);
+            return deleted_count;
+        }
+
+        iterator erase(c_iterator r)
+        {
+            BOOST_ASSERT(r.node_);
+            iterator next(r.node_);
+            ++next;
+            erase_nodes(r.node_, next.node_);
+            return next;
+        }
+
+        iterator erase_range(c_iterator r1, c_iterator r2)
+        {
+            if (r1 == r2) return iterator(r2.node_);
+            erase_nodes(r1.node_, r2.node_);
+            return iterator(r2.node_);
+        }
+
+        void erase_nodes(node_pointer i, node_pointer j)
+        {
+            std::size_t bucket_index = this->hash_to_bucket(i->hash_);
+
+            // Find the node before i.
+            link_pointer prev = this->get_previous_start(bucket_index);
+            while(prev->next_ != i) prev = prev->next_;
+
+            // Delete the nodes.
+            do {
+                this->delete_node(prev);
+                bucket_index = this->fix_bucket(bucket_index, prev);
+            } while (prev->next_ != j);
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // fill_buckets
+
+        template <class NodeCreator>
+        static void fill_buckets(iterator n, table& dst,
+            NodeCreator& creator)
+        {
+            link_pointer prev = dst.get_previous_start();
+
+            while (n.node_) {
+                node_pointer node = creator.create(*n);
+                node->hash_ = n.node_->hash_;
+                prev->next_ = node;
+                ++dst.size_;
+                ++n;
+
+                prev = place_in_bucket(dst, prev);
+            }
+        }
+
+        // strong otherwise exception safety
+        void rehash_impl(std::size_t num_buckets)
+        {
+            BOOST_ASSERT(this->buckets_);
+
+            this->create_buckets(num_buckets);
+            link_pointer prev = this->get_previous_start();
+            while (prev->next_)
+                prev = place_in_bucket(*this, prev);
+        }
+
+        // Iterate through the nodes placing them in the correct buckets.
+        // pre: prev->next_ is not null.
+        static link_pointer place_in_bucket(table& dst, link_pointer prev)
+        {
+            node_pointer n = static_cast<node_pointer>(prev->next_);
+            bucket_pointer b = dst.get_bucket(dst.hash_to_bucket(n->hash_));
+
+            if (!b->next_) {
+                b->next_ = prev;
+                return n;
+            }
+            else {
+                prev->next_ = n->next_;
+                n->next_ = b->next_->next_;
+                b->next_->next_ = n;
+                return prev;
+            }
+        }
+    };
+}}}
+
+#endif

--- a/ibtk/contrib/boost/boost/unordered/detail/util.hpp
+++ b/ibtk/contrib/boost/boost/unordered/detail/util.hpp
@@ -1,0 +1,266 @@
+
+// Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
+// Copyright (C) 2005-2011 Daniel James
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_UNORDERED_DETAIL_UTIL_HPP_INCLUDED
+#define BOOST_UNORDERED_DETAIL_UTIL_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/type_traits/is_convertible.hpp>
+#include <boost/type_traits/is_empty.hpp>
+#include <boost/iterator/iterator_categories.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/detail/select_type.hpp>
+#include <boost/move/move.hpp>
+#include <boost/preprocessor/seq/size.hpp>
+#include <boost/preprocessor/seq/enum.hpp>
+#include <boost/swap.hpp>
+
+namespace boost { namespace unordered { namespace detail {
+
+    static const float minimum_max_load_factor = 1e-3f;
+    static const std::size_t default_bucket_count = 11;
+    struct move_tag {};
+    struct empty_emplace {};
+
+    namespace func {
+        template <class T>
+        inline void ignore_unused_variable_warning(T const&) {}
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // iterator SFINAE
+
+    template <typename I>
+    struct is_forward :
+        boost::is_convertible<
+            typename boost::iterator_traversal<I>::type,
+            boost::forward_traversal_tag>
+    {};
+
+    template <typename I, typename ReturnType>
+    struct enable_if_forward :
+        boost::enable_if_c<
+            boost::unordered::detail::is_forward<I>::value,
+            ReturnType>
+    {};
+
+    template <typename I, typename ReturnType>
+    struct disable_if_forward :
+        boost::disable_if_c<
+            boost::unordered::detail::is_forward<I>::value,
+            ReturnType>
+    {};
+
+    ////////////////////////////////////////////////////////////////////////////
+    // primes
+
+#define BOOST_UNORDERED_PRIMES \
+    (17ul)(29ul)(37ul)(53ul)(67ul)(79ul) \
+    (97ul)(131ul)(193ul)(257ul)(389ul)(521ul)(769ul) \
+    (1031ul)(1543ul)(2053ul)(3079ul)(6151ul)(12289ul)(24593ul) \
+    (49157ul)(98317ul)(196613ul)(393241ul)(786433ul) \
+    (1572869ul)(3145739ul)(6291469ul)(12582917ul)(25165843ul) \
+    (50331653ul)(100663319ul)(201326611ul)(402653189ul)(805306457ul) \
+    (1610612741ul)(3221225473ul)(4294967291ul)
+
+    template<class T> struct prime_list_template
+    {
+        static std::size_t const value[];
+
+#if !defined(SUNPRO_CC)
+        static std::ptrdiff_t const length;
+#else
+        static std::ptrdiff_t const length
+            = BOOST_PP_SEQ_SIZE(BOOST_UNORDERED_PRIMES);
+#endif
+    };
+
+    template<class T>
+    std::size_t const prime_list_template<T>::value[] = {
+        BOOST_PP_SEQ_ENUM(BOOST_UNORDERED_PRIMES)
+    };
+
+#if !defined(SUNPRO_CC)
+    template<class T>
+    std::ptrdiff_t const prime_list_template<T>::length
+        = BOOST_PP_SEQ_SIZE(BOOST_UNORDERED_PRIMES);
+#endif
+
+#undef BOOST_UNORDERED_PRIMES
+
+    typedef prime_list_template<std::size_t> prime_list;
+
+    // no throw
+    inline std::size_t next_prime(std::size_t num) {
+        std::size_t const* const prime_list_begin = prime_list::value;
+        std::size_t const* const prime_list_end = prime_list_begin +
+            prime_list::length;
+        std::size_t const* bound =
+            std::lower_bound(prime_list_begin, prime_list_end, num);
+        if(bound == prime_list_end)
+            bound--;
+        return *bound;
+    }
+
+    // no throw
+    inline std::size_t prev_prime(std::size_t num) {
+        std::size_t const* const prime_list_begin = prime_list::value;
+        std::size_t const* const prime_list_end = prime_list_begin +
+            prime_list::length;
+        std::size_t const* bound =
+            std::upper_bound(prime_list_begin,prime_list_end, num);
+        if(bound != prime_list_begin)
+            bound--;
+        return *bound;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // insert_size/initial_size
+
+#if !defined(BOOST_NO_STD_DISTANCE)
+
+    using ::std::distance;
+
+#else
+
+    template <class ForwardIterator>
+    inline std::size_t distance(ForwardIterator i, ForwardIterator j) {
+        std::size_t x;
+        std::distance(i, j, x);
+        return x;
+    }
+
+#endif
+
+    template <class I>
+    inline typename
+        boost::unordered::detail::enable_if_forward<I, std::size_t>::type
+        insert_size(I i, I j)
+    {
+        return std::distance(i, j);
+    }
+
+    template <class I>
+    inline typename
+        boost::unordered::detail::disable_if_forward<I, std::size_t>::type
+        insert_size(I, I)
+    {
+        return 1;
+    }
+
+    template <class I>
+    inline std::size_t initial_size(I i, I j,
+        std::size_t num_buckets =
+            boost::unordered::detail::default_bucket_count)
+    {
+        // TODO: Why +1?
+        return (std::max)(
+            boost::unordered::detail::insert_size(i, j) + 1,
+            num_buckets);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // compressed
+
+    template <typename T, int Index>
+    struct compressed_base : private T
+    {
+        compressed_base(T const& x) : T(x) {}
+        compressed_base(T& x, move_tag) : T(boost::move(x)) {}
+
+        T& get() { return *this; }
+        T const& get() const { return *this; }
+    };
+    
+    template <typename T, int Index>
+    struct uncompressed_base
+    {
+        uncompressed_base(T const& x) : value_(x) {}
+        uncompressed_base(T& x, move_tag) : value_(boost::move(x)) {}
+
+        T& get() { return value_; }
+        T const& get() const { return value_; }
+    private:
+        T value_;
+    };
+    
+    template <typename T, int Index>
+    struct generate_base
+      : boost::detail::if_true<
+            boost::is_empty<T>::value
+        >:: BOOST_NESTED_TEMPLATE then<
+            boost::unordered::detail::compressed_base<T, Index>,
+            boost::unordered::detail::uncompressed_base<T, Index>
+        >
+    {};
+    
+    template <typename T1, typename T2>
+    struct compressed
+      : private boost::unordered::detail::generate_base<T1, 1>::type,
+        private boost::unordered::detail::generate_base<T2, 2>::type
+    {
+        typedef typename generate_base<T1, 1>::type base1;
+        typedef typename generate_base<T2, 2>::type base2;
+
+        typedef T1 first_type;
+        typedef T2 second_type;
+        
+        first_type& first() {
+            return static_cast<base1*>(this)->get();
+        }
+
+        first_type const& first() const {
+            return static_cast<base1 const*>(this)->get();
+        }
+
+        second_type& second() {
+            return static_cast<base2*>(this)->get();
+        }
+
+        second_type const& second() const {
+            return static_cast<base2 const*>(this)->get();
+        }
+
+        template <typename First, typename Second>
+        compressed(First const& x1, Second const& x2)
+            : base1(x1), base2(x2) {}
+
+        compressed(compressed const& x)
+            : base1(x.first()), base2(x.second()) {}
+
+        compressed(compressed& x, move_tag m)
+            : base1(x.first(), m), base2(x.second(), m) {}
+
+        void assign(compressed const& x)
+        {
+            first() = x.first();
+            second() = x.second();
+        }
+
+        void move_assign(compressed& x)
+        {
+            first() = boost::move(x.first());
+            second() = boost::move(x.second());
+        }
+        
+        void swap(compressed& x)
+        {
+            boost::swap(first(), x.first());
+            boost::swap(second(), x.second());
+        }
+
+    private:
+        // Prevent assignment just to make use of assign or
+        // move_assign explicit.
+        compressed& operator=(compressed const&);
+    };
+}}}
+
+#endif

--- a/ibtk/contrib/boost/boost/unordered/unordered_map.hpp
+++ b/ibtk/contrib/boost/boost/unordered/unordered_map.hpp
@@ -1,0 +1,1657 @@
+
+// Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
+// Copyright (C) 2005-2011 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/unordered for documentation
+
+#ifndef BOOST_UNORDERED_UNORDERED_MAP_HPP_INCLUDED
+#define BOOST_UNORDERED_UNORDERED_MAP_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/unordered/unordered_map_fwd.hpp>
+#include <boost/unordered/detail/equivalent.hpp>
+#include <boost/unordered/detail/unique.hpp>
+#include <boost/unordered/detail/util.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/move/move.hpp>
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+#include <initializer_list>
+#endif
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+#if BOOST_MSVC >= 1400
+#pragma warning(disable:4396) //the inline specifier cannot be used when a
+                              // friend declaration refers to a specialization
+                              // of a function template
+#endif
+#endif
+
+namespace boost
+{
+namespace unordered
+{
+    template <class K, class T, class H, class P, class A>
+    class unordered_map
+    {
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        BOOST_COPYABLE_AND_MOVABLE(unordered_map)
+#endif       
+
+    public:
+
+        typedef K key_type;
+        typedef std::pair<const K, T> value_type;
+        typedef T mapped_type;
+        typedef H hasher;
+        typedef P key_equal;
+        typedef A allocator_type;
+
+    private:
+
+        typedef boost::unordered::detail::map<A, K, T, H, P> types;
+        typedef typename types::traits allocator_traits;
+        typedef typename types::table table;
+
+    public:
+
+        typedef typename allocator_traits::pointer pointer;
+        typedef typename allocator_traits::const_pointer const_pointer;
+
+        typedef value_type& reference;
+        typedef value_type const& const_reference;
+
+        typedef std::size_t size_type;
+        typedef std::ptrdiff_t difference_type;
+
+        typedef typename table::cl_iterator const_local_iterator;
+        typedef typename table::l_iterator local_iterator;
+        typedef typename table::c_iterator const_iterator;
+        typedef typename table::iterator iterator;
+
+    private:
+
+        table table_;
+
+    public:
+
+        // constructors
+
+        explicit unordered_map(
+                size_type = boost::unordered::detail::default_bucket_count,
+                const hasher& = hasher(),
+                const key_equal& = key_equal(),
+                const allocator_type& = allocator_type());
+
+        explicit unordered_map(allocator_type const&);
+
+        template <class InputIt>
+        unordered_map(InputIt, InputIt);
+
+        template <class InputIt>
+        unordered_map(
+                InputIt, InputIt,
+                size_type,
+                const hasher& = hasher(),
+                const key_equal& = key_equal());
+
+        template <class InputIt>
+        unordered_map(
+                InputIt, InputIt,
+                size_type,
+                const hasher&,
+                const key_equal&,
+                const allocator_type&);
+
+        // copy/move constructors
+
+        unordered_map(unordered_map const&);
+
+        unordered_map(unordered_map const&, allocator_type const&);
+
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        unordered_map(BOOST_RV_REF(unordered_map) other)
+                BOOST_NOEXCEPT_IF(table::nothrow_move_constructible)
+            : table_(other.table_, boost::unordered::detail::move_tag())
+        {
+        }
+#elif !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_map(unordered_map&& other)
+                BOOST_NOEXCEPT_IF(table::nothrow_move_constructible)
+            : table_(other.table_, boost::unordered::detail::move_tag())
+        {
+        }
+#endif
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_map(unordered_map&&, allocator_type const&);
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        unordered_map(
+                std::initializer_list<value_type>,
+                size_type = boost::unordered::detail::default_bucket_count,
+                const hasher& = hasher(),
+                const key_equal&l = key_equal(),
+                const allocator_type& = allocator_type());
+#endif
+
+        // Destructor
+
+        ~unordered_map() BOOST_NOEXCEPT;
+
+        // Assign
+
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        unordered_map& operator=(BOOST_COPY_ASSIGN_REF(unordered_map) x)
+        {
+            table_.assign(x.table_);
+            return *this;
+        }
+
+        unordered_map& operator=(BOOST_RV_REF(unordered_map) x)
+        {
+            table_.move_assign(x.table_);
+            return *this;
+        }
+#else
+        unordered_map& operator=(unordered_map const& x)
+        {
+            table_.assign(x.table_);
+            return *this;
+        }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_map& operator=(unordered_map&& x)
+        {
+            table_.move_assign(x.table_);
+            return *this;
+        }
+#endif
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        unordered_map& operator=(std::initializer_list<value_type>);
+#endif
+
+        allocator_type get_allocator() const BOOST_NOEXCEPT
+        {
+            return table_.node_alloc();
+        }
+
+        // size and capacity
+
+        bool empty() const BOOST_NOEXCEPT
+        {
+            return table_.size_ == 0;
+        }
+
+        size_type size() const BOOST_NOEXCEPT
+        {
+            return table_.size_;
+        }
+
+        size_type max_size() const BOOST_NOEXCEPT;
+
+        // iterators
+
+        iterator begin() BOOST_NOEXCEPT
+        {
+            return table_.begin();
+        }
+
+        const_iterator begin() const BOOST_NOEXCEPT
+        {
+            return table_.begin();
+        }
+
+        iterator end() BOOST_NOEXCEPT
+        {
+            return iterator();
+        }
+
+        const_iterator end() const BOOST_NOEXCEPT
+        {
+            return const_iterator();
+        }
+
+        const_iterator cbegin() const BOOST_NOEXCEPT
+        {
+            return table_.begin();
+        }
+
+        const_iterator cend() const BOOST_NOEXCEPT
+        {
+            return const_iterator();
+        }
+
+        // emplace
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+        template <class... Args>
+        std::pair<iterator, bool> emplace(BOOST_FWD_REF(Args)... args)
+        {
+            return table_.emplace(boost::forward<Args>(args)...);
+        }
+
+        template <class... Args>
+        iterator emplace_hint(const_iterator, BOOST_FWD_REF(Args)... args)
+        {
+            return table_.emplace(boost::forward<Args>(args)...).first;
+        }
+#else
+
+#if !BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x5100))
+
+        // 0 argument emplace requires special treatment in case
+        // the container is instantiated with a value type that
+        // doesn't have a default constructor.
+
+        std::pair<iterator, bool> emplace(
+                boost::unordered::detail::empty_emplace
+                    = boost::unordered::detail::empty_emplace(),
+                value_type v = value_type())
+        {
+            return this->emplace(boost::move(v));
+        }
+
+        iterator emplace_hint(const_iterator hint,
+                boost::unordered::detail::empty_emplace
+                    = boost::unordered::detail::empty_emplace(),
+                value_type v = value_type()
+            )
+        {
+            return this->emplace_hint(hint, boost::move(v));
+        }
+
+#endif
+
+        template <typename A0>
+        std::pair<iterator, bool> emplace(BOOST_FWD_REF(A0) a0)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0))
+            );
+        }
+
+        template <typename A0>
+        iterator emplace_hint(const_iterator, BOOST_FWD_REF(A0) a0)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0))
+            ).first;
+        }
+
+        template <typename A0, typename A1>
+        std::pair<iterator, bool> emplace(
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1))
+            );
+        }
+
+        template <typename A0, typename A1>
+        iterator emplace_hint(const_iterator,
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1))
+            ).first;
+        }
+
+        template <typename A0, typename A1, typename A2>
+        std::pair<iterator, bool> emplace(
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1,
+            BOOST_FWD_REF(A2) a2)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1),
+                    boost::forward<A2>(a2))
+            );
+        }
+
+        template <typename A0, typename A1, typename A2>
+        iterator emplace_hint(const_iterator,
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1,
+            BOOST_FWD_REF(A2) a2)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1),
+                    boost::forward<A2>(a2))
+            ).first;
+        }
+
+#define BOOST_UNORDERED_EMPLACE(z, n, _)                                    \
+            template <                                                      \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)                    \
+            >                                                               \
+            std::pair<iterator, bool> emplace(                              \
+                    BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_FWD_PARAM, a)      \
+            )                                                               \
+            {                                                               \
+                return table_.emplace(                                      \
+                    boost::unordered::detail::create_emplace_args(          \
+                        BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_CALL_FORWARD,  \
+                            a)                                              \
+                ));                                                         \
+            }                                                               \
+                                                                            \
+            template <                                                      \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)                    \
+            >                                                               \
+            iterator emplace_hint(                                          \
+                    const_iterator,                                         \
+                    BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_FWD_PARAM, a)      \
+            )                                                               \
+            {                                                               \
+                return table_.emplace(                                      \
+                    boost::unordered::detail::create_emplace_args(          \
+                        BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_CALL_FORWARD,  \
+                            a)                                              \
+                )).first;                                                   \
+            }
+
+        BOOST_PP_REPEAT_FROM_TO(4, BOOST_UNORDERED_EMPLACE_LIMIT,
+            BOOST_UNORDERED_EMPLACE, _)
+
+#undef BOOST_UNORDERED_EMPLACE
+
+#endif
+
+        std::pair<iterator, bool> insert(value_type const& x)
+        {
+            return this->emplace(x);
+        }
+
+        std::pair<iterator, bool> insert(BOOST_RV_REF(value_type) x)
+        {
+            return this->emplace(boost::move(x));
+        }
+
+        iterator insert(const_iterator hint, value_type const& x)
+        {
+            return this->emplace_hint(hint, x);
+        }
+
+        iterator insert(const_iterator hint, BOOST_RV_REF(value_type) x)
+        {
+            return this->emplace_hint(hint, boost::move(x));
+        }
+
+        template <class InputIt> void insert(InputIt, InputIt);
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        void insert(std::initializer_list<value_type>);
+#endif
+
+        iterator erase(const_iterator);
+        size_type erase(const key_type&);
+        iterator erase(const_iterator, const_iterator);
+        void quick_erase(const_iterator it) { erase(it); }
+        void erase_return_void(const_iterator it) { erase(it); }
+
+        void clear();
+        void swap(unordered_map&);
+
+        // observers
+
+        hasher hash_function() const;
+        key_equal key_eq() const;
+
+        mapped_type& operator[](const key_type&);
+        mapped_type& at(const key_type&);
+        mapped_type const& at(const key_type&) const;
+
+        // lookup
+
+        iterator find(const key_type&);
+        const_iterator find(const key_type&) const;
+
+        template <class CompatibleKey, class CompatibleHash,
+            class CompatiblePredicate>
+        iterator find(
+                CompatibleKey const&,
+                CompatibleHash const&,
+                CompatiblePredicate const&);
+
+        template <class CompatibleKey, class CompatibleHash,
+            class CompatiblePredicate>
+        const_iterator find(
+                CompatibleKey const&,
+                CompatibleHash const&,
+                CompatiblePredicate const&) const;
+
+        size_type count(const key_type&) const;
+
+        std::pair<iterator, iterator>
+        equal_range(const key_type&);
+        std::pair<const_iterator, const_iterator>
+        equal_range(const key_type&) const;
+
+        // bucket interface
+
+        size_type bucket_count() const BOOST_NOEXCEPT
+        {
+            return table_.bucket_count_;
+        }
+
+        size_type max_bucket_count() const BOOST_NOEXCEPT
+        {
+            return table_.max_bucket_count();
+        }
+
+        size_type bucket_size(size_type) const;
+
+        size_type bucket(const key_type& k) const
+        {
+            return table_.hash_to_bucket(table_.hash(k));
+        }
+
+        local_iterator begin(size_type n)
+        {
+            return local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        const_local_iterator begin(size_type n) const
+        {
+            return const_local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        local_iterator end(size_type)
+        {
+            return local_iterator();
+        }
+
+        const_local_iterator end(size_type) const
+        {
+            return const_local_iterator();
+        }
+
+        const_local_iterator cbegin(size_type n) const
+        {
+            return const_local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        const_local_iterator cend(size_type) const
+        {
+            return const_local_iterator();
+        }
+
+        // hash policy
+
+        float max_load_factor() const BOOST_NOEXCEPT
+        {
+            return table_.mlf_;
+        }
+
+        float load_factor() const BOOST_NOEXCEPT;
+        void max_load_factor(float) BOOST_NOEXCEPT;
+        void rehash(size_type);
+        void reserve(size_type);
+
+#if !BOOST_WORKAROUND(__BORLANDC__, < 0x0582)
+        friend bool operator==<K,T,H,P,A>(
+                unordered_map const&, unordered_map const&);
+        friend bool operator!=<K,T,H,P,A>(
+                unordered_map const&, unordered_map const&);
+#endif
+    }; // class template unordered_map
+
+    template <class K, class T, class H, class P, class A>
+    class unordered_multimap
+    {
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        BOOST_COPYABLE_AND_MOVABLE(unordered_multimap)
+#endif
+    public:
+
+        typedef K key_type;
+        typedef std::pair<const K, T> value_type;
+        typedef T mapped_type;
+        typedef H hasher;
+        typedef P key_equal;
+        typedef A allocator_type;
+
+    private:
+
+        typedef boost::unordered::detail::multimap<A, K, T, H, P> types;
+        typedef typename types::traits allocator_traits;
+        typedef typename types::table table;
+
+    public:
+
+        typedef typename allocator_traits::pointer pointer;
+        typedef typename allocator_traits::const_pointer const_pointer;
+
+        typedef value_type& reference;
+        typedef value_type const& const_reference;
+
+        typedef std::size_t size_type;
+        typedef std::ptrdiff_t difference_type;
+
+        typedef typename table::cl_iterator const_local_iterator;
+        typedef typename table::l_iterator local_iterator;
+        typedef typename table::c_iterator const_iterator;
+        typedef typename table::iterator iterator;
+
+    private:
+
+        table table_;
+        
+    public:
+
+        // constructors
+
+        explicit unordered_multimap(
+                size_type = boost::unordered::detail::default_bucket_count,
+                const hasher& = hasher(),
+                const key_equal& = key_equal(),
+                const allocator_type& = allocator_type());
+
+        explicit unordered_multimap(allocator_type const&);
+
+        template <class InputIt>
+        unordered_multimap(InputIt, InputIt);
+
+        template <class InputIt>
+        unordered_multimap(
+                InputIt, InputIt,
+                size_type,
+                const hasher& = hasher(),
+                const key_equal& = key_equal());
+
+        template <class InputIt>
+        unordered_multimap(
+                InputIt, InputIt,
+                size_type,
+                const hasher&,
+                const key_equal&,
+                const allocator_type&);
+
+        // copy/move constructors
+
+        unordered_multimap(unordered_multimap const&);
+
+        unordered_multimap(unordered_multimap const&, allocator_type const&);
+
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        unordered_multimap(BOOST_RV_REF(unordered_multimap) other)
+                BOOST_NOEXCEPT_IF(table::nothrow_move_constructible)
+            : table_(other.table_, boost::unordered::detail::move_tag())
+        {
+        }
+#elif !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_multimap(unordered_multimap&& other)
+                BOOST_NOEXCEPT_IF(table::nothrow_move_constructible)
+            : table_(other.table_, boost::unordered::detail::move_tag())
+        {
+        }
+#endif
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_multimap(unordered_multimap&&, allocator_type const&);
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        unordered_multimap(
+                std::initializer_list<value_type>,
+                size_type = boost::unordered::detail::default_bucket_count,
+                const hasher& = hasher(),
+                const key_equal&l = key_equal(),
+                const allocator_type& = allocator_type());
+#endif
+
+        // Destructor
+
+        ~unordered_multimap() BOOST_NOEXCEPT;
+
+        // Assign
+
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        unordered_multimap& operator=(
+                BOOST_COPY_ASSIGN_REF(unordered_multimap) x)
+        {
+            table_.assign(x.table_);
+            return *this;
+        }
+
+        unordered_multimap& operator=(BOOST_RV_REF(unordered_multimap) x)
+        {
+            table_.move_assign(x.table_);
+            return *this;
+        }
+#else
+        unordered_multimap& operator=(unordered_multimap const& x)
+        {
+            table_.assign(x.table_);
+            return *this;
+        }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_multimap& operator=(unordered_multimap&& x)
+        {
+            table_.move_assign(x.table_);
+            return *this;
+        }
+#endif
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        unordered_multimap& operator=(std::initializer_list<value_type>);
+#endif
+
+        allocator_type get_allocator() const BOOST_NOEXCEPT
+        {
+            return table_.node_alloc();
+        }
+
+        // size and capacity
+
+        bool empty() const BOOST_NOEXCEPT
+        {
+            return table_.size_ == 0;
+        }
+
+        size_type size() const BOOST_NOEXCEPT
+        {
+            return table_.size_;
+        }
+
+        size_type max_size() const BOOST_NOEXCEPT;
+
+        // iterators
+
+        iterator begin() BOOST_NOEXCEPT
+        {
+            return table_.begin();
+        }
+
+        const_iterator begin() const BOOST_NOEXCEPT
+        {
+            return table_.begin();
+        }
+
+        iterator end() BOOST_NOEXCEPT
+        {
+            return iterator();
+        }
+
+        const_iterator end() const BOOST_NOEXCEPT
+        {
+            return const_iterator();
+        }
+
+        const_iterator cbegin() const BOOST_NOEXCEPT
+        {
+            return table_.begin();
+        }
+
+        const_iterator cend() const BOOST_NOEXCEPT
+        {
+            return const_iterator();
+        }
+
+        // emplace
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+        template <class... Args>
+        iterator emplace(BOOST_FWD_REF(Args)... args)
+        {
+            return table_.emplace(boost::forward<Args>(args)...);
+        }
+
+        template <class... Args>
+        iterator emplace_hint(const_iterator, BOOST_FWD_REF(Args)... args)
+        {
+            return table_.emplace(boost::forward<Args>(args)...);
+        }
+#else
+
+#if !BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x5100))
+
+        // 0 argument emplace requires special treatment in case
+        // the container is instantiated with a value type that
+        // doesn't have a default constructor.
+
+        iterator emplace(
+                boost::unordered::detail::empty_emplace
+                    = boost::unordered::detail::empty_emplace(),
+                value_type v = value_type())
+        {
+            return this->emplace(boost::move(v));
+        }
+
+        iterator emplace_hint(const_iterator hint,
+                boost::unordered::detail::empty_emplace
+                    = boost::unordered::detail::empty_emplace(),
+                value_type v = value_type()
+            )
+        {
+            return this->emplace_hint(hint, boost::move(v));
+        }
+
+#endif
+
+        template <typename A0>
+        iterator emplace(BOOST_FWD_REF(A0) a0)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0))
+            );
+        }
+
+        template <typename A0>
+        iterator emplace_hint(const_iterator, BOOST_FWD_REF(A0) a0)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0))
+            );
+        }
+
+        template <typename A0, typename A1>
+        iterator emplace(
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1))
+            );
+        }
+
+        template <typename A0, typename A1>
+        iterator emplace_hint(const_iterator,
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1))
+            );
+        }
+
+        template <typename A0, typename A1, typename A2>
+        iterator emplace(
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1,
+            BOOST_FWD_REF(A2) a2)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1),
+                    boost::forward<A2>(a2))
+            );
+        }
+
+        template <typename A0, typename A1, typename A2>
+        iterator emplace_hint(const_iterator,
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1,
+            BOOST_FWD_REF(A2) a2)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1),
+                    boost::forward<A2>(a2))
+            );
+        }
+
+#define BOOST_UNORDERED_EMPLACE(z, n, _)                                    \
+            template <                                                      \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)                    \
+            >                                                               \
+            iterator emplace(                                               \
+                    BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_FWD_PARAM, a)      \
+            )                                                               \
+            {                                                               \
+                return table_.emplace(                                      \
+                    boost::unordered::detail::create_emplace_args(          \
+                        BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_CALL_FORWARD,  \
+                            a)                                              \
+                ));                                                         \
+            }                                                               \
+                                                                            \
+            template <                                                      \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)                    \
+            >                                                               \
+            iterator emplace_hint(                                          \
+                    const_iterator,                                         \
+                    BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_FWD_PARAM, a)      \
+            )                                                               \
+            {                                                               \
+                return table_.emplace(                                      \
+                    boost::unordered::detail::create_emplace_args(          \
+                        BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_CALL_FORWARD,  \
+                            a)                                              \
+                ));                                                         \
+            }
+
+        BOOST_PP_REPEAT_FROM_TO(4, BOOST_UNORDERED_EMPLACE_LIMIT,
+            BOOST_UNORDERED_EMPLACE, _)
+
+#undef BOOST_UNORDERED_EMPLACE
+
+#endif
+
+        iterator insert(value_type const& x)
+        {
+            return this->emplace(x);
+        }
+
+        iterator insert(BOOST_RV_REF(value_type) x)
+        {
+            return this->emplace(boost::move(x));
+        }
+
+        iterator insert(const_iterator hint, value_type const& x)
+        {
+            return this->emplace_hint(hint, x);
+        }
+
+        iterator insert(const_iterator hint, BOOST_RV_REF(value_type) x)
+        {
+            return this->emplace_hint(hint, boost::move(x));
+        }
+
+        template <class InputIt> void insert(InputIt, InputIt);
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        void insert(std::initializer_list<value_type>);
+#endif
+
+        iterator erase(const_iterator);
+        size_type erase(const key_type&);
+        iterator erase(const_iterator, const_iterator);
+        void quick_erase(const_iterator it) { erase(it); }
+        void erase_return_void(const_iterator it) { erase(it); }
+
+        void clear();
+        void swap(unordered_multimap&);
+
+        // observers
+
+        hasher hash_function() const;
+        key_equal key_eq() const;
+
+        // lookup
+
+        iterator find(const key_type&);
+        const_iterator find(const key_type&) const;
+
+        template <class CompatibleKey, class CompatibleHash,
+            class CompatiblePredicate>
+        iterator find(
+                CompatibleKey const&,
+                CompatibleHash const&,
+                CompatiblePredicate const&);
+
+        template <class CompatibleKey, class CompatibleHash,
+            class CompatiblePredicate>
+        const_iterator find(
+                CompatibleKey const&,
+                CompatibleHash const&,
+                CompatiblePredicate const&) const;
+
+        size_type count(const key_type&) const;
+
+        std::pair<iterator, iterator>
+        equal_range(const key_type&);
+        std::pair<const_iterator, const_iterator>
+        equal_range(const key_type&) const;
+
+        // bucket interface
+
+        size_type bucket_count() const BOOST_NOEXCEPT
+        {
+            return table_.bucket_count_;
+        }
+
+        size_type max_bucket_count() const BOOST_NOEXCEPT
+        {
+            return table_.max_bucket_count();
+        }
+
+        size_type bucket_size(size_type) const;
+
+        size_type bucket(const key_type& k) const
+        {
+            return table_.hash_to_bucket(table_.hash(k));
+        }
+
+        local_iterator begin(size_type n)
+        {
+            return local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        const_local_iterator begin(size_type n) const
+        {
+            return const_local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        local_iterator end(size_type)
+        {
+            return local_iterator();
+        }
+
+        const_local_iterator end(size_type) const
+        {
+            return const_local_iterator();
+        }
+
+        const_local_iterator cbegin(size_type n) const
+        {
+            return const_local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        const_local_iterator cend(size_type) const
+        {
+            return const_local_iterator();
+        }
+
+        // hash policy
+
+        float max_load_factor() const BOOST_NOEXCEPT
+        {
+            return table_.mlf_;
+        }
+
+        float load_factor() const BOOST_NOEXCEPT;
+        void max_load_factor(float) BOOST_NOEXCEPT;
+        void rehash(size_type);
+        void reserve(size_type);
+
+#if !BOOST_WORKAROUND(__BORLANDC__, < 0x0582)
+        friend bool operator==<K,T,H,P,A>(
+                unordered_multimap const&, unordered_multimap const&);
+        friend bool operator!=<K,T,H,P,A>(
+                unordered_multimap const&, unordered_multimap const&);
+#endif
+    }; // class template unordered_multimap
+
+////////////////////////////////////////////////////////////////////////////////
+
+    template <class K, class T, class H, class P, class A>
+    unordered_map<K,T,H,P,A>::unordered_map(
+            size_type n, const hasher &hf, const key_equal &eql,
+            const allocator_type &a)
+      : table_(n, hf, eql, a)
+    {
+    }
+
+    template <class K, class T, class H, class P, class A>
+    unordered_map<K,T,H,P,A>::unordered_map(allocator_type const& a)
+      : table_(boost::unordered::detail::default_bucket_count,
+            hasher(), key_equal(), a)
+    {
+    }
+
+    template <class K, class T, class H, class P, class A>
+    unordered_map<K,T,H,P,A>::unordered_map(
+            unordered_map const& other, allocator_type const& a)
+      : table_(other.table_, a)
+    {
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_map<K,T,H,P,A>::unordered_map(InputIt f, InputIt l)
+      : table_(boost::unordered::detail::initial_size(f, l),
+        hasher(), key_equal(), allocator_type())
+    {
+        table_.insert_range(f, l);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_map<K,T,H,P,A>::unordered_map(
+            InputIt f, InputIt l,
+            size_type n,
+            const hasher &hf,
+            const key_equal &eql)
+      : table_(boost::unordered::detail::initial_size(f, l, n),
+            hf, eql, allocator_type())
+    {
+        table_.insert_range(f, l);
+    }
+    
+    template <class K, class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_map<K,T,H,P,A>::unordered_map(
+            InputIt f, InputIt l,
+            size_type n,
+            const hasher &hf,
+            const key_equal &eql,
+            const allocator_type &a)
+      : table_(boost::unordered::detail::initial_size(f, l, n), hf, eql, a)
+    {
+        table_.insert_range(f, l);
+    }
+    
+    template <class K, class T, class H, class P, class A>
+    unordered_map<K,T,H,P,A>::~unordered_map() BOOST_NOEXCEPT {}
+
+    template <class K, class T, class H, class P, class A>
+    unordered_map<K,T,H,P,A>::unordered_map(
+            unordered_map const& other)
+      : table_(other.table_)
+    {
+    }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+    template <class K, class T, class H, class P, class A>
+    unordered_map<K,T,H,P,A>::unordered_map(
+            unordered_map&& other, allocator_type const& a)
+      : table_(other.table_, a, boost::unordered::detail::move_tag())
+    {
+    }
+
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+
+    template <class K, class T, class H, class P, class A>
+    unordered_map<K,T,H,P,A>::unordered_map(
+            std::initializer_list<value_type> list, size_type n,
+            const hasher &hf, const key_equal &eql, const allocator_type &a)
+      : table_(
+            boost::unordered::detail::initial_size(
+                list.begin(), list.end(), n),
+            hf, eql, a)
+    {
+        table_.insert_range(list.begin(), list.end());
+    }
+
+    template <class K, class T, class H, class P, class A>
+    unordered_map<K,T,H,P,A>& unordered_map<K,T,H,P,A>::operator=(
+            std::initializer_list<value_type> list)
+    {
+        table_.clear();
+        table_.insert_range(list.begin(), list.end());
+        return *this;
+    }
+
+#endif
+
+    // size and capacity
+
+    template <class K, class T, class H, class P, class A>
+    std::size_t unordered_map<K,T,H,P,A>::max_size() const BOOST_NOEXCEPT
+    {
+        return table_.max_size();
+    }
+
+    // modifiers
+
+    template <class K, class T, class H, class P, class A>
+    template <class InputIt>
+    void unordered_map<K,T,H,P,A>::insert(InputIt first, InputIt last)
+    {
+        table_.insert_range(first, last);
+    }
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+    template <class K, class T, class H, class P, class A>
+    void unordered_map<K,T,H,P,A>::insert(
+            std::initializer_list<value_type> list)
+    {
+        table_.insert_range(list.begin(), list.end());
+    }
+#endif
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::iterator
+        unordered_map<K,T,H,P,A>::erase(const_iterator position)
+    {
+        return table_.erase(position);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::size_type
+        unordered_map<K,T,H,P,A>::erase(const key_type& k)
+    {
+        return table_.erase_key(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::iterator
+        unordered_map<K,T,H,P,A>::erase(
+            const_iterator first, const_iterator last)
+    {
+        return table_.erase_range(first, last);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    void unordered_map<K,T,H,P,A>::clear()
+    {
+        table_.clear();
+    }
+
+    template <class K, class T, class H, class P, class A>
+    void unordered_map<K,T,H,P,A>::swap(unordered_map& other)
+    {
+        table_.swap(other.table_);
+    }
+
+    // observers
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::hasher
+        unordered_map<K,T,H,P,A>::hash_function() const
+    {
+        return table_.hash_function();
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::key_equal
+        unordered_map<K,T,H,P,A>::key_eq() const
+    {
+        return table_.key_eq();
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::mapped_type&
+        unordered_map<K,T,H,P,A>::operator[](const key_type &k)
+    {
+        return table_[k].second;
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::mapped_type&
+        unordered_map<K,T,H,P,A>::at(const key_type& k)
+    {
+        return table_.at(k).second;
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::mapped_type const&
+        unordered_map<K,T,H,P,A>::at(const key_type& k) const
+    {
+        return table_.at(k).second;
+    }
+
+    // lookup
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::iterator
+        unordered_map<K,T,H,P,A>::find(const key_type& k)
+    {
+        return table_.find_node(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::const_iterator
+        unordered_map<K,T,H,P,A>::find(const key_type& k) const
+    {
+        return table_.find_node(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <class CompatibleKey, class CompatibleHash,
+        class CompatiblePredicate>
+    typename unordered_map<K,T,H,P,A>::iterator
+        unordered_map<K,T,H,P,A>::find(
+            CompatibleKey const& k,
+            CompatibleHash const& hash,
+            CompatiblePredicate const& eq)
+    {
+        return table_.generic_find_node(k, hash, eq);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <class CompatibleKey, class CompatibleHash,
+        class CompatiblePredicate>
+    typename unordered_map<K,T,H,P,A>::const_iterator
+        unordered_map<K,T,H,P,A>::find(
+            CompatibleKey const& k,
+            CompatibleHash const& hash,
+            CompatiblePredicate const& eq) const
+    {
+        return table_.generic_find_node(k, hash, eq);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::size_type
+        unordered_map<K,T,H,P,A>::count(const key_type& k) const
+    {
+        return table_.count(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    std::pair<
+            typename unordered_map<K,T,H,P,A>::iterator,
+            typename unordered_map<K,T,H,P,A>::iterator>
+        unordered_map<K,T,H,P,A>::equal_range(const key_type& k)
+    {
+        return table_.equal_range(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    std::pair<
+            typename unordered_map<K,T,H,P,A>::const_iterator,
+            typename unordered_map<K,T,H,P,A>::const_iterator>
+        unordered_map<K,T,H,P,A>::equal_range(const key_type& k) const
+    {
+        return table_.equal_range(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_map<K,T,H,P,A>::size_type
+        unordered_map<K,T,H,P,A>::bucket_size(size_type n) const
+    {
+        return table_.bucket_size(n);
+    }
+
+    // hash policy
+
+    template <class K, class T, class H, class P, class A>
+    float unordered_map<K,T,H,P,A>::load_factor() const BOOST_NOEXCEPT
+    {
+        return table_.load_factor();
+    }
+
+    template <class K, class T, class H, class P, class A>
+    void unordered_map<K,T,H,P,A>::max_load_factor(float m) BOOST_NOEXCEPT
+    {
+        table_.max_load_factor(m);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    void unordered_map<K,T,H,P,A>::rehash(size_type n)
+    {
+        table_.rehash(n);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    void unordered_map<K,T,H,P,A>::reserve(size_type n)
+    {
+        table_.reserve(n);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    inline bool operator==(
+            unordered_map<K,T,H,P,A> const& m1,
+            unordered_map<K,T,H,P,A> const& m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_map<K,T,H,P,A> x; };
+#endif
+        return m1.table_.equals(m2.table_);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    inline bool operator!=(
+            unordered_map<K,T,H,P,A> const& m1,
+            unordered_map<K,T,H,P,A> const& m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_map<K,T,H,P,A> x; };
+#endif
+        return !m1.table_.equals(m2.table_);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    inline void swap(
+            unordered_map<K,T,H,P,A> &m1,
+            unordered_map<K,T,H,P,A> &m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_map<K,T,H,P,A> x; };
+#endif
+        m1.swap(m2);
+    }
+
+////////////////////////////////////////////////////////////////////////////////
+
+    template <class K, class T, class H, class P, class A>
+    unordered_multimap<K,T,H,P,A>::unordered_multimap(
+            size_type n, const hasher &hf, const key_equal &eql,
+            const allocator_type &a)
+      : table_(n, hf, eql, a)
+    {
+    }
+
+    template <class K, class T, class H, class P, class A>
+    unordered_multimap<K,T,H,P,A>::unordered_multimap(allocator_type const& a)
+      : table_(boost::unordered::detail::default_bucket_count,
+            hasher(), key_equal(), a)
+    {
+    }
+
+    template <class K, class T, class H, class P, class A>
+    unordered_multimap<K,T,H,P,A>::unordered_multimap(
+            unordered_multimap const& other, allocator_type const& a)
+      : table_(other.table_, a)
+    {
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_multimap<K,T,H,P,A>::unordered_multimap(InputIt f, InputIt l)
+      : table_(boost::unordered::detail::initial_size(f, l),
+        hasher(), key_equal(), allocator_type())
+    {
+        table_.insert_range(f, l);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_multimap<K,T,H,P,A>::unordered_multimap(
+            InputIt f, InputIt l,
+            size_type n,
+            const hasher &hf,
+            const key_equal &eql)
+      : table_(boost::unordered::detail::initial_size(f, l, n),
+            hf, eql, allocator_type())
+    {
+        table_.insert_range(f, l);
+    }
+    
+    template <class K, class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_multimap<K,T,H,P,A>::unordered_multimap(
+            InputIt f, InputIt l,
+            size_type n,
+            const hasher &hf,
+            const key_equal &eql,
+            const allocator_type &a)
+      : table_(boost::unordered::detail::initial_size(f, l, n), hf, eql, a)
+    {
+        table_.insert_range(f, l);
+    }
+    
+    template <class K, class T, class H, class P, class A>
+    unordered_multimap<K,T,H,P,A>::~unordered_multimap() BOOST_NOEXCEPT {}
+
+    template <class K, class T, class H, class P, class A>
+    unordered_multimap<K,T,H,P,A>::unordered_multimap(
+            unordered_multimap const& other)
+      : table_(other.table_)
+    {
+    }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+    template <class K, class T, class H, class P, class A>
+    unordered_multimap<K,T,H,P,A>::unordered_multimap(
+            unordered_multimap&& other, allocator_type const& a)
+      : table_(other.table_, a, boost::unordered::detail::move_tag())
+    {
+    }
+
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+
+    template <class K, class T, class H, class P, class A>
+    unordered_multimap<K,T,H,P,A>::unordered_multimap(
+            std::initializer_list<value_type> list, size_type n,
+            const hasher &hf, const key_equal &eql, const allocator_type &a)
+      : table_(
+            boost::unordered::detail::initial_size(
+                list.begin(), list.end(), n),
+            hf, eql, a)
+    {
+        table_.insert_range(list.begin(), list.end());
+    }
+
+    template <class K, class T, class H, class P, class A>
+    unordered_multimap<K,T,H,P,A>& unordered_multimap<K,T,H,P,A>::operator=(
+            std::initializer_list<value_type> list)
+    {
+        table_.clear();
+        table_.insert_range(list.begin(), list.end());
+        return *this;
+    }
+
+#endif
+
+    // size and capacity
+
+    template <class K, class T, class H, class P, class A>
+    std::size_t unordered_multimap<K,T,H,P,A>::max_size() const BOOST_NOEXCEPT
+    {
+        return table_.max_size();
+    }
+
+    // modifiers
+
+    template <class K, class T, class H, class P, class A>
+    template <class InputIt>
+    void unordered_multimap<K,T,H,P,A>::insert(InputIt first, InputIt last)
+    {
+        table_.insert_range(first, last);
+    }
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+    template <class K, class T, class H, class P, class A>
+    void unordered_multimap<K,T,H,P,A>::insert(
+            std::initializer_list<value_type> list)
+    {
+        table_.insert_range(list.begin(), list.end());
+    }
+#endif
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_multimap<K,T,H,P,A>::iterator
+        unordered_multimap<K,T,H,P,A>::erase(const_iterator position)
+    {
+        return table_.erase(position);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_multimap<K,T,H,P,A>::size_type
+        unordered_multimap<K,T,H,P,A>::erase(const key_type& k)
+    {
+        return table_.erase_key(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_multimap<K,T,H,P,A>::iterator
+        unordered_multimap<K,T,H,P,A>::erase(
+            const_iterator first, const_iterator last)
+    {
+        return table_.erase_range(first, last);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    void unordered_multimap<K,T,H,P,A>::clear()
+    {
+        table_.clear();
+    }
+
+    template <class K, class T, class H, class P, class A>
+    void unordered_multimap<K,T,H,P,A>::swap(unordered_multimap& other)
+    {
+        table_.swap(other.table_);
+    }
+
+    // observers
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_multimap<K,T,H,P,A>::hasher
+        unordered_multimap<K,T,H,P,A>::hash_function() const
+    {
+        return table_.hash_function();
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_multimap<K,T,H,P,A>::key_equal
+        unordered_multimap<K,T,H,P,A>::key_eq() const
+    {
+        return table_.key_eq();
+    }
+
+    // lookup
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_multimap<K,T,H,P,A>::iterator
+        unordered_multimap<K,T,H,P,A>::find(const key_type& k)
+    {
+        return table_.find_node(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_multimap<K,T,H,P,A>::const_iterator
+        unordered_multimap<K,T,H,P,A>::find(const key_type& k) const
+    {
+        return table_.find_node(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <class CompatibleKey, class CompatibleHash,
+        class CompatiblePredicate>
+    typename unordered_multimap<K,T,H,P,A>::iterator
+        unordered_multimap<K,T,H,P,A>::find(
+            CompatibleKey const& k,
+            CompatibleHash const& hash,
+            CompatiblePredicate const& eq)
+    {
+        return table_.generic_find_node(k, hash, eq);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <class CompatibleKey, class CompatibleHash,
+        class CompatiblePredicate>
+    typename unordered_multimap<K,T,H,P,A>::const_iterator
+        unordered_multimap<K,T,H,P,A>::find(
+            CompatibleKey const& k,
+            CompatibleHash const& hash,
+            CompatiblePredicate const& eq) const
+    {
+        return table_.generic_find_node(k, hash, eq);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_multimap<K,T,H,P,A>::size_type
+        unordered_multimap<K,T,H,P,A>::count(const key_type& k) const
+    {
+        return table_.count(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    std::pair<
+            typename unordered_multimap<K,T,H,P,A>::iterator,
+            typename unordered_multimap<K,T,H,P,A>::iterator>
+        unordered_multimap<K,T,H,P,A>::equal_range(const key_type& k)
+    {
+        return table_.equal_range(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    std::pair<
+            typename unordered_multimap<K,T,H,P,A>::const_iterator,
+            typename unordered_multimap<K,T,H,P,A>::const_iterator>
+        unordered_multimap<K,T,H,P,A>::equal_range(const key_type& k) const
+    {
+        return table_.equal_range(k);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    typename unordered_multimap<K,T,H,P,A>::size_type
+        unordered_multimap<K,T,H,P,A>::bucket_size(size_type n) const
+    {
+        return table_.bucket_size(n);
+    }
+
+    // hash policy
+
+    template <class K, class T, class H, class P, class A>
+    float unordered_multimap<K,T,H,P,A>::load_factor() const BOOST_NOEXCEPT
+    {
+        return table_.load_factor();
+    }
+
+    template <class K, class T, class H, class P, class A>
+    void unordered_multimap<K,T,H,P,A>::max_load_factor(float m) BOOST_NOEXCEPT
+    {
+        table_.max_load_factor(m);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    void unordered_multimap<K,T,H,P,A>::rehash(size_type n)
+    {
+        table_.rehash(n);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    void unordered_multimap<K,T,H,P,A>::reserve(size_type n)
+    {
+        table_.reserve(n);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    inline bool operator==(
+            unordered_multimap<K,T,H,P,A> const& m1,
+            unordered_multimap<K,T,H,P,A> const& m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_multimap<K,T,H,P,A> x; };
+#endif
+        return m1.table_.equals(m2.table_);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    inline bool operator!=(
+            unordered_multimap<K,T,H,P,A> const& m1,
+            unordered_multimap<K,T,H,P,A> const& m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_multimap<K,T,H,P,A> x; };
+#endif
+        return !m1.table_.equals(m2.table_);
+    }
+
+    template <class K, class T, class H, class P, class A>
+    inline void swap(
+            unordered_multimap<K,T,H,P,A> &m1,
+            unordered_multimap<K,T,H,P,A> &m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_multimap<K,T,H,P,A> x; };
+#endif
+        m1.swap(m2);
+    }
+
+} // namespace unordered
+} // namespace boost
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+#endif // BOOST_UNORDERED_UNORDERED_MAP_HPP_INCLUDED

--- a/ibtk/contrib/boost/boost/unordered/unordered_map_fwd.hpp
+++ b/ibtk/contrib/boost/boost/unordered/unordered_map_fwd.hpp
@@ -1,0 +1,65 @@
+
+// Copyright (C) 2008-2011 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_UNORDERED_MAP_FWD_HPP_INCLUDED
+#define BOOST_UNORDERED_MAP_FWD_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <memory>
+#include <functional>
+#include <boost/functional/hash_fwd.hpp>
+#include <boost/unordered/detail/fwd.hpp>
+
+namespace boost
+{
+    namespace unordered
+    {
+        template <class K,
+            class T,
+            class H = boost::hash<K>,
+            class P = std::equal_to<K>,
+            class A = std::allocator<std::pair<const K, T> > >
+        class unordered_map;
+
+        template <class K, class T, class H, class P, class A>
+        inline bool operator==(unordered_map<K, T, H, P, A> const&,
+            unordered_map<K, T, H, P, A> const&);
+        template <class K, class T, class H, class P, class A>
+        inline bool operator!=(unordered_map<K, T, H, P, A> const&,
+            unordered_map<K, T, H, P, A> const&);
+        template <class K, class T, class H, class P, class A>
+        inline void swap(unordered_map<K, T, H, P, A>&,
+                unordered_map<K, T, H, P, A>&);
+
+        template <class K,
+            class T,
+            class H = boost::hash<K>,
+            class P = std::equal_to<K>,
+            class A = std::allocator<std::pair<const K, T> > >
+        class unordered_multimap;
+
+        template <class K, class T, class H, class P, class A>
+        inline bool operator==(unordered_multimap<K, T, H, P, A> const&,
+            unordered_multimap<K, T, H, P, A> const&);
+        template <class K, class T, class H, class P, class A>
+        inline bool operator!=(unordered_multimap<K, T, H, P, A> const&,
+            unordered_multimap<K, T, H, P, A> const&);
+        template <class K, class T, class H, class P, class A>
+        inline void swap(unordered_multimap<K, T, H, P, A>&,
+                unordered_multimap<K, T, H, P, A>&);
+    }
+
+    using boost::unordered::unordered_map;
+    using boost::unordered::unordered_multimap;
+    using boost::unordered::swap;
+    using boost::unordered::operator==;
+    using boost::unordered::operator!=;
+}
+
+#endif

--- a/ibtk/contrib/boost/boost/unordered/unordered_set.hpp
+++ b/ibtk/contrib/boost/boost/unordered/unordered_set.hpp
@@ -1,0 +1,1554 @@
+
+// Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
+// Copyright (C) 2005-2011 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/unordered for documentation
+
+#ifndef BOOST_UNORDERED_UNORDERED_SET_HPP_INCLUDED
+#define BOOST_UNORDERED_UNORDERED_SET_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/unordered/unordered_set_fwd.hpp>
+#include <boost/unordered/detail/equivalent.hpp>
+#include <boost/unordered/detail/unique.hpp>
+#include <boost/unordered/detail/util.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/move/move.hpp>
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+#include <initializer_list>
+#endif
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+#if BOOST_MSVC >= 1400
+#pragma warning(disable:4396) //the inline specifier cannot be used when a
+                              // friend declaration refers to a specialization
+                              // of a function template
+#endif
+#endif
+
+namespace boost
+{
+namespace unordered
+{
+    template <class T, class H, class P, class A>
+    class unordered_set
+    {
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        BOOST_COPYABLE_AND_MOVABLE(unordered_set)
+#endif
+    public:
+
+        typedef T key_type;
+        typedef T value_type;
+        typedef H hasher;
+        typedef P key_equal;
+        typedef A allocator_type;
+
+    private:
+
+        typedef boost::unordered::detail::set<A, T, H, P> types;
+        typedef typename types::traits allocator_traits;
+        typedef typename types::table table;
+
+    public:
+
+        typedef typename allocator_traits::pointer pointer;
+        typedef typename allocator_traits::const_pointer const_pointer;
+
+        typedef value_type& reference;
+        typedef value_type const& const_reference;
+
+        typedef std::size_t size_type;
+        typedef std::ptrdiff_t difference_type;
+
+        typedef typename table::cl_iterator const_local_iterator;
+        typedef typename table::cl_iterator local_iterator;
+        typedef typename table::c_iterator const_iterator;
+        typedef typename table::c_iterator iterator;
+
+    private:
+
+        table table_;
+
+    public:
+
+        // constructors
+
+        explicit unordered_set(
+                size_type = boost::unordered::detail::default_bucket_count,
+                const hasher& = hasher(),
+                const key_equal& = key_equal(),
+                const allocator_type& = allocator_type());
+
+        explicit unordered_set(allocator_type const&);
+
+        template <class InputIt>
+        unordered_set(InputIt, InputIt);
+
+        template <class InputIt>
+        unordered_set(
+                InputIt, InputIt,
+                size_type,
+                const hasher& = hasher(),
+                const key_equal& = key_equal());
+
+        template <class InputIt>
+        unordered_set(
+                InputIt, InputIt,
+                size_type,
+                const hasher&,
+                const key_equal&,
+                const allocator_type&);
+
+        // copy/move constructors
+
+        unordered_set(unordered_set const&);
+
+        unordered_set(unordered_set const&, allocator_type const&);
+
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        unordered_set(BOOST_RV_REF(unordered_set) other)
+                BOOST_NOEXCEPT_IF(table::nothrow_move_constructible)
+            : table_(other.table_, boost::unordered::detail::move_tag())
+        {
+        }
+#elif !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_set(unordered_set&& other)
+                BOOST_NOEXCEPT_IF(table::nothrow_move_constructible)
+            : table_(other.table_, boost::unordered::detail::move_tag())
+        {
+        }
+#endif
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_set(unordered_set&&, allocator_type const&);
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        unordered_set(
+                std::initializer_list<value_type>,
+                size_type = boost::unordered::detail::default_bucket_count,
+                const hasher& = hasher(),
+                const key_equal&l = key_equal(),
+                const allocator_type& = allocator_type());
+#endif
+
+        // Destructor
+
+        ~unordered_set() BOOST_NOEXCEPT;
+
+        // Assign
+
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        unordered_set& operator=(BOOST_COPY_ASSIGN_REF(unordered_set) x)
+        {
+            table_.assign(x.table_);
+            return *this;
+        }
+
+        unordered_set& operator=(BOOST_RV_REF(unordered_set) x)
+        {
+            table_.move_assign(x.table_);
+            return *this;
+        }
+#else
+        unordered_set& operator=(unordered_set const& x)
+        {
+            table_.assign(x.table_);
+            return *this;
+        }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_set& operator=(unordered_set&& x)
+        {
+            table_.move_assign(x.table_);
+            return *this;
+        }
+#endif
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        unordered_set& operator=(std::initializer_list<value_type>);
+#endif
+
+        allocator_type get_allocator() const BOOST_NOEXCEPT
+        {
+            return table_.node_alloc();
+        }
+
+        // size and capacity
+
+        bool empty() const BOOST_NOEXCEPT
+        {
+            return table_.size_ == 0;
+        }
+
+        size_type size() const BOOST_NOEXCEPT
+        {
+            return table_.size_;
+        }
+
+        size_type max_size() const BOOST_NOEXCEPT;
+
+        // iterators
+
+        iterator begin() BOOST_NOEXCEPT
+        {
+            return table_.begin();
+        }
+
+        const_iterator begin() const BOOST_NOEXCEPT
+        {
+            return table_.begin();
+        }
+
+        iterator end() BOOST_NOEXCEPT
+        {
+            return iterator();
+        }
+
+        const_iterator end() const BOOST_NOEXCEPT
+        {
+            return const_iterator();
+        }
+
+        const_iterator cbegin() const BOOST_NOEXCEPT
+        {
+            return table_.begin();
+        }
+
+        const_iterator cend() const BOOST_NOEXCEPT
+        {
+            return const_iterator();
+        }
+
+        // emplace
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+        template <class... Args>
+        std::pair<iterator, bool> emplace(BOOST_FWD_REF(Args)... args)
+        {
+            return table_.emplace(boost::forward<Args>(args)...);
+        }
+
+        template <class... Args>
+        iterator emplace_hint(const_iterator, BOOST_FWD_REF(Args)... args)
+        {
+            return table_.emplace(boost::forward<Args>(args)...).first;
+        }
+#else
+
+#if !BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x5100))
+
+        // 0 argument emplace requires special treatment in case
+        // the container is instantiated with a value type that
+        // doesn't have a default constructor.
+
+        std::pair<iterator, bool> emplace(
+                boost::unordered::detail::empty_emplace
+                    = boost::unordered::detail::empty_emplace(),
+                value_type v = value_type())
+        {
+            return this->emplace(boost::move(v));
+        }
+
+        iterator emplace_hint(const_iterator hint,
+                boost::unordered::detail::empty_emplace
+                    = boost::unordered::detail::empty_emplace(),
+                value_type v = value_type()
+            )
+        {
+            return this->emplace_hint(hint, boost::move(v));
+        }
+
+#endif
+
+        template <typename A0>
+        std::pair<iterator, bool> emplace(BOOST_FWD_REF(A0) a0)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0))
+            );
+        }
+
+        template <typename A0>
+        iterator emplace_hint(const_iterator, BOOST_FWD_REF(A0) a0)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0))
+            ).first;
+        }
+
+        template <typename A0, typename A1>
+        std::pair<iterator, bool> emplace(
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1))
+            );
+        }
+
+        template <typename A0, typename A1>
+        iterator emplace_hint(const_iterator,
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1))
+            ).first;
+        }
+
+        template <typename A0, typename A1, typename A2>
+        std::pair<iterator, bool> emplace(
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1,
+            BOOST_FWD_REF(A2) a2)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1),
+                    boost::forward<A2>(a2))
+            );
+        }
+
+        template <typename A0, typename A1, typename A2>
+        iterator emplace_hint(const_iterator,
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1,
+            BOOST_FWD_REF(A2) a2)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1),
+                    boost::forward<A2>(a2))
+            ).first;
+        }
+
+#define BOOST_UNORDERED_EMPLACE(z, n, _)                                    \
+            template <                                                      \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)                    \
+            >                                                               \
+            std::pair<iterator, bool> emplace(                              \
+                    BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_FWD_PARAM, a)      \
+            )                                                               \
+            {                                                               \
+                return table_.emplace(                                      \
+                    boost::unordered::detail::create_emplace_args(          \
+                        BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_CALL_FORWARD,  \
+                            a)                                              \
+                ));                                                         \
+            }                                                               \
+                                                                            \
+            template <                                                      \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)                    \
+            >                                                               \
+            iterator emplace_hint(                                          \
+                    const_iterator,                                         \
+                    BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_FWD_PARAM, a)      \
+            )                                                               \
+            {                                                               \
+                return table_.emplace(                                      \
+                    boost::unordered::detail::create_emplace_args(          \
+                        BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_CALL_FORWARD,  \
+                            a)                                              \
+                )).first;                                                   \
+            }
+
+        BOOST_PP_REPEAT_FROM_TO(4, BOOST_UNORDERED_EMPLACE_LIMIT,
+            BOOST_UNORDERED_EMPLACE, _)
+
+#undef BOOST_UNORDERED_EMPLACE
+
+#endif
+
+        std::pair<iterator, bool> insert(value_type const& x)
+        {
+            return this->emplace(x);
+        }
+
+        std::pair<iterator, bool> insert(BOOST_UNORDERED_RV_REF(value_type) x)
+        {
+            return this->emplace(boost::move(x));
+        }
+
+        iterator insert(const_iterator hint, value_type const& x)
+        {
+            return this->emplace_hint(hint, x);
+        }
+
+        iterator insert(const_iterator hint,
+                BOOST_UNORDERED_RV_REF(value_type) x)
+        {
+            return this->emplace_hint(hint, boost::move(x));
+        }
+
+        template <class InputIt> void insert(InputIt, InputIt);
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        void insert(std::initializer_list<value_type>);
+#endif
+
+        iterator erase(const_iterator);
+        size_type erase(const key_type&);
+        iterator erase(const_iterator, const_iterator);
+        void quick_erase(const_iterator it) { erase(it); }
+        void erase_return_void(const_iterator it) { erase(it); }
+
+        void clear();
+        void swap(unordered_set&);
+
+        // observers
+
+        hasher hash_function() const;
+        key_equal key_eq() const;
+
+        // lookup
+
+        const_iterator find(const key_type&) const;
+
+        template <class CompatibleKey, class CompatibleHash,
+            class CompatiblePredicate>
+        const_iterator find(
+                CompatibleKey const&,
+                CompatibleHash const&,
+                CompatiblePredicate const&) const;
+
+        size_type count(const key_type&) const;
+
+        std::pair<const_iterator, const_iterator>
+        equal_range(const key_type&) const;
+
+        // bucket interface
+
+        size_type bucket_count() const BOOST_NOEXCEPT
+        {
+            return table_.bucket_count_;
+        }
+
+        size_type max_bucket_count() const BOOST_NOEXCEPT
+        {
+            return table_.max_bucket_count();
+        }
+
+        size_type bucket_size(size_type) const;
+
+        size_type bucket(const key_type& k) const
+        {
+            return table_.hash_to_bucket(table_.hash(k));
+        }
+
+        local_iterator begin(size_type n)
+        {
+            return local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        const_local_iterator begin(size_type n) const
+        {
+            return const_local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        local_iterator end(size_type)
+        {
+            return local_iterator();
+        }
+
+        const_local_iterator end(size_type) const
+        {
+            return const_local_iterator();
+        }
+
+        const_local_iterator cbegin(size_type n) const
+        {
+            return const_local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        const_local_iterator cend(size_type) const
+        {
+            return const_local_iterator();
+        }
+
+        // hash policy
+
+        float max_load_factor() const BOOST_NOEXCEPT
+        {
+            return table_.mlf_;
+        }
+
+        float load_factor() const BOOST_NOEXCEPT;
+        void max_load_factor(float) BOOST_NOEXCEPT;
+        void rehash(size_type);
+        void reserve(size_type);
+
+#if !BOOST_WORKAROUND(__BORLANDC__, < 0x0582)
+        friend bool operator==<T,H,P,A>(
+                unordered_set const&, unordered_set const&);
+        friend bool operator!=<T,H,P,A>(
+                unordered_set const&, unordered_set const&);
+#endif
+    }; // class template unordered_set
+
+    template <class T, class H, class P, class A>
+    class unordered_multiset
+    {
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        BOOST_COPYABLE_AND_MOVABLE(unordered_multiset)
+#endif
+    public:
+
+        typedef T key_type;
+        typedef T value_type;
+        typedef H hasher;
+        typedef P key_equal;
+        typedef A allocator_type;
+
+    private:
+
+        typedef boost::unordered::detail::multiset<A, T, H, P> types;
+        typedef typename types::traits allocator_traits;
+        typedef typename types::table table;
+
+    public:
+
+        typedef typename allocator_traits::pointer pointer;
+        typedef typename allocator_traits::const_pointer const_pointer;
+
+        typedef value_type& reference;
+        typedef value_type const& const_reference;
+
+        typedef std::size_t size_type;
+        typedef std::ptrdiff_t difference_type;
+
+        typedef typename table::cl_iterator const_local_iterator;
+        typedef typename table::cl_iterator local_iterator;
+        typedef typename table::c_iterator const_iterator;
+        typedef typename table::c_iterator iterator;
+
+    private:
+
+        table table_;
+
+    public:
+
+        // constructors
+
+        explicit unordered_multiset(
+                size_type = boost::unordered::detail::default_bucket_count,
+                const hasher& = hasher(),
+                const key_equal& = key_equal(),
+                const allocator_type& = allocator_type());
+
+        explicit unordered_multiset(allocator_type const&);
+
+        template <class InputIt>
+        unordered_multiset(InputIt, InputIt);
+
+        template <class InputIt>
+        unordered_multiset(
+                InputIt, InputIt,
+                size_type,
+                const hasher& = hasher(),
+                const key_equal& = key_equal());
+
+        template <class InputIt>
+        unordered_multiset(
+                InputIt, InputIt,
+                size_type,
+                const hasher&,
+                const key_equal&,
+                const allocator_type&);
+
+        // copy/move constructors
+
+        unordered_multiset(unordered_multiset const&);
+
+        unordered_multiset(unordered_multiset const&, allocator_type const&);
+
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        unordered_multiset(BOOST_RV_REF(unordered_multiset) other)
+                BOOST_NOEXCEPT_IF(table::nothrow_move_constructible)
+            : table_(other.table_, boost::unordered::detail::move_tag())
+        {
+        }
+#elif !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_multiset(unordered_multiset&& other)
+                BOOST_NOEXCEPT_IF(table::nothrow_move_constructible)
+            : table_(other.table_, boost::unordered::detail::move_tag())
+        {
+        }
+#endif
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_multiset(unordered_multiset&&, allocator_type const&);
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        unordered_multiset(
+                std::initializer_list<value_type>,
+                size_type = boost::unordered::detail::default_bucket_count,
+                const hasher& = hasher(),
+                const key_equal&l = key_equal(),
+                const allocator_type& = allocator_type());
+#endif
+
+        // Destructor
+
+        ~unordered_multiset() BOOST_NOEXCEPT;
+
+        // Assign
+
+#if defined(BOOST_UNORDERED_USE_MOVE)
+        unordered_multiset& operator=(
+                BOOST_COPY_ASSIGN_REF(unordered_multiset) x)
+        {
+            table_.assign(x.table_);
+            return *this;
+        }
+
+        unordered_multiset& operator=(BOOST_RV_REF(unordered_multiset) x)
+        {
+            table_.move_assign(x.table_);
+            return *this;
+        }
+#else
+        unordered_multiset& operator=(unordered_multiset const& x)
+        {
+            table_.assign(x.table_);
+            return *this;
+        }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        unordered_multiset& operator=(unordered_multiset&& x)
+        {
+            table_.move_assign(x.table_);
+            return *this;
+        }
+#endif
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        unordered_multiset& operator=(std::initializer_list<value_type>);
+#endif
+
+        allocator_type get_allocator() const BOOST_NOEXCEPT
+        {
+            return table_.node_alloc();
+        }
+
+        // size and capacity
+
+        bool empty() const BOOST_NOEXCEPT
+        {
+            return table_.size_ == 0;
+        }
+
+        size_type size() const BOOST_NOEXCEPT
+        {
+            return table_.size_;
+        }
+
+        size_type max_size() const BOOST_NOEXCEPT;
+
+        // iterators
+
+        iterator begin() BOOST_NOEXCEPT
+        {
+            return iterator(table_.begin());
+        }
+
+        const_iterator begin() const BOOST_NOEXCEPT
+        {
+            return const_iterator(table_.begin());
+        }
+
+        iterator end() BOOST_NOEXCEPT
+        {
+            return iterator();
+        }
+
+        const_iterator end() const BOOST_NOEXCEPT
+        {
+            return const_iterator();
+        }
+
+        const_iterator cbegin() const BOOST_NOEXCEPT
+        {
+            return const_iterator(table_.begin());
+        }
+
+        const_iterator cend() const BOOST_NOEXCEPT
+        {
+            return const_iterator();
+        }
+
+        // emplace
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+        template <class... Args>
+        iterator emplace(BOOST_FWD_REF(Args)... args)
+        {
+            return table_.emplace(boost::forward<Args>(args)...);
+        }
+
+        template <class... Args>
+        iterator emplace_hint(const_iterator, BOOST_FWD_REF(Args)... args)
+        {
+            return table_.emplace(boost::forward<Args>(args)...);
+        }
+#else
+
+#if !BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x5100))
+
+        // 0 argument emplace requires special treatment in case
+        // the container is instantiated with a value type that
+        // doesn't have a default constructor.
+
+        iterator emplace(
+                boost::unordered::detail::empty_emplace
+                    = boost::unordered::detail::empty_emplace(),
+                value_type v = value_type())
+        {
+            return this->emplace(boost::move(v));
+        }
+
+        iterator emplace_hint(const_iterator hint,
+                boost::unordered::detail::empty_emplace
+                    = boost::unordered::detail::empty_emplace(),
+                value_type v = value_type()
+            )
+        {
+            return this->emplace_hint(hint, boost::move(v));
+        }
+
+#endif
+
+        template <typename A0>
+        iterator emplace(BOOST_FWD_REF(A0) a0)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0))
+            );
+        }
+
+        template <typename A0>
+        iterator emplace_hint(const_iterator, BOOST_FWD_REF(A0) a0)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0))
+            );
+        }
+
+        template <typename A0, typename A1>
+        iterator emplace(
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1))
+            );
+        }
+
+        template <typename A0, typename A1>
+        iterator emplace_hint(const_iterator,
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1))
+            );
+        }
+
+        template <typename A0, typename A1, typename A2>
+        iterator emplace(
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1,
+            BOOST_FWD_REF(A2) a2)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1),
+                    boost::forward<A2>(a2))
+            );
+        }
+
+        template <typename A0, typename A1, typename A2>
+        iterator emplace_hint(const_iterator,
+            BOOST_FWD_REF(A0) a0,
+            BOOST_FWD_REF(A1) a1,
+            BOOST_FWD_REF(A2) a2)
+        {
+            return table_.emplace(
+                boost::unordered::detail::create_emplace_args(
+                    boost::forward<A0>(a0),
+                    boost::forward<A1>(a1),
+                    boost::forward<A2>(a2))
+            );
+        }
+
+#define BOOST_UNORDERED_EMPLACE(z, n, _)                                    \
+            template <                                                      \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)                    \
+            >                                                               \
+            iterator emplace(                                               \
+                    BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_FWD_PARAM, a)      \
+            )                                                               \
+            {                                                               \
+                return table_.emplace(                                      \
+                    boost::unordered::detail::create_emplace_args(          \
+                        BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_CALL_FORWARD,  \
+                            a)                                              \
+                ));                                                         \
+            }                                                               \
+                                                                            \
+            template <                                                      \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, typename A)                    \
+            >                                                               \
+            iterator emplace_hint(                                          \
+                    const_iterator,                                         \
+                    BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_FWD_PARAM, a)      \
+            )                                                               \
+            {                                                               \
+                return table_.emplace(                                      \
+                    boost::unordered::detail::create_emplace_args(          \
+                        BOOST_PP_ENUM_##z(n, BOOST_UNORDERED_CALL_FORWARD,  \
+                            a)                                              \
+                ));                                                         \
+            }
+
+        BOOST_PP_REPEAT_FROM_TO(4, BOOST_UNORDERED_EMPLACE_LIMIT,
+            BOOST_UNORDERED_EMPLACE, _)
+
+#undef BOOST_UNORDERED_EMPLACE
+
+#endif
+
+        iterator insert(value_type const& x)
+        {
+            return this->emplace(x);
+        }
+
+        iterator insert(BOOST_UNORDERED_RV_REF(value_type) x)
+        {
+            return this->emplace(boost::move(x));
+        }
+
+        iterator insert(const_iterator hint, value_type const& x)
+        {
+            return this->emplace_hint(hint, x);
+        }
+
+        iterator insert(const_iterator hint,
+                BOOST_UNORDERED_RV_REF(value_type) x)
+        {
+            return this->emplace_hint(hint, boost::move(x));
+        }
+
+        template <class InputIt> void insert(InputIt, InputIt);
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+        void insert(std::initializer_list<value_type>);
+#endif
+
+        iterator erase(const_iterator);
+        size_type erase(const key_type&);
+        iterator erase(const_iterator, const_iterator);
+        void quick_erase(const_iterator it) { erase(it); }
+        void erase_return_void(const_iterator it) { erase(it); }
+
+        void clear();
+        void swap(unordered_multiset&);
+
+        // observers
+
+        hasher hash_function() const;
+        key_equal key_eq() const;
+
+        // lookup
+
+        const_iterator find(const key_type&) const;
+
+        template <class CompatibleKey, class CompatibleHash,
+            class CompatiblePredicate>
+        const_iterator find(
+                CompatibleKey const&,
+                CompatibleHash const&,
+                CompatiblePredicate const&) const;
+
+        size_type count(const key_type&) const;
+
+        std::pair<const_iterator, const_iterator>
+        equal_range(const key_type&) const;
+
+        // bucket interface
+
+        size_type bucket_count() const BOOST_NOEXCEPT
+        {
+            return table_.bucket_count_;
+        }
+
+        size_type max_bucket_count() const BOOST_NOEXCEPT
+        {
+            return table_.max_bucket_count();
+        }
+
+        size_type bucket_size(size_type) const;
+
+        size_type bucket(const key_type& k) const
+        {
+            return table_.hash_to_bucket(table_.hash(k));
+        }
+
+        local_iterator begin(size_type n)
+        {
+            return local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        const_local_iterator begin(size_type n) const
+        {
+            return const_local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        local_iterator end(size_type)
+        {
+            return local_iterator();
+        }
+
+        const_local_iterator end(size_type) const
+        {
+            return const_local_iterator();
+        }
+
+        const_local_iterator cbegin(size_type n) const
+        {
+            return const_local_iterator(
+                table_.begin(n), n, table_.bucket_count_);
+        }
+
+        const_local_iterator cend(size_type) const
+        {
+            return const_local_iterator();
+        }
+
+        // hash policy
+
+        float max_load_factor() const BOOST_NOEXCEPT
+        {
+            return table_.mlf_;
+        }
+
+        float load_factor() const BOOST_NOEXCEPT;
+        void max_load_factor(float) BOOST_NOEXCEPT;
+        void rehash(size_type);
+        void reserve(size_type);
+
+#if !BOOST_WORKAROUND(__BORLANDC__, < 0x0582)
+        friend bool operator==<T,H,P,A>(
+                unordered_multiset const&, unordered_multiset const&);
+        friend bool operator!=<T,H,P,A>(
+                unordered_multiset const&, unordered_multiset const&);
+#endif
+    }; // class template unordered_multiset
+
+////////////////////////////////////////////////////////////////////////////////
+
+    template <class T, class H, class P, class A>
+    unordered_set<T,H,P,A>::unordered_set(
+            size_type n, const hasher &hf, const key_equal &eql,
+            const allocator_type &a)
+      : table_(n, hf, eql, a)
+    {
+    }
+
+    template <class T, class H, class P, class A>
+    unordered_set<T,H,P,A>::unordered_set(allocator_type const& a)
+      : table_(boost::unordered::detail::default_bucket_count,
+            hasher(), key_equal(), a)
+    {
+    }
+
+    template <class T, class H, class P, class A>
+    unordered_set<T,H,P,A>::unordered_set(
+            unordered_set const& other, allocator_type const& a)
+      : table_(other.table_, a)
+    {
+    }
+
+    template <class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_set<T,H,P,A>::unordered_set(InputIt f, InputIt l)
+      : table_(boost::unordered::detail::initial_size(f, l),
+        hasher(), key_equal(), allocator_type())
+    {
+        table_.insert_range(f, l);
+    }
+
+    template <class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_set<T,H,P,A>::unordered_set(
+            InputIt f, InputIt l,
+            size_type n,
+            const hasher &hf,
+            const key_equal &eql)
+      : table_(boost::unordered::detail::initial_size(f, l, n),
+            hf, eql, allocator_type())
+    {
+        table_.insert_range(f, l);
+    }
+    
+    template <class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_set<T,H,P,A>::unordered_set(
+            InputIt f, InputIt l,
+            size_type n,
+            const hasher &hf,
+            const key_equal &eql,
+            const allocator_type &a)
+      : table_(boost::unordered::detail::initial_size(f, l, n), hf, eql, a)
+    {
+        table_.insert_range(f, l);
+    }
+    
+    template <class T, class H, class P, class A>
+    unordered_set<T,H,P,A>::~unordered_set() BOOST_NOEXCEPT {}
+
+    template <class T, class H, class P, class A>
+    unordered_set<T,H,P,A>::unordered_set(
+            unordered_set const& other)
+      : table_(other.table_)
+    {
+    }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+    template <class T, class H, class P, class A>
+    unordered_set<T,H,P,A>::unordered_set(
+            unordered_set&& other, allocator_type const& a)
+      : table_(other.table_, a, boost::unordered::detail::move_tag())
+    {
+    }
+
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+
+    template <class T, class H, class P, class A>
+    unordered_set<T,H,P,A>::unordered_set(
+            std::initializer_list<value_type> list, size_type n,
+            const hasher &hf, const key_equal &eql, const allocator_type &a)
+      : table_(
+            boost::unordered::detail::initial_size(
+                list.begin(), list.end(), n),
+            hf, eql, a)
+    {
+        table_.insert_range(list.begin(), list.end());
+    }
+
+    template <class T, class H, class P, class A>
+    unordered_set<T,H,P,A>& unordered_set<T,H,P,A>::operator=(
+            std::initializer_list<value_type> list)
+    {
+        table_.clear();
+        table_.insert_range(list.begin(), list.end());
+        return *this;
+    }
+
+#endif
+
+    // size and capacity
+
+    template <class T, class H, class P, class A>
+    std::size_t unordered_set<T,H,P,A>::max_size() const BOOST_NOEXCEPT
+    {
+        return table_.max_size();
+    }
+
+    // modifiers
+
+    template <class T, class H, class P, class A>
+    template <class InputIt>
+    void unordered_set<T,H,P,A>::insert(InputIt first, InputIt last)
+    {
+        table_.insert_range(first, last);
+    }
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+    template <class T, class H, class P, class A>
+    void unordered_set<T,H,P,A>::insert(
+            std::initializer_list<value_type> list)
+    {
+        table_.insert_range(list.begin(), list.end());
+    }
+#endif
+
+    template <class T, class H, class P, class A>
+    typename unordered_set<T,H,P,A>::iterator
+        unordered_set<T,H,P,A>::erase(const_iterator position)
+    {
+        return table_.erase(position);
+    }
+
+    template <class T, class H, class P, class A>
+    typename unordered_set<T,H,P,A>::size_type
+        unordered_set<T,H,P,A>::erase(const key_type& k)
+    {
+        return table_.erase_key(k);
+    }
+
+    template <class T, class H, class P, class A>
+    typename unordered_set<T,H,P,A>::iterator
+        unordered_set<T,H,P,A>::erase(
+            const_iterator first, const_iterator last)
+    {
+        return table_.erase_range(first, last);
+    }
+
+    template <class T, class H, class P, class A>
+    void unordered_set<T,H,P,A>::clear()
+    {
+        table_.clear();
+    }
+
+    template <class T, class H, class P, class A>
+    void unordered_set<T,H,P,A>::swap(unordered_set& other)
+    {
+        table_.swap(other.table_);
+    }
+
+    // observers
+
+    template <class T, class H, class P, class A>
+    typename unordered_set<T,H,P,A>::hasher
+        unordered_set<T,H,P,A>::hash_function() const
+    {
+        return table_.hash_function();
+    }
+
+    template <class T, class H, class P, class A>
+    typename unordered_set<T,H,P,A>::key_equal
+        unordered_set<T,H,P,A>::key_eq() const
+    {
+        return table_.key_eq();
+    }
+
+    // lookup
+
+    template <class T, class H, class P, class A>
+    typename unordered_set<T,H,P,A>::const_iterator
+        unordered_set<T,H,P,A>::find(const key_type& k) const
+    {
+        return table_.find_node(k);
+    }
+
+    template <class T, class H, class P, class A>
+    template <class CompatibleKey, class CompatibleHash,
+        class CompatiblePredicate>
+    typename unordered_set<T,H,P,A>::const_iterator
+        unordered_set<T,H,P,A>::find(
+            CompatibleKey const& k,
+            CompatibleHash const& hash,
+            CompatiblePredicate const& eq) const
+    {
+        return table_.generic_find_node(k, hash, eq);
+    }
+
+    template <class T, class H, class P, class A>
+    typename unordered_set<T,H,P,A>::size_type
+        unordered_set<T,H,P,A>::count(const key_type& k) const
+    {
+        return table_.count(k);
+    }
+
+    template <class T, class H, class P, class A>
+    std::pair<
+            typename unordered_set<T,H,P,A>::const_iterator,
+            typename unordered_set<T,H,P,A>::const_iterator>
+        unordered_set<T,H,P,A>::equal_range(const key_type& k) const
+    {
+        return table_.equal_range(k);
+    }
+
+    template <class T, class H, class P, class A>
+    typename unordered_set<T,H,P,A>::size_type
+        unordered_set<T,H,P,A>::bucket_size(size_type n) const
+    {
+        return table_.bucket_size(n);
+    }
+
+    // hash policy
+
+    template <class T, class H, class P, class A>
+    float unordered_set<T,H,P,A>::load_factor() const BOOST_NOEXCEPT
+    {
+        return table_.load_factor();
+    }
+
+    template <class T, class H, class P, class A>
+    void unordered_set<T,H,P,A>::max_load_factor(float m) BOOST_NOEXCEPT
+    {
+        table_.max_load_factor(m);
+    }
+
+    template <class T, class H, class P, class A>
+    void unordered_set<T,H,P,A>::rehash(size_type n)
+    {
+        table_.rehash(n);
+    }
+
+    template <class T, class H, class P, class A>
+    void unordered_set<T,H,P,A>::reserve(size_type n)
+    {
+        table_.reserve(n);
+    }
+
+    template <class T, class H, class P, class A>
+    inline bool operator==(
+            unordered_set<T,H,P,A> const& m1,
+            unordered_set<T,H,P,A> const& m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_set<T,H,P,A> x; };
+#endif
+        return m1.table_.equals(m2.table_);
+    }
+
+    template <class T, class H, class P, class A>
+    inline bool operator!=(
+            unordered_set<T,H,P,A> const& m1,
+            unordered_set<T,H,P,A> const& m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_set<T,H,P,A> x; };
+#endif
+        return !m1.table_.equals(m2.table_);
+    }
+
+    template <class T, class H, class P, class A>
+    inline void swap(
+            unordered_set<T,H,P,A> &m1,
+            unordered_set<T,H,P,A> &m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_set<T,H,P,A> x; };
+#endif
+        m1.swap(m2);
+    }
+
+////////////////////////////////////////////////////////////////////////////////
+
+    template <class T, class H, class P, class A>
+    unordered_multiset<T,H,P,A>::unordered_multiset(
+            size_type n, const hasher &hf, const key_equal &eql,
+            const allocator_type &a)
+      : table_(n, hf, eql, a)
+    {
+    }
+
+    template <class T, class H, class P, class A>
+    unordered_multiset<T,H,P,A>::unordered_multiset(allocator_type const& a)
+      : table_(boost::unordered::detail::default_bucket_count,
+            hasher(), key_equal(), a)
+    {
+    }
+
+    template <class T, class H, class P, class A>
+    unordered_multiset<T,H,P,A>::unordered_multiset(
+            unordered_multiset const& other, allocator_type const& a)
+      : table_(other.table_, a)
+    {
+    }
+
+    template <class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_multiset<T,H,P,A>::unordered_multiset(InputIt f, InputIt l)
+      : table_(boost::unordered::detail::initial_size(f, l),
+        hasher(), key_equal(), allocator_type())
+    {
+        table_.insert_range(f, l);
+    }
+
+    template <class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_multiset<T,H,P,A>::unordered_multiset(
+            InputIt f, InputIt l,
+            size_type n,
+            const hasher &hf,
+            const key_equal &eql)
+      : table_(boost::unordered::detail::initial_size(f, l, n),
+            hf, eql, allocator_type())
+    {
+        table_.insert_range(f, l);
+    }
+    
+    template <class T, class H, class P, class A>
+    template <class InputIt>
+    unordered_multiset<T,H,P,A>::unordered_multiset(
+            InputIt f, InputIt l,
+            size_type n,
+            const hasher &hf,
+            const key_equal &eql,
+            const allocator_type &a)
+      : table_(boost::unordered::detail::initial_size(f, l, n), hf, eql, a)
+    {
+        table_.insert_range(f, l);
+    }
+    
+    template <class T, class H, class P, class A>
+    unordered_multiset<T,H,P,A>::~unordered_multiset() BOOST_NOEXCEPT {}
+
+    template <class T, class H, class P, class A>
+    unordered_multiset<T,H,P,A>::unordered_multiset(
+            unordered_multiset const& other)
+      : table_(other.table_)
+    {
+    }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+    template <class T, class H, class P, class A>
+    unordered_multiset<T,H,P,A>::unordered_multiset(
+            unordered_multiset&& other, allocator_type const& a)
+      : table_(other.table_, a, boost::unordered::detail::move_tag())
+    {
+    }
+
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+
+    template <class T, class H, class P, class A>
+    unordered_multiset<T,H,P,A>::unordered_multiset(
+            std::initializer_list<value_type> list, size_type n,
+            const hasher &hf, const key_equal &eql, const allocator_type &a)
+      : table_(
+            boost::unordered::detail::initial_size(
+                list.begin(), list.end(), n),
+            hf, eql, a)
+    {
+        table_.insert_range(list.begin(), list.end());
+    }
+
+    template <class T, class H, class P, class A>
+    unordered_multiset<T,H,P,A>& unordered_multiset<T,H,P,A>::operator=(
+            std::initializer_list<value_type> list)
+    {
+        table_.clear();
+        table_.insert_range(list.begin(), list.end());
+        return *this;
+    }
+
+#endif
+
+    // size and capacity
+
+    template <class T, class H, class P, class A>
+    std::size_t unordered_multiset<T,H,P,A>::max_size() const BOOST_NOEXCEPT
+    {
+        return table_.max_size();
+    }
+
+    // modifiers
+
+    template <class T, class H, class P, class A>
+    template <class InputIt>
+    void unordered_multiset<T,H,P,A>::insert(InputIt first, InputIt last)
+    {
+        table_.insert_range(first, last);
+    }
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+    template <class T, class H, class P, class A>
+    void unordered_multiset<T,H,P,A>::insert(
+            std::initializer_list<value_type> list)
+    {
+        table_.insert_range(list.begin(), list.end());
+    }
+#endif
+
+    template <class T, class H, class P, class A>
+    typename unordered_multiset<T,H,P,A>::iterator
+        unordered_multiset<T,H,P,A>::erase(const_iterator position)
+    {
+        return table_.erase(position);
+    }
+
+    template <class T, class H, class P, class A>
+    typename unordered_multiset<T,H,P,A>::size_type
+        unordered_multiset<T,H,P,A>::erase(const key_type& k)
+    {
+        return table_.erase_key(k);
+    }
+
+    template <class T, class H, class P, class A>
+    typename unordered_multiset<T,H,P,A>::iterator
+        unordered_multiset<T,H,P,A>::erase(
+                const_iterator first, const_iterator last)
+    {
+        return table_.erase_range(first, last);
+    }
+
+    template <class T, class H, class P, class A>
+    void unordered_multiset<T,H,P,A>::clear()
+    {
+        table_.clear();
+    }
+
+    template <class T, class H, class P, class A>
+    void unordered_multiset<T,H,P,A>::swap(unordered_multiset& other)
+    {
+        table_.swap(other.table_);
+    }
+
+    // observers
+
+    template <class T, class H, class P, class A>
+    typename unordered_multiset<T,H,P,A>::hasher
+        unordered_multiset<T,H,P,A>::hash_function() const
+    {
+        return table_.hash_function();
+    }
+
+    template <class T, class H, class P, class A>
+    typename unordered_multiset<T,H,P,A>::key_equal
+        unordered_multiset<T,H,P,A>::key_eq() const
+    {
+        return table_.key_eq();
+    }
+
+    // lookup
+
+    template <class T, class H, class P, class A>
+    typename unordered_multiset<T,H,P,A>::const_iterator
+        unordered_multiset<T,H,P,A>::find(const key_type& k) const
+    {
+        return table_.find_node(k);
+    }
+
+    template <class T, class H, class P, class A>
+    template <class CompatibleKey, class CompatibleHash,
+        class CompatiblePredicate>
+    typename unordered_multiset<T,H,P,A>::const_iterator
+        unordered_multiset<T,H,P,A>::find(
+            CompatibleKey const& k,
+            CompatibleHash const& hash,
+            CompatiblePredicate const& eq) const
+    {
+        return table_.generic_find_node(k, hash, eq);
+    }
+
+    template <class T, class H, class P, class A>
+    typename unordered_multiset<T,H,P,A>::size_type
+        unordered_multiset<T,H,P,A>::count(const key_type& k) const
+    {
+        return table_.count(k);
+    }
+
+    template <class T, class H, class P, class A>
+    std::pair<
+            typename unordered_multiset<T,H,P,A>::const_iterator,
+            typename unordered_multiset<T,H,P,A>::const_iterator>
+        unordered_multiset<T,H,P,A>::equal_range(const key_type& k) const
+    {
+        return table_.equal_range(k);
+    }
+
+    template <class T, class H, class P, class A>
+    typename unordered_multiset<T,H,P,A>::size_type
+        unordered_multiset<T,H,P,A>::bucket_size(size_type n) const
+    {
+        return table_.bucket_size(n);
+    }
+
+    // hash policy
+
+    template <class T, class H, class P, class A>
+    float unordered_multiset<T,H,P,A>::load_factor() const BOOST_NOEXCEPT
+    {
+        return table_.load_factor();
+    }
+
+    template <class T, class H, class P, class A>
+    void unordered_multiset<T,H,P,A>::max_load_factor(float m) BOOST_NOEXCEPT
+    {
+        table_.max_load_factor(m);
+    }
+
+    template <class T, class H, class P, class A>
+    void unordered_multiset<T,H,P,A>::rehash(size_type n)
+    {
+        table_.rehash(n);
+    }
+
+    template <class T, class H, class P, class A>
+    void unordered_multiset<T,H,P,A>::reserve(size_type n)
+    {
+        table_.reserve(n);
+    }
+
+    template <class T, class H, class P, class A>
+    inline bool operator==(
+            unordered_multiset<T,H,P,A> const& m1,
+            unordered_multiset<T,H,P,A> const& m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_multiset<T,H,P,A> x; };
+#endif
+        return m1.table_.equals(m2.table_);
+    }
+
+    template <class T, class H, class P, class A>
+    inline bool operator!=(
+            unordered_multiset<T,H,P,A> const& m1,
+            unordered_multiset<T,H,P,A> const& m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_multiset<T,H,P,A> x; };
+#endif
+        return !m1.table_.equals(m2.table_);
+    }
+
+    template <class T, class H, class P, class A>
+    inline void swap(
+            unordered_multiset<T,H,P,A> &m1,
+            unordered_multiset<T,H,P,A> &m2)
+    {
+#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+        struct dummy { unordered_multiset<T,H,P,A> x; };
+#endif
+        m1.swap(m2);
+    }
+} // namespace unordered
+} // namespace boost
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+#endif // BOOST_UNORDERED_UNORDERED_SET_HPP_INCLUDED

--- a/ibtk/contrib/boost/boost/unordered/unordered_set_fwd.hpp
+++ b/ibtk/contrib/boost/boost/unordered/unordered_set_fwd.hpp
@@ -1,0 +1,63 @@
+
+// Copyright (C) 2008-2011 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_UNORDERED_SET_FWD_HPP_INCLUDED
+#define BOOST_UNORDERED_SET_FWD_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <memory>
+#include <functional>
+#include <boost/functional/hash_fwd.hpp>
+#include <boost/unordered/detail/fwd.hpp>
+
+namespace boost
+{
+    namespace unordered
+    {
+        template <class T,
+            class H = boost::hash<T>,
+            class P = std::equal_to<T>,
+            class A = std::allocator<T> >
+        class unordered_set;
+
+        template <class T, class H, class P, class A>
+        inline bool operator==(unordered_set<T, H, P, A> const&,
+            unordered_set<T, H, P, A> const&);
+        template <class T, class H, class P, class A>
+        inline bool operator!=(unordered_set<T, H, P, A> const&,
+            unordered_set<T, H, P, A> const&);
+        template <class T, class H, class P, class A>
+        inline void swap(unordered_set<T, H, P, A> &m1,
+                unordered_set<T, H, P, A> &m2);
+
+        template <class T,
+            class H = boost::hash<T>,
+            class P = std::equal_to<T>,
+            class A = std::allocator<T> >
+        class unordered_multiset;
+
+        template <class T, class H, class P, class A>
+        inline bool operator==(unordered_multiset<T, H, P, A> const&,
+            unordered_multiset<T, H, P, A> const&);
+        template <class T, class H, class P, class A>
+        inline bool operator!=(unordered_multiset<T, H, P, A> const&,
+            unordered_multiset<T, H, P, A> const&);
+        template <class T, class H, class P, class A>
+        inline void swap(unordered_multiset<T, H, P, A> &m1,
+                unordered_multiset<T, H, P, A> &m2);
+    }
+
+    using boost::unordered::unordered_set;
+    using boost::unordered::unordered_multiset;
+    using boost::unordered::swap;
+    using boost::unordered::operator==;
+    using boost::unordered::operator!=;
+}
+
+#endif

--- a/ibtk/contrib/boost/boost/unordered_map.hpp
+++ b/ibtk/contrib/boost/boost/unordered_map.hpp
@@ -1,0 +1,19 @@
+
+// Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
+// Copyright (C) 2005-2008 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/unordered for documentation
+
+#ifndef BOOST_UNORDERED_MAP_HPP_INCLUDED
+#define BOOST_UNORDERED_MAP_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#pragma once
+#endif
+
+#include <boost/unordered/unordered_map.hpp>
+
+#endif // BOOST_UNORDERED_MAP_HPP_INCLUDED

--- a/include/ibamr/IBFEPostProcessor.h
+++ b/include/ibamr/IBFEPostProcessor.h
@@ -35,7 +35,6 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
-#include "boost/tuple/tuple.hpp"
 #include "ibamr/IBFEMethod.h"
 #include "ibtk/FEDataManager.h"
 #include "ibtk/HierarchyGhostCellInterpolation.h"

--- a/include/ibamr/IBRedundantInitializer.h
+++ b/include/ibamr/IBRedundantInitializer.h
@@ -48,7 +48,6 @@
 #include "ibtk/LSiloDataWriter.h"
 #include "ibtk/ibtk_utilities.h"
 #include "tbox/Pointer.h"
-#include <boost/concept_check.hpp>
 
 namespace IBTK
 {


### PR DESCRIPTION
We use `boost::unordered_map` in IBTK but the bundled copy of boost does not include the necessary headers. I added enough headers to get this working.

While I was here I deleted two unused boost `#include`s.

This is an issue on macs which usually do not have a copy of boost available in a system directory.

Part of #266.