### PR TITLE
Fix links in top level README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ What Is the IB Method?
 
 The immersed boundary (IB) method is a general-purpose numerical method for simulating fluid-structure interaction.  The IB formulation of such problems uses an Eulerian description of the fluid and a Lagrangian description of the structure.  Interaction equations that couple the Eulerian and Lagrangian variables take the form of integral equations with delta function kernels.
 
-For general information about the IB method, see [here](http://math.nyu.edu/faculty/peskin).  For visualizations of simulations that use IBAMR, see [here](http://ibamr.github.io).
+For general information about the IB method, see [here](http://math.nyu.edu/faculty/peskin).  For additional information about the IBAMR software, see [here](http://ibamr.github.io).  We are happy to host visualizations of simulations that use IBAMR.
 
 Getting Started
 ---------------
@@ -48,4 +48,4 @@ Please use the GitHub issue tracking system to report bugs, feature requests, or
 Acknowledgments
 ---------------
 
-IBAMR development is supported in part by an NSF <i>Software Infrastructure for Sustained Innovation</i> award (NSF OCI 1047734).  Work to extend IBAMR to support finite element mechanics models is also supported in part by the NSF (NSF DMS 1016554).  We gratefully acknowledge this support.
+IBAMR development is supported in part by NSF <i>Software Infrastructure for Sustained Innovation</i> awards OAC 1450327 (to UNC-Chapel Hill), OAC 1450374 (to Northwestern University), and OAC 1607042 (to Rice University).  Additional support is provided by NSF CAREER award OAC 1652541 (to UNC-Chapel Hill).  Prior support was provided by NSF awards DMS 1016554 (to New York University), DMS 1460368 (to UNC-Chapel Hill), OAC 1047734 (to New York University), and OAC 1460334 (to UNC-Chapel Hill).  We gratefully acknowledge this support.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ What Is the IB Method?
 
 The immersed boundary (IB) method is a general-purpose numerical method for simulating fluid-structure interaction.  The IB formulation of such problems uses an Eulerian description of the fluid and a Lagrangian description of the structure.  Interaction equations that couple the Eulerian and Lagrangian variables take the form of integral equations with delta function kernels.
 
-For general information about the IB method, see http://math.nyu.edu/faculty/peskin.  For visualizations of simulations that use IBAMR, see http://cims.nyu.edu/~griffith.
+For general information about the IB method, see [here](http://math.nyu.edu/faculty/peskin).  For visualizations of simulations that use IBAMR, see [here](http://ibamr.github.io).
 
 Getting Started
 ---------------
@@ -33,7 +33,7 @@ IBAMR requires a number of [third-party libraries](../../wiki/ThirdPartyLibrarie
 Documentation
 -------------
 
-Source code documentation [for IBAMR is available on-line](http://ibamr.github.io/IBAMR/ibamr/html).  Source code documentation is also available [for the IBTK support library](http://ibamr.github.io/IBAMR/ibtk/html).  File format documentation [is also available on-line](http://ibamr.github.io/IBAMR/ibamr/html/class_i_b_a_m_r_1_1_i_b_standard_initializer.html#details).  There is also list of [frequently asked questions](../../wiki/FAQ).
+Source code documentation [for the IBAMR library and supporting IBTK library is available on-line](http://ibamr.github.io/docs). File format documentation [is also available on-line](https://ibamr.github.io/IBAMR-docs/ibamr/html/class_i_b_a_m_r_1_1_i_b_standard_initializer.html#details).  There is also list of [frequently asked questions](https://ibamr.github.io/faq).
 
 Support
 -------

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ What Is the IB Method?
 
 The immersed boundary (IB) method is a general-purpose numerical method for simulating fluid-structure interaction.  The IB formulation of such problems uses an Eulerian description of the fluid and a Lagrangian description of the structure.  Interaction equations that couple the Eulerian and Lagrangian variables take the form of integral equations with delta function kernels.
 
-For general information about the IB method, see [here](http://math.nyu.edu/faculty/peskin).  For additional information about the IBAMR software, see [here](http://ibamr.github.io).  We are happy to host visualizations of simulations that use IBAMR.
+For general information about the IB method, see [math.nyu.edu/faculty/peskin](http://math.nyu.edu/faculty/peskin).  For additional information about the IBAMR software, see [ibamr.github.io](http://ibamr.github.io).  We are happy to host visualizations of simulations that use IBAMR.
 
 Getting Started
 ---------------


### PR DESCRIPTION
Part of #266.  This updates a few links to correctly direct to the `github.io` pages. Note that we claim in the README that there are visualization examples on the `github.io` pages (or we will once this is merged), but there are no such visualizations at this time.