### PR TITLE
Remove boost::math::{iround,round}.

### DIFF
--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -84,7 +84,6 @@
 #include "VariableContext.h"
 #include "VariableDatabase.h"
 #include "VisItDataWriter.h"
-#include "boost/math/special_functions/round.hpp"
 #include "boost/multi_array.hpp"
 #include "ibtk/IBTK_CHKERRQ.h"
 #include "ibtk/IndexUtilities.h"
@@ -1448,7 +1447,7 @@ LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int finest
             IntVector<NDIM> periodic_offset;
             for (int d = 0; d < NDIM; ++d)
             {
-                periodic_offset[d] = boost::math::round(periodic_displacement[d] / level_dx[d]);
+                periodic_offset[d] = int(std::round(periodic_displacement[d] / level_dx[d]));
             }
             if (periodic_offset != IntVector<NDIM>(0))
             {

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -61,7 +61,6 @@
 #include "SideIndex.h"
 #include "Variable.h"
 #include "VariableDatabase.h"
-#include "boost/math/special_functions/round.hpp"
 #include "boost/multi_array.hpp"
 #include "ibamr/IBFESurfaceMethod.h"
 #include "ibamr/IBHierarchyIntegrator.h"
@@ -1669,7 +1668,8 @@ IBFESurfaceMethod::imposeJumpConditions(const int f_data_idx,
                         const libMesh::Point x = r + intersections[k].first * q;
                         const libMesh::Point& xi = intersections[k].second;
                         SideIndex<NDIM> i_s(i_c, axis, 0);
-                        i_s(axis) = boost::math::iround((x(axis) - x_lower[axis]) / dx[axis]) + patch_lower[axis];
+                        i_s(axis) = int(std::round((x(axis) - x_lower[axis]) / dx[axis]))
+                            + patch_lower[axis];
                         if (extended_box.contains(i_s))
                         {
                             std::vector<libMesh::Point> ref_coords(1, xi);

--- a/src/IB/IBRedundantInitializer.cpp
+++ b/src/IB/IBRedundantInitializer.cpp
@@ -56,7 +56,6 @@
 #include "Patch.h"
 #include "PatchHierarchy.h"
 #include "PatchLevel.h"
-#include "boost/math/special_functions/round.hpp"
 #include "boost/multi_array.hpp"
 #include "ibamr/IBAnchorPointSpec.h"
 #include "ibamr/IBBeamForceSpec.h"
@@ -1046,7 +1045,7 @@ IBRedundantInitializer::initializeDataOnPatchLevel(const int lag_node_index_idx,
             IntVector<NDIM> periodic_offset;
             for (int d = 0; d < NDIM; ++d)
             {
-                periodic_offset[d] = boost::math::round(periodic_displacement[d] / patch_dx[d]);
+                periodic_offset[d] = int(std::round(periodic_displacement[d] / patch_dx[d]));
             }
 
             // Ensure that all points are initially within the computational

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -65,7 +65,6 @@
 #include "SideVariable.h"
 #include "Variable.h"
 #include "VariableDatabase.h"
-#include "boost/math/special_functions/round.hpp"
 #include "boost/multi_array.hpp"
 #include "ibamr/IMPMethod.h"
 #include "ibamr/MaterialPointSpec.h"
@@ -127,7 +126,7 @@ kernel(const double X,
        boost::multi_array<double, 1>& dphi)
 {
     const double X_o_dx = (X - patch_x_lower) / dx;
-    stencil_box_lower = boost::math::round(X_o_dx) + patch_box_lower - kernel_width;
+    stencil_box_lower = int(std::round(X_o_dx)) + patch_box_lower - kernel_width;
     stencil_box_upper = stencil_box_lower + 2 * kernel_width - 1;
     const double r = 1.0 - X_o_dx + ((stencil_box_lower + kernel_width - 1 - patch_box_lower) + 0.5);
 


### PR DESCRIPTION
We now have std::round so this is not needed.

Followup from #347.