### PR TITLE
Check for an incompatible libMesh setting.

### DIFF
--- a/configure
+++ b/configure
@@ -23452,6 +23452,56 @@ fi
   LIBMESH_FCFLAGS="`$LIBMESH_CONFIG --fflags`"
   LIBMESH_LIBS="`$LIBMESH_CONFIG --libs`"
 
+  # libMesh implements UniquePtr by including parts of boost in
+  # libmesh/unique_ptr.hpp (or in contrib/unique_ptr/unique_ptr.hpp). This
+  # causes compilation errors when one #includes both that file and the original
+  # file from boost, since the preprocessor guards on the libMesh-provided
+  # unique_ptr.hpp do not match the preprocessor guards on the boost headers (so
+  # we get multiple definition errors). To ensure that this does not happen,
+  # check that libMesh will not include unique_ptr.hpp in its own auto_ptr.hpp
+  # file (which we use). libMesh uses the preprocessor guard symbol
+  # UNIQUE_PTR_HPP in 1.0, 1.1, 1.2, and 1.3, so we check for that.
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for a usable libMesh UniquePtr/unique_ptr configuration" >&5
+$as_echo_n "checking for a usable libMesh UniquePtr/unique_ptr configuration... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <libmesh/auto_ptr.h>
+
+#ifdef UNIQUE_PTR_HPP
+#error
+#endif
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  LIBMESH_UNIQUE_PTR_OK=yes
+else
+  LIBMESH_UNIQUE_PTR_OK=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${LIBMESH_UNIQUE_PTR_OK}" >&5
+$as_echo "${LIBMESH_UNIQUE_PTR_OK}" >&6; }
+  if test "$LIBMESH_UNIQUE_PTR_OK" = no; then
+    as_fn_error $? "If libMesh is compiled without C++11 support then it must be compiled with --disable-unique-ptr or (in version 1.1 or later) compiled with a copy of boost including boost.move." "$LINENO" 5
+  fi
+
 
 
 

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -23598,6 +23598,56 @@ fi
   LIBMESH_FCFLAGS="`$LIBMESH_CONFIG --fflags`"
   LIBMESH_LIBS="`$LIBMESH_CONFIG --libs`"
 
+  # libMesh implements UniquePtr by including parts of boost in
+  # libmesh/unique_ptr.hpp (or in contrib/unique_ptr/unique_ptr.hpp). This
+  # causes compilation errors when one #includes both that file and the original
+  # file from boost, since the preprocessor guards on the libMesh-provided
+  # unique_ptr.hpp do not match the preprocessor guards on the boost headers (so
+  # we get multiple definition errors). To ensure that this does not happen,
+  # check that libMesh will not include unique_ptr.hpp in its own auto_ptr.hpp
+  # file (which we use). libMesh uses the preprocessor guard symbol
+  # UNIQUE_PTR_HPP in 1.0, 1.1, 1.2, and 1.3, so we check for that.
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for a usable libMesh UniquePtr/unique_ptr configuration" >&5
+$as_echo_n "checking for a usable libMesh UniquePtr/unique_ptr configuration... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <libmesh/auto_ptr.h>
+
+#ifdef UNIQUE_PTR_HPP
+#error
+#endif
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  LIBMESH_UNIQUE_PTR_OK=yes
+else
+  LIBMESH_UNIQUE_PTR_OK=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${LIBMESH_UNIQUE_PTR_OK}" >&5
+$as_echo "${LIBMESH_UNIQUE_PTR_OK}" >&6; }
+  if test "$LIBMESH_UNIQUE_PTR_OK" = no; then
+    as_fn_error $? "If libMesh is compiled without C++11 support then it must be compiled with --disable-unique-ptr or (in version 1.1 or later) compiled with a copy of boost including boost.move." "$LINENO" 5
+  fi
+
 
 
 

--- a/ibtk/m4/configure_libmesh.m4
+++ b/ibtk/m4/configure_libmesh.m4
@@ -116,6 +116,30 @@ int main()
   LIBMESH_FCFLAGS="`$LIBMESH_CONFIG --fflags`"
   LIBMESH_LIBS="`$LIBMESH_CONFIG --libs`"
 
+  # libMesh implements UniquePtr by including parts of boost in
+  # libmesh/unique_ptr.hpp (or in contrib/unique_ptr/unique_ptr.hpp). This
+  # causes compilation errors when one #includes both that file and the original
+  # file from boost, since the preprocessor guards on the libMesh-provided
+  # unique_ptr.hpp do not match the preprocessor guards on the boost headers (so
+  # we get multiple definition errors). To ensure that this does not happen,
+  # check that libMesh will not include unique_ptr.hpp in its own auto_ptr.hpp
+  # file (which we use). libMesh uses the preprocessor guard symbol
+  # UNIQUE_PTR_HPP in 1.0, 1.1, 1.2, and 1.3, so we check for that.
+
+  AC_MSG_CHECKING([for a usable libMesh UniquePtr/unique_ptr configuration])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <libmesh/auto_ptr.h>
+
+#ifdef UNIQUE_PTR_HPP
+#error
+#endif
+
+  ]])],[LIBMESH_UNIQUE_PTR_OK=yes],[LIBMESH_UNIQUE_PTR_OK=no])
+  AC_MSG_RESULT([${LIBMESH_UNIQUE_PTR_OK}])
+  if test "$LIBMESH_UNIQUE_PTR_OK" = no; then
+    AC_MSG_ERROR([If libMesh is compiled without C++11 support then it must be compiled with --disable-unique-ptr or (in version 1.1 or later) compiled with a copy of boost including boost.move.])
+  fi
+
   AC_LIB_HAVE_LINKFLAGS([netcdf])
   if test "$HAVE_LIBNETCDF" = yes ; then
     LIBMESH_LIBS="$LIBMESH_LIBS $LIBNETCDF"

--- a/m4/configure_libmesh.m4
+++ b/m4/configure_libmesh.m4
@@ -116,6 +116,30 @@ int main()
   LIBMESH_FCFLAGS="`$LIBMESH_CONFIG --fflags`"
   LIBMESH_LIBS="`$LIBMESH_CONFIG --libs`"
 
+  # libMesh implements UniquePtr by including parts of boost in
+  # libmesh/unique_ptr.hpp (or in contrib/unique_ptr/unique_ptr.hpp). This
+  # causes compilation errors when one #includes both that file and the original
+  # file from boost, since the preprocessor guards on the libMesh-provided
+  # unique_ptr.hpp do not match the preprocessor guards on the boost headers (so
+  # we get multiple definition errors). To ensure that this does not happen,
+  # check that libMesh will not include unique_ptr.hpp in its own auto_ptr.hpp
+  # file (which we use). libMesh uses the preprocessor guard symbol
+  # UNIQUE_PTR_HPP in 1.0, 1.1, 1.2, and 1.3, so we check for that.
+
+  AC_MSG_CHECKING([for a usable libMesh UniquePtr/unique_ptr configuration])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <libmesh/auto_ptr.h>
+
+#ifdef UNIQUE_PTR_HPP
+#error
+#endif
+
+  ]])],[LIBMESH_UNIQUE_PTR_OK=yes],[LIBMESH_UNIQUE_PTR_OK=no])
+  AC_MSG_RESULT([${LIBMESH_UNIQUE_PTR_OK}])
+  if test "$LIBMESH_UNIQUE_PTR_OK" = no; then
+    AC_MSG_ERROR([If libMesh is compiled without C++11 support then it must be compiled with --disable-unique-ptr or (in version 1.1 or later) compiled with a copy of boost including boost.move.])
+  fi
+
   AC_LIB_HAVE_LINKFLAGS([netcdf])
   if test "$HAVE_LIBNETCDF" = yes ; then
     LIBMESH_LIBS="$LIBMESH_LIBS $LIBNETCDF"


### PR DESCRIPTION
We cannot use libMesh when it is compiled with its own implementation of `boost::unique_ptr` due to conflicts with our own boost usage.

This change causes `configure` to print a useful message and quit early on instead of compilation crashing with difficult to understand (this took me most of the afternoon to figure out) boost template conflict errors.