### PR TITLE
Make call to INS regridHierarchy in IB integrator

### DIFF
--- a/src/IB/IBHierarchyIntegrator.cpp
+++ b/src/IB/IBHierarchyIntegrator.cpp
@@ -477,7 +477,7 @@ IBHierarchyIntegrator::regridHierarchy()
 
     // Use the INSHierarchyIntegrator to handle Eulerian data management.
     if (d_enable_logging) plog << d_object_name << "::regridHierarchy(): regridding the patch hierarchy\n";
-    HierarchyIntegrator::regridHierarchy();
+    d_ins_hier_integrator->regridHierarchy();
 
     // After regridding, finish Lagrangian data movement.
     if (d_enable_logging) plog << d_object_name << "::regridHierarchy(): finishing Lagrangian data movement\n";

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1563,6 +1563,10 @@ INSCollocatedHierarchyIntegrator::regridHierarchy()
     // Project the interpolated velocity.
     regridProjection();
 
+    // Reinitialize composite grid data.
+    const bool initial_time = false;
+    initializeCompositeHierarchyData(d_integrator_time, initial_time);
+
     // Synchronize the state data on the patch hierarchy.
     synchronizeHierarchyData(CURRENT_DATA);
     return;

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1491,6 +1491,10 @@ INSStaggeredHierarchyIntegrator::regridHierarchy()
         regridProjection();
     }
 
+    // Reinitialize composite grid data.
+    const bool initial_time = false;
+    initializeCompositeHierarchyData(d_integrator_time, initial_time);
+
     // Synchronize the state data on the patch hierarchy.
     synchronizeHierarchyData(CURRENT_DATA);
     return;

--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -1383,6 +1383,10 @@ INSVCStaggeredHierarchyIntegrator::regridHierarchy()
         regridProjection();
     }
 
+    // Reinitialize composite grid data.
+    const bool initial_time = false;
+    initializeCompositeHierarchyData(d_integrator_time, initial_time);
+
     // Synchronize the state data on the patch hierarchy.
     synchronizeHierarchyData(CURRENT_DATA);
     return;


### PR DESCRIPTION
In reference to https://github.com/IBAMR/IBAMR/issues/250

We should call the INS specific regridHierarchy() functions to ensure that their regridProjection() routines are called. Also adding calls to initializeCompositeHierarchyData() in the overridden calls.