### PR TITLE
Fixing out-of-bounds error for vectors

### DIFF
--- a/src/IB/IBFEDirectForcingKinematics.cpp
+++ b/src/IB/IBFEDirectForcingKinematics.cpp
@@ -724,7 +724,7 @@ IBFEDirectForcingKinematics::computeImposedLagrangianForceDensity(PetscVector<do
     for (unsigned int d = 0; d < NDIM; ++d)
     {
         nodal_indices[d].reserve(total_local_nodes);
-        nodal_X_values[d].reserve(total_local_nodes);
+        nodal_X_values[d].resize(total_local_nodes);
     }
 
     for (MeshBase::node_iterator it = mesh.local_nodes_begin(); it != mesh.local_nodes_end(); ++it)

--- a/src/IB/IBStandardForceGen.cpp
+++ b/src/IB/IBStandardForceGen.cpp
@@ -1267,6 +1267,7 @@ IBStandardForceGen::computeLagrangianTargetPointForce(Pointer<LData> F_data,
     double max_displacement = 0.0;
 
     const int num_target_points = static_cast<int>(d_target_point_data[level_number].petsc_node_idxs.size());
+    if (num_target_points == 0) return;
     const int* const petsc_node_idxs = &d_target_point_data[level_number].petsc_node_idxs[0];
     const double** const kappa = &d_target_point_data[level_number].kappa[0];
     const double** const eta = &d_target_point_data[level_number].eta[0];

--- a/src/IB/IBStandardForceGen.cpp
+++ b/src/IB/IBStandardForceGen.cpp
@@ -1267,11 +1267,12 @@ IBStandardForceGen::computeLagrangianTargetPointForce(Pointer<LData> F_data,
     double max_displacement = 0.0;
 
     const int num_target_points = static_cast<int>(d_target_point_data[level_number].petsc_node_idxs.size());
-    if (num_target_points == 0) return;
-    const int* const petsc_node_idxs = &d_target_point_data[level_number].petsc_node_idxs[0];
-    const double** const kappa = &d_target_point_data[level_number].kappa[0];
-    const double** const eta = &d_target_point_data[level_number].eta[0];
-    const Point** const X0 = &d_target_point_data[level_number].X0[0];
+    const bool uses_target_points = (num_target_points > 0);
+    const int* const petsc_node_idxs =
+        uses_target_points ? &d_target_point_data[level_number].petsc_node_idxs[0] : NULL;
+    const double** const kappa = uses_target_points ? &d_target_point_data[level_number].kappa[0] : NULL;
+    const double** const eta = uses_target_points ? &d_target_point_data[level_number].eta[0] : NULL;
+    const Point** const X0 = uses_target_points ? &d_target_point_data[level_number].X0[0] : NULL;
     double* const F_node = F_data->getLocalFormVecArray()->data();
     const double* const X_node = X_data->getLocalFormVecArray()->data();
     const double* const U_node = U_data->getLocalFormVecArray()->data();

--- a/src/IB/IBStandardForceGen.cpp
+++ b/src/IB/IBStandardForceGen.cpp
@@ -872,13 +872,15 @@ IBStandardForceGen::computeLagrangianSpringForce(Pointer<LData> F_data,
                                                  LDataManager* const /*l_data_manager*/)
 {
     const int num_springs = static_cast<int>(d_spring_data[level_number].lag_mastr_node_idxs.size());
-    if (num_springs == 0) return;
-    const int* const lag_mastr_node_idxs = &d_spring_data[level_number].lag_mastr_node_idxs[0];
-    const int* const lag_slave_node_idxs = &d_spring_data[level_number].lag_slave_node_idxs[0];
-    const int* const petsc_mastr_node_idxs = &d_spring_data[level_number].petsc_mastr_node_idxs[0];
-    const int* const petsc_slave_node_idxs = &d_spring_data[level_number].petsc_slave_node_idxs[0];
-    const SpringForceFcnPtr* const force_fcns = &d_spring_data[level_number].force_fcns[0];
-    const double** const parameters = &d_spring_data[level_number].parameters[0];
+    const bool uses_springs = (num_springs > 0);
+    const int* const lag_mastr_node_idxs = uses_springs ? &d_spring_data[level_number].lag_mastr_node_idxs[0] : NULL;
+    const int* const lag_slave_node_idxs = uses_springs ? &d_spring_data[level_number].lag_slave_node_idxs[0] : NULL;
+    const int* const petsc_mastr_node_idxs =
+        uses_springs ? &d_spring_data[level_number].petsc_mastr_node_idxs[0] : NULL;
+    const int* const petsc_slave_node_idxs =
+        uses_springs ? &d_spring_data[level_number].petsc_slave_node_idxs[0] : NULL;
+    const SpringForceFcnPtr* const force_fcns = uses_springs ? &d_spring_data[level_number].force_fcns[0] : NULL;
+    const double** const parameters = uses_springs ? &d_spring_data[level_number].parameters[0] : NULL;
     double* const F_node = F_data->getLocalFormVecArray()->data();
     const double* const X_node = X_data->getGhostedLocalFormVecArray()->data();
 
@@ -1098,12 +1100,12 @@ IBStandardForceGen::computeLagrangianBeamForce(Pointer<LData> F_data,
                                                LDataManager* const /*l_data_manager*/)
 {
     const int num_beams = static_cast<int>(d_beam_data[level_number].petsc_mastr_node_idxs.size());
-    if (num_beams == 0) return;
-    const int* const petsc_mastr_node_idxs = &d_beam_data[level_number].petsc_mastr_node_idxs[0];
-    const int* const petsc_next_node_idxs = &d_beam_data[level_number].petsc_next_node_idxs[0];
-    const int* const petsc_prev_node_idxs = &d_beam_data[level_number].petsc_prev_node_idxs[0];
-    const double** const rigidities = &d_beam_data[level_number].rigidities[0];
-    const Vector** const curvatures = &d_beam_data[level_number].curvatures[0];
+    const bool uses_beams = (num_beams > 0);
+    const int* const petsc_mastr_node_idxs = uses_beams ? &d_beam_data[level_number].petsc_mastr_node_idxs[0] : NULL;
+    const int* const petsc_next_node_idxs = uses_beams ? &d_beam_data[level_number].petsc_next_node_idxs[0] : NULL;
+    const int* const petsc_prev_node_idxs = uses_beams ? &d_beam_data[level_number].petsc_prev_node_idxs[0] : NULL;
+    const double** const rigidities = uses_beams ? &d_beam_data[level_number].rigidities[0] : NULL;
+    const Vector** const curvatures = uses_beams ? &d_beam_data[level_number].curvatures[0] : NULL;
     double* const F_node = F_data->getLocalFormVecArray()->data();
     const double* const X_node = X_data->getGhostedLocalFormVecArray()->data();
 


### PR DESCRIPTION
For certain compilers, one will hit the following assertion in debug mode when trying to access or pass `&some_vector[0]` when some_vector is empty:

```
/usr/include/c++/4.8.3/debug/vector:346:error: attempt to subscript 
    container with out-of-bounds index 0, but container only holds 0     
    elements.
```

I found this because some of the examples will crash in debug mode during the first time step. The changes in this PR fixes that.

For IBStandardForceGen, I think it's safer to include the return statement. This is already done for beams and springs, but it was missing for target points.

For  IBFEDirectForcingKinematics, nodal_X_values should be resized before it gets passed here:
https://github.com/IBAMR/IBAMR/blob/nishant/fix-vector-dbg-assert/src/IB/IBFEDirectForcingKinematics.cpp#L747

@boyceg @amneetb Thoughts?

This should probably go in 0.3 as well.