### PR TITLE
Allow versions of PETSc newer than 3.9.

### DIFF
--- a/configure
+++ b/configure
@@ -30268,8 +30268,8 @@ fi
 
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSc version 3.7, 3.8, or 3.9" >&5
-$as_echo_n "checking for PETSc version 3.7, 3.8, or 3.9... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSc version 3.7 or newer" >&5
+$as_echo_n "checking for PETSc version 3.7 or newer... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -30292,9 +30292,9 @@ int
 main ()
 {
 
-#if ((PETSC_VERSION_GE(3,7,0) && PETSC_VERSION_LT(3,10,0)) || !PETSC_VERSION_RELEASE)
+#if PETSC_VERSION_GE(3,7,0)
 #else
-asdf
+#error
 #endif
 
   ;
@@ -30310,7 +30310,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${PETSC_VERSION_VALID}" >&5
 $as_echo "${PETSC_VERSION_VALID}" >&6; }
 if test "$PETSC_VERSION_VALID" = no; then
-  as_fn_error $? "invalid PETSc version detected: please use PETSc 3.7, 3.8, or 3.9" "$LINENO" 5
+  as_fn_error $? "invalid PETSc version detected: please use PETSc 3.7 or newer" "$LINENO" 5
 fi
 
 LIBS="$PETSC_EXTERNAL_LIB_BASIC $LIBS"

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -30414,8 +30414,8 @@ fi
 
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSc version 3.7, 3.8, or 3.9" >&5
-$as_echo_n "checking for PETSc version 3.7, 3.8, or 3.9... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSc version 3.7 or newer" >&5
+$as_echo_n "checking for PETSc version 3.7 or newer... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -30438,9 +30438,9 @@ int
 main ()
 {
 
-#if ((PETSC_VERSION_GE(3,7,0) && PETSC_VERSION_LT(3,10,0)) || !PETSC_VERSION_RELEASE)
+#if PETSC_VERSION_GE(3,7,0)
 #else
-asdf
+#error
 #endif
 
   ;
@@ -30456,7 +30456,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${PETSC_VERSION_VALID}" >&5
 $as_echo "${PETSC_VERSION_VALID}" >&6; }
 if test "$PETSC_VERSION_VALID" = no; then
-  as_fn_error $? "invalid PETSc version detected: please use PETSc 3.7, 3.8, or 3.9" "$LINENO" 5
+  as_fn_error $? "invalid PETSc version detected: please use PETSc 3.7 or newer" "$LINENO" 5
 fi
 
 LIBS="$PETSC_EXTERNAL_LIB_BASIC $LIBS"

--- a/ibtk/m4/configure_petsc.m4
+++ b/ibtk/m4/configure_petsc.m4
@@ -23,7 +23,7 @@ PETSC_WITH_EXTERNAL_LIB=`grep "PETSC_WITH_EXTERNAL_LIB =" $PETSC_DIR/$PETSC_ARCH
 CPPFLAGS_PREPEND($PETSC_CC_INCLUDES)
 AC_CHECK_HEADER([petsc.h],,AC_MSG_ERROR([could not find header file petsc.h]))
 
-AC_MSG_CHECKING([for PETSc version 3.7, 3.8, or 3.9])
+AC_MSG_CHECKING([for PETSc version 3.7 or newer])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <petscversion.h>
 
@@ -32,14 +32,14 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   (!PETSC_VERSION_LT(MAJOR,MINOR,SUBMINOR))
 #endif
 ]], [[
-#if ((PETSC_VERSION_GE(3,7,0) && PETSC_VERSION_LT(3,10,0)) || !PETSC_VERSION_RELEASE)
+#if PETSC_VERSION_GE(3,7,0)
 #else
-asdf
+#error
 #endif
 ]])],[PETSC_VERSION_VALID=yes],[PETSC_VERSION_VALID=no])
 AC_MSG_RESULT([${PETSC_VERSION_VALID}])
 if test "$PETSC_VERSION_VALID" = no; then
-  AC_MSG_ERROR([invalid PETSc version detected: please use PETSc 3.7, 3.8, or 3.9])
+  AC_MSG_ERROR([invalid PETSc version detected: please use PETSc 3.7 or newer])
 fi
 
 LIBS_PREPEND($PETSC_EXTERNAL_LIB_BASIC)

--- a/m4/configure_petsc.m4
+++ b/m4/configure_petsc.m4
@@ -23,7 +23,7 @@ PETSC_WITH_EXTERNAL_LIB=`grep "PETSC_WITH_EXTERNAL_LIB =" $PETSC_DIR/$PETSC_ARCH
 CPPFLAGS_PREPEND($PETSC_CC_INCLUDES)
 AC_CHECK_HEADER([petsc.h],,AC_MSG_ERROR([could not find header file petsc.h]))
 
-AC_MSG_CHECKING([for PETSc version 3.7, 3.8, or 3.9])
+AC_MSG_CHECKING([for PETSc version 3.7 or newer])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <petscversion.h>
 
@@ -32,14 +32,14 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   (!PETSC_VERSION_LT(MAJOR,MINOR,SUBMINOR))
 #endif
 ]], [[
-#if ((PETSC_VERSION_GE(3,7,0) && PETSC_VERSION_LT(3,10,0)) || !PETSC_VERSION_RELEASE)
+#if PETSC_VERSION_GE(3,7,0)
 #else
-asdf
+#error
 #endif
 ]])],[PETSC_VERSION_VALID=yes],[PETSC_VERSION_VALID=no])
 AC_MSG_RESULT([${PETSC_VERSION_VALID}])
 if test "$PETSC_VERSION_VALID" = no; then
-  AC_MSG_ERROR([invalid PETSc version detected: please use PETSc 3.7, 3.8, or 3.9])
+  AC_MSG_ERROR([invalid PETSc version detected: please use PETSc 3.7 or newer])
 fi
 
 LIBS_PREPEND($PETSC_EXTERNAL_LIB_BASIC)


### PR DESCRIPTION
PETSc 3.10 will be out soon and we are compatible with it. However, the m4 scripts currently limit us to using 3.9 or older; this PR deletes the upper bound.

The PETSc interfaces we use are quite stable and are unlikely to change in the near future, so there is no reason to specify a maximum version: we should simply document what works and let users use new versions if they like.