### PR TITLE
Remove some unused preprocessor guards.

### DIFF
--- a/examples/ConstraintIB/falling_sphere/CartGridBodyForce.cpp
+++ b/examples/ConstraintIB/falling_sphere/CartGridBodyForce.cpp
@@ -33,15 +33,9 @@
 
 ////////////////////////////// INCLUDES /////////////////////////////////////
 
-#ifndef included_IBTK_config
 #include <IBTK_config.h>
-#define included_IBTK_config
-#endif
 
-#ifndef included_SAMRAI_config
 #include <SAMRAI_config.h>
-#define included_SAMRAI_config
-#endif
 
 #include "CellData.h"
 #include "CellVariable.h"


### PR DESCRIPTION
The headers define their own inclusion checks so these are not necessary.