### PR TITLE
Use auto where appropriate

### DIFF
--- a/ibtk/src/boundary/HierarchyGhostCellInterpolation.cpp
+++ b/ibtk/src/boundary/HierarchyGhostCellInterpolation.cpp
@@ -334,9 +334,7 @@ HierarchyGhostCellInterpolation::initializeOperatorState(
 
         const std::vector<RobinBcCoefStrategy<NDIM>*>& robin_bc_coefs = d_transaction_comps[comp_idx].d_robin_bc_coefs;
         bool null_bc_coefs = true;
-        for (std::vector<RobinBcCoefStrategy<NDIM>*>::const_iterator cit = robin_bc_coefs.begin();
-             cit != robin_bc_coefs.end();
-             ++cit)
+        for (auto cit = robin_bc_coefs.begin(); cit != robin_bc_coefs.end(); ++cit)
         {
             if (*cit) null_bc_coefs = false;
         }
@@ -516,9 +514,7 @@ HierarchyGhostCellInterpolation::resetTransactionComponents(
         const std::vector<RobinBcCoefStrategy<NDIM>*>& robin_bc_coefs = d_transaction_comps[comp_idx].d_robin_bc_coefs;
 #if !defined(NDEBUG)
         bool null_bc_coefs = true;
-        for (std::vector<RobinBcCoefStrategy<NDIM>*>::const_iterator cit = robin_bc_coefs.begin();
-             cit != robin_bc_coefs.end();
-             ++cit)
+        for (auto cit = robin_bc_coefs.begin(); cit != robin_bc_coefs.end(); ++cit)
         {
             if (*cit) null_bc_coefs = false;
         }

--- a/ibtk/src/boundary/cf_interface/CartCellDoubleLinearCFInterpolation.cpp
+++ b/ibtk/src/boundary/cf_interface/CartCellDoubleLinearCFInterpolation.cpp
@@ -150,7 +150,7 @@ CartCellDoubleLinearCFInterpolation::postprocessRefine(Patch<NDIM>& fine,
                                                        const Box<NDIM>& fine_box,
                                                        const IntVector<NDIM>& ratio)
 {
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int& patch_data_index = *cit;
         d_refine_op->refine(fine, coarse, patch_data_index, patch_data_index, fine_box, ratio);
@@ -235,13 +235,13 @@ void
 CartCellDoubleLinearCFInterpolation::clearPatchHierarchy()
 {
     d_hierarchy.setNull();
-    for (std::vector<CoarseFineBoundary<NDIM>*>::iterator it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
+    for (auto it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
     {
         delete (*it);
         (*it) = nullptr;
     }
     d_cf_boundary.clear();
-    for (std::vector<BoxArray<NDIM>*>::iterator it = d_domain_boxes.begin(); it != d_domain_boxes.end(); ++it)
+    for (auto it = d_domain_boxes.begin(); it != d_domain_boxes.end(); ++it)
     {
         delete (*it);
         (*it) = nullptr;
@@ -281,7 +281,7 @@ CartCellDoubleLinearCFInterpolation::computeNormalExtension(Patch<NDIM>& patch,
     if (n_cf_bdry_codim1_boxes == 0) return;
 
     // Get the patch data.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int& patch_data_index = *cit;
         Pointer<CellData<NDIM, double> > data = patch.getPatchData(patch_data_index);

--- a/ibtk/src/boundary/cf_interface/CartCellDoubleQuadraticCFInterpolation.cpp
+++ b/ibtk/src/boundary/cf_interface/CartCellDoubleQuadraticCFInterpolation.cpp
@@ -159,9 +159,7 @@ coarsen(const Index<NDIM>& index, const IntVector<NDIM>& ratio)
 inline bool
 bdry_boxes_contain_index(const Index<NDIM>& i, const std::vector<const BoundaryBox<NDIM>*>& patch_cf_bdry_boxes)
 {
-    for (std::vector<const BoundaryBox<NDIM>*>::const_iterator cit = patch_cf_bdry_boxes.begin();
-         cit != patch_cf_bdry_boxes.end();
-         ++cit)
+    for (auto cit = patch_cf_bdry_boxes.begin(); cit != patch_cf_bdry_boxes.end(); ++cit)
     {
         const BoundaryBox<NDIM>& bdry_box = *(*cit);
         if (bdry_box.getBox().contains(i)) return true;
@@ -275,7 +273,7 @@ CartCellDoubleQuadraticCFInterpolation::postprocessRefine(Patch<NDIM>& fine,
     // boundary box information.
     if (!fine.inHierarchy())
     {
-        for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+        for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
         {
             const int& patch_data_index = *cit;
             d_refine_op->refine(fine, coarse, patch_data_index, patch_data_index, fine_box, ratio);
@@ -374,13 +372,13 @@ void
 CartCellDoubleQuadraticCFInterpolation::clearPatchHierarchy()
 {
     d_hierarchy.setNull();
-    for (std::vector<CoarseFineBoundary<NDIM>*>::iterator it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
+    for (auto it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
     {
         delete (*it);
         (*it) = nullptr;
     }
     d_cf_boundary.clear();
-    for (std::vector<BoxArray<NDIM>*>::iterator it = d_domain_boxes.begin(); it != d_domain_boxes.end(); ++it)
+    for (auto it = d_domain_boxes.begin(); it != d_domain_boxes.end(); ++it)
     {
         delete (*it);
         (*it) = nullptr;
@@ -465,7 +463,7 @@ CartCellDoubleQuadraticCFInterpolation::postprocessRefine_expensive(Patch<NDIM>&
     if (patch_cf_bdry_boxes.empty()) return;
 
     // Get the patch data.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int& patch_data_index = *cit;
         Pointer<CellData<NDIM, double> > fdata = fine.getPatchData(patch_data_index);
@@ -500,9 +498,7 @@ CartCellDoubleQuadraticCFInterpolation::postprocessRefine_expensive(Patch<NDIM>&
         // we perform coarse interpolation in all directions.
         const BoxArray<NDIM>& domain_boxes = *d_domain_boxes[fine_patch_level_num];
         const IntVector<NDIM>& periodic_shift = d_periodic_shift[fine_patch_level_num];
-        for (std::vector<const BoundaryBox<NDIM>*>::const_iterator cit = patch_cf_bdry_boxes.begin();
-             cit != patch_cf_bdry_boxes.end();
-             ++cit)
+        for (auto cit = patch_cf_bdry_boxes.begin(); cit != patch_cf_bdry_boxes.end(); ++cit)
         {
             const BoundaryBox<NDIM>& bdry_box = *(*cit);
             const Box<NDIM> bc_fill_box = pgeom_fine->getBoundaryFillBox(bdry_box, patch_box_fine, ghost_width_to_fill);
@@ -631,7 +627,7 @@ CartCellDoubleQuadraticCFInterpolation::postprocessRefine_optimized(Patch<NDIM>&
     if (cf_bdry_codim1_boxes.size() == 0) return;
 
     // Get the patch data.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int& patch_data_index = *cit;
         Pointer<CellData<NDIM, double> > fdata = fine.getPatchData(patch_data_index);
@@ -748,7 +744,7 @@ CartCellDoubleQuadraticCFInterpolation::computeNormalExtension_expensive(Patch<N
 #endif
 
     // Get the patch data.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int& patch_data_index = *cit;
         Pointer<CellData<NDIM, double> > data = patch.getPatchData(patch_data_index);
@@ -797,7 +793,7 @@ CartCellDoubleQuadraticCFInterpolation::computeNormalExtension_expensive(Patch<N
                         i_intr1(bdry_normal_axis) = patch_upper(bdry_normal_axis) - 1;
                     }
 
-                    const double r = static_cast<double>(ratio(bdry_normal_axis));
+                    const auto r = static_cast<double>(ratio(bdry_normal_axis));
                     const int i = (is_lower ? i_bdry(bdry_normal_axis) - patch_lower(bdry_normal_axis) :
                                               i_bdry(bdry_normal_axis) - patch_upper(bdry_normal_axis));
 
@@ -839,7 +835,7 @@ CartCellDoubleQuadraticCFInterpolation::computeNormalExtension_optimized(Patch<N
     if (n_cf_bdry_codim1_boxes == 0) return;
 
     // Get the patch data.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int& patch_data_index = *cit;
         Pointer<CellData<NDIM, double> > data = patch.getPatchData(patch_data_index);

--- a/ibtk/src/boundary/cf_interface/CartSideDoubleQuadraticCFInterpolation.cpp
+++ b/ibtk/src/boundary/cf_interface/CartSideDoubleQuadraticCFInterpolation.cpp
@@ -233,7 +233,7 @@ CartSideDoubleQuadraticCFInterpolation::postprocessRefine(Patch<NDIM>& fine,
     // boundary box information.
     if (!fine.inHierarchy())
     {
-        for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+        for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
         {
             const int& patch_data_index = *cit;
             d_refine_op->refine(fine, coarse, patch_data_index, patch_data_index, fine_box, ratio);
@@ -259,7 +259,7 @@ CartSideDoubleQuadraticCFInterpolation::postprocessRefine(Patch<NDIM>& fine,
     if (cf_bdry_codim1_boxes.size() == 0) return;
 
     // Get the patch data.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int& patch_data_index = *cit;
         Pointer<SideData<NDIM, double> > fdata = fine.getPatchData(patch_data_index);
@@ -451,7 +451,7 @@ void
 CartSideDoubleQuadraticCFInterpolation::clearPatchHierarchy()
 {
     d_hierarchy.setNull();
-    for (std::vector<CoarseFineBoundary<NDIM>*>::iterator it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
+    for (auto it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
     {
         delete (*it);
         (*it) = nullptr;
@@ -495,7 +495,7 @@ CartSideDoubleQuadraticCFInterpolation::computeNormalExtension(Patch<NDIM>& patc
     if (n_cf_bdry_codim1_boxes == 0) return;
 
     // Get the patch data.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int& patch_data_index = *cit;
         Pointer<SideData<NDIM, double> > data = patch.getPatchData(patch_data_index);

--- a/ibtk/src/boundary/physical_boundary/CartCellRobinPhysBdryOp.cpp
+++ b/ibtk/src/boundary/physical_boundary/CartCellRobinPhysBdryOp.cpp
@@ -281,7 +281,7 @@ CartCellRobinPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
 
     // Ensure the target patch data corresponds to a cell centered variable and
     // that the proper number of boundary condition objects have been provided.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         Pointer<CellData<NDIM, double> > patch_data = patch.getPatchData(patch_data_idx);
@@ -315,7 +315,7 @@ CartCellRobinPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
     static const bool adjoint_op = false;
     const Array<BoundaryBox<NDIM> > physical_codim1_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim1Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1(
@@ -323,7 +323,7 @@ CartCellRobinPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
     }
     const Array<BoundaryBox<NDIM> > physical_codim2_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim2Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim2(patch_data_idx, physical_codim2_boxes, ghost_width_to_fill, patch, adjoint_op);
@@ -355,7 +355,7 @@ CartCellRobinPhysBdryOp::accumulateFromPhysicalBoundaryData(Patch<NDIM>& patch,
 
     // Ensure the target patch data corresponds to a cell centered variable and
     // that the proper number of boundary condition objects have been provided.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         Pointer<CellData<NDIM, double> > patch_data = patch.getPatchData(patch_data_idx);
@@ -398,14 +398,14 @@ CartCellRobinPhysBdryOp::accumulateFromPhysicalBoundaryData(Patch<NDIM>& patch,
 #endif
     const Array<BoundaryBox<NDIM> > physical_codim2_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim2Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim2(patch_data_idx, physical_codim2_boxes, ghost_width_to_fill, patch, adjoint_op);
     }
     const Array<BoundaryBox<NDIM> > physical_codim1_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim1Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1(
@@ -465,7 +465,7 @@ CartCellRobinPhysBdryOp::fillGhostCellValuesCodim1(const int patch_data_idx,
         for (int d = 0; d < patch_data_depth; ++d)
         {
             RobinBcCoefStrategy<NDIM>* bc_coef = d_bc_coefs[d];
-            ExtendedRobinBcCoefStrategy* const extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coef);
+            auto const extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coef);
             if (extended_bc_coef)
             {
                 extended_bc_coef->setTargetPatchDataIndex(patch_data_idx);

--- a/ibtk/src/boundary/physical_boundary/CartExtrapPhysBdryOp.cpp
+++ b/ibtk/src/boundary/physical_boundary/CartExtrapPhysBdryOp.cpp
@@ -361,7 +361,7 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_cell(
 
     // Set the physical boundary conditions for the specified patch data
     // indices.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -374,9 +374,7 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_cell(
         const Box<NDIM>& ghost_box = patch_data->getGhostBox();
 
         // Loop over the boundary fill boxes and extrapolate the data.
-        for (std::vector<std::pair<Box<NDIM>, std::pair<int, int> > >::const_iterator it = bdry_fill_boxes.begin();
-             it != bdry_fill_boxes.end();
-             ++it)
+        for (auto it = bdry_fill_boxes.begin(); it != bdry_fill_boxes.end(); ++it)
         {
             const Box<NDIM>& bdry_fill_box = it->first;
             const unsigned int location_index = it->second.first;
@@ -466,7 +464,7 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_face(
 
     // Set the physical boundary conditions for the specified patch data
     // indices.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -478,9 +476,7 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_face(
         const Box<NDIM>& ghost_box = patch_data->getGhostBox();
 
         // Loop over the boundary fill boxes and extrapolate the data.
-        for (std::vector<std::pair<Box<NDIM>, std::pair<int, int> > >::const_iterator it = bdry_fill_boxes.begin();
-             it != bdry_fill_boxes.end();
-             ++it)
+        for (auto it = bdry_fill_boxes.begin(); it != bdry_fill_boxes.end(); ++it)
         {
             const Box<NDIM>& bdry_fill_box = it->first;
             const unsigned int location_index = it->second.first;
@@ -578,7 +574,7 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_node(
 
     // Set the physical boundary conditions for the specified patch data
     // indices.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -590,9 +586,7 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_node(
         const Box<NDIM>& ghost_box = patch_data->getGhostBox();
 
         // Loop over the boundary fill boxes and extrapolate the data.
-        for (std::vector<std::pair<Box<NDIM>, std::pair<int, int> > >::const_iterator it = bdry_fill_boxes.begin();
-             it != bdry_fill_boxes.end();
-             ++it)
+        for (auto it = bdry_fill_boxes.begin(); it != bdry_fill_boxes.end(); ++it)
         {
             const Box<NDIM>& bdry_fill_box = it->first;
             const unsigned int location_index = it->second.first;
@@ -682,7 +676,7 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_side(
 
     // Set the physical boundary conditions for the specified patch data
     // indices.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -694,9 +688,7 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_side(
         const Box<NDIM>& ghost_box = patch_data->getGhostBox();
 
         // Loop over the boundary fill boxes and extrapolate the data.
-        for (std::vector<std::pair<Box<NDIM>, std::pair<int, int> > >::const_iterator it = bdry_fill_boxes.begin();
-             it != bdry_fill_boxes.end();
-             ++it)
+        for (auto it = bdry_fill_boxes.begin(); it != bdry_fill_boxes.end(); ++it)
         {
             const Box<NDIM>& bdry_fill_box = it->first;
             const unsigned int location_index = it->second.first;

--- a/ibtk/src/boundary/physical_boundary/CartSideRobinPhysBdryOp.cpp
+++ b/ibtk/src/boundary/physical_boundary/CartSideRobinPhysBdryOp.cpp
@@ -365,7 +365,7 @@ CartSideRobinPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
 
     // Ensure the target patch data corresponds to a side centered variable and
     // that the proper number of boundary condition objects have been provided.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         Pointer<SideData<NDIM, double> > patch_data = patch.getPatchData(patch_data_idx);
@@ -399,13 +399,13 @@ CartSideRobinPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
     static const bool adjoint_op = false;
     const Array<BoundaryBox<NDIM> > physical_codim1_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim1Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1Normal(
             patch_data_idx, physical_codim1_boxes, fill_time, ghost_width_to_fill, patch, adjoint_op);
     }
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1Transverse(
@@ -413,7 +413,7 @@ CartSideRobinPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
     }
     const Array<BoundaryBox<NDIM> > physical_codim2_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim2Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim2(patch_data_idx, physical_codim2_boxes, ghost_width_to_fill, patch, adjoint_op);
@@ -445,7 +445,7 @@ CartSideRobinPhysBdryOp::accumulateFromPhysicalBoundaryData(Patch<NDIM>& patch,
 
     // Ensure the target patch data corresponds to a side centered variable and
     // that the proper number of boundary condition objects have been provided.
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         Pointer<SideData<NDIM, double> > patch_data = patch.getPatchData(patch_data_idx);
@@ -488,20 +488,20 @@ CartSideRobinPhysBdryOp::accumulateFromPhysicalBoundaryData(Patch<NDIM>& patch,
 #endif
     const Array<BoundaryBox<NDIM> > physical_codim2_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim2Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim2(patch_data_idx, physical_codim2_boxes, ghost_width_to_fill, patch, adjoint_op);
     }
     const Array<BoundaryBox<NDIM> > physical_codim1_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim1Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1Transverse(
             patch_data_idx, physical_codim1_boxes, fill_time, ghost_width_to_fill, patch, adjoint_op);
     }
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
     {
         const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1Normal(
@@ -564,7 +564,7 @@ CartSideRobinPhysBdryOp::fillGhostCellValuesCodim1Normal(const int patch_data_id
         for (int d = 0; d < patch_data_depth; ++d)
         {
             RobinBcCoefStrategy<NDIM>* bc_coef = d_bc_coefs[NDIM * d + bdry_normal_axis];
-            ExtendedRobinBcCoefStrategy* const extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coef);
+            auto const extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coef);
             if (extended_bc_coef)
             {
                 extended_bc_coef->setTargetPatchDataIndex(patch_data_idx);
@@ -747,8 +747,7 @@ CartSideRobinPhysBdryOp::fillGhostCellValuesCodim1Transverse(const int patch_dat
                 for (int d = 0; d < patch_data_depth; ++d)
                 {
                     RobinBcCoefStrategy<NDIM>* bc_coef = d_bc_coefs[NDIM * d + axis];
-                    ExtendedRobinBcCoefStrategy* const extended_bc_coef =
-                        dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coef);
+                    auto const extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coef);
                     if (extended_bc_coef)
                     {
                         extended_bc_coef->setTargetPatchDataIndex(patch_data_idx);

--- a/ibtk/src/boundary/physical_boundary/muParserRobinBcCoefs.cpp
+++ b/ibtk/src/boundary/physical_boundary/muParserRobinBcCoefs.cpp
@@ -244,7 +244,7 @@ muParserRobinBcCoefs::muParserRobinBcCoefs(const std::string& object_name,
     const double pi = 3.1415926535897932384626433832795;
     const double* const xLower = grid_geom->getXLower();
     const double* const xUpper = grid_geom->getXUpper();
-    for (std::vector<mu::Parser*>::const_iterator cit = all_parsers.begin(); cit != all_parsers.end(); ++cit)
+    for (auto cit = all_parsers.begin(); cit != all_parsers.end(); ++cit)
     {
         // Various names for pi.
         (*cit)->DefineConst("pi", pi);
@@ -312,8 +312,7 @@ muParserRobinBcCoefs::muParserRobinBcCoefs(const std::string& object_name,
         }
 
         // User-provided constants.
-        for (std::map<std::string, double>::const_iterator map_cit = d_constants.begin(); map_cit != d_constants.end();
-             ++map_cit)
+        for (auto map_cit = d_constants.begin(); map_cit != d_constants.end(); ++map_cit)
         {
             (*cit)->DefineConst(map_cit->first, map_cit->second);
         }

--- a/ibtk/src/lagrangian/FEDataInterpolation.cpp
+++ b/ibtk/src/lagrangian/FEDataInterpolation.cpp
@@ -76,9 +76,7 @@ FEDataInterpolation::registerSystem(const System& system,
 {
     TBOX_ASSERT(!d_initialized && (!phi_vars.empty() || !dphi_vars.empty()));
     const unsigned int sys_num = system.number();
-    for (std::vector<const System *>::iterator it = d_noninterp_systems.begin(), it_end = d_noninterp_systems.end();
-         it != it_end;
-         ++it)
+    for (auto it = d_noninterp_systems.begin(), it_end = d_noninterp_systems.end(); it != it_end; ++it)
     {
         if ((*it)->number() == sys_num)
         {
@@ -128,7 +126,7 @@ FEDataInterpolation::registerInterpolatedSystem(const System& system,
 {
     TBOX_ASSERT(!d_initialized && (!vars.empty() || !grad_vars.empty()));
     const unsigned int sys_num = system.number();
-    for (std::vector<const System *>::iterator it = d_systems.begin(), it_end = d_systems.end(); it != it_end; ++it)
+    for (auto it = d_systems.begin(), it_end = d_systems.end(); it != it_end; ++it)
     {
         if ((*it)->number() == sys_num)
         {
@@ -480,7 +478,7 @@ FEDataInterpolation::interpolateCommon(
         // Interpolate regular variables.
         {
             const std::vector<size_t>& var_idxs = d_system_var_idx[system_idx];
-            const unsigned int n_vars = static_cast<unsigned int>(var_idxs.size());
+            const auto n_vars = static_cast<unsigned int>(var_idxs.size());
             for (unsigned int qp = 0; qp < n_qp; ++qp)
             {
                 system_var_data[qp][system_idx].resize(n_vars);
@@ -505,7 +503,7 @@ FEDataInterpolation::interpolateCommon(
         // Interpolate gradient variables.
         {
             const std::vector<size_t>& grad_var_idxs = d_system_grad_var_idx[system_idx];
-            const unsigned int n_grad_vars = static_cast<unsigned int>(grad_var_idxs.size());
+            const auto n_grad_vars = static_cast<unsigned int>(grad_var_idxs.size());
             for (unsigned int qp = 0; qp < n_qp; ++qp)
             {
                 system_grad_var_data[qp][system_idx].resize(n_grad_vars);

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -185,7 +185,7 @@ inline void
 collect_unique_elems(std::vector<Elem*>& elems, const ContainerOfContainers& elem_patch_map)
 {
     std::set<Elem*, ElemComp> elem_set;
-    for (typename ContainerOfContainers::const_iterator it = elem_patch_map.begin(); it != elem_patch_map.end(); ++it)
+    for (auto it = elem_patch_map.begin(); it != elem_patch_map.end(); ++it)
     {
         elem_set.insert(it->begin(), it->end());
     }
@@ -197,7 +197,7 @@ inline short int
 get_dirichlet_bdry_ids(const std::vector<short int>& bdry_ids)
 {
     short int dirichlet_bdry_ids = 0;
-    for (std::vector<short int>::const_iterator cit = bdry_ids.begin(); cit != bdry_ids.end(); ++cit)
+    for (auto cit = bdry_ids.begin(); cit != bdry_ids.end(); ++cit)
     {
         const short int bdry_id = *cit;
         if (bdry_id == FEDataManager::ZERO_DISPLACEMENT_X_BDRY_ID ||
@@ -295,9 +295,7 @@ FEDataManager::getManager(const std::string& name,
 void
 FEDataManager::freeAllManagers()
 {
-    for (std::map<std::string, FEDataManager*>::iterator it = s_data_manager_instances.begin();
-         it != s_data_manager_instances.end();
-         ++it)
+    for (auto it = s_data_manager_instances.begin(); it != s_data_manager_instances.end(); ++it)
     {
         if (it->second)
         {
@@ -429,9 +427,7 @@ FEDataManager::reinitElementMappings()
     d_active_patch_elem_map.clear();
     d_active_patch_node_map.clear();
     d_active_patch_ghost_dofs.clear();
-    for (std::map<std::string, NumericVector<double>*>::iterator it = d_system_ghost_vec.begin();
-         it != d_system_ghost_vec.end();
-         ++it)
+    for (auto it = d_system_ghost_vec.begin(); it != d_system_ghost_vec.end(); ++it)
     {
         delete it->second;
     }
@@ -608,14 +604,14 @@ FEDataManager::spread(const int f_data_idx,
         F_dX_vec->close();
 
         // Extract local form vectors.
-        PetscVector<double>* F_dX_petsc_vec = static_cast<PetscVector<double>*>(F_dX_vec.get());
+        auto F_dX_petsc_vec = static_cast<PetscVector<double>*>(F_dX_vec.get());
         Vec F_dX_global_vec = F_dX_petsc_vec->vec();
         Vec F_dX_local_vec;
         VecGhostGetLocalForm(F_dX_global_vec, &F_dX_local_vec);
         double* F_dX_local_soln;
         VecGetArray(F_dX_local_vec, &F_dX_local_soln);
 
-        PetscVector<double>* X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
+        auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
         VecGhostGetLocalForm(X_global_vec, &X_local_vec);
@@ -642,7 +638,7 @@ FEDataManager::spread(const int f_data_idx,
                 for (unsigned int i = 0; i < n_vars; ++i)
                 {
                     IBTK::get_nodal_dof_indices(F_dof_map, n, i, F_idxs);
-                    for (std::vector<dof_id_type>::iterator it = F_idxs.begin(); it != F_idxs.end(); ++it)
+                    for (auto it = F_idxs.begin(); it != F_idxs.end(); ++it)
                     {
                         F_dX_node.push_back(F_dX_local_soln[F_dX_petsc_vec->map_global_to_local_index(*it)]);
                     }
@@ -650,7 +646,7 @@ FEDataManager::spread(const int f_data_idx,
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {
                     IBTK::get_nodal_dof_indices(X_dof_map, n, d, X_idxs);
-                    for (std::vector<dof_id_type>::iterator it = X_idxs.begin(); it != X_idxs.end(); ++it)
+                    for (auto it = X_idxs.begin(); it != X_idxs.end(); ++it)
                     {
                         X_node.push_back(X_local_soln[X_petsc_vec->map_global_to_local_index(*it)]);
                     }
@@ -700,14 +696,14 @@ FEDataManager::spread(const int f_data_idx,
     else
     {
         // Extract local form vectors.
-        PetscVector<double>* F_petsc_vec = static_cast<PetscVector<double>*>(&F_vec);
+        auto F_petsc_vec = static_cast<PetscVector<double>*>(&F_vec);
         Vec F_global_vec = F_petsc_vec->vec();
         Vec F_local_vec;
         VecGhostGetLocalForm(F_global_vec, &F_local_vec);
         double* F_local_soln;
         VecGetArray(F_local_vec, &F_local_soln);
 
-        PetscVector<double>* X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
+        auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
         VecGhostGetLocalForm(X_global_vec, &X_local_vec);
@@ -915,7 +911,7 @@ FEDataManager::prolongData(const int f_data_idx,
     // Communicate any unsynchronized ghost data and extract the underlying
     // solution data.
     if (close_F) F_vec.close();
-    PetscVector<double>* F_petsc_vec = static_cast<PetscVector<double>*>(&F_vec);
+    auto F_petsc_vec = static_cast<PetscVector<double>*>(&F_vec);
     Vec F_global_vec = F_petsc_vec->vec();
     Vec F_local_vec;
     VecGhostGetLocalForm(F_global_vec, &F_local_vec);
@@ -923,7 +919,7 @@ FEDataManager::prolongData(const int f_data_idx,
     VecGetArray(F_local_vec, &F_local_soln);
 
     if (close_X) X_vec.close();
-    PetscVector<double>* X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
+    auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
     Vec X_global_vec = X_petsc_vec->vec();
     Vec X_local_vec;
     VecGhostGetLocalForm(X_global_vec, &X_local_vec);
@@ -1175,7 +1171,7 @@ FEDataManager::interpWeighted(const int f_data_idx,
     if (use_nodal_quadrature)
     {
         // Extract the local form vectors.
-        PetscVector<double>* X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
+        auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
         VecGhostGetLocalForm(X_global_vec, &X_local_vec);
@@ -1274,7 +1270,7 @@ FEDataManager::interpWeighted(const int f_data_idx,
     else
     {
         // Extract local form vectors.
-        PetscVector<double>* X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
+        auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
         VecGhostGetLocalForm(X_global_vec, &X_local_vec);
@@ -1538,7 +1534,7 @@ FEDataManager::restrictData(const int f_data_idx,
     // Communicate any unsynchronized ghost data and extract the underlying
     // solution data.
     if (close_X) X_vec.close();
-    PetscVector<double>* X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
+    auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
     Vec X_global_vec = X_petsc_vec->vec();
     Vec X_local_vec;
     VecGhostGetLocalForm(X_global_vec, &X_local_vec);
@@ -1752,7 +1748,7 @@ FEDataManager::buildL2ProjectionSolver(const std::string& system_name)
             for (unsigned int var_num = 0; var_num < dof_map.n_variables(); ++var_num)
             {
                 dof_map_cache.dof_indices(elem, dof_indices, var_num);
-                const unsigned int dof_indices_sz = static_cast<unsigned int>(dof_indices.size());
+                const auto dof_indices_sz = static_cast<unsigned int>(dof_indices.size());
                 M_e.resize(dof_indices_sz, dof_indices_sz);
                 const size_t n_basis = dof_indices.size();
                 const unsigned int n_qp = qrule->n_points();
@@ -1802,9 +1798,7 @@ FEDataManager::buildL2ProjectionSolver(const std::string& system_name)
                                 if (!(dirichlet_bdry_ids & dirichlet_bdry_id_set[comp])) continue;
                                 const unsigned int node_dof_index = node->dof_number(sys_num, var_num, comp);
                                 if (!dof_map.is_constrained_dof(node_dof_index)) continue;
-                                for (std::vector<unsigned int>::const_iterator cit = dof_indices.begin();
-                                     cit != dof_indices.end();
-                                     ++cit)
+                                for (auto cit = dof_indices.begin(); cit != dof_indices.end(); ++cit)
                                 {
                                     const unsigned int k = *cit;
                                     M_mat->set(node_dof_index, k, (node_dof_index == k ? 1.0 : 0.0));
@@ -1877,7 +1871,7 @@ FEDataManager::buildDiagonalL2MassMatrix(const std::string& system_name)
             for (unsigned int var_num = 0; var_num < dof_map.n_variables(); ++var_num)
             {
                 dof_map_cache.dof_indices(elem, dof_indices, var_num);
-                const unsigned int dof_indices_sz = static_cast<unsigned int>(dof_indices.size());
+                const auto dof_indices_sz = static_cast<unsigned int>(dof_indices.size());
                 M_e.resize(dof_indices_sz, dof_indices_sz);
                 M_e_vec.resize(dof_indices_sz);
                 const size_t n_basis = dof_indices.size();
@@ -1978,8 +1972,8 @@ FEDataManager::computeL2Projection(NumericVector<double>& U_vec,
     {
         std::pair<libMesh::LinearSolver<double>*, SparseMatrix<double>*> proj_solver_components =
             buildL2ProjectionSolver(system_name);
-        PetscLinearSolver<double>* solver = static_cast<PetscLinearSolver<double>*>(proj_solver_components.first);
-        PetscMatrix<double>* M_mat = static_cast<PetscMatrix<double>*>(proj_solver_components.second);
+        auto solver = static_cast<PetscLinearSolver<double>*>(proj_solver_components.first);
+        auto M_mat = static_cast<PetscMatrix<double>*>(proj_solver_components.second);
         PetscBool rtol_set;
         double runtime_rtol;
         ierr = PetscOptionsGetReal(nullptr, "", "-ksp_rtol", &runtime_rtol, &rtol_set);
@@ -1999,7 +1993,7 @@ FEDataManager::computeL2Projection(NumericVector<double>& U_vec,
     }
     else
     {
-        PetscVector<double>* M_diag_vec = static_cast<PetscVector<double>*>(buildDiagonalL2MassMatrix(system_name));
+        auto M_diag_vec = static_cast<PetscVector<double>*>(buildDiagonalL2MassMatrix(system_name));
         Vec M_diag_petsc_vec = M_diag_vec->vec();
         Vec U_petsc_vec = static_cast<PetscVector<double>*>(&U_vec)->vec();
         Vec F_petsc_vec = static_cast<PetscVector<double>*>(&F_vec)->vec();
@@ -2200,7 +2194,7 @@ FEDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> > hi
         UniquePtr<NumericVector<double> > X_ghost_vec = NumericVector<double>::build(comm);
         X_ghost_vec->init(X_vec->size(), X_vec->local_size(), X_ghost_dofs, true, GHOSTED);
         X_vec->localize(*X_ghost_vec);
-        PetscVector<double>* X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec.get());
+        auto X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec.get());
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
         VecGhostGetLocalForm(X_global_vec, &X_local_vec);
@@ -2384,27 +2378,19 @@ FEDataManager::FEDataManager(const std::string& object_name,
 
 FEDataManager::~FEDataManager()
 {
-    for (std::map<std::string, NumericVector<double>*>::iterator it = d_system_ghost_vec.begin();
-         it != d_system_ghost_vec.end();
-         ++it)
+    for (auto it = d_system_ghost_vec.begin(); it != d_system_ghost_vec.end(); ++it)
     {
         delete it->second;
     }
-    for (std::map<std::string, LinearSolver<double>*>::iterator it = d_L2_proj_solver.begin();
-         it != d_L2_proj_solver.end();
-         ++it)
+    for (auto it = d_L2_proj_solver.begin(); it != d_L2_proj_solver.end(); ++it)
     {
         delete it->second;
     }
-    for (std::map<std::string, SparseMatrix<double>*>::iterator it = d_L2_proj_matrix.begin();
-         it != d_L2_proj_matrix.end();
-         ++it)
+    for (auto it = d_L2_proj_matrix.begin(); it != d_L2_proj_matrix.end(); ++it)
     {
         delete it->second;
     }
-    for (std::map<std::string, NumericVector<double>*>::iterator it = d_L2_proj_matrix_diag.begin();
-         it != d_L2_proj_matrix_diag.end();
-         ++it)
+    for (auto it = d_L2_proj_matrix_diag.begin(); it != d_L2_proj_matrix_diag.end(); ++it)
     {
         delete it->second;
     }
@@ -2445,7 +2431,7 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
 
         // Extract the underlying solution data.
         NumericVector<double>* X_ghost_vec = buildGhostedCoordsVector();
-        PetscVector<double>* X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec);
+        auto X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
         VecGhostGetLocalForm(X_global_vec, &X_local_vec);
@@ -2671,7 +2657,7 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
         collectGhostDOFIndices(X_ghost_dofs, frontier_elems, COORDINATES_SYSTEM_NAME);
         X_ghost_vec->init(X_vec->size(), X_vec->local_size(), X_ghost_dofs, true, GHOSTED);
         X_vec->localize(*X_ghost_vec);
-        PetscVector<double>* X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec.get());
+        auto X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec.get());
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
         VecGhostGetLocalForm(X_global_vec, &X_local_vec);
@@ -2697,7 +2683,7 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
             const double* const patch_dx = patch_geom->getDx();
             const double patch_dx_min = *std::min_element(patch_dx, patch_dx + NDIM);
 
-            std::set<Elem*>::const_iterator el_it = frontier_elems.begin();
+            auto el_it = frontier_elems.begin();
             const std::set<Elem*>::const_iterator el_end = frontier_elems.end();
             for (; el_it != el_end; ++el_it)
             {
@@ -2750,7 +2736,7 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
             frontier_elems.clear();
             if (local_elems.empty()) continue;
 
-            for (std::set<Elem*>::const_iterator cit = local_elems.begin(); cit != local_elems.end(); ++cit)
+            for (auto cit = local_elems.begin(); cit != local_elems.end(); ++cit)
             {
                 const Elem* const elem = *cit;
                 for (unsigned int n = 0; n < elem->n_neighbors(); ++n)
@@ -2783,7 +2769,7 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
         const std::set<Elem*>& local_elems = local_patch_elems[local_patch_num];
         active_elems.resize(local_elems.size());
         int k = 0;
-        for (std::set<Elem*>::const_iterator cit = local_elems.begin(); cit != local_elems.end(); ++cit, ++k)
+        for (auto cit = local_elems.begin(); cit != local_elems.end(); ++cit, ++k)
         {
             active_elems[k] = *cit;
         }
@@ -2811,7 +2797,7 @@ FEDataManager::collectActivePatchNodes(std::vector<std::vector<Node*> >& active_
         }
         const unsigned int num_active_nodes = active_node_ids.size();
         active_patch_nodes[k].reserve(num_active_nodes);
-        for (std::set<dof_id_type>::iterator it = active_node_ids.begin(); it != active_node_ids.end(); ++it)
+        for (auto it = active_node_ids.begin(); it != active_node_ids.end(); ++it)
         {
             active_patch_nodes[k].push_back(const_cast<Node*>(mesh.node_ptr(*it)));
         }
@@ -2833,13 +2819,13 @@ FEDataManager::collectGhostDOFIndices(std::vector<unsigned int>& ghost_dofs,
     // Include non-local DOF constraint dependencies for local DOFs in the list
     // of ghost DOFs.
     std::vector<unsigned int> constraint_dependency_dof_list;
-    for (DofConstraints::const_iterator i = dof_map.constraint_rows_begin(); i != dof_map.constraint_rows_end(); ++i)
+    for (auto i = dof_map.constraint_rows_begin(); i != dof_map.constraint_rows_end(); ++i)
     {
         const unsigned int constrained_dof = i->first;
         if (constrained_dof >= first_local_dof && constrained_dof < end_local_dof)
         {
             const DofConstraintRow& constraint_row = i->second;
-            for (DofConstraintRow::const_iterator j = constraint_row.begin(); j != constraint_row.end(); ++j)
+            for (auto j = constraint_row.begin(); j != constraint_row.end(); ++j)
             {
                 const unsigned int constraint_dependency = j->first;
                 if (constraint_dependency < first_local_dof || constraint_dependency >= end_local_dof)

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -212,9 +212,7 @@ LDataManager::getManager(const std::string& name,
 void
 LDataManager::freeAllManagers()
 {
-    for (std::map<std::string, LDataManager*>::iterator it = s_data_manager_instances.begin();
-         it != s_data_manager_instances.end();
-         ++it)
+    for (auto it = s_data_manager_instances.begin(); it != s_data_manager_instances.end(); ++it)
     {
         if (it->second)
         {
@@ -935,7 +933,7 @@ LDataManager::computeLagrangianStructureCenterOfMass(const int structure_id, con
         *d_lag_mesh_data[level_number][POSN_DATA_NAME]->getLocalFormVecArray();
     const Pointer<LMesh> mesh = getLMesh(level_number);
     const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const int lag_idx = node_idx->getLagrangianIndex();
@@ -975,7 +973,7 @@ LDataManager::computeLagrangianStructureBoundingBox(const int structure_id, cons
         *d_lag_mesh_data[level_number][POSN_DATA_NAME]->getLocalFormVecArray();
     const Pointer<LMesh> mesh = getLMesh(level_number);
     const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const int lag_idx = node_idx->getLagrangianIndex();
@@ -1014,7 +1012,7 @@ LDataManager::reinitLagrangianStructure(const Point& X_center, const int structu
 
     const Pointer<LMesh> mesh = getLMesh(level_number);
     const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const int lag_idx = node_idx->getLagrangianIndex();
@@ -1076,7 +1074,7 @@ LDataManager::reinitLagrangianStructure(const Point& X_center, const int structu
             {
                 LNodeSet::DataSet unmoved_idxs;
                 unmoved_idxs.reserve(node_set->size());
-                for (LNodeSet::iterator it = node_set->begin(); it != node_set->end(); ++it)
+                for (auto it = node_set->begin(); it != node_set->end(); ++it)
                 {
                     LNodeSet::value_type& node_idx = *it;
                     const int lag_idx = node_idx->getLagrangianIndex();
@@ -1155,7 +1153,7 @@ LDataManager::displaceLagrangianStructure(const Vector& dX, const int structure_
             {
                 LNodeSet::DataSet unmoved_idxs;
                 unmoved_idxs.reserve(node_set->size());
-                for (LNodeSet::iterator it = node_set->begin(); it != node_set->end(); ++it)
+                for (auto it = node_set->begin(); it != node_set->end(); ++it)
                 {
                     LNodeSet::value_type& node_idx = *it;
                     const int lag_idx = node_idx->getLagrangianIndex();
@@ -1192,7 +1190,7 @@ LDataManager::activateLagrangianStructures(const std::vector<int>& structure_ids
 #if !defined(NDEBUG)
     TBOX_ASSERT(d_coarsest_ln <= level_number && d_finest_ln >= level_number);
 #endif
-    for (std::vector<int>::const_iterator cit = structure_ids.begin(); cit != structure_ids.end(); ++cit)
+    for (auto cit = structure_ids.begin(); cit != structure_ids.end(); ++cit)
     {
         d_inactive_strcts[level_number].removeItem(*cit);
     }
@@ -1206,7 +1204,7 @@ LDataManager::inactivateLagrangianStructures(const std::vector<int>& structure_i
 #if !defined(NDEBUG)
     TBOX_ASSERT(d_coarsest_ln <= level_number && d_finest_ln >= level_number);
 #endif
-    for (std::vector<int>::const_iterator cit = structure_ids.begin(); cit != structure_ids.end(); ++cit)
+    for (auto cit = structure_ids.begin(); cit != structure_ids.end(); ++cit)
     {
         d_inactive_strcts[level_number].addItem(*cit);
     }
@@ -1229,7 +1227,7 @@ LDataManager::zeroInactivatedComponents(Pointer<LData> lag_data, const int level
     // Instead, it is a list of ALL of the inactivated indices.  Thus, idxs will
     // have the same contents for all MPI processes.
     std::vector<int> idxs;
-    for (std::set<int>::const_iterator cit = d_inactive_strcts[level_number].getSet().begin();
+    for (auto cit = d_inactive_strcts[level_number].getSet().begin();
          cit != d_inactive_strcts[level_number].getSet().end();
          ++cit)
     {
@@ -1261,7 +1259,7 @@ LDataManager::zeroInactivatedComponents(Pointer<LData> lag_data, const int level
     std::vector<int> ix(bs);
     std::vector<double> y(bs, 0.0);
     std::sort(idxs.begin(), idxs.end());
-    for (std::vector<int>::const_iterator cit = idxs.begin(); cit != idxs.end(); ++cit)
+    for (auto cit = idxs.begin(); cit != idxs.end(); ++cit)
     {
         const int l = *cit;
         if (l * bs >= lo && l * bs < hi)
@@ -1492,7 +1490,7 @@ LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int finest
                 LNodeSet* const old_node_set = current_idx_data->getItem(old_cell_idx);
                 if (old_node_set)
                 {
-                    for (LNodeSet::iterator n = old_node_set->begin(); n != old_node_set->end(); ++n)
+                    for (auto n = old_node_set->begin(); n != old_node_set->end(); ++n)
                     {
                         LNodeSet::value_type& node_idx = *n;
                         const int local_idx = node_idx->getLocalPETScIndex();
@@ -1500,8 +1498,7 @@ LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int finest
                         const CellIndex<NDIM> new_cell_idx = IndexUtilities::getCellIndex(X, grid_geom, ratio);
                         if (patch_box.contains(new_cell_idx))
                         {
-                            std::map<int, IntVector<NDIM> >::const_iterator it_offset =
-                                periodic_offset_data[level_number].find(local_idx);
+                            auto it_offset = periodic_offset_data[level_number].find(local_idx);
                             const bool periodic_node = it_offset != periodic_offset_data[level_number].end();
                             const bool unregistered_periodic_node =
                                 periodic_node &&
@@ -1511,8 +1508,7 @@ LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int finest
                                 if (unregistered_periodic_node)
                                 {
                                     const IntVector<NDIM>& periodic_offset = it_offset->second;
-                                    std::map<int, Vector>::const_iterator it_displacement =
-                                        periodic_displacement_data[level_number].find(local_idx);
+                                    auto it_displacement = periodic_displacement_data[level_number].find(local_idx);
                                     const Vector& periodic_displacement = it_displacement->second;
                                     node_idx->registerPeriodicShift(periodic_offset, periodic_displacement);
                                     registered_periodic_idx.insert(local_idx);
@@ -1643,9 +1639,7 @@ LDataManager::endDataRedistribution(const int coarsest_ln_in, const int finest_l
                 {
                     Pointer<LNodeTransaction> transaction = transactions[src_proc][dst_proc];
                     const std::vector<LNodeTransactionComponent>& dst_index_set = transaction->getDestinationData();
-                    for (std::vector<LNodeTransactionComponent>::const_iterator cit = dst_index_set.begin();
-                         cit != dst_index_set.end();
-                         ++cit)
+                    for (auto cit = dst_index_set.begin(); cit != dst_index_set.end(); ++cit)
                     {
                         d_displaced_strct_lnode_idxs[level_number].push_back(cit->item);
                         d_displaced_strct_lnode_posns[level_number].push_back(cit->posn);
@@ -1966,13 +1960,13 @@ LDataManager::endDataRedistribution(const int coarsest_ln_in, const int finest_l
         }
         d_ao[level_number] = new_ao[level_number];
 
-        for (std::map<int, IS>::iterator it = src_IS[level_number].begin(); it != src_IS[level_number].end(); ++it)
+        for (auto it = src_IS[level_number].begin(); it != src_IS[level_number].end(); ++it)
         {
             ierr = ISDestroy(&it->second);
             IBTK_CHKERRQ(ierr);
         }
 
-        for (std::map<int, IS>::iterator it = dst_IS[level_number].begin(); it != dst_IS[level_number].end(); ++it)
+        for (auto it = dst_IS[level_number].begin(); it != dst_IS[level_number].end(); ++it)
         {
             ierr = ISDestroy(&it->second);
             IBTK_CHKERRQ(ierr);
@@ -2184,7 +2178,7 @@ LDataManager::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> > hiera
             hierarchy, level_number, init_data_time, can_be_refined, initial_time);
         const unsigned int num_local_nodes = d_lag_init->computeLocalNodeCountOnPatchLevel(
             hierarchy, level_number, init_data_time, can_be_refined, initial_time);
-        const unsigned int sum_num_local_nodes =
+        const auto sum_num_local_nodes =
             static_cast<unsigned int>(SAMRAI_MPI::sumReduction(static_cast<int>(num_local_nodes)));
         if (num_global_nodes != sum_num_local_nodes)
         {
@@ -2307,7 +2301,7 @@ LDataManager::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> > hiera
                     (*node_count_data)(i) = node_set.size();
                 }
 
-                for (LNodeSet::iterator n = node_set.begin(); n != node_set.end(); ++n)
+                for (auto n = node_set.begin(); n != node_set.end(); ++n)
                 {
                     LNode* const node_idx = *n;
                     const int lag_idx = node_idx->getLagrangianIndex();
@@ -2329,7 +2323,7 @@ LDataManager::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> > hiera
                 }
             }
         }
-        const unsigned int num_initialized_global_nodes =
+        const auto num_initialized_global_nodes =
             static_cast<unsigned int>(SAMRAI_MPI::sumReduction(static_cast<int>(local_nodes.size())));
         if (num_initialized_global_nodes != d_num_nodes[level_number])
         {
@@ -2512,8 +2506,7 @@ LDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> > hie
 
             for (int ln = level_number + 1; ln <= d_finest_ln; ++ln)
             {
-                for (std::vector<std::pair<Point, Point> >::const_iterator cit =
-                         d_displaced_strct_bounding_boxes[ln].begin();
+                for (auto cit = d_displaced_strct_bounding_boxes[ln].begin();
                      cit != d_displaced_strct_bounding_boxes[ln].end();
                      ++cit)
                 {
@@ -2568,7 +2561,7 @@ LDataManager::putToDatabase(Pointer<Database> db)
 
         std::vector<int> lstruct_ids, lstruct_lag_idx_range_first, lstruct_lag_idx_range_second, lstruct_activation;
         std::vector<std::string> lstruct_names;
-        for (std::map<int, std::string>::iterator it = d_strct_id_to_strct_name_map[level_number].begin();
+        for (auto it = d_strct_id_to_strct_name_map[level_number].begin();
              it != d_strct_id_to_strct_name_map[level_number].end();
              ++it)
         {
@@ -2597,9 +2590,7 @@ LDataManager::putToDatabase(Pointer<Database> db)
         }
 
         std::vector<std::string> ldata_names;
-        for (std::map<std::string, Pointer<LData> >::iterator it = d_lag_mesh_data[level_number].begin();
-             it != d_lag_mesh_data[level_number].end();
-             ++it)
+        for (auto it = d_lag_mesh_data[level_number].begin(); it != d_lag_mesh_data[level_number].end(); ++it)
         {
             ldata_names.push_back(it->first);
             it->second->putToDatabase(level_db->putDatabase(ldata_names.back()));
@@ -2908,7 +2899,7 @@ LDataManager::beginNonlocalDataFill(const int coarsest_ln_in, const int finest_l
     for (int level_number = coarsest_ln; level_number <= finest_ln; ++level_number)
     {
         std::map<std::string, Pointer<LData> >& level_data = d_lag_mesh_data[level_number];
-        for (std::map<std::string, Pointer<LData> >::iterator it = level_data.begin(); it != level_data.end(); ++it)
+        for (auto it = level_data.begin(); it != level_data.end(); ++it)
         {
             it->second->beginGhostUpdate();
         }
@@ -2934,7 +2925,7 @@ LDataManager::endNonlocalDataFill(const int coarsest_ln_in, const int finest_ln_
     for (int level_number = coarsest_ln; level_number <= finest_ln; ++level_number)
     {
         std::map<std::string, Pointer<LData> >& level_data = d_lag_mesh_data[level_number];
-        for (std::map<std::string, Pointer<LData> >::iterator it = level_data.begin(); it != level_data.end(); ++it)
+        for (auto it = level_data.begin(); it != level_data.end(); ++it)
         {
             it->second->endGhostUpdate();
         }
@@ -3037,7 +3028,7 @@ LDataManager::computeNodeDistribution(AO& ao,
             {
                 LNode* const node_idx = *it;
                 const int lag_idx = node_idx->getLagrangianIndex();
-                std::map<int, int>::const_iterator idx_it = lag_idx_to_petsc_idx.find(lag_idx);
+                auto idx_it = lag_idx_to_petsc_idx.find(lag_idx);
                 if (idx_it == lag_idx_to_petsc_idx.end())
                 {
                     // This is the first time we have encountered this index; it
@@ -3060,8 +3051,8 @@ LDataManager::computeNodeDistribution(AO& ao,
 
     // Determine how many nodes are on each processor to calculate the PETSc
     // indexing scheme.
-    const unsigned int num_local_nodes = static_cast<unsigned int>(local_lag_indices.size());
-    const unsigned int num_nonlocal_nodes = static_cast<unsigned int>(nonlocal_lag_indices.size());
+    const auto num_local_nodes = static_cast<unsigned int>(local_lag_indices.size());
+    const auto num_nonlocal_nodes = static_cast<unsigned int>(nonlocal_lag_indices.size());
 
     if (local_offset != (num_local_nodes + num_nonlocal_nodes))
     {
@@ -3273,7 +3264,7 @@ LDataManager::getFromRestart()
         }
 
         std::set<int> data_depths;
-        for (std::vector<std::string>::iterator it = ldata_names.begin(); it != ldata_names.end(); ++it)
+        for (auto it = ldata_names.begin(); it != ldata_names.end(); ++it)
         {
             const std::string& ldata_name = *it;
             d_lag_mesh_data[level_number][ldata_name] = new LData(level_db->getDatabase(ldata_name));

--- a/ibtk/src/lagrangian/LEInteractor.cpp
+++ b/ibtk/src/lagrangian/LEInteractor.cpp
@@ -4799,7 +4799,7 @@ LEInteractor::buildLocalIndices(std::vector<int>& local_indices,
                 }
             }
             const LSet<T>& idx_set = it.getItem();
-            for (typename LSet<T>::const_iterator n = idx_set.begin(); n != idx_set.end(); ++n)
+            for (auto n = idx_set.begin(); n != idx_set.end(); ++n)
             {
                 const typename LSet<T>::value_type& idx = *n;
                 local_indices.push_back(idx->getLocalPETScIndex());

--- a/ibtk/src/lagrangian/LIndexSetData.cpp
+++ b/ibtk/src/lagrangian/LIndexSetData.cpp
@@ -140,7 +140,7 @@ LIndexSetData<T>::cacheLocalIndices(Pointer<Patch<NDIM> > patch, const IntVector
         }
         const LSet<T>& idx_set = *it;
         const bool patch_owns_idx_set = patch_box.contains(i);
-        for (typename LSet<T>::const_iterator n = idx_set.begin(); n != idx_set.end(); ++n)
+        for (auto n = idx_set.begin(); n != idx_set.end(); ++n)
         {
             const typename LSet<T>::value_type& idx = *n;
             const int lag_idx = idx->getLagrangianIndex();

--- a/ibtk/src/lagrangian/LSiloDataWriter.cpp
+++ b/ibtk/src/lagrangian/LSiloDataWriter.cpp
@@ -149,7 +149,7 @@ build_local_marker_cloud(DBfile* dbfile,
 
     // Write out the variables.
     int cycle = time_step;
-    float time = float(simulation_time);
+    auto time = float(simulation_time);
     double dtime = simulation_time;
 
     static const int MAX_OPTS = 3;
@@ -315,7 +315,7 @@ build_local_curv_block(DBfile* dbfile,
 
     // Write out the variables.
     int cycle = time_step;
-    float time = float(simulation_time);
+    auto time = float(simulation_time);
     double dtime = simulation_time;
 
     static const int MAX_OPTS = 3;
@@ -440,7 +440,7 @@ build_local_ucd_mesh(DBfile* dbfile,
 
     int offset = 0;
     std::map<int, int> local_vertex_map;
-    for (std::set<int>::const_iterator it = vertices.begin(); it != vertices.end(); ++it)
+    for (auto it = vertices.begin(); it != vertices.end(); ++it)
     {
         const int idx = (*it);
         local_vertex_map[idx] = offset;
@@ -469,7 +469,7 @@ build_local_ucd_mesh(DBfile* dbfile,
 
     // Prune duplicate edges.
     std::set<std::pair<int, int> > local_edge_set;
-    for (std::multimap<int, std::pair<int, int> >::const_iterator it = edge_map.begin(); it != edge_map.end(); ++it)
+    for (auto it = edge_map.begin(); it != edge_map.end(); ++it)
     {
         std::pair<int, int> e = it->second;
 #if !defined(NDEBUG)
@@ -485,7 +485,7 @@ build_local_ucd_mesh(DBfile* dbfile,
 
     // Create an edge map corresponding to the pruned edge list.
     std::multimap<int, int> local_edge_map;
-    for (std::set<std::pair<int, int> >::const_iterator it = local_edge_set.begin(); it != local_edge_set.end(); ++it)
+    for (auto it = local_edge_set.begin(); it != local_edge_set.end(); ++it)
     {
         const int e1 = it->first;
         const int e2 = it->second;
@@ -505,7 +505,7 @@ build_local_ucd_mesh(DBfile* dbfile,
     int ndims = NDIM;
 
     int cycle = time_step;
-    float time = float(simulation_time);
+    auto time = float(simulation_time);
     double dtime = simulation_time;
 
     static const int MAX_OPTS = 3;
@@ -527,7 +527,7 @@ build_local_ucd_mesh(DBfile* dbfile,
     std::vector<int> nodelist;
     nodelist.reserve(2 * local_edge_map.size());
 
-    for (std::multimap<int, int>::const_iterator it = local_edge_map.begin(); it != local_edge_map.end(); ++it)
+    for (auto it = local_edge_map.begin(); it != local_edge_map.end(); ++it)
     {
         nodelist.push_back(it->first);
         nodelist.push_back(it->second);
@@ -708,7 +708,7 @@ LSiloDataWriter::~LSiloDataWriter()
     int ierr;
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
-        for (std::map<int, Vec>::iterator it = d_dst_vec[ln].begin(); it != d_dst_vec[ln].end(); ++it)
+        for (auto it = d_dst_vec[ln].begin(); it != d_dst_vec[ln].end(); ++it)
         {
             Vec& v = it->second;
             if (v)
@@ -717,7 +717,7 @@ LSiloDataWriter::~LSiloDataWriter()
                 IBTK_CHKERRQ(ierr);
             }
         }
-        for (std::map<int, VecScatter>::iterator it = d_vec_scatter[ln].begin(); it != d_vec_scatter[ln].end(); ++it)
+        for (auto it = d_vec_scatter[ln].begin(); it != d_vec_scatter[ln].end(); ++it)
         {
             VecScatter& vs = it->second;
             if (vs)
@@ -756,7 +756,7 @@ LSiloDataWriter::resetLevels(const int coarsest_ln, const int finest_ln)
     int ierr;
     for (int ln = std::max(d_coarsest_ln, 0); (ln <= d_finest_ln) && (ln < coarsest_ln); ++ln)
     {
-        for (std::map<int, Vec>::iterator it = d_dst_vec[ln].begin(); it != d_dst_vec[ln].end(); ++it)
+        for (auto it = d_dst_vec[ln].begin(); it != d_dst_vec[ln].end(); ++it)
         {
             Vec& v = it->second;
             if (v)
@@ -765,7 +765,7 @@ LSiloDataWriter::resetLevels(const int coarsest_ln, const int finest_ln)
                 IBTK_CHKERRQ(ierr);
             }
         }
-        for (std::map<int, VecScatter>::iterator it = d_vec_scatter[ln].begin(); it != d_vec_scatter[ln].end(); ++it)
+        for (auto it = d_vec_scatter[ln].begin(); it != d_vec_scatter[ln].end(); ++it)
         {
             VecScatter& vs = it->second;
             if (vs)
@@ -778,7 +778,7 @@ LSiloDataWriter::resetLevels(const int coarsest_ln, const int finest_ln)
 
     for (int ln = finest_ln + 1; ln <= d_finest_ln; ++ln)
     {
-        for (std::map<int, Vec>::iterator it = d_dst_vec[ln].begin(); it != d_dst_vec[ln].end(); ++it)
+        for (auto it = d_dst_vec[ln].begin(); it != d_dst_vec[ln].end(); ++it)
         {
             Vec& v = it->second;
             if (v)
@@ -787,7 +787,7 @@ LSiloDataWriter::resetLevels(const int coarsest_ln, const int finest_ln)
                 IBTK_CHKERRQ(ierr);
             }
         }
-        for (std::map<int, VecScatter>::iterator it = d_vec_scatter[ln].begin(); it != d_vec_scatter[ln].end(); ++it)
+        for (auto it = d_vec_scatter[ln].begin(); it != d_vec_scatter[ln].end(); ++it)
         {
             VecScatter& vs = it->second;
             if (vs)
@@ -1106,7 +1106,7 @@ LSiloDataWriter::registerUnstructuredMesh(const std::string& name,
 
     // Extract the list of vertices from the list of edges.
     std::set<int> vertices;
-    for (std::multimap<int, std::pair<int, int> >::const_iterator it = edge_map.begin(); it != edge_map.end(); ++it)
+    for (auto it = edge_map.begin(); it != edge_map.end(); ++it)
     {
         const std::pair<int, int>& e = it->second;
         vertices.insert(e.first);
@@ -1827,7 +1827,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
         }
 
         int cycle = time_step_number;
-        float time = float(simulation_time);
+        auto time = float(simulation_time);
         double dtime = simulation_time;
 
         static const int MAX_OPTS = 3;
@@ -1850,7 +1850,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                     std::ostringstream stream;
                     stream << current_file_name << ":level_" << ln << "_cloud_" << cloud << "/mesh";
                     std::string meshname = stream.str();
-                    char* meshname_ptr = const_cast<char*>(meshname.c_str());
+                    auto meshname_ptr = const_cast<char*>(meshname.c_str());
                     int meshtype = DB_POINTMESH;
 
                     std::string& cloud_name = cloud_names_per_proc[ln][proc][cloud];
@@ -1876,7 +1876,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                     std::ostringstream stream;
                     stream << current_file_name << ":level_" << ln << "_block_" << block << "/mesh";
                     std::string meshname = stream.str();
-                    char* meshname_ptr = const_cast<char*>(meshname.c_str());
+                    auto meshname_ptr = const_cast<char*>(meshname.c_str());
                     int meshtype = meshtypes_per_proc[ln][proc][block];
 
                     std::string& block_name = block_names_per_proc[ln][proc][block];
@@ -1900,7 +1900,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                     current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
                     const int nblocks = mb_nblocks_per_proc[ln][proc][mb];
-                    char** meshnames = new char*[nblocks];
+                    auto meshnames = new char*[nblocks];
 
                     for (int block = 0; block < nblocks; ++block)
                     {
@@ -1943,7 +1943,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                     std::ostringstream stream;
                     stream << current_file_name << ":level_" << ln << "_mesh_" << mesh << "/mesh";
                     std::string meshname = stream.str();
-                    char* meshname_ptr = const_cast<char*>(meshname.c_str());
+                    auto meshname_ptr = const_cast<char*>(meshname.c_str());
                     int meshtype = DB_UCDMESH;
 
                     std::string& mesh_name = ucd_mesh_names_per_proc[ln][proc][mesh];
@@ -1972,7 +1972,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                         varname_stream << current_file_name << ":level_" << ln << "_cloud_" << cloud << "/"
                                        << d_var_names[ln][v];
                         std::string varname = varname_stream.str();
-                        char* varname_ptr = const_cast<char*>(varname.c_str());
+                        auto varname_ptr = const_cast<char*>(varname.c_str());
                         int vartype = DB_POINTVAR;
 
                         std::string& cloud_name = cloud_names_per_proc[ln][proc][cloud];
@@ -1995,7 +1995,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                         varname_stream << current_file_name << ":level_" << ln << "_block_" << block << "/"
                                        << d_var_names[ln][v];
                         std::string varname = varname_stream.str();
-                        char* varname_ptr = const_cast<char*>(varname.c_str());
+                        auto varname_ptr = const_cast<char*>(varname.c_str());
                         int vartype = vartypes_per_proc[ln][proc][block];
 
                         std::string& block_name = block_names_per_proc[ln][proc][block];
@@ -2015,7 +2015,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                         current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
                         const int nblocks = mb_nblocks_per_proc[ln][proc][mb];
-                        char** varnames = new char*[nblocks];
+                        auto varnames = new char*[nblocks];
 
                         for (int block = 0; block < nblocks; ++block)
                         {
@@ -2056,7 +2056,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                         varname_stream << current_file_name << ":level_" << ln << "_mesh_" << mesh << "/"
                                        << d_var_names[ln][v];
                         std::string varname = varname_stream.str();
-                        char* varname_ptr = const_cast<char*>(varname.c_str());
+                        auto varname_ptr = const_cast<char*>(varname.c_str());
                         int vartype = DB_UCDVAR;
 
                         std::string& mesh_name = ucd_mesh_names_per_proc[ln][proc][mesh];
@@ -2138,9 +2138,7 @@ LSiloDataWriter::putToDatabase(Pointer<Database> db)
 
             std::vector<int> flattened_block_nelems;
             flattened_block_nelems.reserve(NDIM * d_block_nelems.size());
-            for (std::vector<IntVector<NDIM> >::const_iterator cit = d_block_nelems[ln].begin();
-                 cit != d_block_nelems[ln].end();
-                 ++cit)
+            for (auto cit = d_block_nelems[ln].begin(); cit != d_block_nelems[ln].end(); ++cit)
             {
                 flattened_block_nelems.insert(flattened_block_nelems.end(), &(*cit)[0], &(*cit)[0] + NDIM);
             }
@@ -2150,9 +2148,7 @@ LSiloDataWriter::putToDatabase(Pointer<Database> db)
 
             std::vector<int> flattened_block_periodic;
             flattened_block_periodic.reserve(NDIM * d_block_periodic.size());
-            for (std::vector<IntVector<NDIM> >::const_iterator cit = d_block_periodic[ln].begin();
-                 cit != d_block_periodic[ln].end();
-                 ++cit)
+            for (auto cit = d_block_periodic[ln].begin(); cit != d_block_periodic[ln].end(); ++cit)
             {
                 flattened_block_periodic.insert(flattened_block_periodic.end(), &(*cit)[0], &(*cit)[0] + NDIM);
             }
@@ -2181,9 +2177,7 @@ LSiloDataWriter::putToDatabase(Pointer<Database> db)
                 {
                     std::vector<int> flattened_mb_nelems;
                     flattened_mb_nelems.reserve(NDIM * d_mb_nelems.size());
-                    for (std::vector<IntVector<NDIM> >::const_iterator cit = d_mb_nelems[ln][mb].begin();
-                         cit != d_mb_nelems[ln][mb].end();
-                         ++cit)
+                    for (auto cit = d_mb_nelems[ln][mb].begin(); cit != d_mb_nelems[ln][mb].end(); ++cit)
                     {
                         flattened_mb_nelems.insert(flattened_mb_nelems.end(), &(*cit)[0], &(*cit)[0] + NDIM);
                     }
@@ -2193,9 +2187,7 @@ LSiloDataWriter::putToDatabase(Pointer<Database> db)
 
                     std::vector<int> flattened_mb_periodic;
                     flattened_mb_periodic.reserve(NDIM * d_mb_periodic.size());
-                    for (std::vector<IntVector<NDIM> >::const_iterator cit = d_mb_periodic[ln][mb].begin();
-                         cit != d_mb_periodic[ln][mb].end();
-                         ++cit)
+                    for (auto cit = d_mb_periodic[ln][mb].begin(); cit != d_mb_periodic[ln][mb].end(); ++cit)
                     {
                         flattened_mb_periodic.insert(flattened_mb_periodic.end(), &(*cit)[0], &(*cit)[0] + NDIM);
                     }
@@ -2225,8 +2217,7 @@ LSiloDataWriter::putToDatabase(Pointer<Database> db)
 
                 std::vector<int> ucd_mesh_vertices_vector;
                 ucd_mesh_vertices_vector.reserve(d_ucd_mesh_vertices[ln][mesh].size());
-                for (std::set<int>::const_iterator cit = d_ucd_mesh_vertices[ln][mesh].begin();
-                     cit != d_ucd_mesh_vertices[ln][mesh].end();
+                for (auto cit = d_ucd_mesh_vertices[ln][mesh].begin(); cit != d_ucd_mesh_vertices[ln][mesh].end();
                      ++cit)
                 {
                     ucd_mesh_vertices_vector.push_back(*cit);
@@ -2239,9 +2230,7 @@ LSiloDataWriter::putToDatabase(Pointer<Database> db)
 
                 std::vector<int> ucd_mesh_edge_maps_vector;
                 ucd_mesh_edge_maps_vector.reserve(3 * d_ucd_mesh_edge_maps[ln][mesh].size());
-                for (std::multimap<int, std::pair<int, int> >::const_iterator cit =
-                         d_ucd_mesh_edge_maps[ln][mesh].begin();
-                     cit != d_ucd_mesh_edge_maps[ln][mesh].end();
+                for (auto cit = d_ucd_mesh_edge_maps[ln][mesh].begin(); cit != d_ucd_mesh_edge_maps[ln][mesh].end();
                      ++cit)
                 {
                     const int i = cit->first;
@@ -2351,7 +2340,7 @@ LSiloDataWriter::buildVecScatters(AO& ao, const int level_number)
     // Create the VecScatters to scatter data from the global PETSc Vec to
     // contiguous local subgrids.  VecScatter objects are individually created
     // for data depths as necessary.
-    for (std::map<int, std::vector<int> >::iterator it = src_is_idxs.begin(); it != src_is_idxs.end(); ++it)
+    for (auto it = src_is_idxs.begin(); it != src_is_idxs.end(); ++it)
     {
         const int depth = it->first;
         const std::vector<int>& idxs = it->second;

--- a/ibtk/src/lagrangian/LTransaction.cpp
+++ b/ibtk/src/lagrangian/LTransaction.cpp
@@ -72,9 +72,7 @@ LTransaction<T>::LTransaction(const int src_proc,
     : d_src_item_set(src_item_set), d_src_proc(src_proc), d_outgoing_bytes(0), d_dst_item_set(), d_dst_proc(dst_proc)
 {
     d_outgoing_bytes = AbstractStream::sizeofInt();
-    for (typename std::vector<LTransactionComponent>::const_iterator cit = d_src_item_set.begin();
-         cit != d_src_item_set.end();
-         ++cit)
+    for (auto cit = d_src_item_set.begin(); cit != d_src_item_set.end(); ++cit)
     {
         d_outgoing_bytes += cit->item->getDataStreamSize() + NDIM * AbstractStream::sizeofDouble();
     }
@@ -128,8 +126,7 @@ void
 LTransaction<T>::packStream(AbstractStream& stream)
 {
     stream << static_cast<int>(d_src_item_set.size());
-    for (typename std::vector<LTransactionComponent>::iterator it = d_src_item_set.begin(); it != d_src_item_set.end();
-         ++it)
+    for (auto it = d_src_item_set.begin(); it != d_src_item_set.end(); ++it)
     {
         typename LSet<T>::value_type& item = it->item;
         item->packStream(stream);
@@ -147,8 +144,7 @@ LTransaction<T>::unpackStream(AbstractStream& stream)
     int num_items;
     stream >> num_items;
     d_dst_item_set.resize(num_items);
-    for (typename std::vector<LTransactionComponent>::iterator it = d_dst_item_set.begin(); it != d_dst_item_set.end();
-         ++it)
+    for (auto it = d_dst_item_set.begin(); it != d_dst_item_set.end(); ++it)
     {
         it->item->unpackStream(stream, periodic_offset);
         Point& posn = it->posn;

--- a/ibtk/src/math/PoissonUtilities.cpp
+++ b/ibtk/src/math/PoissonUtilities.cpp
@@ -318,7 +318,7 @@ PoissonUtilities::computeMatrixCoefficients(CellData<NDIM, double>& matrix_coeff
         for (int d = 0; d < depth; ++d)
         {
             static const bool homogeneous_bc = true;
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[d]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[d]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->clearTargetPatchDataIndex();
@@ -387,7 +387,7 @@ PoissonUtilities::computeMatrixCoefficients(CellData<NDIM, double>& matrix_coeff
     // Setup the matrix coefficients.
     for (int d = 0; d < depth; ++d)
     {
-        const unsigned int offset = static_cast<unsigned int>(d * stencil_sz);
+        const auto offset = static_cast<unsigned int>(d * stencil_sz);
         for (Box<NDIM>::Iterator b(patch_box); b; b++)
         {
             const Index<NDIM>& i = b();
@@ -549,7 +549,7 @@ PoissonUtilities::computeMatrixCoefficients(SideData<NDIM, double>& matrix_coeff
 
             // Set the boundary condition coefficients.
             static const bool homogeneous_bc = true;
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->clearTargetPatchDataIndex();
@@ -645,7 +645,7 @@ PoissonUtilities::computeMatrixCoefficients(SideData<NDIM, double>& matrix_coeff
 
             // Set the boundary condition coefficients.
             static const bool homogeneous_bc = true;
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->clearTargetPatchDataIndex();
@@ -927,7 +927,7 @@ PoissonUtilities::computeVCSCViscousOpMatrixCoefficients(
 
             // Set the boundary condition coefficients.
             static const bool homogeneous_bc = true;
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->clearTargetPatchDataIndex();
@@ -1046,8 +1046,7 @@ PoissonUtilities::computeVCSCViscousOpMatrixCoefficients(
 
                 // Set the boundary condition coefficients.
                 static const bool homogeneous_bc = true;
-                ExtendedRobinBcCoefStrategy* extended_bc_coef =
-                    dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[comp]);
+                auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[comp]);
                 if (extended_bc_coef)
                 {
                     extended_bc_coef->clearTargetPatchDataIndex();
@@ -1160,7 +1159,7 @@ PoissonUtilities::computeVCSCViscousOpMatrixCoefficients(
 
             // Set the boundary condition coefficients.
             static const bool homogeneous_bc = true;
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->clearTargetPatchDataIndex();
@@ -1290,7 +1289,7 @@ PoissonUtilities::adjustRHSAtPhysicalBoundary(CellData<NDIM, double>& rhs_data,
 
         for (int d = 0; d < depth; ++d)
         {
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[d]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[d]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->clearTargetPatchDataIndex();
@@ -1436,7 +1435,7 @@ PoissonUtilities::adjustRHSAtPhysicalBoundary(SideData<NDIM, double>& rhs_data,
                                                                      shifted_patch_x_upper.data()));
 
             // Set the boundary condition coefficients.
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->clearTargetPatchDataIndex();
@@ -1519,7 +1518,7 @@ PoissonUtilities::adjustRHSAtPhysicalBoundary(SideData<NDIM, double>& rhs_data,
             Pointer<ArrayData<NDIM, double> > gcoef_data = new ArrayData<NDIM, double>(bc_coef_box, 1);
 
             // Set the boundary condition coefficients.
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->clearTargetPatchDataIndex();
@@ -1665,7 +1664,7 @@ PoissonUtilities::adjustVCSCViscousOpRHSAtPhysicalBoundary(SideData<NDIM, double
                                                                      shifted_patch_x_upper.data()));
 
             // Set the boundary condition coefficients.
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->clearTargetPatchDataIndex();
@@ -1781,8 +1780,7 @@ PoissonUtilities::adjustVCSCViscousOpRHSAtPhysicalBoundary(SideData<NDIM, double
                                                                          shifted_patch_x_upper.data()));
 
                 // Set the boundary condition coefficients.
-                ExtendedRobinBcCoefStrategy* extended_bc_coef =
-                    dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[comp]);
+                auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[comp]);
                 if (extended_bc_coef)
                 {
                     extended_bc_coef->clearTargetPatchDataIndex();
@@ -1881,7 +1879,7 @@ PoissonUtilities::adjustVCSCViscousOpRHSAtPhysicalBoundary(SideData<NDIM, double
             Pointer<ArrayData<NDIM, double> > gcoef_data = new ArrayData<NDIM, double>(bc_coef_box, 1);
 
             // Set the boundary condition coefficients.
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[axis]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->clearTargetPatchDataIndex();

--- a/ibtk/src/refine_ops/LMarkerRefine.cpp
+++ b/ibtk/src/refine_ops/LMarkerRefine.cpp
@@ -143,7 +143,7 @@ LMarkerRefine::refine(Patch<NDIM>& fine,
         if (coarse_box.contains(coarse_i))
         {
             const LMarkerSet& coarse_mark_set = it();
-            for (LMarkerSet::const_iterator cit = coarse_mark_set.begin(); cit != coarse_mark_set.end(); ++cit)
+            for (auto cit = coarse_mark_set.begin(); cit != coarse_mark_set.end(); ++cit)
             {
                 const LMarkerSet::value_type& coarse_mark = *cit;
                 const Point& X = coarse_mark->getPosition();

--- a/ibtk/src/solvers/impls/BGaussSeidelPreconditioner.cpp
+++ b/ibtk/src/solvers/impls/BGaussSeidelPreconditioner.cpp
@@ -208,7 +208,7 @@ BGaussSeidelPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAMRA
 
     // Apply the component preconditioners.
     int count = 0;
-    for (std::vector<int>::const_iterator it = comps.begin(); it != comps.end(); ++it, ++count)
+    for (auto it = comps.begin(); it != comps.end(); ++it, ++count)
     {
         const int comp = (*it);
 
@@ -290,20 +290,16 @@ BGaussSeidelPreconditioner::deallocateSolverState()
     if (!d_is_initialized) return;
 
     // Deallocate the component preconditioners.
-    for (std::map<unsigned int, Pointer<LinearSolver> >::iterator it = d_pc_map.begin(); it != d_pc_map.end(); ++it)
+    for (auto it = d_pc_map.begin(); it != d_pc_map.end(); ++it)
     {
         it->second->deallocateSolverState();
     }
 
     // Deallocate the component operators.
-    for (std::map<unsigned int, std::vector<Pointer<LinearOperator> > >::iterator it = d_linear_ops_map.begin();
-         it != d_linear_ops_map.end();
-         ++it)
+    for (auto it = d_linear_ops_map.begin(); it != d_linear_ops_map.end(); ++it)
     {
         std::vector<Pointer<LinearOperator> >& comp_linear_ops = it->second;
-        for (std::vector<Pointer<LinearOperator> >::iterator comp_it = comp_linear_ops.begin();
-             comp_it != comp_linear_ops.end();
-             ++comp_it)
+        for (auto comp_it = comp_linear_ops.begin(); comp_it != comp_linear_ops.end(); ++comp_it)
         {
             if (*comp_it) (*comp_it)->deallocateOperatorState();
         }

--- a/ibtk/src/solvers/impls/BJacobiPreconditioner.cpp
+++ b/ibtk/src/solvers/impls/BJacobiPreconditioner.cpp
@@ -171,7 +171,7 @@ BJacobiPreconditioner::initializeSolverState(const SAMRAIVectorReal<NDIM, double
     // Initialize the component preconditioners.
     const std::string& x_name = x.getName();
     const std::string& b_name = b.getName();
-    for (std::map<unsigned int, Pointer<LinearSolver> >::iterator it = d_pc_map.begin(); it != d_pc_map.end(); ++it)
+    for (auto it = d_pc_map.begin(); it != d_pc_map.end(); ++it)
     {
         const int comp = it->first;
         SAMRAIVectorReal<NDIM, double> x_comp(x_name + "_component", hierarchy, coarsest_ln, finest_ln);
@@ -194,7 +194,7 @@ BJacobiPreconditioner::deallocateSolverState()
     if (!d_is_initialized) return;
 
     // Deallocate the component preconditioners.
-    for (std::map<unsigned int, Pointer<LinearSolver> >::iterator it = d_pc_map.begin(); it != d_pc_map.end(); ++it)
+    for (auto it = d_pc_map.begin(); it != d_pc_map.end(); ++it)
     {
         const int comp = it->first;
         d_pc_map[comp]->deallocateSolverState();

--- a/ibtk/src/solvers/impls/CCPoissonBoxRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonBoxRelaxationFACOperator.cpp
@@ -412,9 +412,7 @@ CCPoissonBoxRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, double>& e
             if (update_local_data)
             {
                 const std::map<int, Box<NDIM> > neighbor_overlap = d_patch_neighbor_overlap[level_num][patch_counter];
-                for (std::map<int, Box<NDIM> >::const_iterator cit = neighbor_overlap.begin();
-                     cit != neighbor_overlap.end();
-                     ++cit)
+                for (auto cit = neighbor_overlap.begin(); cit != neighbor_overlap.end(); ++cit)
                 {
                     const int src_patch_num = cit->first;
                     const Box<NDIM>& overlap = cit->second;
@@ -481,7 +479,7 @@ CCPoissonBoxRelaxationFACOperator::solveCoarsestLevel(SAMRAIVectorReal<NDIM, dou
         d_coarse_solver->setMaxIterations(d_coarse_solver_max_iterations);
         d_coarse_solver->setAbsoluteTolerance(d_coarse_solver_abs_residual_tol);
         d_coarse_solver->setRelativeTolerance(d_coarse_solver_rel_residual_tol);
-        LinearSolver* p_coarse_solver = dynamic_cast<LinearSolver*>(d_coarse_solver.getPointer());
+        auto p_coarse_solver = dynamic_cast<LinearSolver*>(d_coarse_solver.getPointer());
         if (p_coarse_solver) p_coarse_solver->setInitialGuessNonzero(true);
         d_coarse_solver->solveSystem(*getLevelSAMRAIVectorReal(error, d_coarsest_ln),
                                      *getLevelSAMRAIVectorReal(residual, d_coarsest_ln));
@@ -748,28 +746,28 @@ CCPoissonBoxRelaxationFACOperator::deallocateOperatorStateSpecialized(const int 
     int ierr;
     for (int ln = coarsest_reset_ln; ln <= std::min(d_finest_ln, finest_reset_ln); ++ln)
     {
-        for (std::vector<Vec>::iterator it = d_patch_vec_e[ln].begin(); it != d_patch_vec_e[ln].end(); ++it)
+        for (auto it = d_patch_vec_e[ln].begin(); it != d_patch_vec_e[ln].end(); ++it)
         {
             Vec& e = *it;
             ierr = VecDestroy(&e);
             IBTK_CHKERRQ(ierr);
         }
         d_patch_vec_e[ln].clear();
-        for (std::vector<Vec>::iterator it = d_patch_vec_f[ln].begin(); it != d_patch_vec_f[ln].end(); ++it)
+        for (auto it = d_patch_vec_f[ln].begin(); it != d_patch_vec_f[ln].end(); ++it)
         {
             Vec& f = *it;
             ierr = VecDestroy(&f);
             IBTK_CHKERRQ(ierr);
         }
         d_patch_vec_f[ln].clear();
-        for (std::vector<Mat>::iterator it = d_patch_mat[ln].begin(); it != d_patch_mat[ln].end(); ++it)
+        for (auto it = d_patch_mat[ln].begin(); it != d_patch_mat[ln].end(); ++it)
         {
             Mat& A = *it;
             ierr = MatDestroy(&A);
             IBTK_CHKERRQ(ierr);
         }
         d_patch_mat[ln].clear();
-        for (std::vector<KSP>::iterator it = d_patch_ksp[ln].begin(); it != d_patch_ksp[ln].end(); ++it)
+        for (auto it = d_patch_ksp[ln].begin(); it != d_patch_ksp[ln].end(); ++it)
         {
             KSP& ksp = *it;
             ierr = KSPDestroy(&ksp);

--- a/ibtk/src/solvers/impls/CCPoissonLevelRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonLevelRelaxationFACOperator.cpp
@@ -331,13 +331,13 @@ CCPoissonLevelRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, double>&
         Pointer<PoissonSolver> level_solver = d_level_solvers[level_num];
         level_solver->setSolutionTime(d_solution_time);
         level_solver->setTimeInterval(d_current_time, d_new_time);
-        LinearSolver* p_level_solver = dynamic_cast<LinearSolver*>(level_solver.getPointer());
+        auto p_level_solver = dynamic_cast<LinearSolver*>(level_solver.getPointer());
         if (p_level_solver)
         {
             bool initial_guess_nonzero = true;
 
-            PETScKrylovLinearSolver* p_petsc_solver = dynamic_cast<PETScKrylovLinearSolver*>(p_level_solver);
-            PETScLevelSolver* p_petsc_level_solver = dynamic_cast<PETScLevelSolver*>(p_level_solver);
+            auto p_petsc_solver = dynamic_cast<PETScKrylovLinearSolver*>(p_level_solver);
+            auto p_petsc_level_solver = dynamic_cast<PETScLevelSolver*>(p_level_solver);
 
             if (p_petsc_solver || p_petsc_level_solver)
             {
@@ -370,12 +370,12 @@ CCPoissonLevelRelaxationFACOperator::solveCoarsestLevel(SAMRAIVectorReal<NDIM, d
     Pointer<SAMRAIVectorReal<NDIM, double> > r_level = getLevelSAMRAIVectorReal(residual, coarsest_ln);
     d_coarse_solver->setSolutionTime(d_solution_time);
     d_coarse_solver->setTimeInterval(d_current_time, d_new_time);
-    LinearSolver* p_coarse_solver = dynamic_cast<LinearSolver*>(d_coarse_solver.getPointer());
+    auto p_coarse_solver = dynamic_cast<LinearSolver*>(d_coarse_solver.getPointer());
     if (p_coarse_solver)
     {
         bool initial_guess_nonzero = true;
-        PETScKrylovLinearSolver* p_petsc_solver = dynamic_cast<PETScKrylovLinearSolver*>(p_coarse_solver);
-        PETScLevelSolver* p_petsc_level_solver = dynamic_cast<PETScLevelSolver*>(p_coarse_solver);
+        auto p_petsc_solver = dynamic_cast<PETScKrylovLinearSolver*>(p_coarse_solver);
+        auto p_petsc_level_solver = dynamic_cast<PETScLevelSolver*>(p_coarse_solver);
         if (p_petsc_solver || p_petsc_level_solver)
         {
             const KSP& petsc_ksp = p_petsc_solver ? p_petsc_solver->getPETScKSP() : p_petsc_level_solver->getPETScKSP();

--- a/ibtk/src/solvers/impls/CCPoissonPointRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonPointRelaxationFACOperator.cpp
@@ -518,9 +518,7 @@ CCPoissonPointRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, double>&
             if (update_local_data)
             {
                 const std::map<int, Box<NDIM> > neighbor_overlap = d_patch_neighbor_overlap[level_num][patch_counter];
-                for (std::map<int, Box<NDIM> >::const_iterator cit = neighbor_overlap.begin();
-                     cit != neighbor_overlap.end();
-                     ++cit)
+                for (auto cit = neighbor_overlap.begin(); cit != neighbor_overlap.end(); ++cit)
                 {
                     const int src_patch_num = cit->first;
                     const Box<NDIM>& overlap = cit->second;
@@ -673,7 +671,7 @@ CCPoissonPointRelaxationFACOperator::solveCoarsestLevel(SAMRAIVectorReal<NDIM, d
         d_coarse_solver->setMaxIterations(d_coarse_solver_max_iterations);
         d_coarse_solver->setAbsoluteTolerance(d_coarse_solver_abs_residual_tol);
         d_coarse_solver->setRelativeTolerance(d_coarse_solver_rel_residual_tol);
-        LinearSolver* p_coarse_solver = dynamic_cast<LinearSolver*>(d_coarse_solver.getPointer());
+        auto p_coarse_solver = dynamic_cast<LinearSolver*>(d_coarse_solver.getPointer());
         if (p_coarse_solver) p_coarse_solver->setInitialGuessNonzero(true);
         d_coarse_solver->solveSystem(*getLevelSAMRAIVectorReal(error, d_coarsest_ln),
                                      *getLevelSAMRAIVectorReal(residual, d_coarsest_ln));

--- a/ibtk/src/solvers/impls/CCPoissonSolverManager.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonSolverManager.cpp
@@ -122,7 +122,7 @@ CCPoissonSolverManager::allocateSolver(const std::string& solver_type,
                                        Pointer<Database> solver_input_db,
                                        const std::string& solver_default_options_prefix) const
 {
-    std::map<std::string, SolverMaker>::const_iterator it = d_solver_maker_map.find(solver_type);
+    auto it = d_solver_maker_map.find(solver_type);
     if (it == d_solver_maker_map.end())
     {
         TBOX_ERROR("CCPoissonSolverManager::allocateSolver():\n"

--- a/ibtk/src/solvers/impls/KrylovLinearSolverManager.cpp
+++ b/ibtk/src/solvers/impls/KrylovLinearSolverManager.cpp
@@ -92,7 +92,7 @@ KrylovLinearSolverManager::allocateSolver(const std::string& solver_type,
                                           Pointer<Database> solver_input_db,
                                           const std::string& solver_default_options_prefix) const
 {
-    std::map<std::string, SolverMaker>::const_iterator it = d_solver_maker_map.find(solver_type);
+    auto it = d_solver_maker_map.find(solver_type);
     if (it == d_solver_maker_map.end())
     {
         TBOX_ERROR("KrylovLinearSolverManager::allocateSolver():\n"

--- a/ibtk/src/solvers/impls/KrylovLinearSolverPoissonSolverInterface.cpp
+++ b/ibtk/src/solvers/impls/KrylovLinearSolverPoissonSolverInterface.cpp
@@ -76,7 +76,7 @@ KrylovLinearSolverPoissonSolverInterface::~KrylovLinearSolverPoissonSolverInterf
 void
 KrylovLinearSolverPoissonSolverInterface::setPoissonSpecifications(const PoissonSpecifications& poisson_spec)
 {
-    KrylovLinearSolver* p_this = dynamic_cast<KrylovLinearSolver*>(this);
+    auto p_this = dynamic_cast<KrylovLinearSolver*>(this);
 #if !defined(NDEBUG)
     TBOX_ASSERT(p_this);
 #endif
@@ -91,7 +91,7 @@ KrylovLinearSolverPoissonSolverInterface::setPoissonSpecifications(const Poisson
 void
 KrylovLinearSolverPoissonSolverInterface::setPhysicalBcCoef(RobinBcCoefStrategy<NDIM>* bc_coef)
 {
-    KrylovLinearSolver* p_this = dynamic_cast<KrylovLinearSolver*>(this);
+    auto p_this = dynamic_cast<KrylovLinearSolver*>(this);
 #if !defined(NDEBUG)
     TBOX_ASSERT(p_this);
 #endif
@@ -106,7 +106,7 @@ KrylovLinearSolverPoissonSolverInterface::setPhysicalBcCoef(RobinBcCoefStrategy<
 void
 KrylovLinearSolverPoissonSolverInterface::setPhysicalBcCoefs(const std::vector<RobinBcCoefStrategy<NDIM>*>& bc_coefs)
 {
-    KrylovLinearSolver* p_this = dynamic_cast<KrylovLinearSolver*>(this);
+    auto p_this = dynamic_cast<KrylovLinearSolver*>(this);
 #if !defined(NDEBUG)
     TBOX_ASSERT(p_this);
 #endif

--- a/ibtk/src/solvers/impls/LaplaceOperator.cpp
+++ b/ibtk/src/solvers/impls/LaplaceOperator.cpp
@@ -68,8 +68,7 @@ LaplaceOperator::LaplaceOperator(const std::string& object_name, bool homogeneou
     // Dirichlet boundary conditions.
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        LocationIndexRobinBcCoefs<NDIM>* p_default_bc_coef =
-            dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_bc_coef);
+        auto p_default_bc_coef = dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_bc_coef);
         p_default_bc_coef->setBoundaryValue(2 * d, 0.0);
         p_default_bc_coef->setBoundaryValue(2 * d + 1, 0.0);
     }

--- a/ibtk/src/solvers/impls/NewtonKrylovSolverManager.cpp
+++ b/ibtk/src/solvers/impls/NewtonKrylovSolverManager.cpp
@@ -92,7 +92,7 @@ NewtonKrylovSolverManager::allocateSolver(const std::string& solver_type,
                                           Pointer<Database> solver_input_db,
                                           const std::string& solver_default_options_prefix) const
 {
-    std::map<std::string, SolverMaker>::const_iterator it = d_solver_maker_map.find(solver_type);
+    auto it = d_solver_maker_map.find(solver_type);
     if (it == d_solver_maker_map.end())
     {
         TBOX_ERROR("NewtonKrylovSolverManager::allocateSolver():\n"

--- a/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
@@ -832,7 +832,7 @@ PETScKrylovLinearSolver::MatVecMult_SAMRAI(Mat A, Vec x, Vec y)
     void* p_ctx;
     ierr = MatShellGetContext(A, &p_ctx);
     CHKERRQ(ierr);
-    PETScKrylovLinearSolver* krylov_solver = static_cast<PETScKrylovLinearSolver*>(p_ctx);
+    auto krylov_solver = static_cast<PETScKrylovLinearSolver*>(p_ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(krylov_solver);
     TBOX_ASSERT(krylov_solver->d_A);
@@ -853,7 +853,7 @@ PETScKrylovLinearSolver::PCApply_SAMRAI(PC pc, Vec x, Vec y)
     void* ctx;
     ierr = PCShellGetContext(pc, &ctx);
     CHKERRQ(ierr);
-    PETScKrylovLinearSolver* krylov_solver = static_cast<PETScKrylovLinearSolver*>(ctx);
+    auto krylov_solver = static_cast<PETScKrylovLinearSolver*>(ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(krylov_solver);
     TBOX_ASSERT(krylov_solver->d_pc_solver);

--- a/ibtk/src/solvers/impls/PETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScLevelSolver.cpp
@@ -847,7 +847,7 @@ PETScLevelSolver::PCApply_Additive(PC pc, Vec x, Vec y)
     void* ctx;
     ierr = PCShellGetContext(pc, &ctx);
     CHKERRQ(ierr);
-    PETScLevelSolver* solver = static_cast<PETScLevelSolver*>(ctx);
+    auto solver = static_cast<PETScLevelSolver*>(ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(solver);
 #endif
@@ -893,7 +893,7 @@ PETScLevelSolver::PCApply_Multiplicative(PC pc, Vec x, Vec y)
     void* ctx;
     ierr = PCShellGetContext(pc, &ctx);
     CHKERRQ(ierr);
-    PETScLevelSolver* solver = static_cast<PETScLevelSolver*>(ctx);
+    auto solver = static_cast<PETScLevelSolver*>(ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(solver);
 #endif

--- a/ibtk/src/solvers/impls/PETScMFFDJacobianOperator.cpp
+++ b/ibtk/src/solvers/impls/PETScMFFDJacobianOperator.cpp
@@ -235,7 +235,7 @@ PETScMFFDJacobianOperator::deallocateOperatorState()
 PetscErrorCode
 PETScMFFDJacobianOperator::FormFunction_SAMRAI(void* p_ctx, Vec x, Vec f)
 {
-    PETScMFFDJacobianOperator* jac_op = static_cast<PETScMFFDJacobianOperator*>(p_ctx);
+    auto jac_op = static_cast<PETScMFFDJacobianOperator*>(p_ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(jac_op);
     TBOX_ASSERT(jac_op->d_F);

--- a/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
@@ -673,7 +673,7 @@ PETScNewtonKrylovSolver::resetSNESJacobian()
 PetscErrorCode
 PETScNewtonKrylovSolver::FormFunction_SAMRAI(SNES /*snes*/, Vec x, Vec f, void* p_ctx)
 {
-    PETScNewtonKrylovSolver* newton_solver = static_cast<PETScNewtonKrylovSolver*>(p_ctx);
+    auto newton_solver = static_cast<PETScNewtonKrylovSolver*>(p_ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(newton_solver);
     TBOX_ASSERT(newton_solver->d_F);
@@ -691,7 +691,7 @@ PetscErrorCode
 PETScNewtonKrylovSolver::FormJacobian_SAMRAI(SNES snes, Vec x, Mat A, Mat /*B*/, void* p_ctx)
 {
     int ierr;
-    PETScNewtonKrylovSolver* newton_solver = static_cast<PETScNewtonKrylovSolver*>(p_ctx);
+    auto newton_solver = static_cast<PETScNewtonKrylovSolver*>(p_ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(newton_solver);
 #endif
@@ -726,7 +726,7 @@ PETScNewtonKrylovSolver::MatVecMult_SAMRAI(Mat A, Vec x, Vec y)
     void* p_ctx;
     ierr = MatShellGetContext(A, &p_ctx);
     CHKERRQ(ierr);
-    PETScNewtonKrylovSolver* newton_solver = static_cast<PETScNewtonKrylovSolver*>(p_ctx);
+    auto newton_solver = static_cast<PETScNewtonKrylovSolver*>(p_ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(newton_solver);
     TBOX_ASSERT(newton_solver->d_J);

--- a/ibtk/src/solvers/impls/PoissonFACPreconditionerStrategy.cpp
+++ b/ibtk/src/solvers/impls/PoissonFACPreconditionerStrategy.cpp
@@ -147,8 +147,7 @@ PoissonFACPreconditionerStrategy::PoissonFACPreconditionerStrategy(const std::st
     // Dirichlet boundary conditions.
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        LocationIndexRobinBcCoefs<NDIM>* p_default_bc_coef =
-            dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_bc_coef);
+        auto p_default_bc_coef = dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_bc_coef);
         p_default_bc_coef->setBoundaryValue(2 * d, 0.0);
         p_default_bc_coef->setBoundaryValue(2 * d + 1, 0.0);
     }
@@ -587,7 +586,7 @@ PoissonFACPreconditionerStrategy::xeqScheduleProlongation(const int dst_idx, con
     d_bc_op->setHomogeneousBc(true);
     for (unsigned int k = 0; k < d_bc_coefs.size(); ++k)
     {
-        ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
+        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
         if (extended_bc_coef)
         {
             extended_bc_coef->setTargetPatchDataIndex(dst_idx);
@@ -601,7 +600,7 @@ PoissonFACPreconditionerStrategy::xeqScheduleProlongation(const int dst_idx, con
     d_prolongation_refine_algorithm->resetSchedule(d_prolongation_refine_schedules[dst_ln]);
     for (unsigned int k = 0; k < d_bc_coefs.size(); ++k)
     {
-        ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
+        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
         if (extended_bc_coef) extended_bc_coef->clearTargetPatchDataIndex();
     }
     return;
@@ -626,7 +625,7 @@ PoissonFACPreconditionerStrategy::xeqScheduleGhostFillNoCoarse(const int dst_idx
     d_bc_op->setHomogeneousBc(true);
     for (unsigned int k = 0; k < d_bc_coefs.size(); ++k)
     {
-        ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
+        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
         if (extended_bc_coef)
         {
             extended_bc_coef->setTargetPatchDataIndex(dst_idx);
@@ -640,7 +639,7 @@ PoissonFACPreconditionerStrategy::xeqScheduleGhostFillNoCoarse(const int dst_idx
     d_ghostfill_nocoarse_refine_algorithm->resetSchedule(d_ghostfill_nocoarse_refine_schedules[dst_ln]);
     for (unsigned int k = 0; k < d_bc_coefs.size(); ++k)
     {
-        ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
+        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
         if (extended_bc_coef) extended_bc_coef->clearTargetPatchDataIndex();
     }
     return;

--- a/ibtk/src/solvers/impls/PoissonSolver.cpp
+++ b/ibtk/src/solvers/impls/PoissonSolver.cpp
@@ -110,8 +110,7 @@ PoissonSolver::initSpecialized(const std::string& object_name, const bool /*homo
     d_default_bc_coef = new LocationIndexRobinBcCoefs<NDIM>(object_name + "::default_bc_coef", Pointer<Database>(nullptr));
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        LocationIndexRobinBcCoefs<NDIM>* p_default_bc_coef =
-            dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_bc_coef);
+        auto p_default_bc_coef = dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_bc_coef);
         p_default_bc_coef->setBoundaryValue(2 * d, 0.0);
         p_default_bc_coef->setBoundaryValue(2 * d + 1, 0.0);
     }

--- a/ibtk/src/solvers/impls/SCPoissonPointRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonPointRelaxationFACOperator.cpp
@@ -509,9 +509,7 @@ SCPoissonPointRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, double>&
                 {
                     const std::map<int, Box<NDIM> > neighbor_overlap =
                         d_patch_neighbor_overlap[level_num][patch_counter][axis];
-                    for (std::map<int, Box<NDIM> >::const_iterator cit = neighbor_overlap.begin();
-                         cit != neighbor_overlap.end();
-                         ++cit)
+                    for (auto cit = neighbor_overlap.begin(); cit != neighbor_overlap.end(); ++cit)
                     {
                         const int src_patch_num = cit->first;
                         const Box<NDIM>& overlap = cit->second;
@@ -658,7 +656,7 @@ SCPoissonPointRelaxationFACOperator::solveCoarsestLevel(SAMRAIVectorReal<NDIM, d
         d_coarse_solver->setMaxIterations(d_coarse_solver_max_iterations);
         d_coarse_solver->setAbsoluteTolerance(d_coarse_solver_abs_residual_tol);
         d_coarse_solver->setRelativeTolerance(d_coarse_solver_rel_residual_tol);
-        LinearSolver* p_coarse_solver = dynamic_cast<LinearSolver*>(d_coarse_solver.getPointer());
+        auto p_coarse_solver = dynamic_cast<LinearSolver*>(d_coarse_solver.getPointer());
         if (p_coarse_solver) p_coarse_solver->setInitialGuessNonzero(true);
         d_coarse_solver->solveSystem(*getLevelSAMRAIVectorReal(error, d_coarsest_ln),
                                      *getLevelSAMRAIVectorReal(residual, d_coarsest_ln));

--- a/ibtk/src/solvers/impls/SCPoissonSolverManager.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonSolverManager.cpp
@@ -118,7 +118,7 @@ SCPoissonSolverManager::allocateSolver(const std::string& solver_type,
                                        Pointer<Database> solver_input_db,
                                        const std::string& solver_default_options_prefix) const
 {
-    std::map<std::string, SolverMaker>::const_iterator it = d_solver_maker_map.find(solver_type);
+    auto it = d_solver_maker_map.find(solver_type);
     if (it == d_solver_maker_map.end())
     {
         TBOX_ERROR("CCPoissonSolverManager::allocateSolver():\n"

--- a/ibtk/src/solvers/impls/VCSCViscousOpPointRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/VCSCViscousOpPointRelaxationFACOperator.cpp
@@ -531,9 +531,7 @@ VCSCViscousOpPointRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, doub
                 {
                     const std::map<int, Box<NDIM> > neighbor_overlap =
                         d_patch_neighbor_overlap[level_num][patch_counter][axis];
-                    for (std::map<int, Box<NDIM> >::const_iterator cit = neighbor_overlap.begin();
-                         cit != neighbor_overlap.end();
-                         ++cit)
+                    for (auto cit = neighbor_overlap.begin(); cit != neighbor_overlap.end(); ++cit)
                     {
                         const int src_patch_num = cit->first;
                         const Box<NDIM>& overlap = cit->second;

--- a/ibtk/src/utilities/CellNoCornersFillPattern.cpp
+++ b/ibtk/src/utilities/CellNoCornersFillPattern.cpp
@@ -94,7 +94,7 @@ CellNoCornersFillPattern::calculateOverlap(const BoxGeometry<NDIM>& dst_geometry
 #if !defined(NDEBUG)
     TBOX_ASSERT(box_geom_overlap);
 #endif
-    const CellGeometry<NDIM>* const t_dst_geometry = dynamic_cast<const CellGeometry<NDIM>*>(&dst_geometry);
+    auto const t_dst_geometry = dynamic_cast<const CellGeometry<NDIM>*>(&dst_geometry);
 #if !defined(NDEBUG)
     TBOX_ASSERT(t_dst_geometry);
 #endif
@@ -163,7 +163,7 @@ CellNoCornersFillPattern::calculateOverlapOnLevel(const BoxGeometry<NDIM>& dst_g
 #if !defined(NDEBUG)
     TBOX_ASSERT(box_geom_overlap);
 #endif
-    const CellGeometry<NDIM>* const t_dst_geometry = dynamic_cast<const CellGeometry<NDIM>*>(&dst_geometry);
+    auto const t_dst_geometry = dynamic_cast<const CellGeometry<NDIM>*>(&dst_geometry);
 #if !defined(NDEBUG)
     TBOX_ASSERT(t_dst_geometry);
 #endif

--- a/ibtk/src/utilities/CoarsenPatchStrategySet.cpp
+++ b/ibtk/src/utilities/CoarsenPatchStrategySet.cpp
@@ -59,7 +59,8 @@ CoarsenPatchStrategySet::~CoarsenPatchStrategySet()
     if (d_managed)
     {
         using coarsen_strategy_set = std::vector<CoarsenPatchStrategy<NDIM>*>;
-        for (coarsen_strategy_set::const_iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+        typedef std::vector<CoarsenPatchStrategy<NDIM>*> coarsen_strategy_set;
+        for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
         {
             delete (*it);
         }
@@ -72,7 +73,7 @@ CoarsenPatchStrategySet::getCoarsenOpStencilWidth() const
 {
     IntVector<NDIM> width = 0;
     using coarsen_strategy_set = std::vector<CoarsenPatchStrategy<NDIM>*>;
-    for (coarsen_strategy_set::const_iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         width = IntVector<NDIM>::max(width, (*it)->getCoarsenOpStencilWidth());
     }
@@ -86,7 +87,7 @@ CoarsenPatchStrategySet::preprocessCoarsen(Patch<NDIM>& coarse,
                                            const IntVector<NDIM>& ratio)
 {
     using coarsen_strategy_set = std::vector<CoarsenPatchStrategy<NDIM>*>;
-    for (coarsen_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->preprocessCoarsen(coarse, fine, coarse_box, ratio);
     }
@@ -100,7 +101,7 @@ CoarsenPatchStrategySet::postprocessCoarsen(Patch<NDIM>& coarse,
                                             const IntVector<NDIM>& ratio)
 {
     using coarsen_strategy_set = std::vector<CoarsenPatchStrategy<NDIM>*>;
-    for (coarsen_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->postprocessCoarsen(coarse, fine, coarse_box, ratio);
     }

--- a/ibtk/src/utilities/EdgeSynchCopyFillPattern.cpp
+++ b/ibtk/src/utilities/EdgeSynchCopyFillPattern.cpp
@@ -88,7 +88,7 @@ EdgeSynchCopyFillPattern::calculateOverlap(const BoxGeometry<NDIM>& dst_geometry
 #endif
     if (box_geom_overlap->isOverlapEmpty()) return box_geom_overlap;
 
-    const EdgeGeometry<NDIM>* const t_dst_geometry = dynamic_cast<const EdgeGeometry<NDIM>*>(&dst_geometry);
+    auto const t_dst_geometry = dynamic_cast<const EdgeGeometry<NDIM>*>(&dst_geometry);
 #if !defined(NDEBUG)
     TBOX_ASSERT(t_dst_geometry);
 #endif

--- a/ibtk/src/utilities/FaceSynchCopyFillPattern.cpp
+++ b/ibtk/src/utilities/FaceSynchCopyFillPattern.cpp
@@ -88,7 +88,7 @@ FaceSynchCopyFillPattern::calculateOverlap(const BoxGeometry<NDIM>& dst_geometry
 #endif
     if (box_geom_overlap->isOverlapEmpty()) return box_geom_overlap;
 
-    const FaceGeometry<NDIM>* const t_dst_geometry = dynamic_cast<const FaceGeometry<NDIM>*>(&dst_geometry);
+    auto const t_dst_geometry = dynamic_cast<const FaceGeometry<NDIM>*>(&dst_geometry);
 #if !defined(NDEBUG)
     TBOX_ASSERT(t_dst_geometry);
 #endif

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -184,17 +184,17 @@ HierarchyIntegrator::~HierarchyIntegrator()
         d_registered_for_restart = false;
     }
 
-    for (RefinePatchStrategyMap::iterator it = d_ghostfill_strategies.begin(); it != d_ghostfill_strategies.end(); ++it)
+    for (auto it = d_ghostfill_strategies.begin(); it != d_ghostfill_strategies.end(); ++it)
     {
         delete it->second;
     }
 
-    for (RefinePatchStrategyMap::iterator it = d_prolong_strategies.begin(); it != d_prolong_strategies.end(); ++it)
+    for (auto it = d_prolong_strategies.begin(); it != d_prolong_strategies.end(); ++it)
     {
         delete it->second;
     }
 
-    for (CoarsenPatchStrategyMap::iterator it = d_coarsen_strategies.begin(); it != d_coarsen_strategies.end(); ++it)
+    for (auto it = d_coarsen_strategies.begin(); it != d_coarsen_strategies.end(); ++it)
     {
         delete it->second;
     }
@@ -396,8 +396,7 @@ double
 HierarchyIntegrator::getMinimumTimeStepSize()
 {
     double dt = getMinimumTimeStepSizeSpecialized();
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         dt = std::max(dt, (*it)->getMinimumTimeStepSize());
     }
@@ -408,8 +407,7 @@ double
 HierarchyIntegrator::getMaximumTimeStepSize()
 {
     double dt = getMaximumTimeStepSizeSpecialized();
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         dt = std::min(dt, (*it)->getMaximumTimeStepSize());
     }
@@ -420,8 +418,7 @@ void
 HierarchyIntegrator::synchronizeHierarchyData(VariableContextType ctx_type)
 {
     synchronizeHierarchyDataSpecialized(ctx_type);
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         (*it)->synchronizeHierarchyData(ctx_type);
     }
@@ -432,8 +429,7 @@ void
 HierarchyIntegrator::resetTimeDependentHierarchyData(const double new_time)
 {
     resetTimeDependentHierarchyDataSpecialized(new_time);
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         (*it)->resetTimeDependentHierarchyData(new_time);
     }
@@ -444,8 +440,7 @@ void
 HierarchyIntegrator::resetIntegratorToPreadvanceState()
 {
     resetIntegratorToPreadvanceStateSpecialized();
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         (*it)->resetIntegratorToPreadvanceState();
     }
@@ -503,9 +498,7 @@ bool
 HierarchyIntegrator::atRegridPoint() const
 {
     bool regrid_hierarchy = atRegridPointSpecialized();
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin();
-         it != d_child_integrators.end() && !regrid_hierarchy;
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end() && !regrid_hierarchy; ++it)
     {
         regrid_hierarchy = regrid_hierarchy || (*it)->atRegridPoint();
     }
@@ -565,8 +558,7 @@ void
 HierarchyIntegrator::registerVisItDataWriter(Pointer<VisItDataWriter<NDIM> > visit_writer)
 {
     d_visit_writer = visit_writer;
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         (*it)->registerVisItDataWriter(visit_writer);
     }
@@ -583,8 +575,7 @@ void
 HierarchyIntegrator::setupPlotData()
 {
     setupPlotDataSpecialized();
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         (*it)->setupPlotData();
     }
@@ -718,8 +709,7 @@ HierarchyIntegrator::initializeCompositeHierarchyData(double init_data_time, boo
     initializeCompositeHierarchyDataSpecialized(init_data_time, initial_time);
 
     // Initialize data associated with any child integrators.
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         (*it)->initializeCompositeHierarchyData(init_data_time, initial_time);
     }
@@ -785,9 +775,7 @@ HierarchyIntegrator::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> 
     if (initial_time)
     {
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-        for (std::list<Pointer<Variable<NDIM> > >::const_iterator cit = d_state_variables.begin();
-             cit != d_state_variables.end();
-             ++cit)
+        for (auto cit = d_state_variables.begin(); cit != d_state_variables.end(); ++cit)
         {
             Pointer<Variable<NDIM> > var = *cit;
             const int var_current_idx = var_db->mapVariableAndContextToIndex(var, getCurrentContext());
@@ -826,8 +814,7 @@ HierarchyIntegrator::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> 
         base_hierarchy, level_number, init_data_time, can_be_refined, initial_time, base_old_level, allocate_data);
 
     // Initialize data associated with any child integrators.
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         (*it)->initializeLevelData(
             base_hierarchy, level_number, init_data_time, can_be_refined, initial_time, base_old_level, allocate_data);
@@ -862,24 +849,24 @@ HierarchyIntegrator::resetHierarchyConfiguration(const Pointer<BasePatchHierarch
 
     // If we have added or removed a level, resize the communication schedule
     // vectors.
-    for (RefineAlgorithmMap::const_iterator it = d_ghostfill_algs.begin(); it != d_ghostfill_algs.end(); ++it)
+    for (auto it = d_ghostfill_algs.begin(); it != d_ghostfill_algs.end(); ++it)
     {
         d_ghostfill_scheds[it->first].resize(finest_hier_level + 1);
     }
 
-    for (RefineAlgorithmMap::const_iterator it = d_prolong_algs.begin(); it != d_prolong_algs.end(); ++it)
+    for (auto it = d_prolong_algs.begin(); it != d_prolong_algs.end(); ++it)
     {
         d_prolong_scheds[it->first].resize(finest_hier_level + 1);
     }
 
-    for (CoarsenAlgorithmMap::const_iterator it = d_coarsen_algs.begin(); it != d_coarsen_algs.end(); ++it)
+    for (auto it = d_coarsen_algs.begin(); it != d_coarsen_algs.end(); ++it)
     {
         d_coarsen_scheds[it->first].resize(finest_hier_level + 1);
     }
 
     // (Re)build ghost cell filling communication schedules.  These are created
     // for all levels in the hierarchy.
-    for (RefineAlgorithmMap::const_iterator it = d_ghostfill_algs.begin(); it != d_ghostfill_algs.end(); ++it)
+    for (auto it = d_ghostfill_algs.begin(); it != d_ghostfill_algs.end(); ++it)
     {
         for (int ln = coarsest_level; ln <= std::min(finest_level + 1, finest_hier_level); ++ln)
         {
@@ -891,7 +878,7 @@ HierarchyIntegrator::resetHierarchyConfiguration(const Pointer<BasePatchHierarch
 
     // (Re)build data prolongation communication schedules.  These are set only for levels
     // >= 1.
-    for (RefineAlgorithmMap::const_iterator it = d_prolong_algs.begin(); it != d_prolong_algs.end(); ++it)
+    for (auto it = d_prolong_algs.begin(); it != d_prolong_algs.end(); ++it)
     {
         for (int ln = std::max(coarsest_level, 1); ln <= std::min(finest_level + 1, finest_level); ++ln)
         {
@@ -903,7 +890,7 @@ HierarchyIntegrator::resetHierarchyConfiguration(const Pointer<BasePatchHierarch
 
     // (Re)build coarsen communication schedules.  These are set only for levels
     // >= 1.
-    for (CoarsenAlgorithmMap::const_iterator it = d_coarsen_algs.begin(); it != d_coarsen_algs.end(); ++it)
+    for (auto it = d_coarsen_algs.begin(); it != d_coarsen_algs.end(); ++it)
     {
         for (int ln = std::max(coarsest_level, 1); ln <= std::min(finest_level + 1, finest_level); ++ln)
         {
@@ -918,8 +905,7 @@ HierarchyIntegrator::resetHierarchyConfiguration(const Pointer<BasePatchHierarch
     resetHierarchyConfigurationSpecialized(base_hierarchy, coarsest_level, finest_level);
 
     // Reset data associated with any child integrators.
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         (*it)->resetHierarchyConfiguration(base_hierarchy, coarsest_level, finest_level);
     }
@@ -959,8 +945,7 @@ HierarchyIntegrator::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM
         hierarchy, level_number, error_data_time, tag_index, initial_time, uses_richardson_extrapolation_too);
 
     // ALlow child integrators to tag cells for refinement.
-    for (std::set<HierarchyIntegrator*>::iterator it = d_child_integrators.begin(); it != d_child_integrators.end();
-         ++it)
+    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
     {
         (*it)->applyGradientDetector(
             hierarchy, level_number, error_data_time, tag_index, initial_time, uses_richardson_extrapolation_too);
@@ -1227,9 +1212,7 @@ HierarchyIntegrator::resetTimeDependentHierarchyDataSpecialized(const double new
 
     // Swap PatchData<NDIM> pointers between the current and new contexts.
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    for (std::list<Pointer<Variable<NDIM> > >::const_iterator sv = d_state_variables.begin();
-         sv != d_state_variables.end();
-         ++sv)
+    for (auto sv = d_state_variables.begin(); sv != d_state_variables.end(); ++sv)
     {
         const Pointer<Variable<NDIM> >& v = *sv;
         const int src_idx = var_db->mapVariableAndContextToIndex(v, getNewContext());
@@ -1452,7 +1435,7 @@ HierarchyIntegrator::registerCoarsenAlgorithm(const std::string& name,
 Pointer<RefineAlgorithm<NDIM> >
 HierarchyIntegrator::getGhostfillRefineAlgorithm(const std::string& name) const
 {
-    RefineAlgorithmMap::const_iterator alg_it = d_ghostfill_algs.find(name);
+    auto alg_it = d_ghostfill_algs.find(name);
 #if !defined(NDEBUG)
     TBOX_ASSERT(alg_it != d_ghostfill_algs.end());
 #endif
@@ -1462,7 +1445,7 @@ HierarchyIntegrator::getGhostfillRefineAlgorithm(const std::string& name) const
 Pointer<RefineAlgorithm<NDIM> >
 HierarchyIntegrator::getProlongRefineAlgorithm(const std::string& name) const
 {
-    RefineAlgorithmMap::const_iterator alg_it = d_prolong_algs.find(name);
+    auto alg_it = d_prolong_algs.find(name);
 #if !defined(NDEBUG)
     TBOX_ASSERT(alg_it != d_prolong_algs.end());
 #endif
@@ -1472,7 +1455,7 @@ HierarchyIntegrator::getProlongRefineAlgorithm(const std::string& name) const
 Pointer<CoarsenAlgorithm<NDIM> >
 HierarchyIntegrator::getCoarsenAlgorithm(const std::string& name) const
 {
-    CoarsenAlgorithmMap::const_iterator alg_it = d_coarsen_algs.find(name);
+    auto alg_it = d_coarsen_algs.find(name);
 #if !defined(NDEBUG)
     TBOX_ASSERT(alg_it != d_coarsen_algs.end());
 #endif
@@ -1482,7 +1465,7 @@ HierarchyIntegrator::getCoarsenAlgorithm(const std::string& name) const
 const std::vector<Pointer<RefineSchedule<NDIM> > >&
 HierarchyIntegrator::getGhostfillRefineSchedules(const std::string& name) const
 {
-    RefineScheduleMap::const_iterator sched_it = d_ghostfill_scheds.find(name);
+    auto sched_it = d_ghostfill_scheds.find(name);
 #if !defined(NDEBUG)
     TBOX_ASSERT(sched_it != d_ghostfill_scheds.end());
 #endif
@@ -1492,7 +1475,7 @@ HierarchyIntegrator::getGhostfillRefineSchedules(const std::string& name) const
 const std::vector<Pointer<RefineSchedule<NDIM> > >&
 HierarchyIntegrator::getProlongRefineSchedules(const std::string& name) const
 {
-    RefineScheduleMap::const_iterator sched_it = d_prolong_scheds.find(name);
+    auto sched_it = d_prolong_scheds.find(name);
 #if !defined(NDEBUG)
     TBOX_ASSERT(sched_it != d_prolong_scheds.end());
 #endif
@@ -1502,7 +1485,7 @@ HierarchyIntegrator::getProlongRefineSchedules(const std::string& name) const
 const std::vector<Pointer<CoarsenSchedule<NDIM> > >&
 HierarchyIntegrator::getCoarsenSchedules(const std::string& name) const
 {
-    CoarsenScheduleMap::const_iterator sched_it = d_coarsen_scheds.find(name);
+    auto sched_it = d_coarsen_scheds.find(name);
 #if !defined(NDEBUG)
     TBOX_ASSERT(sched_it != d_coarsen_scheds.end());
 #endif

--- a/ibtk/src/utilities/NodeSynchCopyFillPattern.cpp
+++ b/ibtk/src/utilities/NodeSynchCopyFillPattern.cpp
@@ -88,7 +88,7 @@ NodeSynchCopyFillPattern::calculateOverlap(const BoxGeometry<NDIM>& dst_geometry
 #endif
     if (box_geom_overlap->isOverlapEmpty()) return box_geom_overlap;
 
-    const NodeGeometry<NDIM>* const t_dst_geometry = dynamic_cast<const NodeGeometry<NDIM>*>(&dst_geometry);
+    auto const t_dst_geometry = dynamic_cast<const NodeGeometry<NDIM>*>(&dst_geometry);
 #if !defined(NDEBUG)
     TBOX_ASSERT(t_dst_geometry);
 #endif

--- a/ibtk/src/utilities/ParallelEdgeMap.cpp
+++ b/ibtk/src/utilities/ParallelEdgeMap.cpp
@@ -117,17 +117,13 @@ ParallelEdgeMap::communicateData()
 
     static const int SIZE = 3;
     std::vector<int> transactions(SIZE * num_transactions, 0);
-    for (std::multimap<int, std::pair<int, int> >::const_iterator cit = d_pending_additions.begin();
-         cit != d_pending_additions.end();
-         ++cit, ++offset)
+    for (auto cit = d_pending_additions.begin(); cit != d_pending_additions.end(); ++cit, ++offset)
     {
         transactions[SIZE * offset] = cit->first;
         transactions[SIZE * offset + 1] = cit->second.first;
         transactions[SIZE * offset + 2] = cit->second.second;
     }
-    for (std::multimap<int, std::pair<int, int> >::const_iterator cit = d_pending_removals.begin();
-         cit != d_pending_removals.end();
-         ++cit, ++offset)
+    for (auto cit = d_pending_removals.begin(); cit != d_pending_removals.end(); ++cit, ++offset)
     {
         transactions[SIZE * offset] = cit->first;
         transactions[SIZE * offset + 1] = cit->second.first;
@@ -158,12 +154,12 @@ ParallelEdgeMap::communicateData()
 
     using multimap_iterator = std::multimap<int, std::pair<int, int> >::iterator;
     using multimap_const_iterator = std::multimap<int, std::pair<int, int> >::const_iterator;
-    for (multimap_const_iterator cit = d_pending_additions.begin(); cit != d_pending_additions.end(); ++cit)
+    for (auto cit = d_pending_additions.begin(); cit != d_pending_additions.end(); ++cit)
     {
         d_edge_map.insert(std::make_pair(cit->first, cit->second));
     }
 
-    for (multimap_const_iterator cit = d_pending_removals.begin(); cit != d_pending_removals.end(); ++cit)
+    for (auto cit = d_pending_removals.begin(); cit != d_pending_removals.end(); ++cit)
     {
         int mastr_idx = cit->first;
         const std::pair<int, int>& link = cit->second;
@@ -171,7 +167,7 @@ ParallelEdgeMap::communicateData()
         bool found_link = false;
 
         std::pair<multimap_iterator, multimap_iterator> range = d_edge_map.equal_range(mastr_idx);
-        for (multimap_iterator it = range.first; it != range.second && !found_link; ++it)
+        for (auto it = range.first; it != range.second && !found_link; ++it)
         {
             if (it->second == link)
             {
@@ -194,7 +190,7 @@ ParallelEdgeMap::communicateData()
             }
 
             std::pair<multimap_iterator, multimap_iterator> range = d_edge_map.equal_range(mastr_idx);
-            for (multimap_iterator it = range.first; it != range.second && !found_link; ++it)
+            for (auto it = range.first; it != range.second && !found_link; ++it)
             {
                 if (it->second == link)
                 {

--- a/ibtk/src/utilities/ParallelMap.cpp
+++ b/ibtk/src/utilities/ParallelMap.cpp
@@ -121,9 +121,7 @@ ParallelMap::communicateData()
         // broadcast by each process.
         std::vector<int> keys_to_send;
         std::vector<tbox::Pointer<Streamable> > data_items_to_send;
-        for (std::map<int, tbox::Pointer<Streamable> >::const_iterator cit = d_pending_additions.begin();
-             cit != d_pending_additions.end();
-             ++cit)
+        for (auto cit = d_pending_additions.begin(); cit != d_pending_additions.end(); ++cit)
         {
             keys_to_send.push_back(cit->first);
             data_items_to_send.push_back(cit->second);

--- a/ibtk/src/utilities/RefinePatchStrategySet.cpp
+++ b/ibtk/src/utilities/RefinePatchStrategySet.cpp
@@ -57,7 +57,7 @@ RefinePatchStrategySet::~RefinePatchStrategySet()
     if (d_managed)
     {
         using refine_strategy_set = std::vector<RefinePatchStrategy<NDIM>*>;
-        for (refine_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+        for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
         {
             delete (*it);
         }
@@ -71,7 +71,7 @@ RefinePatchStrategySet::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
                                                       const IntVector<NDIM>& ghost_width_to_fill)
 {
     using refine_strategy_set = std::vector<RefinePatchStrategy<NDIM>*>;
-    for (refine_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->setPhysicalBoundaryConditions(patch, fill_time, ghost_width_to_fill);
     }
@@ -83,7 +83,7 @@ RefinePatchStrategySet::getRefineOpStencilWidth() const
 {
     IntVector<NDIM> width = 0;
     using refine_strategy_set = std::vector<RefinePatchStrategy<NDIM>*>;
-    for (refine_strategy_set::const_iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         width = IntVector<NDIM>::max(width, (*it)->getRefineOpStencilWidth());
     }
@@ -97,7 +97,7 @@ RefinePatchStrategySet::preprocessRefine(Patch<NDIM>& fine,
                                          const IntVector<NDIM>& ratio)
 {
     using refine_strategy_set = std::vector<RefinePatchStrategy<NDIM>*>;
-    for (refine_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->preprocessRefine(fine, coarse, fine_box, ratio);
     }
@@ -111,7 +111,7 @@ RefinePatchStrategySet::postprocessRefine(Patch<NDIM>& fine,
                                           const IntVector<NDIM>& ratio)
 {
     using refine_strategy_set = std::vector<RefinePatchStrategy<NDIM>*>;
-    for (refine_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->postprocessRefine(fine, coarse, fine_box, ratio);
     }
@@ -125,7 +125,7 @@ RefinePatchStrategySet::preprocessRefineBoxes(Patch<NDIM>& fine,
                                               const IntVector<NDIM>& ratio)
 {
     using refine_strategy_set = std::vector<RefinePatchStrategy<NDIM>*>;
-    for (refine_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->preprocessRefineBoxes(fine, coarse, fine_boxes, ratio);
     }
@@ -139,7 +139,7 @@ RefinePatchStrategySet::postprocessRefineBoxes(Patch<NDIM>& fine,
                                                const IntVector<NDIM>& ratio)
 {
     using refine_strategy_set = std::vector<RefinePatchStrategy<NDIM>*>;
-    for (refine_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->postprocessRefineBoxes(fine, coarse, fine_boxes, ratio);
     }

--- a/ibtk/src/utilities/SideNoCornersFillPattern.cpp
+++ b/ibtk/src/utilities/SideNoCornersFillPattern.cpp
@@ -95,7 +95,7 @@ SideNoCornersFillPattern::calculateOverlap(const BoxGeometry<NDIM>& dst_geometry
 #if !defined(NDEBUG)
     TBOX_ASSERT(box_geom_overlap);
 #endif
-    const SideGeometry<NDIM>* const t_dst_geometry = dynamic_cast<const SideGeometry<NDIM>*>(&dst_geometry);
+    auto const t_dst_geometry = dynamic_cast<const SideGeometry<NDIM>*>(&dst_geometry);
 #if !defined(NDEBUG)
     TBOX_ASSERT(t_dst_geometry);
 #endif
@@ -167,7 +167,7 @@ SideNoCornersFillPattern::calculateOverlapOnLevel(const BoxGeometry<NDIM>& dst_g
 #if !defined(NDEBUG)
     TBOX_ASSERT(box_geom_overlap);
 #endif
-    const SideGeometry<NDIM>* const t_dst_geometry = dynamic_cast<const SideGeometry<NDIM>*>(&dst_geometry);
+    auto const t_dst_geometry = dynamic_cast<const SideGeometry<NDIM>*>(&dst_geometry);
 #if !defined(NDEBUG)
     TBOX_ASSERT(t_dst_geometry);
 #endif

--- a/ibtk/src/utilities/SideSynchCopyFillPattern.cpp
+++ b/ibtk/src/utilities/SideSynchCopyFillPattern.cpp
@@ -88,7 +88,7 @@ SideSynchCopyFillPattern::calculateOverlap(const BoxGeometry<NDIM>& dst_geometry
 #endif
     if (box_geom_overlap->isOverlapEmpty()) return box_geom_overlap;
 
-    const SideGeometry<NDIM>* const t_dst_geometry = dynamic_cast<const SideGeometry<NDIM>*>(&dst_geometry);
+    auto const t_dst_geometry = dynamic_cast<const SideGeometry<NDIM>*>(&dst_geometry);
 #if !defined(NDEBUG)
     TBOX_ASSERT(t_dst_geometry);
 #endif

--- a/ibtk/src/utilities/StandardTagAndInitStrategySet.cpp
+++ b/ibtk/src/utilities/StandardTagAndInitStrategySet.cpp
@@ -59,7 +59,7 @@ StandardTagAndInitStrategySet::~StandardTagAndInitStrategySet()
     if (d_managed)
     {
         using coarsen_strategy_set = std::vector<StandardTagAndInitStrategy<NDIM>*>;
-        for (coarsen_strategy_set::const_iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+        for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
         {
             delete (*it);
         }
@@ -74,7 +74,7 @@ StandardTagAndInitStrategySet::getLevelDt(const Pointer<BasePatchLevel<NDIM> > l
 {
     double dt = std::numeric_limits<double>::max();
     using tag_and_init_strategy_set = std::vector<StandardTagAndInitStrategy<NDIM>*>;
-    for (tag_and_init_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         dt = std::min(dt, (*it)->getLevelDt(level, dt_time, initial_time));
     }
@@ -92,7 +92,7 @@ StandardTagAndInitStrategySet::advanceLevel(const Pointer<BasePatchLevel<NDIM> >
 {
     double dt = std::numeric_limits<double>::max();
     using tag_and_init_strategy_set = std::vector<StandardTagAndInitStrategy<NDIM>*>;
-    for (tag_and_init_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         dt = std::min(
             dt, (*it)->advanceLevel(level, hierarchy, current_time, new_time, first_step, last_step, regrid_advance));
@@ -106,7 +106,7 @@ StandardTagAndInitStrategySet::resetTimeDependentData(const Pointer<BasePatchLev
                                                       const bool can_be_refined)
 {
     using tag_and_init_strategy_set = std::vector<StandardTagAndInitStrategy<NDIM>*>;
-    for (tag_and_init_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->resetTimeDependentData(level, new_time, can_be_refined);
     }
@@ -117,7 +117,7 @@ void
 StandardTagAndInitStrategySet::resetDataToPreadvanceState(const Pointer<BasePatchLevel<NDIM> > level)
 {
     using tag_and_init_strategy_set = std::vector<StandardTagAndInitStrategy<NDIM>*>;
-    for (tag_and_init_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->resetDataToPreadvanceState(level);
     }
@@ -134,7 +134,7 @@ StandardTagAndInitStrategySet::initializeLevelData(const Pointer<BasePatchHierar
                                                    const bool allocate_data)
 {
     using tag_and_init_strategy_set = std::vector<StandardTagAndInitStrategy<NDIM>*>;
-    for (tag_and_init_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->initializeLevelData(
             hierarchy, level_number, init_data_time, can_be_refined, initial_time, old_level, allocate_data);
@@ -148,7 +148,7 @@ StandardTagAndInitStrategySet::resetHierarchyConfiguration(const Pointer<BasePat
                                                            const int finest_level)
 {
     using tag_and_init_strategy_set = std::vector<StandardTagAndInitStrategy<NDIM>*>;
-    for (tag_and_init_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->resetHierarchyConfiguration(hierarchy, coarsest_level, finest_level);
     }
@@ -164,7 +164,7 @@ StandardTagAndInitStrategySet::applyGradientDetector(const Pointer<BasePatchHier
                                                      const bool uses_richardson_extrapolation_too)
 {
     using tag_and_init_strategy_set = std::vector<StandardTagAndInitStrategy<NDIM>*>;
-    for (tag_and_init_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->applyGradientDetector(
             hierarchy, level_number, error_data_time, tag_index, initial_time, uses_richardson_extrapolation_too);
@@ -182,7 +182,7 @@ StandardTagAndInitStrategySet::applyRichardsonExtrapolation(const Pointer<PatchL
                                                             const bool uses_gradient_detector_too)
 {
     using tag_and_init_strategy_set = std::vector<StandardTagAndInitStrategy<NDIM>*>;
-    for (tag_and_init_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->applyRichardsonExtrapolation(
             level, error_data_time, tag_index, deltat, error_coarsen_ratio, initial_time, uses_gradient_detector_too);
@@ -198,7 +198,7 @@ StandardTagAndInitStrategySet::coarsenDataForRichardsonExtrapolation(const Point
                                                                      const bool before_advance)
 {
     using tag_and_init_strategy_set = std::vector<StandardTagAndInitStrategy<NDIM>*>;
-    for (tag_and_init_strategy_set::iterator it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
     {
         (*it)->coarsenDataForRichardsonExtrapolation(
             hierarchy, level_number, coarser_level, coarsen_data_time, before_advance);

--- a/ibtk/src/utilities/muParserCartGridFunction.cpp
+++ b/ibtk/src/utilities/muParserCartGridFunction.cpp
@@ -202,7 +202,7 @@ muParserCartGridFunction::muParserCartGridFunction(const std::string& object_nam
     const double pi = 3.1415926535897932384626433832795;
     const double* const x_lower = grid_geom->getXLower();
     const double* const x_upper = grid_geom->getXUpper();
-    for (std::vector<mu::Parser>::iterator it = d_parsers.begin(); it != d_parsers.end(); ++it)
+    for (auto it = d_parsers.begin(); it != d_parsers.end(); ++it)
     {
         // Various names for pi.
         it->DefineConst("pi", pi);
@@ -270,8 +270,7 @@ muParserCartGridFunction::muParserCartGridFunction(const std::string& object_nam
         }
 
         // User-provided constants.
-        for (std::map<std::string, double>::const_iterator map_cit = d_constants.begin(); map_cit != d_constants.end();
-             ++map_cit)
+        for (auto map_cit = d_constants.begin(); map_cit != d_constants.end(); ++map_cit)
         {
             it->DefineConst(map_cit->first, map_cit->second);
         }

--- a/include/ibamr/IBFEPostProcessor.h
+++ b/include/ibamr/IBFEPostProcessor.h
@@ -116,7 +116,7 @@ public:
         void* ctx)
     {
         TBOX_ASSERT(ctx);
-        IBFEMethod::PK1StressFcnData* PK1_stress_fcn_data = static_cast<IBFEMethod::PK1StressFcnData*>(ctx);
+        auto PK1_stress_fcn_data = static_cast<IBFEMethod::PK1StressFcnData*>(ctx);
         TBOX_ASSERT(PK1_stress_fcn_data);
         IBTK::TensorMeshFcnPtr PK1_stress_fcn = PK1_stress_fcn_data->fcn;
         void* PK1_stress_fcn_ctx = PK1_stress_fcn_data->ctx;

--- a/include/ibamr/private/IBBeamForceSpec-inl.h
+++ b/include/ibamr/private/IBBeamForceSpec-inl.h
@@ -100,7 +100,7 @@ inline IBBeamForceSpec::~IBBeamForceSpec()
 inline unsigned int
 IBBeamForceSpec::getNumberOfBeams() const
 {
-    const unsigned int num_beams = static_cast<unsigned int>(d_neighbor_idxs.size());
+    const auto num_beams = static_cast<unsigned int>(d_neighbor_idxs.size());
 #if !defined(NDEBUG)
     TBOX_ASSERT(num_beams == d_bend_rigidities.size());
     TBOX_ASSERT(num_beams == d_mesh_dependent_curvatures.size());
@@ -173,7 +173,7 @@ IBBeamForceSpec::getDataStreamSize() const
 inline void
 IBBeamForceSpec::packStream(SAMRAI::tbox::AbstractStream& stream)
 {
-    const unsigned int num_beams = static_cast<unsigned int>(d_neighbor_idxs.size());
+    const auto num_beams = static_cast<unsigned int>(d_neighbor_idxs.size());
 #if !defined(NDEBUG)
     TBOX_ASSERT(num_beams == d_bend_rigidities.size());
     TBOX_ASSERT(num_beams == d_mesh_dependent_curvatures.size());

--- a/include/ibamr/private/IBRodForceSpec-inl.h
+++ b/include/ibamr/private/IBRodForceSpec-inl.h
@@ -98,7 +98,7 @@ inline IBRodForceSpec::~IBRodForceSpec()
 inline unsigned int
 IBRodForceSpec::getNumberOfRods() const
 {
-    const unsigned int num_rods = static_cast<unsigned int>(d_next_idxs.size());
+    const auto num_rods = static_cast<unsigned int>(d_next_idxs.size());
 #if !defined(NDEBUG)
     TBOX_ASSERT(num_rods == d_material_params.size());
 #endif
@@ -161,7 +161,7 @@ IBRodForceSpec::getDataStreamSize() const
 inline void
 IBRodForceSpec::packStream(SAMRAI::tbox::AbstractStream& stream)
 {
-    const unsigned int num_rods = static_cast<unsigned int>(d_next_idxs.size());
+    const auto num_rods = static_cast<unsigned int>(d_next_idxs.size());
 #if !defined(NDEBUG)
     TBOX_ASSERT(num_rods == d_material_params.size());
 #endif

--- a/include/ibamr/private/IBSpringForceSpec-inl.h
+++ b/include/ibamr/private/IBSpringForceSpec-inl.h
@@ -97,7 +97,7 @@ inline IBSpringForceSpec::~IBSpringForceSpec()
 inline unsigned int
 IBSpringForceSpec::getNumberOfSprings() const
 {
-    const unsigned int num_springs = static_cast<unsigned int>(d_slave_idxs.size());
+    const auto num_springs = static_cast<unsigned int>(d_slave_idxs.size());
 #if !defined(NDEBUG)
     TBOX_ASSERT(num_springs == d_force_fcn_idxs.size());
     TBOX_ASSERT(num_springs == d_parameters.size());
@@ -179,7 +179,7 @@ IBSpringForceSpec::getDataStreamSize() const
 inline void
 IBSpringForceSpec::packStream(SAMRAI::tbox::AbstractStream& stream)
 {
-    const unsigned int num_springs = static_cast<unsigned int>(d_slave_idxs.size());
+    const auto num_springs = static_cast<unsigned int>(d_slave_idxs.size());
 #if !defined(NDEBUG)
     TBOX_ASSERT(num_springs == d_force_fcn_idxs.size());
     TBOX_ASSERT(num_springs == d_parameters.size());

--- a/src/IB/CIBFEMethod.cpp
+++ b/src/IB/CIBFEMethod.cpp
@@ -983,8 +983,8 @@ CIBFEMethod::setRigidBodyVelocity(const unsigned int part, const RigidDOFVector&
     {
         MeshBase& mesh = equation_systems->get_mesh();
         const unsigned int total_local_nodes = mesh.n_nodes_on_proc(SAMRAI_MPI::getRank());
-        System& X_system = equation_systems->get_system<System>(CIBFEMethod::COORDS_SYSTEM_NAME);
-        System& U_system = equation_systems->get_system<System>(CIBFEMethod::CONSTRAINT_VELOCITY_SYSTEM_NAME);
+        auto& X_system = equation_systems->get_system<System>(CIBFEMethod::COORDS_SYSTEM_NAME);
+        auto& U_system = equation_systems->get_system<System>(CIBFEMethod::CONSTRAINT_VELOCITY_SYSTEM_NAME);
         const unsigned int X_sys_num = X_system.number();
         const unsigned int U_sys_num = U_system.number();
 
@@ -1082,7 +1082,7 @@ CIBFEMethod::initializeFEData()
         d_num_nodes[part] = mesh.n_nodes();
 
         // Assemble additional systems.
-        System& U_constraint_system = equation_systems->get_system<System>(CONSTRAINT_VELOCITY_SYSTEM_NAME);
+        auto& U_constraint_system = equation_systems->get_system<System>(CONSTRAINT_VELOCITY_SYSTEM_NAME);
         U_constraint_system.assemble_before_solve = false;
         U_constraint_system.assemble();
     }
@@ -1267,7 +1267,7 @@ CIBFEMethod::commonConstructor(Pointer<Database> input_db)
     for (unsigned int part = 0; part < d_num_rigid_parts; ++part)
     {
         EquationSystems* equation_systems = d_equation_systems[part];
-        System& U_constraint_system = equation_systems->add_system<System>(CONSTRAINT_VELOCITY_SYSTEM_NAME);
+        auto& U_constraint_system = equation_systems->add_system<System>(CONSTRAINT_VELOCITY_SYSTEM_NAME);
         for (unsigned int d = 0; d < NDIM; ++d)
         {
             std::ostringstream os;
@@ -1358,7 +1358,7 @@ CIBFEMethod::computeCOMOfStructure(Eigen::Vector3d& center_of_mass, EquationSyst
     const std::vector<std::vector<double> >& phi = fe->get_phi();
 
     // Extract the nodal coordinates.
-    PetscVector<double>& X_petsc = dynamic_cast<PetscVector<double>&>(*X_system.current_local_solution.get());
+    auto& X_petsc = dynamic_cast<PetscVector<double>&>(*X_system.current_local_solution.get());
     /*if (!X_petsc.closed())*/ X_petsc.close();
     Vec X_global_vec = X_petsc.vec();
     Vec X_local_ghost_vec;

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -486,7 +486,7 @@ CIBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy,
     const int struct_ln = getStructuresLevelNumber();
     std::vector<int> structIDs = d_l_data_manager->getLagrangianStructureIDs(struct_ln);
     std::sort(structIDs.begin(), structIDs.end());
-    const unsigned structs_on_this_ln = static_cast<unsigned>(structIDs.size());
+    const auto structs_on_this_ln = static_cast<unsigned>(structIDs.size());
 
     for (unsigned struct_no = 0; struct_no < structs_on_this_ln; ++struct_no)
     {
@@ -550,7 +550,7 @@ CIBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy,
 
         const Pointer<LMesh> mesh = d_l_data_manager->getLMesh(struct_ln);
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int local_idx = node_idx->getLocalPETScIndex();
@@ -676,11 +676,11 @@ CIBMethod::forwardEulerStep(double current_time, double new_time)
 
         // Get structures on this level.
         const std::vector<int> structIDs = d_l_data_manager->getLagrangianStructureIDs(ln);
-        const unsigned structs_on_this_ln = static_cast<unsigned>(structIDs.size());
+        const auto structs_on_this_ln = static_cast<unsigned>(structIDs.size());
 #if !defined(NDEBUG)
         TBOX_ASSERT(structs_on_this_ln == d_num_rigid_parts);
 #endif
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
@@ -796,12 +796,12 @@ CIBMethod::midpointStep(double current_time, double new_time)
 
         // Get structures on this level.
         const std::vector<int> structIDs = d_l_data_manager->getLagrangianStructureIDs(ln);
-        const unsigned structs_on_this_ln = (unsigned)structIDs.size();
+        const auto structs_on_this_ln = (unsigned)structIDs.size();
 #if !defined(NDEBUG)
         TBOX_ASSERT(structs_on_this_ln == d_num_rigid_parts);
 #endif
 
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
@@ -1130,7 +1130,7 @@ CIBMethod::setRigidBodyVelocity(const unsigned int part, const RigidDOFVector& U
         const Pointer<LMesh> mesh = d_l_data_manager->getLMesh(struct_ln);
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
         const std::pair<int, int>& part_idx_range = d_struct_lag_idx_range[part];
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
@@ -1186,7 +1186,7 @@ CIBMethod::computeNetRigidGeneralizedForce(const unsigned int part, Vec L, Rigid
     F.setZero();
     const Pointer<LMesh> mesh = d_l_data_manager->getLMesh(struct_ln);
     const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const int lag_idx = node_idx->getLagrangianIndex();
@@ -1233,7 +1233,7 @@ CIBMethod::copyVecToArray(Vec b,
                           const int array_rank)
 {
     if (struct_ids.empty()) return;
-    const unsigned num_structs = static_cast<unsigned>(struct_ids.size());
+    const auto num_structs = static_cast<unsigned>(struct_ids.size());
 
     // Get the Lagrangian indices of the structures.
     std::vector<int> map;
@@ -1306,7 +1306,7 @@ CIBMethod::copyArrayToVec(Vec b,
                           const int array_rank)
 {
     if (struct_ids.empty()) return;
-    const unsigned num_structs = static_cast<unsigned>(struct_ids.size());
+    const auto num_structs = static_cast<unsigned>(struct_ids.size());
 
     // Get the Lagrangian indices of the structures.
     std::vector<int> map;
@@ -1597,7 +1597,7 @@ CIBMethod::rotateArray(double* array,
     {
         const bool position_system = (depth % NDIM == 0);
         const bool force_system = (depth % s_max_free_dofs == 0);
-        const unsigned num_structs = static_cast<unsigned>(struct_ids.size());
+        const auto num_structs = static_cast<unsigned>(struct_ids.size());
         unsigned offset = 0;
 
         for (unsigned k = 0; k < num_structs; ++k)
@@ -1768,12 +1768,12 @@ CIBMethod::computeCOMOfStructures(std::vector<Eigen::Vector3d>& center_of_mass, 
 
         // Get structures on this level.
         const std::vector<int> structIDs = d_l_data_manager->getLagrangianStructureIDs(ln);
-        const unsigned structs_on_this_ln = static_cast<unsigned>(structIDs.size());
+        const auto structs_on_this_ln = static_cast<unsigned>(structIDs.size());
 #if !defined(NDEBUG)
         TBOX_ASSERT(structs_on_this_ln == d_num_rigid_parts);
 #endif
 
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
@@ -1818,7 +1818,7 @@ CIBMethod::setRegularizationWeight(const int level_number)
 
     // Get structures on this level.
     const std::vector<int> structIDs = d_l_data_manager->getLagrangianStructureIDs(level_number);
-    const unsigned structs_on_this_ln = static_cast<unsigned>(structIDs.size());
+    const auto structs_on_this_ln = static_cast<unsigned>(structIDs.size());
 #if !defined(NDEBUG)
     TBOX_ASSERT(structs_on_this_ln == d_num_rigid_parts);
 #endif
@@ -1828,7 +1828,7 @@ CIBMethod::setRegularizationWeight(const int level_number)
         const std::pair<int, int>& lag_idx_range = d_struct_lag_idx_range[struct_no];
         if (d_reg_filename[struct_no].empty())
         {
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -1895,7 +1895,7 @@ CIBMethod::setRegularizationWeight(const int level_number)
             }
         }
 
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
@@ -1938,7 +1938,7 @@ CIBMethod::setInitialLambda(const int level_number)
 
     // Get structures on this level.
     const std::vector<int> structIDs = d_l_data_manager->getLagrangianStructureIDs(level_number);
-    const unsigned structs_on_this_ln = static_cast<unsigned>(structIDs.size());
+    const auto structs_on_this_ln = static_cast<unsigned>(structIDs.size());
 #if !defined(NDEBUG)
     TBOX_ASSERT(structs_on_this_ln == d_num_rigid_parts);
 #endif
@@ -1998,7 +1998,7 @@ CIBMethod::setInitialLambda(const int level_number)
             }
         }
 
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();

--- a/src/IB/CIBSaddlePointSolver.cpp
+++ b/src/IB/CIBSaddlePointSolver.cpp
@@ -721,14 +721,14 @@ CIBSaddlePointSolver::initializeStokesSolver(const SAMRAIVectorReal<NDIM, double
     x_p_vec.addComponent(x_p_cc_var, x_p_idx, sol_vec.getControlVolumeIndex(1));
     b_p_vec.addComponent(b_p_cc_var, b_p_idx, rhs_vec.getControlVolumeIndex(1));
 
-    IBTK::LinearSolver* p_velocity_solver = dynamic_cast<IBTK::LinearSolver*>(d_velocity_solver.getPointer());
+    auto p_velocity_solver = dynamic_cast<IBTK::LinearSolver*>(d_velocity_solver.getPointer());
     if (p_velocity_solver)
     {
         p_velocity_solver->setInitialGuessNonzero(false);
         if (has_velocity_nullspace) p_velocity_solver->setNullspace(false, d_U_nul_vecs);
     }
 
-    IBTK::LinearSolver* p_pressure_solver = dynamic_cast<IBTK::LinearSolver*>(d_pressure_solver.getPointer());
+    auto p_pressure_solver = dynamic_cast<IBTK::LinearSolver*>(d_pressure_solver.getPointer());
     if (p_pressure_solver)
     {
         p_pressure_solver->setInitialGuessNonzero(false);
@@ -739,10 +739,10 @@ CIBSaddlePointSolver::initializeStokesSolver(const SAMRAIVectorReal<NDIM, double
     d_pressure_solver->initializeSolverState(x_p_vec, b_p_vec);
 
     // Initialize LInv (Stokes solver for the preconditioner).
-    IBTK::LinearSolver* p_stokes_linear_solver = dynamic_cast<IBTK::LinearSolver*>(d_LInv.getPointer());
+    auto p_stokes_linear_solver = dynamic_cast<IBTK::LinearSolver*>(d_LInv.getPointer());
     if (!p_stokes_linear_solver)
     {
-        IBTK::NewtonKrylovSolver* p_stokes_newton_solver = dynamic_cast<IBTK::NewtonKrylovSolver*>(d_LInv.getPointer());
+        auto p_stokes_newton_solver = dynamic_cast<IBTK::NewtonKrylovSolver*>(d_LInv.getPointer());
         if (p_stokes_newton_solver)
         {
             p_stokes_linear_solver = p_stokes_newton_solver->getLinearSolver().getPointer();
@@ -750,12 +750,10 @@ CIBSaddlePointSolver::initializeStokesSolver(const SAMRAIVectorReal<NDIM, double
     }
     if (p_stokes_linear_solver)
     {
-        StaggeredStokesBlockPreconditioner* p_stokes_block_pc =
-            dynamic_cast<StaggeredStokesBlockPreconditioner*>(p_stokes_linear_solver);
+        auto p_stokes_block_pc = dynamic_cast<StaggeredStokesBlockPreconditioner*>(p_stokes_linear_solver);
         if (!p_stokes_block_pc)
         {
-            IBTK::KrylovLinearSolver* p_stokes_krylov_solver =
-                dynamic_cast<IBTK::KrylovLinearSolver*>(p_stokes_linear_solver);
+            auto p_stokes_krylov_solver = dynamic_cast<IBTK::KrylovLinearSolver*>(p_stokes_linear_solver);
             if (p_stokes_krylov_solver)
             {
                 p_stokes_block_pc = dynamic_cast<StaggeredStokesBlockPreconditioner*>(
@@ -946,7 +944,7 @@ CIBSaddlePointSolver::MatVecMult_SaddlePoint(Mat A, Vec x, Vec y)
 {
     void* p_ctx;
     MatShellGetContext(A, &p_ctx);
-    CIBSaddlePointSolver* solver = static_cast<CIBSaddlePointSolver*>(p_ctx);
+    auto solver = static_cast<CIBSaddlePointSolver*>(p_ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(solver);
     TBOX_ASSERT(solver->d_A);
@@ -963,7 +961,7 @@ CIBSaddlePointSolver::PCApply_SaddlePoint(PC pc, Vec x, Vec y)
     // in which P is the preconditioner.
     void* ctx;
     PCShellGetContext(pc, &ctx);
-    CIBSaddlePointSolver* solver = static_cast<CIBSaddlePointSolver*>(ctx);
+    auto solver = static_cast<CIBSaddlePointSolver*>(ctx);
     Pointer<IBStrategy> ib_method_ops = solver->d_cib_strategy;
 
 #if !defined(NDEBUG)

--- a/src/IB/ConstraintIBMethod.cpp
+++ b/src/IB/ConstraintIBMethod.cpp
@@ -569,7 +569,7 @@ ConstraintIBMethod::registerEulerianVariables()
         d_Div_u_scratch_idx = var_db->registerVariableAndContext(d_Div_u_var, d_scratch_context, cell_ghosts);
     }
 
-    INSVCStaggeredHierarchyIntegrator* p_vc_ins_hier_integrator =
+    auto p_vc_ins_hier_integrator =
         dynamic_cast<INSVCStaggeredHierarchyIntegrator*>(IBStrategy::getINSHierarchyIntegrator());
     // If using constant rho INS solver,
     // then assert rho_fluid == rho_solid
@@ -964,7 +964,7 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
             double X_com_current[NDIM] = { 0.0 }, X_com_new[NDIM] = { 0.0 };
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -1065,7 +1065,7 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
             Inertia_current.setZero();
             Inertia_new.setZero();
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -1228,7 +1228,7 @@ ConstraintIBMethod::calculateMomentumOfKinematicsVelocity(const int position_han
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
         const std::vector<std::vector<double> >& def_vel = ptr_ib_kinematics->getKinematicsVelocity(ln);
 
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
@@ -1288,7 +1288,7 @@ ConstraintIBMethod::calculateMomentumOfKinematicsVelocity(const int position_han
             const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
             const std::vector<std::vector<double> >& def_vel = ptr_ib_kinematics->getKinematicsVelocity(ln);
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -1522,7 +1522,7 @@ ConstraintIBMethod::calculateRigidTranslationalMomentum()
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
             double U_rigid[NDIM] = { 0.0 };
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -1615,7 +1615,7 @@ ConstraintIBMethod::calculateRigidRotationalMomentum()
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
             double Omega_rigid[3] = { 0.0 };
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -1719,7 +1719,7 @@ ConstraintIBMethod::calculateCurrentLagrangianVelocity()
             const StructureParameters& struct_param = ptr_ib_kinematics->getStructureParameters();
             const std::vector<std::vector<double> >& current_vel = ptr_ib_kinematics->getKinematicsVelocity(ln);
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -1826,7 +1826,7 @@ ConstraintIBMethod::correctVelocityOnLagrangianMesh()
             const StructureParameters& struct_param = ptr_ib_kinematics->getStructureParameters();
             const std::vector<std::vector<double> >& new_vel = ptr_ib_kinematics->getKinematicsVelocity(ln);
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -2119,7 +2119,7 @@ ConstraintIBMethod::updateStructurePositionEulerStep()
             const std::string position_update_method = struct_param.getPositionUpdateMethod();
             const std::vector<std::vector<double> >& current_shape = ptr_ib_kinematics->getShape(ln);
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -2223,7 +2223,7 @@ ConstraintIBMethod::updateStructurePositionMidPointStep()
             const std::string position_update_method = struct_param.getPositionUpdateMethod();
             const std::vector<std::vector<double> >& new_shape = ptr_ib_kinematics->getShape(ln);
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -2470,7 +2470,7 @@ ConstraintIBMethod::calculateDrag()
             const int location_struct_handle =
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -2555,7 +2555,7 @@ ConstraintIBMethod::calculateTorque()
             const int location_struct_handle =
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -2664,7 +2664,7 @@ ConstraintIBMethod::calculatePower()
             const int location_struct_handle =
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -2740,7 +2740,7 @@ ConstraintIBMethod::calculateStructureMomentum()
             const int location_struct_handle =
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
@@ -2802,7 +2802,7 @@ ConstraintIBMethod::calculateStructureRotationalMomentum()
             const int location_struct_handle =
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();

--- a/src/IB/DirectMobilitySolver.cpp
+++ b/src/IB/DirectMobilitySolver.cpp
@@ -145,9 +145,7 @@ DirectMobilitySolver::DirectMobilitySolver(const std::string& object_name,
 
 DirectMobilitySolver::~DirectMobilitySolver()
 {
-    for (std::map<std::string, std::pair<Mat, Mat> >::iterator it = d_petsc_mat_map.begin();
-         it != d_petsc_mat_map.end();
-         ++it)
+    for (auto it = d_petsc_mat_map.begin(); it != d_petsc_mat_map.end(); ++it)
     {
         const std::string& mat_name = it->first;
         Mat& mobility_mat = d_petsc_mat_map[mat_name].first;
@@ -156,28 +154,24 @@ DirectMobilitySolver::~DirectMobilitySolver()
         MatDestroy(&body_mobility_mat);
     }
 
-    for (std::map<std::string, std::pair<double*, double*> >::iterator it = d_mat_map.begin(); it != d_mat_map.end();
-         ++it)
+    for (auto it = d_mat_map.begin(); it != d_mat_map.end(); ++it)
     {
         delete[](it->second).first;
         delete[](it->second).second;
     }
 
-    for (std::map<std::string, Mat>::iterator it = d_petsc_geometric_mat_map.begin();
-         it != d_petsc_geometric_mat_map.end();
-         ++it)
+    for (auto it = d_petsc_geometric_mat_map.begin(); it != d_petsc_geometric_mat_map.end(); ++it)
     {
         Mat& geometric_mat = d_petsc_geometric_mat_map[it->first];
         MatDestroy(&geometric_mat);
     }
 
-    for (std::map<std::string, double*>::iterator it = d_geometric_mat_map.begin(); it != d_geometric_mat_map.end();
-         ++it)
+    for (auto it = d_geometric_mat_map.begin(); it != d_geometric_mat_map.end(); ++it)
     {
         delete[] it->second;
     }
 
-    for (std::map<std::string, std::pair<int*, int*> >::iterator it = d_ipiv_map.begin(); it != d_ipiv_map.end(); ++it)
+    for (auto it = d_ipiv_map.begin(); it != d_ipiv_map.end(); ++it)
     {
         delete[](it->second).first;
         delete[](it->second).second;
@@ -354,9 +348,7 @@ DirectMobilitySolver::solveSystem(Vec x, Vec b)
     const int rank = SAMRAI_MPI::getRank();
     static const int data_depth = NDIM;
 
-    for (std::map<std::string, std::pair<Mat, Mat> >::iterator it = d_petsc_mat_map.begin();
-         it != d_petsc_mat_map.end();
-         ++it)
+    for (auto it = d_petsc_mat_map.begin(); it != d_petsc_mat_map.end(); ++it)
     {
         const std::string& mat_name = it->first;
         Mat& mat = d_petsc_mat_map[mat_name].first;
@@ -410,9 +402,7 @@ DirectMobilitySolver::solveBodySystem(Vec x, Vec b)
     const int rank = SAMRAI_MPI::getRank();
     static const int data_depth = s_max_free_dofs;
 
-    for (std::map<std::string, std::pair<Mat, Mat> >::iterator it = d_petsc_mat_map.begin();
-         it != d_petsc_mat_map.end();
-         ++it)
+    for (auto it = d_petsc_mat_map.begin(); it != d_petsc_mat_map.end(); ++it)
     {
         const std::string& mat_name = it->first;
         Mat& mat = d_petsc_mat_map[mat_name].second;
@@ -462,7 +452,7 @@ DirectMobilitySolver::initializeSolverState(Vec x, Vec /*b*/)
     IBAMR_TIMER_START(t_initialize_solver_state);
 
     int rank = SAMRAI_MPI::getRank();
-    unsigned managed_mats = static_cast<unsigned>(d_mat_map.size());
+    auto managed_mats = static_cast<unsigned>(d_mat_map.size());
 
     static bool recreate_mobility_matrices = true;
     static std::vector<bool> read_files(managed_mats, false);
@@ -492,9 +482,7 @@ DirectMobilitySolver::initializeSolverState(Vec x, Vec /*b*/)
         }
 
         int file_counter = 0;
-        for (std::map<std::string, std::pair<Mat, Mat> >::iterator it = d_petsc_mat_map.begin();
-             it != d_petsc_mat_map.end();
-             ++it, ++file_counter)
+        for (auto it = d_petsc_mat_map.begin(); it != d_petsc_mat_map.end(); ++it, ++file_counter)
         {
             const std::string& mat_name = it->first;
             Mat& mobility_mat = d_petsc_mat_map[mat_name].first;
@@ -603,9 +591,7 @@ void
 DirectMobilitySolver::factorizeMobilityMatrix()
 {
     int rank = SAMRAI_MPI::getRank();
-    for (std::map<std::string, std::pair<Mat, Mat> >::iterator it = d_petsc_mat_map.begin();
-         it != d_petsc_mat_map.end();
-         ++it)
+    for (auto it = d_petsc_mat_map.begin(); it != d_petsc_mat_map.end(); ++it)
     {
         const std::string& mat_name = it->first;
         if (rank != d_mat_proc_map[mat_name]) continue;
@@ -626,9 +612,7 @@ void
 DirectMobilitySolver::constructBodyMobilityMatrix()
 {
     int rank = SAMRAI_MPI::getRank();
-    for (std::map<std::string, std::pair<Mat, Mat> >::iterator it = d_petsc_mat_map.begin();
-         it != d_petsc_mat_map.end();
-         ++it)
+    for (auto it = d_petsc_mat_map.begin(); it != d_petsc_mat_map.end(); ++it)
     {
         const std::string& mat_name = it->first;
         if (rank != d_mat_proc_map[mat_name]) continue;
@@ -643,7 +627,7 @@ DirectMobilitySolver::constructBodyMobilityMatrix()
 
         // Allocate a temporary matrix that holds the Matrix-Matrix product.
         // Here we are multiplying inverse of mobility matrix with geometric matrix.
-        double* product_mat_data = new double[row_size * col_size];
+        auto product_mat_data = new double[row_size * col_size];
         Mat product_mat;
         MatCreateSeqDense(PETSC_COMM_SELF, row_size, col_size, product_mat_data, &product_mat);
         MatCopy(geometric_mat, product_mat, SAME_NONZERO_PATTERN);
@@ -668,9 +652,7 @@ void
 DirectMobilitySolver::factorizeBodyMobilityMatrix()
 {
     int rank = SAMRAI_MPI::getRank();
-    for (std::map<std::string, std::pair<Mat, Mat> >::iterator it = d_petsc_mat_map.begin();
-         it != d_petsc_mat_map.end();
-         ++it)
+    for (auto it = d_petsc_mat_map.begin(); it != d_petsc_mat_map.end(); ++it)
     {
         const std::string& mat_name = it->first;
         if (rank != d_mat_proc_map[mat_name]) continue;

--- a/src/IB/IBFECentroidPostProcessor.cpp
+++ b/src/IB/IBFECentroidPostProcessor.cpp
@@ -179,7 +179,7 @@ IBFECentroidPostProcessor::reconstructVariables(double data_time)
     fe.attachQuadratureRule(qrule.get());
     fe.evalQuadraturePoints();
 
-    System& X_system = equation_systems->get_system<System>(IBFEMethod::COORDS_SYSTEM_NAME);
+    auto& X_system = equation_systems->get_system<System>(IBFEMethod::COORDS_SYSTEM_NAME);
     X_system.solution->localize(*X_system.current_local_solution);
     NumericVector<double>& X_data = *(X_system.current_local_solution);
     X_data.close();

--- a/src/IB/IBFEDirectForcingKinematics.cpp
+++ b/src/IB/IBFEDirectForcingKinematics.cpp
@@ -572,7 +572,7 @@ IBFEDirectForcingKinematics::computeCOMOfStructure(Eigen::Vector3d& X0)
     const std::vector<std::vector<double> >& phi = fe->get_phi();
 
     // Extract the nodal coordinates.
-    PetscVector<double>& X_petsc = dynamic_cast<PetscVector<double>&>(*X_system.current_local_solution.get());
+    auto& X_petsc = dynamic_cast<PetscVector<double>&>(*X_system.current_local_solution.get());
     X_petsc.close();
     Vec X_global_vec = X_petsc.vec();
     Vec X_local_ghost_vec;
@@ -641,7 +641,7 @@ IBFEDirectForcingKinematics::computeMOIOfStructure(Eigen::Matrix3d& I, const Eig
 
     // Extract the nodal coordinates.
     int ierr;
-    PetscVector<double>& X_petsc = dynamic_cast<PetscVector<double>&>(*X_system.current_local_solution.get());
+    auto& X_petsc = dynamic_cast<PetscVector<double>&>(*X_system.current_local_solution.get());
     X_petsc.close();
     Vec X_global_vec = X_petsc.vec();
     Vec X_local_ghost_vec;

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -425,9 +425,7 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
     // on all the processes.
     for (int jj = 0; jj < d_nodeset_IDs_for_meters.size(); ++jj)
     {
-        for (std::set<dof_id_type>::iterator it = temp_node_dof_ID_sets[jj].begin();
-             it != temp_node_dof_ID_sets[jj].end();
-             ++it)
+        for (auto it = temp_node_dof_ID_sets[jj].begin(); it != temp_node_dof_ID_sets[jj].end(); ++it)
         {
             const dof_id_type node_id = *it;
             temp_node_dof_IDs[jj].push_back(node_id);
@@ -522,12 +520,11 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
     for (unsigned int jj = 0; jj < d_num_meters; ++jj)
     {
         d_meter_systems.push_back(new EquationSystems(*d_meter_meshes[jj]));
-        LinearImplicitSystem& velocity_sys =
-            d_meter_systems[jj]->add_system<LinearImplicitSystem>(IBFEMethod::VELOCITY_SYSTEM_NAME);
+        auto& velocity_sys = d_meter_systems[jj]->add_system<LinearImplicitSystem>(IBFEMethod::VELOCITY_SYSTEM_NAME);
         velocity_sys.add_variable("U_0", static_cast<Order>(1), LAGRANGE);
         velocity_sys.add_variable("U_1", static_cast<Order>(1), LAGRANGE);
         velocity_sys.add_variable("U_2", static_cast<Order>(1), LAGRANGE);
-        LinearImplicitSystem& displacement_sys =
+        auto& displacement_sys =
             d_meter_systems[jj]->add_system<LinearImplicitSystem>(IBFEMethod::COORD_MAPPING_SYSTEM_NAME);
         displacement_sys.add_variable("dX_0", static_cast<Order>(1), LAGRANGE);
         displacement_sys.add_variable("dX_1", static_cast<Order>(1), LAGRANGE);
@@ -799,7 +796,7 @@ IBFEInstrumentPanel::readInstrumentData(const int U_data_idx,
                     );
                     if (U_cc_data)
                     {
-                        for (QuadPointMap::const_iterator it = qp_range.first; it != qp_range.second; ++it)
+                        for (auto it = qp_range.first; it != qp_range.second; ++it)
                         {
                             const int& meter_num = it->second.meter_num;
                             const double& JxW = it->second.JxW;
@@ -812,7 +809,7 @@ IBFEInstrumentPanel::readInstrumentData(const int U_data_idx,
                     }
                     if (U_sc_data)
                     {
-                        for (QuadPointMap::const_iterator it = qp_range.first; it != qp_range.second; ++it)
+                        for (auto it = qp_range.first; it != qp_range.second; ++it)
                         {
                             const int& meter_num = it->second.meter_num;
                             const double& JxW = it->second.JxW;
@@ -825,7 +822,7 @@ IBFEInstrumentPanel::readInstrumentData(const int U_data_idx,
                     }
                     if (P_cc_data)
                     {
-                        for (QuadPointMap::const_iterator it = qp_range.first; it != qp_range.second; ++it)
+                        for (auto it = qp_range.first; it != qp_range.second; ++it)
                         {
                             const int& meter_num = it->second.meter_num;
                             const double& JxW = it->second.JxW;
@@ -1024,13 +1021,13 @@ IBFEInstrumentPanel::initializeSystemDependentData(IBFEMethod* ib_method_ops, co
     U_system.update_global_solution(U_coords_parent);
 
     // get displacement and velocity systems for meter mesh
-    LinearImplicitSystem& velocity_sys =
+    auto& velocity_sys =
         d_meter_systems[meter_mesh_number]->get_system<LinearImplicitSystem>(IBFEMethod::VELOCITY_SYSTEM_NAME);
     const unsigned int velocity_sys_num = velocity_sys.number();
     NumericVector<double>& velocity_solution = *velocity_sys.solution;
     NumericVector<double>& velocity_coords = velocity_sys.get_vector("serial solution");
 
-    LinearImplicitSystem& displacement_sys =
+    auto& displacement_sys =
         d_meter_systems[meter_mesh_number]->get_system<LinearImplicitSystem>(IBFEMethod::COORD_MAPPING_SYSTEM_NAME);
     const unsigned int displacement_sys_num = displacement_sys.number();
     NumericVector<double>& displacement_solution = *displacement_sys.solution;

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -147,7 +147,7 @@ inline short int
 get_dirichlet_bdry_ids(const std::vector<short int>& bdry_ids)
 {
     short int dirichlet_bdry_ids = 0;
-    for (std::vector<short int>::const_iterator cit = bdry_ids.begin(); cit != bdry_ids.end(); ++cit)
+    for (auto cit = bdry_ids.begin(); cit != bdry_ids.end(); ++cit)
     {
         const short int bdry_id = *cit;
         if (bdry_id == FEDataManager::ZERO_DISPLACEMENT_X_BDRY_ID ||
@@ -172,7 +172,7 @@ is_physical_bdry(const Elem* elem,
 {
     const std::vector<short int>& bdry_ids = boundary_info.boundary_ids(elem, side);
     bool at_physical_bdry = !elem->neighbor(side);
-    for (std::vector<short int>::const_iterator cit = bdry_ids.begin(); cit != bdry_ids.end(); ++cit)
+    for (auto cit = bdry_ids.begin(); cit != bdry_ids.end(); ++cit)
     {
         if (dof_map.is_periodic_boundary(*cit)) at_physical_bdry = false;
     }
@@ -233,7 +233,7 @@ assemble_poisson(EquationSystems& es, const std::string& /*system_name*/)
     const MeshBase& mesh = es.get_mesh();
     const BoundaryInfo& boundary_info = *mesh.boundary_info;
     const unsigned int dim = mesh.mesh_dimension();
-    LinearImplicitSystem& system = es.get_system<LinearImplicitSystem>(IBFEMethod::PHI_SYSTEM_NAME);
+    auto& system = es.get_system<LinearImplicitSystem>(IBFEMethod::PHI_SYSTEM_NAME);
     const DofMap& dof_map = system.get_dof_map();
     FEType fe_type = dof_map.variable_type(0);
 
@@ -264,7 +264,7 @@ assemble_poisson(EquationSystems& es, const std::string& /*system_name*/)
         const Elem* elem = *el;
         dof_map.dof_indices(elem, dof_indices);
         fe->reinit(elem);
-        unsigned int Ke_size = static_cast<unsigned int>(dof_indices.size());
+        auto Ke_size = static_cast<unsigned int>(dof_indices.size());
         Ke.resize(Ke_size, Ke_size);
         for (unsigned int qp = 0; qp < qrule.n_points(); qp++)
         {
@@ -543,10 +543,10 @@ IBFEMethod::registerOverlappingVelocityReset(const unsigned int part1, const uns
     for (int k = 0; k < 2; ++k)
     {
         es[k] = d_fe_data_managers[part_idx[k]]->getEquationSystems();
-        System& U_system = es[k]->get_system<System>(VELOCITY_SYSTEM_NAME);
+        auto& U_system = es[k]->get_system<System>(VELOCITY_SYSTEM_NAME);
         U_dof_map[k] = &U_system.get_dof_map();
         NumericVector<double>& U_vec = *U_system.solution;
-        System& X_system = es[k]->get_system<System>(COORDS_SYSTEM_NAME);
+        auto& X_system = es[k]->get_system<System>(COORDS_SYSTEM_NAME);
         X_dof_map[k] = &X_system.get_dof_map();
         NumericVector<double>& X_vec = *X_system.solution;
         TBOX_ASSERT(U_vec.first_local_index() == X_vec.first_local_index());
@@ -587,9 +587,7 @@ IBFEMethod::registerOverlappingVelocityReset(const unsigned int part1, const uns
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 U_dof_map[k_master]->dof_indices(other_elem, U_dof_indices[k_master][d], d);
-                for (std::vector<unsigned int>::iterator it = U_dof_indices[k_master][d].begin();
-                     it != U_dof_indices[k_master][d].end();
-                     ++it)
+                for (auto it = U_dof_indices[k_master][d].begin(); it != U_dof_indices[k_master][d].end(); ++it)
                 {
                     const unsigned int idx = *it;
                     if (idx < first_local_idx[k_master] || idx >= last_local_idx[k_master])
@@ -650,8 +648,8 @@ IBFEMethod::registerOverlappingForceConstraint(const unsigned int part1,
     for (int k = 0; k < 2; ++k)
     {
         es[k] = d_fe_data_managers[part_idx[k]]->getEquationSystems();
-        System& F_system = es[k]->get_system<System>(FORCE_SYSTEM_NAME);
-        System& X_system = es[k]->get_system<System>(COORDS_SYSTEM_NAME);
+        auto& F_system = es[k]->get_system<System>(FORCE_SYSTEM_NAME);
+        auto& X_system = es[k]->get_system<System>(COORDS_SYSTEM_NAME);
         F_dof_map[k] = &F_system.get_dof_map();
         X_dof_map[k] = &X_system.get_dof_map();
         NumericVector<double>& X_vec = *X_system.solution;
@@ -695,9 +693,7 @@ IBFEMethod::registerOverlappingForceConstraint(const unsigned int part1,
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 X_dof_map[k]->dof_indices(elem, X_dof_indices[k][d], d);
-                for (std::vector<unsigned int>::iterator it = X_dof_indices[k][d].begin();
-                     it != X_dof_indices[k][d].end();
-                     ++it)
+                for (auto it = X_dof_indices[k][d].begin(); it != X_dof_indices[k][d].end(); ++it)
                 {
                     const unsigned int idx = *it;
                     if (idx < first_local_idx[k] || idx >= last_local_idx[k])
@@ -716,9 +712,7 @@ IBFEMethod::registerOverlappingForceConstraint(const unsigned int part1,
                     for (unsigned int d = 0; d < NDIM; ++d)
                     {
                         X_dof_map[k_next]->dof_indices(other_elem, X_dof_indices[k_next][d], d);
-                        for (std::vector<unsigned int>::iterator it = X_dof_indices[k_next][d].begin();
-                             it != X_dof_indices[k_next][d].end();
-                             ++it)
+                        for (auto it = X_dof_indices[k_next][d].begin(); it != X_dof_indices[k_next][d].end(); ++it)
                         {
                             const unsigned int idx = *it;
                             if (idx < first_local_idx[k_next] || idx >= last_local_idx[k_next])
@@ -1251,7 +1245,7 @@ IBFEMethod::computeLagrangianFluidSource(double data_time)
         const unsigned int dim = mesh.mesh_dimension();
 
         // Extract the FE systems and DOF maps, and setup the FE object.
-        ExplicitSystem& Q_system = equation_systems->get_system<ExplicitSystem>(SOURCE_SYSTEM_NAME);
+        auto& Q_system = equation_systems->get_system<ExplicitSystem>(SOURCE_SYSTEM_NAME);
         const DofMap& Q_dof_map = Q_system.get_dof_map();
         FEDataManager::SystemDofMapCache& Q_dof_map_cache =
             *d_fe_data_managers[part]->getDofMapCache(SOURCE_SYSTEM_NAME);
@@ -1423,7 +1417,7 @@ IBFEMethod::initializeFEEquationSystems()
         }
         else
         {
-            System& X_system = equation_systems->add_system<System>(COORDS_SYSTEM_NAME);
+            auto& X_system = equation_systems->add_system<System>(COORDS_SYSTEM_NAME);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 std::ostringstream os;
@@ -1431,7 +1425,7 @@ IBFEMethod::initializeFEEquationSystems()
                 X_system.add_variable(os.str(), d_fe_order[part], d_fe_family[part]);
             }
 
-            System& dX_system = equation_systems->add_system<System>(COORD_MAPPING_SYSTEM_NAME);
+            auto& dX_system = equation_systems->add_system<System>(COORD_MAPPING_SYSTEM_NAME);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 std::ostringstream os;
@@ -1439,7 +1433,7 @@ IBFEMethod::initializeFEEquationSystems()
                 dX_system.add_variable(os.str(), d_fe_order[part], d_fe_family[part]);
             }
 
-            System& U_system = equation_systems->add_system<System>(VELOCITY_SYSTEM_NAME);
+            auto& U_system = equation_systems->add_system<System>(VELOCITY_SYSTEM_NAME);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 std::ostringstream os;
@@ -1447,7 +1441,7 @@ IBFEMethod::initializeFEEquationSystems()
                 U_system.add_variable(os.str(), d_fe_order[part], d_fe_family[part]);
             }
 
-            System& F_system = equation_systems->add_system<System>(FORCE_SYSTEM_NAME);
+            auto& F_system = equation_systems->add_system<System>(FORCE_SYSTEM_NAME);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 std::ostringstream os;
@@ -1483,10 +1477,10 @@ IBFEMethod::initializeFEData()
         updateCoordinateMapping(part);
 
         // Assemble systems.
-        System& X_system = equation_systems->get_system<System>(COORDS_SYSTEM_NAME);
-        System& dX_system = equation_systems->get_system<System>(COORD_MAPPING_SYSTEM_NAME);
-        System& U_system = equation_systems->get_system<System>(VELOCITY_SYSTEM_NAME);
-        System& F_system = equation_systems->get_system<System>(FORCE_SYSTEM_NAME);
+        auto& X_system = equation_systems->get_system<System>(COORDS_SYSTEM_NAME);
+        auto& dX_system = equation_systems->get_system<System>(COORD_MAPPING_SYSTEM_NAME);
+        auto& U_system = equation_systems->get_system<System>(VELOCITY_SYSTEM_NAME);
+        auto& F_system = equation_systems->get_system<System>(FORCE_SYSTEM_NAME);
 
         X_system.assemble_before_solve = false;
         X_system.assemble();
@@ -1502,7 +1496,7 @@ IBFEMethod::initializeFEData()
 
         if (d_is_stress_normalization_part[part])
         {
-            LinearImplicitSystem& Phi_system = equation_systems->get_system<LinearImplicitSystem>(PHI_SYSTEM_NAME);
+            auto& Phi_system = equation_systems->get_system<LinearImplicitSystem>(PHI_SYSTEM_NAME);
             Phi_system.assemble_before_solve = false;
             Phi_system.assemble();
         }
@@ -1757,7 +1751,7 @@ IBFEMethod::computeStressNormalization(PetscVector<double>& Phi_vec,
     // Setup extra data needed to compute stresses/forces.
 
     // Extract the FE systems and DOF maps, and setup the FE objects.
-    LinearImplicitSystem& Phi_system = equation_systems->get_system<LinearImplicitSystem>(PHI_SYSTEM_NAME);
+    auto& Phi_system = equation_systems->get_system<LinearImplicitSystem>(PHI_SYSTEM_NAME);
     const DofMap& Phi_dof_map = Phi_system.get_dof_map();
     FEDataManager::SystemDofMapCache& Phi_dof_map_cache = *d_fe_data_managers[part]->getDofMapCache(PHI_SYSTEM_NAME);
     std::vector<unsigned int> Phi_dof_indices;
@@ -2467,7 +2461,7 @@ IBFEMethod::resetOverlapNodalValues(const unsigned int part,
     for (int k = 0; k < 2; ++k)
     {
         es[k] = d_fe_data_managers[part_idx[k]]->getEquationSystems();
-        System& F_system = es[k]->get_system<System>(system_name);
+        auto& F_system = es[k]->get_system<System>(system_name);
         F_dof_map[k] = &F_system.get_dof_map();
         fe_type = F_dof_map[k]->variable_type(0);
         for (unsigned int d = 0; d < NDIM; ++d)
@@ -2490,7 +2484,7 @@ IBFEMethod::resetOverlapNodalValues(const unsigned int part,
     const unsigned int k_slave = 0;
     const unsigned int k_master = 1;
     std::map<dof_id_type, dof_id_type>& node_to_elem_map = d_overlap_velocity_part_node_to_elem_map[part_idx[k_slave]];
-    for (std::map<dof_id_type, dof_id_type>::iterator n = node_to_elem_map.begin(); n != node_to_elem_map.end(); ++n)
+    for (auto n = node_to_elem_map.begin(); n != node_to_elem_map.end(); ++n)
     {
         const Node* const node = mesh[k_slave]->node_ptr(n->first);
         const libMesh::Point& X = *node;
@@ -2600,10 +2594,7 @@ IBFEMethod::computeOverlapConstraintForceDensity(std::vector<PetscVector<double>
             const std::vector<libMesh::Point>& q_point = fe[k]->get_xyz();
             const std::vector<double>& JxW = fe[k]->get_JxW();
             const std::vector<std::vector<double> >& phi = fe[k]->get_phi();
-            for (std::map<libMesh::dof_id_type, std::map<unsigned int, libMesh::dof_id_type> >::iterator it =
-                     elem_map[k].begin();
-                 it != elem_map[k].end();
-                 ++it)
+            for (auto it = elem_map[k].begin(); it != elem_map[k].end(); ++it)
             {
                 const Elem* const elem = mesh[k]->elem_ptr(it->first);
                 for (unsigned int d = 0; d < NDIM; ++d)
@@ -2615,9 +2606,7 @@ IBFEMethod::computeOverlapConstraintForceDensity(std::vector<PetscVector<double>
                 fe[k]->reinit(elem);
                 get_values_for_interpolation(x_node[k], *X_vec[part_idx[k]], X_dof_indices[k]);
                 const size_t n_basis = phi.size();
-                for (std::map<unsigned int, libMesh::dof_id_type>::iterator qp_it = it->second.begin();
-                     qp_it != it->second.end();
-                     ++qp_it)
+                for (auto qp_it = it->second.begin(); qp_it != it->second.end(); ++qp_it)
                 {
                     const unsigned int qp = qp_it->first;
                     const libMesh::Point& X = q_point[qp];

--- a/src/IB/IBFEPostProcessor.cpp
+++ b/src/IB/IBFEPostProcessor.cpp
@@ -102,7 +102,7 @@ IBFEPostProcessor::registerScalarVariable(const std::string& name,
                                           void* fcn_ctx)
 {
     EquationSystems* equation_systems = d_fe_data_manager->getEquationSystems();
-    System& system = equation_systems->add_system<System>(name + " reconstruction system");
+    auto& system = equation_systems->add_system<System>(name + " reconstruction system");
     RestartManager* restart_manager = RestartManager::getManager();
     const bool is_from_restart = restart_manager->isFromRestart();
     if (!is_from_restart) system.add_variable(name, fe_order, fe_family);
@@ -124,7 +124,7 @@ IBFEPostProcessor::registerVectorVariable(const std::string& name,
                                           unsigned int dim)
 {
     EquationSystems* equation_systems = d_fe_data_manager->getEquationSystems();
-    System& system = equation_systems->add_system<System>(name + " reconstruction system");
+    auto& system = equation_systems->add_system<System>(name + " reconstruction system");
     RestartManager* restart_manager = RestartManager::getManager();
     const bool is_from_restart = restart_manager->isFromRestart();
     for (unsigned int i = 0; i < dim; ++i)
@@ -152,7 +152,7 @@ IBFEPostProcessor::registerTensorVariable(const std::string& var_name,
                                           unsigned int var_dim)
 {
     EquationSystems* equation_systems = d_fe_data_manager->getEquationSystems();
-    System& system = equation_systems->add_system<System>(var_name + " reconstruction system");
+    auto& system = equation_systems->add_system<System>(var_name + " reconstruction system");
     RestartManager* restart_manager = RestartManager::getManager();
     const bool is_from_restart = restart_manager->isFromRestart();
     for (unsigned int i = 0; i < var_dim; ++i)
@@ -203,7 +203,7 @@ IBFEPostProcessor::registerInterpolatedScalarEulerianVariable(
     const FEDataManager::InterpSpec& interp_spec)
 {
     EquationSystems* equation_systems = d_fe_data_manager->getEquationSystems();
-    System& system = equation_systems->add_system<System>(var_name + " interpolation system");
+    auto& system = equation_systems->add_system<System>(var_name + " interpolation system");
     RestartManager* restart_manager = RestartManager::getManager();
     const bool is_from_restart = restart_manager->isFromRestart();
     if (!is_from_restart) system.add_variable(var_name, var_fe_order, var_fe_family);

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -573,7 +573,7 @@ IBFESurfaceMethod::interpolateVelocity(const int u_data_idx,
         }
 
         X_ghost_vec->close();
-        PetscVector<double>* X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec);
+        auto X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
         VecGhostGetLocalForm(X_global_vec, &X_local_vec);
@@ -1193,7 +1193,7 @@ IBFESurfaceMethod::initializeFEEquationSystems()
         }
         else
         {
-            System& X_system = equation_systems->add_system<System>(COORDS_SYSTEM_NAME);
+            auto& X_system = equation_systems->add_system<System>(COORDS_SYSTEM_NAME);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 std::ostringstream os;
@@ -1202,7 +1202,7 @@ IBFESurfaceMethod::initializeFEEquationSystems()
             }
             X_system.add_vector("INITIAL_COORDINATES", /*projections*/ true, GHOSTED);
 
-            System& dX_system = equation_systems->add_system<System>(COORD_MAPPING_SYSTEM_NAME);
+            auto& dX_system = equation_systems->add_system<System>(COORD_MAPPING_SYSTEM_NAME);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 std::ostringstream os;
@@ -1210,7 +1210,7 @@ IBFESurfaceMethod::initializeFEEquationSystems()
                 dX_system.add_variable(os.str(), d_fe_order[part], d_fe_family[part]);
             }
 
-            System& U_system = equation_systems->add_system<System>(VELOCITY_SYSTEM_NAME);
+            auto& U_system = equation_systems->add_system<System>(VELOCITY_SYSTEM_NAME);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 std::ostringstream os;
@@ -1218,7 +1218,7 @@ IBFESurfaceMethod::initializeFEEquationSystems()
                 U_system.add_variable(os.str(), d_fe_order[part], d_fe_family[part]);
             }
 
-            System& U_n_system = equation_systems->add_system<System>(NORMAL_VELOCITY_SYSTEM_NAME);
+            auto& U_n_system = equation_systems->add_system<System>(NORMAL_VELOCITY_SYSTEM_NAME);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 std::ostringstream os;
@@ -1226,7 +1226,7 @@ IBFESurfaceMethod::initializeFEEquationSystems()
                 U_n_system.add_variable(os.str(), d_fe_order[part], d_fe_family[part]);
             }
 
-            System& U_t_system = equation_systems->add_system<System>(TANGENTIAL_VELOCITY_SYSTEM_NAME);
+            auto& U_t_system = equation_systems->add_system<System>(TANGENTIAL_VELOCITY_SYSTEM_NAME);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 std::ostringstream os;
@@ -1234,7 +1234,7 @@ IBFESurfaceMethod::initializeFEEquationSystems()
                 U_t_system.add_variable(os.str(), d_fe_order[part], d_fe_family[part]);
             }
 
-            System& F_system = equation_systems->add_system<System>(FORCE_SYSTEM_NAME);
+            auto& F_system = equation_systems->add_system<System>(FORCE_SYSTEM_NAME);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 std::ostringstream os;
@@ -1244,7 +1244,7 @@ IBFESurfaceMethod::initializeFEEquationSystems()
 
             if (d_use_jump_conditions)
             {
-                System& DP_system = equation_systems->add_system<System>(PRESSURE_JUMP_SYSTEM_NAME);
+                auto& DP_system = equation_systems->add_system<System>(PRESSURE_JUMP_SYSTEM_NAME);
                 DP_system.add_variable("C_p", d_fe_order[part], d_fe_family[part]);
             }
         }
@@ -1276,12 +1276,12 @@ IBFESurfaceMethod::initializeFEData()
         updateCoordinateMapping(part);
 
         // Assemble systems.
-        System& X_system = equation_systems->get_system<System>(COORDS_SYSTEM_NAME);
-        System& dX_system = equation_systems->get_system<System>(COORD_MAPPING_SYSTEM_NAME);
-        System& U_system = equation_systems->get_system<System>(VELOCITY_SYSTEM_NAME);
-        System& U_n_system = equation_systems->get_system<System>(NORMAL_VELOCITY_SYSTEM_NAME);
-        System& U_t_system = equation_systems->get_system<System>(TANGENTIAL_VELOCITY_SYSTEM_NAME);
-        System& F_system = equation_systems->get_system<System>(FORCE_SYSTEM_NAME);
+        auto& X_system = equation_systems->get_system<System>(COORDS_SYSTEM_NAME);
+        auto& dX_system = equation_systems->get_system<System>(COORD_MAPPING_SYSTEM_NAME);
+        auto& U_system = equation_systems->get_system<System>(VELOCITY_SYSTEM_NAME);
+        auto& U_n_system = equation_systems->get_system<System>(NORMAL_VELOCITY_SYSTEM_NAME);
+        auto& U_t_system = equation_systems->get_system<System>(TANGENTIAL_VELOCITY_SYSTEM_NAME);
+        auto& F_system = equation_systems->get_system<System>(FORCE_SYSTEM_NAME);
 
         X_system.assemble_before_solve = false;
         X_system.assemble();
@@ -1303,7 +1303,7 @@ IBFESurfaceMethod::initializeFEData()
 
         if (d_use_jump_conditions)
         {
-            System& DP_system = equation_systems->get_system<System>(PRESSURE_JUMP_SYSTEM_NAME);
+            auto& DP_system = equation_systems->get_system<System>(PRESSURE_JUMP_SYSTEM_NAME);
             DP_system.assemble_before_solve = false;
             DP_system.assemble();
         }
@@ -1701,10 +1701,9 @@ IBFESurfaceMethod::imposeJumpConditions(const int f_data_idx,
                                     intersection_ref_coords[axis][i_s_prime];
                                 const std::vector<VectorValue<double> >& candidate_normals =
                                     intersection_normals[axis][i_s_prime];
-                                std::vector<libMesh::Point>::const_iterator x_prime_it = candidate_coords.begin();
-                                std::vector<libMesh::Point>::const_iterator xi_prime_it = candidate_ref_coords.begin();
-                                std::vector<VectorValue<double> >::const_iterator n_prime_it =
-                                    candidate_normals.begin();
+                                auto x_prime_it = candidate_coords.begin();
+                                auto xi_prime_it = candidate_ref_coords.begin();
+                                auto n_prime_it = candidate_normals.begin();
                                 for (; x_prime_it != candidate_coords.end(); ++x_prime_it, ++xi_prime_it, ++n_prime_it)
                                 {
                                     const libMesh::Point& x_prime = *x_prime_it;

--- a/src/IB/IBHydrodynamicForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicForceEvaluator.cpp
@@ -324,7 +324,7 @@ IBHydrodynamicForceEvaluator::computeLaggedMomentumIntegral(
     // Whether or not the simulation has adaptive mesh refinement
     const bool amr_case = (coarsest_ln != finest_ln);
 
-    for (std::map<int, IBHydrodynamicForceObject>::iterator it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
+    for (auto it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
     {
         IBHydrodynamicForceObject& fobj = it->second;
 
@@ -493,7 +493,7 @@ IBHydrodynamicForceEvaluator::computeHydrodynamicForce(int u_idx,
     // Whether or not the simulation has adaptive mesh refinement
     const bool amr_case = (coarsest_ln != finest_ln);
 
-    for (std::map<int, IBHydrodynamicForceObject>::iterator it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
+    for (auto it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
     {
         IBHydrodynamicForceObject& fobj = it->second;
 
@@ -790,7 +790,7 @@ IBHydrodynamicForceEvaluator::computeHydrodynamicForce(int u_idx,
 void
 IBHydrodynamicForceEvaluator::postprocessIntegrateData(double /*current_time*/, double new_time)
 {
-    for (std::map<int, IBHydrodynamicForceObject>::iterator it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
+    for (auto it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
     {
         IBHydrodynamicForceObject& force_obj = it->second;
 
@@ -822,8 +822,7 @@ IBHydrodynamicForceEvaluator::postprocessIntegrateData(double /*current_time*/, 
 void
 IBHydrodynamicForceEvaluator::putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db)
 {
-    for (std::map<int, IBHydrodynamicForceObject>::const_iterator it = d_hydro_objs.begin(); it != d_hydro_objs.end();
-         ++it)
+    for (auto it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
     {
         int strct_id = it->first;
         const IBHydrodynamicForceObject& force_obj = it->second;
@@ -1259,7 +1258,7 @@ IBHydrodynamicForceEvaluator::fillPatchData(const int u_src_idx,
             hier_data_ops_manager->getOperationsDouble(d_p_var, patch_hierarchy, true);
         hier_cc_data_ops->copyData(d_p_idx, p_src_idx, true);
 
-        INSStaggeredPressureBcCoef* p_ins_bc_coef = dynamic_cast<INSStaggeredPressureBcCoef*>(p_src_bc_coef);
+        auto p_ins_bc_coef = dynamic_cast<INSStaggeredPressureBcCoef*>(p_src_bc_coef);
 #if !defined(NDEBUG)
         TBOX_ASSERT(p_ins_bc_coef);
 #endif

--- a/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
@@ -123,11 +123,9 @@ IBHydrodynamicSurfaceForceEvaluator::IBHydrodynamicSurfaceForceEvaluator(
     Pointer<VariableContext> p_ctx = var_db->getContext(d_object_name + "::p_ctx");
     d_p_idx = var_db->registerVariableAndContext(p_var, p_ctx, IntVector<NDIM>(GPRESSUREG));
 
-    INSStaggeredHierarchyIntegrator* p_ins_hier_integrator =
-        dynamic_cast<INSStaggeredHierarchyIntegrator*>(d_fluid_solver.getPointer());
+    auto p_ins_hier_integrator = dynamic_cast<INSStaggeredHierarchyIntegrator*>(d_fluid_solver.getPointer());
 
-    INSVCStaggeredHierarchyIntegrator* p_vc_ins_hier_integrator =
-        dynamic_cast<INSVCStaggeredHierarchyIntegrator*>(d_fluid_solver.getPointer());
+    auto p_vc_ins_hier_integrator = dynamic_cast<INSVCStaggeredHierarchyIntegrator*>(d_fluid_solver.getPointer());
 
     if (p_ins_hier_integrator)
     {
@@ -393,8 +391,7 @@ IBHydrodynamicSurfaceForceEvaluator::fillPatchData(Pointer<PatchHierarchy<NDIM> 
     // Fill in ghost cells for viscosity, when necessary
     if (!d_mu_is_const)
     {
-        INSVCStaggeredHierarchyIntegrator* p_vc_ins_hier_integrator =
-            dynamic_cast<INSVCStaggeredHierarchyIntegrator*>(d_fluid_solver.getPointer());
+        auto p_vc_ins_hier_integrator = dynamic_cast<INSVCStaggeredHierarchyIntegrator*>(d_fluid_solver.getPointer());
 #if !defined(NDEBUG)
         TBOX_ASSERT(p_vc_ins_hier_integrator);
 #endif
@@ -411,7 +408,7 @@ IBHydrodynamicSurfaceForceEvaluator::fillPatchData(Pointer<PatchHierarchy<NDIM> 
         else if (mu_ins_var)
         {
             mu_current_idx = var_db->mapVariableAndContextToIndex(mu_ins_var, d_fluid_solver->getCurrentContext());
-            INSVCStaggeredHierarchyIntegrator* p_vc_ins_hier_integrator =
+            auto p_vc_ins_hier_integrator =
                 dynamic_cast<INSVCStaggeredHierarchyIntegrator*>(d_fluid_solver.getPointer());
             mu_bc_coef = p_vc_ins_hier_integrator->getViscosityBoundaryConditions();
         }
@@ -437,9 +434,8 @@ IBHydrodynamicSurfaceForceEvaluator::fillPatchData(Pointer<PatchHierarchy<NDIM> 
         // Fill ghost cells for pressure
         Pointer<CellVariable<NDIM, double> > p_var = d_fluid_solver->getPressureVariable();
         const int p_current_idx = var_db->mapVariableAndContextToIndex(p_var, d_fluid_solver->getCurrentContext());
-        INSStaggeredPressureBcCoef* p_ins_bc_coef =
-            dynamic_cast<INSStaggeredPressureBcCoef*>(d_fluid_solver->getPressureBoundaryConditions());
-        INSVCStaggeredPressureBcCoef* p_vc_ins_bc_coef =
+        auto p_ins_bc_coef = dynamic_cast<INSStaggeredPressureBcCoef*>(d_fluid_solver->getPressureBoundaryConditions());
+        auto p_vc_ins_bc_coef =
             dynamic_cast<INSVCStaggeredPressureBcCoef*>(d_fluid_solver->getPressureBoundaryConditions());
         InterpolationTransactionComponent p_transaction_comp;
         if (p_ins_bc_coef)

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -892,7 +892,7 @@ IBImplicitStaggeredHierarchyIntegrator::integrateHierarchy_velocity(const double
 PetscErrorCode
 IBImplicitStaggeredHierarchyIntegrator::IBFunction_SAMRAI(SNES snes, Vec x, Vec f, void* ctx)
 {
-    IBImplicitStaggeredHierarchyIntegrator* ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
+    auto ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
 
     PetscErrorCode ierr = 1;
     if (ib_integrator->d_solve_for_position)
@@ -1101,7 +1101,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBFunction_velocity(SNES /*snes*/, Vec x
 PetscErrorCode
 IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_SAMRAI(SNES snes, Vec x, Mat A, Mat B, void* ctx)
 {
-    IBImplicitStaggeredHierarchyIntegrator* ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
+    auto ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
 
     PetscErrorCode ierr = 1;
     if (ib_integrator->d_solve_for_position)
@@ -1215,7 +1215,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_SAMRAI(Mat A, Vec x, Vec
     void* ctx;
     ierr = MatShellGetContext(A, &ctx);
     CHKERRQ(ierr);
-    IBImplicitStaggeredHierarchyIntegrator* ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
+    auto ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
     if (ib_integrator->d_solve_for_position)
     {
         ierr = ib_integrator->IBJacobianApply_position(x, f);
@@ -1391,7 +1391,7 @@ IBImplicitStaggeredHierarchyIntegrator::IBPCApply_SAMRAI(PC pc, Vec x, Vec y)
     void* ctx;
     ierr = PCShellGetContext(pc, &ctx);
     CHKERRQ(ierr);
-    IBImplicitStaggeredHierarchyIntegrator* ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
+    auto ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
     if (ib_integrator->d_solve_for_position)
     {
         ierr = ib_integrator->IBPCApply_position(x, y);
@@ -1538,7 +1538,7 @@ IBImplicitStaggeredHierarchyIntegrator::lagrangianSchurApply_SAMRAI(Mat A, Vec x
     void* ctx;
     ierr = MatShellGetContext(A, &ctx);
     CHKERRQ(ierr);
-    IBImplicitStaggeredHierarchyIntegrator* ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
+    auto ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
     ierr = ib_integrator->lagrangianSchurApply(x, y);
     return ierr;
 } // lagrangianSchurApply_SAMRAI

--- a/src/IB/IBInstrumentPanel.cpp
+++ b/src/IB/IBInstrumentPanel.cpp
@@ -273,7 +273,7 @@ build_meter_web(DBfile* dbfile,
 
     // Write out the variables.
     int cycle = timestep;
-    float time = float(simulation_time);
+    auto time = float(simulation_time);
     double dtime = simulation_time;
 
     static const int MAX_OPTS = 3;
@@ -629,7 +629,7 @@ IBInstrumentPanel::initializeHierarchyIndependentData(const Pointer<PatchHierarc
         {
             const Pointer<LMesh> mesh = l_data_manager->getLMesh(ln);
             const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const IBInstrumentationSpec* const spec = node_idx->getNodeDataItem<IBInstrumentationSpec>();
@@ -774,7 +774,7 @@ IBInstrumentPanel::initializeHierarchyDependentData(const Pointer<PatchHierarchy
             // Store the local positions of the perimeter nodes.
             const Pointer<LMesh> mesh = l_data_manager->getLMesh(ln);
             const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const IBInstrumentationSpec* const spec = node_idx->getNodeDataItem<IBInstrumentationSpec>();
@@ -1037,7 +1037,7 @@ IBInstrumentPanel::readInstrumentData(const int U_data_idx,
                                            );
                     if (U_cc_data)
                     {
-                        for (WebPatchMap::const_iterator it = patch_range.first; it != patch_range.second; ++it)
+                        for (auto it = patch_range.first; it != patch_range.second; ++it)
                         {
                             const int& meter_num = it->second.meter_num;
                             const Point& X = *(it->second.X);
@@ -1049,7 +1049,7 @@ IBInstrumentPanel::readInstrumentData(const int U_data_idx,
                     }
                     if (U_sc_data)
                     {
-                        for (WebPatchMap::const_iterator it = patch_range.first; it != patch_range.second; ++it)
+                        for (auto it = patch_range.first; it != patch_range.second; ++it)
                         {
                             const int& meter_num = it->second.meter_num;
                             const Point& X = *(it->second.X);
@@ -1061,7 +1061,7 @@ IBInstrumentPanel::readInstrumentData(const int U_data_idx,
                     }
                     if (P_cc_data)
                     {
-                        for (WebPatchMap::const_iterator it = patch_range.first; it != patch_range.second; ++it)
+                        for (auto it = patch_range.first; it != patch_range.second; ++it)
                         {
                             const int& meter_num = it->second.meter_num;
                             const Point& X = *(it->second.X);
@@ -1087,8 +1087,7 @@ IBInstrumentPanel::readInstrumentData(const int U_data_idx,
                                            );
                     if (P_cc_data)
                     {
-                        for (WebCentroidMap::const_iterator it = centroid_range.first; it != centroid_range.second;
-                             ++it)
+                        for (auto it = centroid_range.first; it != centroid_range.second; ++it)
                         {
                             const int& meter_num = it->second.meter_num;
                             const Point& X = *(it->second.X);
@@ -1139,7 +1138,7 @@ IBInstrumentPanel::readInstrumentData(const int U_data_idx,
             // Store the local velocities of the perimeter nodes.
             const Pointer<LMesh> mesh = l_data_manager->getLMesh(ln);
             const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-            for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
             {
                 const LNode* const node_idx = *cit;
                 const IBInstrumentationSpec* const spec = node_idx->getNodeDataItem<IBInstrumentationSpec>();
@@ -1320,7 +1319,7 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
         }
 
         int cycle = timestep_num;
-        float time = float(simulation_time);
+        auto time = float(simulation_time);
         double dtime = simulation_time;
 
         static const int MAX_OPTS = 3;
@@ -1338,7 +1337,7 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
             current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
             std::string meshname = current_file_name + ":" + d_instrument_names[meter] + "/mesh";
-            char* meshname_ptr = const_cast<char*>(meshname.c_str());
+            auto meshname_ptr = const_cast<char*>(meshname.c_str());
             int meshtype = DB_POINTMESH;
 
             std::string meter_name = d_instrument_names[meter];
@@ -1354,7 +1353,7 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
             }
 
             std::string varname = current_file_name + ":" + d_instrument_names[meter] + "/scaled_normal";
-            char* varname_ptr = const_cast<char*>(varname.c_str());
+            auto varname_ptr = const_cast<char*>(varname.c_str());
             int vartype = DB_POINTVAR;
 
             std::string var_name = d_instrument_names[meter] + "_normal";

--- a/src/IB/IBKirchhoffRodForceGen.cpp
+++ b/src/IB/IBKirchhoffRodForceGen.cpp
@@ -98,7 +98,7 @@ IBKirchhoffRodForceGen::IBKirchhoffRodForceGen(Pointer<Database> input_db)
 IBKirchhoffRodForceGen::~IBKirchhoffRodForceGen()
 {
     int ierr;
-    for (std::vector<Mat>::iterator it = d_D_next_mats.begin(); it != d_D_next_mats.end(); ++it)
+    for (auto it = d_D_next_mats.begin(); it != d_D_next_mats.end(); ++it)
     {
         if (*it)
         {
@@ -106,7 +106,7 @@ IBKirchhoffRodForceGen::~IBKirchhoffRodForceGen()
             IBTK_CHKERRQ(ierr);
         }
     }
-    for (std::vector<Mat>::iterator it = d_X_next_mats.begin(); it != d_X_next_mats.end(); ++it)
+    for (auto it = d_X_next_mats.begin(); it != d_X_next_mats.end(); ++it)
     {
         if (*it)
         {
@@ -174,7 +174,7 @@ IBKirchhoffRodForceGen::initializeLevelData(const Pointer<PatchHierarchy<NDIM> >
 
     // Determine the "next" node indices for all rods associated with the
     // present MPI process.
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const IBRodForceSpec* const force_spec = node_idx->getNodeDataItem<IBRodForceSpec>();

--- a/src/IB/IBLagrangianForceStrategySet.cpp
+++ b/src/IB/IBLagrangianForceStrategySet.cpp
@@ -61,9 +61,7 @@ IBLagrangianForceStrategySet::~IBLagrangianForceStrategySet()
 void
 IBLagrangianForceStrategySet::setTimeInterval(const double current_time, const double new_time)
 {
-    for (std::vector<Pointer<IBLagrangianForceStrategy> >::const_iterator cit = d_strategy_set.begin();
-         cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->setTimeInterval(current_time, new_time);
     }
@@ -77,9 +75,7 @@ IBLagrangianForceStrategySet::initializeLevelData(const Pointer<PatchHierarchy<N
                                                   const bool initial_time,
                                                   LDataManager* const l_data_manager)
 {
-    for (std::vector<Pointer<IBLagrangianForceStrategy> >::const_iterator cit = d_strategy_set.begin();
-         cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->initializeLevelData(hierarchy, level_number, init_data_time, initial_time, l_data_manager);
     }
@@ -95,9 +91,7 @@ IBLagrangianForceStrategySet::computeLagrangianForce(Pointer<LData> F_data,
                                                      const double data_time,
                                                      LDataManager* const l_data_manager)
 {
-    for (std::vector<Pointer<IBLagrangianForceStrategy> >::const_iterator cit = d_strategy_set.begin();
-         cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->computeLagrangianForce(F_data, X_data, U_data, hierarchy, level_number, data_time, l_data_manager);
     }
@@ -112,9 +106,7 @@ IBLagrangianForceStrategySet::computeLagrangianForceJacobianNonzeroStructure(
     const int level_number,
     LDataManager* const l_data_manager)
 {
-    for (std::vector<Pointer<IBLagrangianForceStrategy> >::const_iterator cit = d_strategy_set.begin();
-         cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->computeLagrangianForceJacobianNonzeroStructure(d_nnz, o_nnz, hierarchy, level_number, l_data_manager);
     }
@@ -133,9 +125,7 @@ IBLagrangianForceStrategySet::computeLagrangianForceJacobian(Mat& J_mat,
                                                              const double data_time,
                                                              LDataManager* const l_data_manager)
 {
-    for (std::vector<Pointer<IBLagrangianForceStrategy> >::const_iterator cit = d_strategy_set.begin();
-         cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->computeLagrangianForceJacobian(J_mat,
                                                MAT_FLUSH_ASSEMBLY,
@@ -168,9 +158,7 @@ IBLagrangianForceStrategySet::computeLagrangianEnergy(Pointer<LData> X_data,
                                                       LDataManager* const l_data_manager)
 {
     double ret_val = 0.0;
-    for (std::vector<Pointer<IBLagrangianForceStrategy> >::const_iterator cit = d_strategy_set.begin();
-         cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         ret_val += (*cit)->computeLagrangianEnergy(X_data, U_data, hierarchy, level_number, data_time, l_data_manager);
     }

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -1217,7 +1217,7 @@ IBMethod::spreadFluidSource(const int q_data_idx,
         }
         BoxList<NDIM> bdry_boxes;
         bdry_boxes.removeIntersections(domain_box, interior_box);
-        double vol = static_cast<double>(bdry_boxes.getTotalSizeOfBoxes());
+        auto vol = static_cast<double>(bdry_boxes.getTotalSizeOfBoxes());
         for (unsigned int d = 0; d < NDIM; ++d)
         {
             vol *= dx_coarsest[d];
@@ -1556,7 +1556,7 @@ IBMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > hierarchy,
 
         const Pointer<LMesh> mesh = d_l_data_manager->getLMesh(ln);
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const IBAnchorPointSpec* const anchor_point_spec = node_idx->getNodeDataItem<IBAnchorPointSpec>();
@@ -1929,9 +1929,7 @@ IBMethod::resetAnchorPointValues(std::vector<Pointer<LData> > U_data, const int 
         double* U_arr;
         ierr = VecGetArray(U_vec, &U_arr);
         IBTK_CHKERRQ(ierr);
-        for (std::set<int>::const_iterator cit = d_anchor_point_local_idxs[ln].begin();
-             cit != d_anchor_point_local_idxs[ln].end();
-             ++cit)
+        for (auto cit = d_anchor_point_local_idxs[ln].begin(); cit != d_anchor_point_local_idxs[ln].end(); ++cit)
         {
             const int& i = *cit;
             for (int d = 0; d < depth; ++d)
@@ -2152,7 +2150,7 @@ PetscErrorCode
 IBMethod::computeForce_SAMRAI(void* ctx, Vec X, Vec F)
 {
     PetscErrorCode ierr;
-    IBMethod* ib_method_ops = static_cast<IBMethod*>(ctx);
+    auto ib_method_ops = static_cast<IBMethod*>(ctx);
     ierr = ib_method_ops->computeForce(X, F);
     CHKERRQ(ierr);
     return ierr;

--- a/src/IB/IBRedundantInitializer.cpp
+++ b/src/IB/IBRedundantInitializer.cpp
@@ -404,9 +404,7 @@ IBRedundantInitializer::initializeSprings()
 
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
-                for (std::multimap<int, Edge>::iterator it = d_spring_edge_map[ln][j].begin();
-                     it != d_spring_edge_map[ln][j].end();
-                     ++it)
+                for (auto it = d_spring_edge_map[ln][j].begin(); it != d_spring_edge_map[ln][j].end(); ++it)
                 {
                     Edge& e = it->second;
                     const SpringSpec& spec = d_spring_spec_data[ln][j][e];
@@ -461,9 +459,7 @@ IBRedundantInitializer::initializeXSprings()
                 d_init_xspring_on_level_fcn(j, ln, d_xspring_edge_map[ln][j], d_xspring_spec_data[ln][j]);
                 const int min_idx = 0;
                 const int max_idx = std::accumulate(d_num_vertex[ln].begin(), d_num_vertex[ln].end(), 0);
-                for (std::multimap<int, Edge>::iterator it = d_xspring_edge_map[ln][j].begin();
-                     it != d_xspring_edge_map[ln][j].end();
-                     ++it)
+                for (auto it = d_xspring_edge_map[ln][j].begin(); it != d_xspring_edge_map[ln][j].end(); ++it)
                 {
                     Edge& e = it->second;
                     const XSpringSpec& spec = d_xspring_spec_data[ln][j][e];
@@ -519,9 +515,7 @@ IBRedundantInitializer::initializeBeams()
 
                 const int min_idx = 0;
                 const int max_idx = d_num_vertex[ln][j];
-                for (std::multimap<int, BeamSpec>::const_iterator it = d_beam_spec_data[ln][j].begin();
-                     it != d_beam_spec_data[ln][j].end();
-                     ++it)
+                for (auto it = d_beam_spec_data[ln][j].begin(); it != d_beam_spec_data[ln][j].end(); ++it)
                 {
                     const BeamSpec& e = it->second;
                     const std::pair<int, int>& idxs = e.neighbor_idxs;
@@ -570,8 +564,7 @@ IBRedundantInitializer::initializeTargetPts()
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
                 d_target_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
-                for (std::multimap<int, TargetSpec>::const_iterator it = tg_pt_spec.begin(); it != tg_pt_spec.end();
-                     ++it)
+                for (auto it = tg_pt_spec.begin(); it != tg_pt_spec.end(); ++it)
                 {
                     if ((it->first < min_idx) || (it->first > max_idx))
                     {
@@ -657,9 +650,7 @@ IBRedundantInitializer::initializeDirectorAndRods()
                         }
                     }
                 }
-                for (std::multimap<int, Edge>::const_iterator it = d_rod_edge_map[ln][j].begin();
-                     it != d_rod_edge_map[ln][j].end();
-                     ++it)
+                for (auto it = d_rod_edge_map[ln][j].begin(); it != d_rod_edge_map[ln][j].end(); ++it)
                 {
                     const Edge& e = it->second;
                     const RodSpec& rod_spec = d_rod_spec_data[ln][j][e];
@@ -744,7 +735,7 @@ IBRedundantInitializer::initializeBoundaryMass()
                 d_bdry_mass_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
-                for (std::multimap<int, BdryMassSpec>::const_iterator it = bdry_map.begin(); it != bdry_map.end(); ++it)
+                for (auto it = bdry_map.begin(); it != bdry_map.end(); ++it)
                 {
                     if ((it->first < min_idx) || (it->first > max_idx))
                     {
@@ -798,8 +789,7 @@ IBRedundantInitializer::initializeAnchorPts()
                 d_anchor_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
-                for (std::multimap<int, AnchorSpec>::const_iterator it = anchor_map.begin(); it != anchor_map.end();
-                     ++it)
+                for (auto it = anchor_map.begin(); it != anchor_map.end(); ++it)
                 {
                     if ((it->first < min_idx) || (it->first > max_idx))
                     {
@@ -839,13 +829,10 @@ IBRedundantInitializer::initializeInstrumentationData()
                 d_init_instrumentation_on_level_fcn(j, ln, new_names, d_instrument_idx[ln][j]);
                 std::vector<bool> encountered_instrument_idx;
                 std::map<int, std::vector<bool> > encountered_node_idxs;
-                for (std::vector<std::string>::iterator i = new_names.begin(); i != new_names.end(); ++i)
-                    instrument_names.push_back(*i);
+                for (auto i = new_names.begin(); i != new_names.end(); ++i) instrument_names.push_back(*i);
                 const int min_idx = 0;
                 const int max_idx = d_num_vertex[ln][j];
-                for (std::map<int, std::pair<int, int> >::iterator it = d_instrument_idx[ln][j].begin();
-                     it != d_instrument_idx[ln][j].end();
-                     ++it)
+                for (auto it = d_instrument_idx[ln][j].begin(); it != d_instrument_idx[ln][j].end(); ++it)
                 {
                     if ((it->first < min_idx) || (it->first >= max_idx))
                     {
@@ -881,8 +868,7 @@ IBRedundantInitializer::initializeInstrumentationData()
 
                     meter_map.first += instrument_offset;
                 }
-                for (std::vector<bool>::iterator meter_it = encountered_instrument_idx.begin();
-                     meter_it != encountered_instrument_idx.end();
+                for (auto meter_it = encountered_instrument_idx.begin(); meter_it != encountered_instrument_idx.end();
                      ++meter_it)
                 {
                     const size_t meter_idx = std::distance(encountered_instrument_idx.begin(), meter_it);
@@ -893,9 +879,7 @@ IBRedundantInitializer::initializeInstrumentationData()
                     }
 
                     std::vector<bool>& meter_node_idxs = encountered_node_idxs[meter_idx];
-                    for (std::vector<bool>::iterator node_it = meter_node_idxs.begin();
-                         node_it != meter_node_idxs.end();
-                         ++node_it)
+                    for (auto node_it = meter_node_idxs.begin(); node_it != meter_node_idxs.end(); ++node_it)
                     {
                         const size_t node_idx = std::distance(meter_node_idxs.begin(), node_it);
                         if ((*node_it) == false)
@@ -945,13 +929,10 @@ IBRedundantInitializer::initializeSourceData()
                                              << source_names.size() << " is not equal to number of radii "
                                              << source_radii.size() << ".\n");
                 }
-                for (std::vector<std::string>::iterator i = new_names.begin(); i != new_names.end(); ++i)
-                    source_names.push_back(*i);
-                for (std::vector<double>::iterator i = new_radii.begin(); i != new_radii.end(); ++i)
-                    source_radii.push_back(*i);
+                for (auto i = new_names.begin(); i != new_names.end(); ++i) source_names.push_back(*i);
+                for (auto i = new_radii.begin(); i != new_radii.end(); ++i) source_radii.push_back(*i);
                 num_source = new_names.size();
-                for (std::map<int, int>::iterator it = d_source_idx[ln][j].begin(); it != d_source_idx[ln][j].end();
-                     ++it)
+                for (auto it = d_source_idx[ln][j].begin(); it != d_source_idx[ln][j].end(); ++it)
                 {
                     int& src_num = it->second;
                     if ((it->first < min_idx) || (it->first >= max_idx))
@@ -1031,8 +1012,7 @@ IBRedundantInitializer::initializeDataOnPatchLevel(const int lag_node_index_idx,
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(patch_vertices, patch, hierarchy);
         local_node_count += patch_vertices.size();
-        for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin(); it != patch_vertices.end();
-             ++it)
+        for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
         {
             const std::pair<int, int>& point_idx = (*it);
             const int lagrangian_idx = getCanonicalLagrangianIndex(point_idx, level_number) + global_index_offset;
@@ -1086,7 +1066,7 @@ IBRedundantInitializer::initializeDataOnPatchLevel(const int lag_node_index_idx,
             // vertex.
             std::vector<Pointer<Streamable> > node_data =
                 initializeNodeData(point_idx, global_index_offset, level_number);
-            for (std::vector<Pointer<Streamable> >::iterator it = node_data.begin(); it != node_data.end(); ++it)
+            for (auto it = node_data.begin(); it != node_data.end(); ++it)
             {
                 (*it)->registerPeriodicShift(periodic_offset, periodic_displacement);
             }
@@ -1161,8 +1141,7 @@ IBRedundantInitializer::initializeMassDataOnPatchLevel(const unsigned int /*glob
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(patch_vertices, patch, hierarchy);
         local_node_count += patch_vertices.size();
-        for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin(); it != patch_vertices.end();
-             ++it)
+        for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
         {
             const std::pair<int, int>& point_idx = (*it);
             const int local_petsc_idx = ++local_idx + local_index_offset;
@@ -1224,8 +1203,7 @@ IBRedundantInitializer::initializeDirectorDataOnPatchLevel(const unsigned int /*
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(patch_vertices, patch, hierarchy);
         local_node_count += patch_vertices.size();
-        for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin(); it != patch_vertices.end();
-             ++it)
+        for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
         {
             const std::pair<int, int>& point_idx = (*it);
             const int local_petsc_idx = ++local_idx + local_index_offset;
@@ -1278,9 +1256,7 @@ IBRedundantInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarch
         {
             std::vector<std::pair<int, int> > patch_vertices;
             getPatchVerticesAtLevel(patch_vertices, patch, hierarchy, ln);
-            for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin();
-                 it != patch_vertices.end();
-                 ++it)
+            for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
             {
                 const std::pair<int, int>& point_idx = (*it);
 
@@ -1525,8 +1501,7 @@ std::pair<int, int>
 IBRedundantInitializer::getVertexInstrumentationIndices(const std::pair<int, int>& point_index,
                                                         const int level_number) const
 {
-    std::map<int, std::pair<int, int> >::const_iterator it =
-        d_instrument_idx[level_number][point_index.first].find(point_index.second);
+    auto it = d_instrument_idx[level_number][point_index.first].find(point_index.second);
     if (it != d_instrument_idx[level_number][point_index.first].end())
     {
         return it->second;
@@ -1540,7 +1515,7 @@ IBRedundantInitializer::getVertexInstrumentationIndices(const std::pair<int, int
 int
 IBRedundantInitializer::getVertexSourceIndices(const std::pair<int, int>& point_index, const int level_number) const
 {
-    std::map<int, int>::const_iterator it = d_source_idx[level_number][point_index.first].find(point_index.second);
+    auto it = d_source_idx[level_number][point_index.first].find(point_index.second);
     if (it != d_source_idx[level_number][point_index.first].end())
     {
         return it->second;
@@ -1565,7 +1540,7 @@ IBRedundantInitializer::initializeNodeData(const std::pair<int, int>& point_inde
     {
         std::vector<int> slave_idxs, force_fcn_idxs;
         std::vector<std::vector<double> > parameters;
-        for (std::multimap<int, Edge>::const_iterator it = d_spring_edge_map[level_number][j].lower_bound(mastr_idx);
+        for (auto it = d_spring_edge_map[level_number][j].lower_bound(mastr_idx);
              it != d_spring_edge_map[level_number][j].upper_bound(mastr_idx);
              ++it)
         {
@@ -1591,8 +1566,7 @@ IBRedundantInitializer::initializeNodeData(const std::pair<int, int>& point_inde
         const size_t num_base_filename = d_base_filename[level_number].size();
         for (unsigned int j = 0; j < num_base_filename; ++j)
         {
-            for (std::multimap<int, Edge>::const_iterator it =
-                     d_xspring_edge_map[level_number][j].lower_bound(mastr_idx);
+            for (auto it = d_xspring_edge_map[level_number][j].lower_bound(mastr_idx);
                  it != d_xspring_edge_map[level_number][j].upper_bound(mastr_idx);
                  ++it)
             {
@@ -1627,7 +1601,7 @@ IBRedundantInitializer::initializeNodeData(const std::pair<int, int>& point_inde
         std::vector<std::pair<int, int> > beam_neighbor_idxs;
         std::vector<double> beam_bend_rigidity;
         std::vector<Vector> beam_mesh_dependent_curvature;
-        for (std::multimap<int, BeamSpec>::const_iterator it = d_beam_spec_data[level_number][j].lower_bound(mastr_idx);
+        for (auto it = d_beam_spec_data[level_number][j].lower_bound(mastr_idx);
              it != d_beam_spec_data[level_number][j].upper_bound(mastr_idx);
              ++it)
         {
@@ -1647,7 +1621,7 @@ IBRedundantInitializer::initializeNodeData(const std::pair<int, int>& point_inde
     {
         std::vector<int> rod_next_idxs;
         std::vector<std::array<double, IBRodForceSpec::NUM_MATERIAL_PARAMS> > rod_material_params;
-        for (std::multimap<int, Edge>::const_iterator it = d_rod_edge_map[level_number][j].lower_bound(mastr_idx);
+        for (auto it = d_rod_edge_map[level_number][j].lower_bound(mastr_idx);
              it != d_rod_edge_map[level_number][j].upper_bound(mastr_idx);
              ++it)
         {

--- a/src/IB/IBStandardForceGen.cpp
+++ b/src/IB/IBStandardForceGen.cpp
@@ -79,7 +79,7 @@ resetLocalPETScIndices(std::vector<int>& inds, const int global_node_offset, con
 #if defined(NDEBUG)
     NULL_USE(num_local_nodes);
 #endif
-    for (std::vector<int>::iterator it = inds.begin(); it != inds.end(); ++it)
+    for (auto it = inds.begin(); it != inds.end(); ++it)
     {
         int& idx = *it;
 #if !defined(NDEBUG)
@@ -96,7 +96,7 @@ resetLocalOrNonlocalPETScIndices(std::vector<int>& inds,
                                  const int num_local_nodes,
                                  const std::vector<int>& nonlocal_petsc_idxs)
 {
-    for (std::vector<int>::iterator it = inds.begin(); it != inds.end(); ++it)
+    for (auto it = inds.begin(); it != inds.end(); ++it)
     {
         int& idx = *it;
         if (idx >= global_node_offset && idx < global_node_offset + num_local_nodes)
@@ -785,7 +785,7 @@ IBStandardForceGen::initializeSpringLevelData(std::set<int>& nonlocal_petsc_idx_
 
     // Determine how many springs are associated with the present MPI process.
     unsigned int num_springs = 0;
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const IBSpringForceSpec* const force_spec = node_idx->getNodeDataItem<IBSpringForceSpec>();
@@ -805,7 +805,7 @@ IBStandardForceGen::initializeSpringLevelData(std::set<int>& nonlocal_petsc_idx_
 
     // Setup the data structures used to compute spring forces.
     int current_spring = 0;
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const IBSpringForceSpec* const force_spec = node_idx->getNodeDataItem<IBSpringForceSpec>();
@@ -1005,7 +1005,7 @@ IBStandardForceGen::initializeBeamLevelData(std::set<int>& nonlocal_petsc_idx_se
 
     // Determine how many beams are associated with the present MPI process.
     unsigned int num_beams = 0;
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const IBBeamForceSpec* const force_spec = node_idx->getNodeDataItem<IBBeamForceSpec>();
@@ -1022,7 +1022,7 @@ IBStandardForceGen::initializeBeamLevelData(std::set<int>& nonlocal_petsc_idx_se
 
     // Setup the data structures used to compute beam forces.
     int current_beam = 0;
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const IBBeamForceSpec* const force_spec = node_idx->getNodeDataItem<IBBeamForceSpec>();
@@ -1071,7 +1071,7 @@ IBStandardForceGen::initializeBeamLevelData(std::set<int>& nonlocal_petsc_idx_se
     //
     // NOTE: Only neighbor nodes can be "off processor".  Master nodes are
     // guaranteed to be "on processor".
-    for (std::vector<int>::const_iterator cit = petsc_next_node_idxs.begin(); cit != petsc_next_node_idxs.end(); ++cit)
+    for (auto cit = petsc_next_node_idxs.begin(); cit != petsc_next_node_idxs.end(); ++cit)
     {
         const int idx = *cit;
         if (idx < global_node_offset || idx >= global_node_offset + num_local_nodes)
@@ -1079,7 +1079,7 @@ IBStandardForceGen::initializeBeamLevelData(std::set<int>& nonlocal_petsc_idx_se
             nonlocal_petsc_idx_set.insert(idx);
         }
     }
-    for (std::vector<int>::const_iterator cit = petsc_prev_node_idxs.begin(); cit != petsc_prev_node_idxs.end(); ++cit)
+    for (auto cit = petsc_prev_node_idxs.begin(); cit != petsc_prev_node_idxs.end(); ++cit)
     {
         const int idx = *cit;
         if (idx < global_node_offset || idx >= global_node_offset + num_local_nodes)
@@ -1223,7 +1223,7 @@ IBStandardForceGen::initializeTargetPointLevelData(std::set<int>& /*nonlocal_pet
     // Determine how many target points are associated with the present MPI
     // process.
     unsigned int num_target_points = 0;
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const IBTargetPointForceSpec* const force_spec = node_idx->getNodeDataItem<IBTargetPointForceSpec>();
@@ -1240,7 +1240,7 @@ IBStandardForceGen::initializeTargetPointLevelData(std::set<int>& /*nonlocal_pet
 
     // Setup the data structures used to compute target point forces.
     int current_target_point = 0;
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const IBTargetPointForceSpec* const force_spec = node_idx->getNodeDataItem<IBTargetPointForceSpec>();

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -600,7 +600,7 @@ IBStandardInitializer::readSpringFiles(const std::string& extension, const bool 
                     bool found_connection = false;
                     std::pair<std::multimap<int, Edge>::iterator, std::multimap<int, Edge>::iterator> range =
                         d_spring_edge_map[ln][j].equal_range(e.first);
-                    for (std::multimap<int, Edge>::iterator it = range.first; it != range.second; ++it)
+                    for (auto it = range.first; it != range.second; ++it)
                     {
                         if (it->second == e) found_connection = true;
                     }
@@ -859,7 +859,7 @@ IBStandardInitializer::readXSpringFiles(const std::string& extension, const bool
                     bool found_connection = false;
                     std::pair<std::multimap<int, Edge>::iterator, std::multimap<int, Edge>::iterator> range =
                         d_xspring_edge_map[ln][j].equal_range(e.first);
-                    for (std::multimap<int, Edge>::iterator it = range.first; it != range.second; ++it)
+                    for (auto it = range.first; it != range.second; ++it)
                     {
                         if (it->second == e) found_connection = true;
                     }
@@ -1124,7 +1124,7 @@ IBStandardInitializer::readBeamFiles(const std::string& extension, const bool in
                     bool found_connection = false;
                     std::pair<std::multimap<int, BeamSpec>::iterator, std::multimap<int, BeamSpec>::iterator> range =
                         d_beam_spec_data[ln][j].equal_range(curr_idx);
-                    for (std::multimap<int, BeamSpec>::iterator it = range.first; it != range.second; ++it)
+                    for (auto it = range.first; it != range.second; ++it)
                     {
                         const BeamSpec& spec_data = it->second;
                         if (spec_data.neighbor_idxs == std::make_pair(next_idx, prev_idx)) found_connection = true;
@@ -1497,7 +1497,7 @@ IBStandardInitializer::readRodFiles(const std::string& extension, const bool inp
                     bool found_connection = false;
                     std::pair<std::multimap<int, Edge>::iterator, std::multimap<int, Edge>::iterator> range =
                         d_rod_edge_map[ln][j].equal_range(curr_idx);
-                    for (std::multimap<int, Edge>::iterator it = range.first; it != range.second; ++it)
+                    for (auto it = range.first; it != range.second; ++it)
                     {
                         if (it->second == e) found_connection = true;
                     }
@@ -2412,8 +2412,7 @@ IBStandardInitializer::readInstrumentationFiles(const std::string& extension)
 
                 // Ensure that a complete range of instrument indices were found
                 // in the input file.
-                for (std::vector<bool>::iterator meter_it = encountered_instrument_idx.begin();
-                     meter_it != encountered_instrument_idx.end();
+                for (auto meter_it = encountered_instrument_idx.begin(); meter_it != encountered_instrument_idx.end();
                      ++meter_it)
                 {
                     const size_t meter_idx = std::distance(encountered_instrument_idx.begin(), meter_it);
@@ -2428,9 +2427,7 @@ IBStandardInitializer::readInstrumentationFiles(const std::string& extension)
                     }
 
                     std::vector<bool>& meter_node_idxs = encountered_node_idx[meter_idx];
-                    for (std::vector<bool>::iterator node_it = meter_node_idxs.begin();
-                         node_it != meter_node_idxs.end();
-                         ++node_it)
+                    for (auto node_it = meter_node_idxs.begin(); node_it != meter_node_idxs.end(); ++node_it)
                     {
                         const size_t node_idx = std::distance(meter_node_idxs.begin(), node_it);
                         if ((*node_it) == false)
@@ -2727,8 +2724,7 @@ IBStandardInitializer::initializeNodeData(const std::pair<int, int>& point_index
         std::vector<std::vector<double> > parameters;
         if (d_enable_springs[level_number][j])
         {
-            for (std::multimap<int, Edge>::const_iterator it =
-                     d_spring_edge_map[level_number][j].lower_bound(mastr_idx);
+            for (auto it = d_spring_edge_map[level_number][j].lower_bound(mastr_idx);
                  it != d_spring_edge_map[level_number][j].upper_bound(mastr_idx);
                  ++it)
             {
@@ -2756,8 +2752,7 @@ IBStandardInitializer::initializeNodeData(const std::pair<int, int>& point_index
         for (unsigned int j = 0; j < num_base_filename; ++j)
         {
             if (!d_enable_xsprings[level_number][j]) continue;
-            for (std::multimap<int, Edge>::const_iterator it =
-                     d_xspring_edge_map[level_number][j].lower_bound(mastr_idx);
+            for (auto it = d_xspring_edge_map[level_number][j].lower_bound(mastr_idx);
                  it != d_xspring_edge_map[level_number][j].upper_bound(mastr_idx);
                  ++it)
             {
@@ -2793,7 +2788,7 @@ IBStandardInitializer::initializeNodeData(const std::pair<int, int>& point_index
         std::vector<std::pair<int, int> > beam_neighbor_idxs;
         std::vector<double> beam_bend_rigidity;
         std::vector<Vector> beam_mesh_dependent_curvature;
-        for (std::multimap<int, BeamSpec>::const_iterator it = d_beam_spec_data[level_number][j].lower_bound(mastr_idx);
+        for (auto it = d_beam_spec_data[level_number][j].lower_bound(mastr_idx);
              it != d_beam_spec_data[level_number][j].upper_bound(mastr_idx);
              ++it)
         {
@@ -2814,7 +2809,7 @@ IBStandardInitializer::initializeNodeData(const std::pair<int, int>& point_index
     {
         std::vector<int> rod_next_idxs;
         std::vector<std::array<double, IBRodForceSpec::NUM_MATERIAL_PARAMS> > rod_material_params;
-        for (std::multimap<int, Edge>::const_iterator it = d_rod_edge_map[level_number][j].lower_bound(mastr_idx);
+        for (auto it = d_rod_edge_map[level_number][j].lower_bound(mastr_idx);
              it != d_rod_edge_map[level_number][j].upper_bound(mastr_idx);
              ++it)
         {

--- a/src/IB/IBStandardSourceGen.cpp
+++ b/src/IB/IBStandardSourceGen.cpp
@@ -178,7 +178,7 @@ IBStandardSourceGen::initializeLevelData(const Pointer<PatchHierarchy<NDIM> > /*
     std::fill(d_num_perimeter_nodes[level_number].begin(), d_num_perimeter_nodes[level_number].end(), 0);
     const Pointer<LMesh> mesh = l_data_manager->getLMesh(level_number);
     const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const IBSourceSpec* const spec = node_idx->getNodeDataItem<IBSourceSpec>();
@@ -227,7 +227,7 @@ IBStandardSourceGen::getSourceLocations(std::vector<Point>& X_src,
     const double* const X_node = X_data->getLocalFormVecArray()->data();
     const Pointer<LMesh> mesh = l_data_manager->getLMesh(level_number);
     const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-    for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
     {
         const LNode* const node_idx = *cit;
         const IBSourceSpec* const spec = node_idx->getNodeDataItem<IBSourceSpec>();

--- a/src/IB/IBStrategySet.cpp
+++ b/src/IB/IBStrategySet.cpp
@@ -89,8 +89,7 @@ IBStrategySet::~IBStrategySet()
 void
 IBStrategySet::registerIBHierarchyIntegrator(IBHierarchyIntegrator* ib_solver)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->registerIBHierarchyIntegrator(ib_solver);
     }
@@ -100,8 +99,7 @@ IBStrategySet::registerIBHierarchyIntegrator(IBHierarchyIntegrator* ib_solver)
 void
 IBStrategySet::registerEulerianVariables()
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->registerEulerianVariables();
     }
@@ -111,8 +109,7 @@ IBStrategySet::registerEulerianVariables()
 void
 IBStrategySet::registerEulerianCommunicationAlgorithms()
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->registerEulerianCommunicationAlgorithms();
     }
@@ -123,8 +120,7 @@ const IntVector<NDIM>&
 IBStrategySet::getMinimumGhostCellWidth() const
 {
     static IntVector<NDIM> ghost_cell_width = 0;
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         ghost_cell_width = IntVector<NDIM>::max(ghost_cell_width, (*cit)->getMinimumGhostCellWidth());
     }
@@ -134,8 +130,7 @@ IBStrategySet::getMinimumGhostCellWidth() const
 void
 IBStrategySet::setupTagBuffer(Array<int>& tag_buffer, Pointer<GriddingAlgorithm<NDIM> > gridding_alg) const
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->setupTagBuffer(tag_buffer, gridding_alg);
     }
@@ -145,8 +140,7 @@ IBStrategySet::setupTagBuffer(Array<int>& tag_buffer, Pointer<GriddingAlgorithm<
 void
 IBStrategySet::preprocessIntegrateData(double current_time, double new_time, int num_cycles)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->preprocessIntegrateData(current_time, new_time, num_cycles);
     }
@@ -156,8 +150,7 @@ IBStrategySet::preprocessIntegrateData(double current_time, double new_time, int
 void
 IBStrategySet::postprocessIntegrateData(double current_time, double new_time, int num_cycles)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->postprocessIntegrateData(current_time, new_time, num_cycles);
     }
@@ -167,8 +160,7 @@ IBStrategySet::postprocessIntegrateData(double current_time, double new_time, in
 void
 IBStrategySet::updateFixedLEOperators()
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->updateFixedLEOperators();
     }
@@ -181,8 +173,7 @@ IBStrategySet::interpolateVelocity(int u_data_idx,
                                    const std::vector<Pointer<RefineSchedule<NDIM> > >& u_ghost_fill_scheds,
                                    double data_time)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->interpolateVelocity(u_data_idx, u_synch_scheds, u_ghost_fill_scheds, data_time);
     }
@@ -192,8 +183,7 @@ IBStrategySet::interpolateVelocity(int u_data_idx,
 void
 IBStrategySet::IBStrategySet::forwardEulerStep(double current_time, double new_time)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->forwardEulerStep(current_time, new_time);
     }
@@ -203,8 +193,7 @@ IBStrategySet::IBStrategySet::forwardEulerStep(double current_time, double new_t
 void
 IBStrategySet::midpointStep(double current_time, double new_time)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->midpointStep(current_time, new_time);
     }
@@ -214,8 +203,7 @@ IBStrategySet::midpointStep(double current_time, double new_time)
 void
 IBStrategySet::trapezoidalStep(double current_time, double new_time)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->trapezoidalStep(current_time, new_time);
     }
@@ -225,8 +213,7 @@ IBStrategySet::trapezoidalStep(double current_time, double new_time)
 void
 IBStrategySet::computeLagrangianForce(double data_time)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->computeLagrangianForce(data_time);
     }
@@ -239,8 +226,7 @@ IBStrategySet::spreadForce(int f_data_idx,
                            const std::vector<Pointer<RefineSchedule<NDIM> > >& f_prolongation_scheds,
                            double data_time)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->spreadForce(f_data_idx, f_phys_bdry_op, f_prolongation_scheds, data_time);
     }
@@ -251,8 +237,7 @@ bool
 IBStrategySet::hasFluidSources() const
 {
     bool has_fluid_sources = false;
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         has_fluid_sources = has_fluid_sources || (*cit)->hasFluidSources();
     }
@@ -262,8 +247,7 @@ IBStrategySet::hasFluidSources() const
 void
 IBStrategySet::computeLagrangianFluidSource(double data_time)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->computeLagrangianFluidSource(data_time);
     }
@@ -276,8 +260,7 @@ IBStrategySet::spreadFluidSource(int q_data_idx,
                                  const std::vector<Pointer<RefineSchedule<NDIM> > >& q_prolongation_scheds,
                                  double data_time)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->spreadFluidSource(q_data_idx, q_phys_bdry_op, q_prolongation_scheds, data_time);
     }
@@ -290,8 +273,7 @@ IBStrategySet::interpolatePressure(int p_data_idx,
                                    const std::vector<Pointer<RefineSchedule<NDIM> > >& p_ghost_fill_scheds,
                                    double data_time)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->interpolatePressure(p_data_idx, p_synch_scheds, p_ghost_fill_scheds, data_time);
     }
@@ -301,8 +283,7 @@ IBStrategySet::interpolatePressure(int p_data_idx,
 void
 IBStrategySet::preprocessSolveFluidEquations(double current_time, double new_time, int cycle_num)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->preprocessSolveFluidEquations(current_time, new_time, cycle_num);
     }
@@ -312,8 +293,7 @@ IBStrategySet::preprocessSolveFluidEquations(double current_time, double new_tim
 void
 IBStrategySet::postprocessSolveFluidEquations(double current_time, double new_time, int cycle_num)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->postprocessSolveFluidEquations(current_time, new_time, cycle_num);
     }
@@ -323,8 +303,7 @@ IBStrategySet::postprocessSolveFluidEquations(double current_time, double new_ti
 void
 IBStrategySet::postprocessData()
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->postprocessData();
     }
@@ -341,8 +320,7 @@ IBStrategySet::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy
                                         double init_data_time,
                                         bool initial_time)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->initializePatchHierarchy(hierarchy,
                                          gridding_alg,
@@ -359,8 +337,7 @@ IBStrategySet::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy
 void
 IBStrategySet::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, int workload_data_idx)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->registerLoadBalancer(load_balancer, workload_data_idx);
     }
@@ -370,8 +347,7 @@ IBStrategySet::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, 
 void
 IBStrategySet::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > hierarchy, int workload_data_idx)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->updateWorkloadEstimates(hierarchy, workload_data_idx);
     }
@@ -382,8 +358,7 @@ void
 IBStrategySet::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > hierarchy,
                                        Pointer<GriddingAlgorithm<NDIM> > gridding_alg)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->beginDataRedistribution(hierarchy, gridding_alg);
     }
@@ -394,8 +369,7 @@ void
 IBStrategySet::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > hierarchy,
                                      Pointer<GriddingAlgorithm<NDIM> > gridding_alg)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->endDataRedistribution(hierarchy, gridding_alg);
     }
@@ -411,8 +385,7 @@ IBStrategySet::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
                                    Pointer<BasePatchLevel<NDIM> > old_level,
                                    bool allocate_data)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->initializeLevelData(
             hierarchy, level_number, init_data_time, can_be_refined, initial_time, old_level, allocate_data);
@@ -425,8 +398,7 @@ IBStrategySet::resetHierarchyConfiguration(Pointer<BasePatchHierarchy<NDIM> > hi
                                            int coarsest_level,
                                            int finest_level)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->resetHierarchyConfiguration(hierarchy, coarsest_level, finest_level);
     }
@@ -441,8 +413,7 @@ IBStrategySet::applyGradientDetector(Pointer<BasePatchHierarchy<NDIM> > hierarch
                                      bool initial_time,
                                      bool uses_richardson_extrapolation_too)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->applyGradientDetector(
             hierarchy, level_number, error_data_time, tag_index, initial_time, uses_richardson_extrapolation_too);
@@ -453,8 +424,7 @@ IBStrategySet::applyGradientDetector(Pointer<BasePatchHierarchy<NDIM> > hierarch
 void
 IBStrategySet::putToDatabase(Pointer<Database> db)
 {
-    for (std::vector<Pointer<IBStrategy> >::const_iterator cit = d_strategy_set.begin(); cit != d_strategy_set.end();
-         ++cit)
+    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
     {
         (*cit)->putToDatabase(db);
     }

--- a/src/IB/IMPInitializer.cpp
+++ b/src/IB/IMPInitializer.cpp
@@ -145,7 +145,7 @@ IMPInitializer::registerMesh(MeshBase* mesh, int level_number)
     const int max_levels = d_gridding_alg->getMaxLevels();
     if (level_number < 0) level_number = max_levels - 1;
     level_number = std::min(level_number, max_levels - 1);
-    const unsigned int mesh_idx = static_cast<unsigned int>(d_meshes[level_number].size());
+    const auto mesh_idx = static_cast<unsigned int>(d_meshes[level_number].size());
     d_meshes[level_number].push_back(mesh);
 
     // Compute the Cartesian grid spacing on the specified level of the mesh.
@@ -351,8 +351,7 @@ IMPInitializer::initializeDataOnPatchLevel(const int lag_node_index_idx,
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(patch_vertices, patch, level_number, can_be_refined);
         local_node_count += patch_vertices.size();
-        for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin(); it != patch_vertices.end();
-             ++it)
+        for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
         {
             const std::pair<int, int>& point_idx = (*it);
             const int lagrangian_idx = getCanonicalLagrangianIndex(point_idx, level_number) + global_index_offset;
@@ -451,9 +450,7 @@ IMPInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarchy<NDIM> 
         {
             std::vector<std::pair<int, int> > patch_vertices;
             getPatchVertices(patch_vertices, patch, ln, can_be_refined);
-            for (std::vector<std::pair<int, int> >::const_iterator it = patch_vertices.begin();
-                 it != patch_vertices.end();
-                 ++it)
+            for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
             {
                 const std::pair<int, int>& point_idx = (*it);
                 const libMesh::Point& X = getVertexPosn(point_idx, ln);

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -475,7 +475,7 @@ IMPMethod::interpolateVelocity(const int u_data_idx,
                 const Index<NDIM>& i = *it;
                 LNodeSet* const node_set = idx_data->getItem(i);
                 if (!node_set) continue;
-                for (LNodeSet::iterator it = node_set->begin(); it != node_set->end(); ++it)
+                for (auto it = node_set->begin(); it != node_set->end(); ++it)
                 {
                     const LNode* const node_idx = *it;
                     const int local_idx = node_idx->getLocalPETScIndex();
@@ -583,7 +583,7 @@ IMPMethod::forwardEulerStep(const double current_time, const double new_time)
         boost::multi_array_ref<double, 2>& Grad_U_array = *(*Grad_U_data)[ln]->getVecArray();
         TensorValue<double> F_current, F_new, F_half, Grad_U;
         TensorValue<double> I(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int idx = node_idx->getGlobalPETScIndex();
@@ -640,7 +640,7 @@ IMPMethod::midpointStep(const double current_time, const double new_time)
         boost::multi_array_ref<double, 2>& Grad_U_array = *(*Grad_U_data)[ln]->getVecArray();
         TensorValue<double> F_current, F_new, Grad_U;
         TensorValue<double> I(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int idx = node_idx->getGlobalPETScIndex();
@@ -700,7 +700,7 @@ IMPMethod::trapezoidalStep(const double current_time, const double new_time)
         boost::multi_array_ref<double, 2>& Grad_U_new_array = *(*Grad_U_new_data)[ln]->getVecArray();
         TensorValue<double> F_current, F_new, Grad_U_current, Grad_U_new;
         TensorValue<double> I(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int idx = node_idx->getGlobalPETScIndex();
@@ -751,11 +751,11 @@ IMPMethod::computeLagrangianForce(const double data_time)
         boost::multi_array_ref<double, 2>& tau_array = *d_tau_data[ln]->getVecArray();
         TensorValue<double> FF, PP, tau;
         VectorValue<double> X, x;
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int idx = node_idx->getGlobalPETScIndex();
-            MaterialPointSpec* mp_spec = node_idx->getNodeDataItem<MaterialPointSpec>();
+            auto mp_spec = node_idx->getNodeDataItem<MaterialPointSpec>();
             if (mp_spec && d_PK1_stress_fcn)
             {
                 for (int i = 0; i < NDIM; ++i)
@@ -868,10 +868,10 @@ IMPMethod::spreadForce(const int f_data_idx,
                 const Index<NDIM>& i = *it;
                 LNodeSet* const node_set = idx_data->getItem(i);
                 if (!node_set) continue;
-                for (LNodeSet::iterator it = node_set->begin(); it != node_set->end(); ++it)
+                for (auto it = node_set->begin(); it != node_set->end(); ++it)
                 {
                     const LNode* const node_idx = *it;
-                    MaterialPointSpec* mp_spec = node_idx->getNodeDataItem<MaterialPointSpec>();
+                    auto mp_spec = node_idx->getNodeDataItem<MaterialPointSpec>();
                     if (!mp_spec) continue;
                     const double wgt = mp_spec->getWeight();
                     const int local_idx = node_idx->getLocalPETScIndex();
@@ -1064,7 +1064,7 @@ IMPMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
         boost::multi_array_ref<double, 2>& F_array = *F_data->getLocalFormVecArray();
         boost::multi_array_ref<double, 2>& tau_array = *tau_data->getLocalFormVecArray();
-        for (std::vector<LNode*>::const_iterator cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
         {
             const LNode* const node_idx = *cit;
             const int idx = node_idx->getLocalPETScIndex();

--- a/src/IB/KrylovFreeBodyMobilitySolver.cpp
+++ b/src/IB/KrylovFreeBodyMobilitySolver.cpp
@@ -471,7 +471,7 @@ KrylovFreeBodyMobilitySolver::MatVecMult_KFBMSolver(Mat A, Vec x, Vec y)
 {
     void* p_ctx;
     MatShellGetContext(A, &p_ctx);
-    KrylovFreeBodyMobilitySolver* solver = static_cast<KrylovFreeBodyMobilitySolver*>(p_ctx);
+    auto solver = static_cast<KrylovFreeBodyMobilitySolver*>(p_ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(solver);
 #endif
@@ -500,7 +500,7 @@ KrylovFreeBodyMobilitySolver::PCApply_KFBMSolver(PC pc, Vec x, Vec y)
     // Here we are trying to the solve the problem of the type: Py = x for y.
     void* ctx;
     PCShellGetContext(pc, &ctx);
-    KrylovFreeBodyMobilitySolver* solver = static_cast<KrylovFreeBodyMobilitySolver*>(ctx);
+    auto solver = static_cast<KrylovFreeBodyMobilitySolver*>(ctx);
 #if !defined(NDEBUG)
     TBOX_ASSERT(solver);
 #endif

--- a/src/IB/KrylovMobilitySolver.cpp
+++ b/src/IB/KrylovMobilitySolver.cpp
@@ -667,14 +667,14 @@ KrylovMobilitySolver::initializeStokesSolver(const SAMRAIVectorReal<NDIM, double
     x_p_vec.addComponent(x_p_cc_var, x_p_idx, sol_vec.getControlVolumeIndex(1));
     b_p_vec.addComponent(b_p_cc_var, b_p_idx, rhs_vec.getControlVolumeIndex(1));
 
-    IBTK::LinearSolver* p_velocity_solver = dynamic_cast<IBTK::LinearSolver*>(d_velocity_solver.getPointer());
+    auto p_velocity_solver = dynamic_cast<IBTK::LinearSolver*>(d_velocity_solver.getPointer());
     if (p_velocity_solver)
     {
         p_velocity_solver->setInitialGuessNonzero(false);
         if (has_velocity_nullspace) p_velocity_solver->setNullspace(false, d_U_nul_vecs);
     }
 
-    IBTK::LinearSolver* p_pressure_solver = dynamic_cast<IBTK::LinearSolver*>(d_pressure_solver.getPointer());
+    auto p_pressure_solver = dynamic_cast<IBTK::LinearSolver*>(d_pressure_solver.getPointer());
     if (p_pressure_solver)
     {
         p_pressure_solver->setInitialGuessNonzero(false);
@@ -685,10 +685,10 @@ KrylovMobilitySolver::initializeStokesSolver(const SAMRAIVectorReal<NDIM, double
     d_pressure_solver->initializeSolverState(x_p_vec, b_p_vec);
 
     // Initialize LInv (Stokes solver for the mobility matrix).
-    IBTK::LinearSolver* p_stokes_linear_solver = dynamic_cast<IBTK::LinearSolver*>(d_LInv.getPointer());
+    auto p_stokes_linear_solver = dynamic_cast<IBTK::LinearSolver*>(d_LInv.getPointer());
     if (!p_stokes_linear_solver)
     {
-        IBTK::NewtonKrylovSolver* p_stokes_newton_solver = dynamic_cast<IBTK::NewtonKrylovSolver*>(d_LInv.getPointer());
+        auto p_stokes_newton_solver = dynamic_cast<IBTK::NewtonKrylovSolver*>(d_LInv.getPointer());
         if (p_stokes_newton_solver)
         {
             p_stokes_linear_solver = p_stokes_newton_solver->getLinearSolver().getPointer();
@@ -696,12 +696,10 @@ KrylovMobilitySolver::initializeStokesSolver(const SAMRAIVectorReal<NDIM, double
     }
     if (p_stokes_linear_solver)
     {
-        StaggeredStokesBlockPreconditioner* p_stokes_block_pc =
-            dynamic_cast<StaggeredStokesBlockPreconditioner*>(p_stokes_linear_solver);
+        auto p_stokes_block_pc = dynamic_cast<StaggeredStokesBlockPreconditioner*>(p_stokes_linear_solver);
         if (!p_stokes_block_pc)
         {
-            IBTK::KrylovLinearSolver* p_stokes_krylov_solver =
-                dynamic_cast<IBTK::KrylovLinearSolver*>(p_stokes_linear_solver);
+            auto p_stokes_krylov_solver = dynamic_cast<IBTK::KrylovLinearSolver*>(p_stokes_linear_solver);
             if (p_stokes_krylov_solver)
             {
                 p_stokes_block_pc = dynamic_cast<StaggeredStokesBlockPreconditioner*>(
@@ -913,7 +911,7 @@ KrylovMobilitySolver::MatVecMult_KMInv(Mat A, Vec x, Vec y)
 {
     void* p_ctx;
     MatShellGetContext(A, &p_ctx);
-    KrylovMobilitySolver* solver = static_cast<KrylovMobilitySolver*>(p_ctx);
+    auto solver = static_cast<KrylovMobilitySolver*>(p_ctx);
     Pointer<IBStrategy> ib_method_ops = solver->d_cib_strategy;
 
 #if !defined(NDEBUG)

--- a/src/IB/NonbondedForceEvaluator.cpp
+++ b/src/IB/NonbondedForceEvaluator.cpp
@@ -202,15 +202,14 @@ NonbondedForceEvaluator::computeLagrangianForce(Pointer<LData> F_data,
                         // we have a set of nodes in the first cell and the search cell,
                         // add up forces
                         // and accumulate for the first cell.
-                        for (LNodeSet::iterator it = mstr_node_set->begin(); it != mstr_node_set->end(); ++it)
+                        for (auto it = mstr_node_set->begin(); it != mstr_node_set->end(); ++it)
                         {
                             // master nodes
                             LNodeSet::value_type& mstr_node_idx = *it;
                             const int mstr_lag_idx = mstr_node_idx->getLagrangianIndex();
                             const int mstr_petsc_idx = mstr_node_idx->getLocalPETScIndex();
 
-                            for (LNodeSet::iterator sit = search_node_set->begin(); sit != search_node_set->end();
-                                 ++sit)
+                            for (auto sit = search_node_set->begin(); sit != search_node_set->end(); ++sit)
                             {
                                 LNodeSet::value_type& search_node_idx = *sit;
                                 const int search_lag_idx = search_node_idx->getLagrangianIndex();

--- a/src/IB/WallForceEvaluator.cpp
+++ b/src/IB/WallForceEvaluator.cpp
@@ -94,7 +94,7 @@ void
 WallForceEvaluator::registerWallForceFcn(Wall::WallForceFcnPtr wall_force_fcn)
 {
     // register the given force function pointer with all walls
-    for (std::vector<Wall>::iterator wall_it = d_walls_vec.begin(); wall_it != d_walls_vec.end(); ++wall_it)
+    for (auto wall_it = d_walls_vec.begin(); wall_it != d_walls_vec.end(); ++wall_it)
     { // iterate through walls
         wall_it->registerWallForceFcn(wall_force_fcn);
     }
@@ -130,7 +130,7 @@ WallForceEvaluator::computeLagrangianForce(Pointer<LData> F_data,
 
     const int lag_node_idx_current_idx = l_data_manager->getLNodePatchDescriptorIndex();
 
-    for (std::vector<Wall>::iterator wall_it = d_walls_vec.begin(); wall_it != d_walls_vec.end(); ++wall_it)
+    for (auto wall_it = d_walls_vec.begin(); wall_it != d_walls_vec.end(); ++wall_it)
     { // iterate through walls
 
         // get axis (which direction the wall is normal to)
@@ -158,7 +158,7 @@ WallForceEvaluator::computeLagrangianForce(Pointer<LData> F_data,
                 // if particles exist in this cell, add forces to them
                 if (search_node_set)
                 {
-                    for (LNodeSet::iterator it = search_node_set->begin(); it != search_node_set->end(); ++it)
+                    for (auto it = search_node_set->begin(); it != search_node_set->end(); ++it)
                     {
                         // get node data
                         LNodeSet::value_type& particle_node_idx = *it;

--- a/src/adv_diff/AdvDiffConvectiveOperatorManager.cpp
+++ b/src/adv_diff/AdvDiffConvectiveOperatorManager.cpp
@@ -111,7 +111,7 @@ AdvDiffConvectiveOperatorManager::allocateOperator(const std::string& operator_t
                                                    ConvectiveDifferencingType difference_form,
                                                    const std::vector<RobinBcCoefStrategy<NDIM>*>& bc_coefs) const
 {
-    std::map<std::string, OperatorMaker>::const_iterator it = d_operator_maker_map.find(operator_type);
+    auto it = d_operator_maker_map.find(operator_type);
     if (it == d_operator_maker_map.end())
     {
         TBOX_ERROR("AdvDiffConvectiveOperatorManager::allocateOperator():\n"

--- a/src/adv_diff/AdvDiffHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffHierarchyIntegrator.cpp
@@ -696,7 +696,7 @@ AdvDiffHierarchyIntegrator::getHelmholtzSolver(Pointer<CellVariable<NDIM, double
 void
 AdvDiffHierarchyIntegrator::setHelmholtzSolversNeedInit()
 {
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::iterator it = d_Q_var.begin(); it != d_Q_var.end(); ++it)
+    for (auto it = d_Q_var.begin(); it != d_Q_var.end(); ++it)
     {
         setHelmholtzSolverNeedsInit(*it);
     }
@@ -754,7 +754,7 @@ AdvDiffHierarchyIntegrator::getHelmholtzRHSOperator(Pointer<CellVariable<NDIM, d
 void
 AdvDiffHierarchyIntegrator::setHelmholtzRHSOperatorsNeedInit()
 {
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::iterator it = d_Q_var.begin(); it != d_Q_var.end(); ++it)
+    for (auto it = d_Q_var.begin(); it != d_Q_var.end(); ++it)
     {
         setHelmholtzRHSOperatorNeedsInit(*it);
     }
@@ -792,8 +792,7 @@ AdvDiffHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHierarchy
     // Setup coarsening communications algorithms, used in synchronizing refined
     // regions of coarse data with the underlying fine data.
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         const int Q_current_idx = var_db->mapVariableAndContextToIndex(Q_var, getCurrentContext());
@@ -825,8 +824,7 @@ AdvDiffHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHierarchy
     }
     d_helmholtz_solvers.resize(d_Q_var.size());
     d_helmholtz_solvers_need_init.resize(d_Q_var.size());
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         const size_t l = distance(d_Q_var.begin(), std::find(d_Q_var.begin(), d_Q_var.end(), Q_var));
@@ -834,8 +832,7 @@ AdvDiffHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHierarchy
     }
     d_helmholtz_rhs_ops.resize(d_Q_var.size());
     d_helmholtz_rhs_ops_need_init.resize(d_Q_var.size());
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         const size_t l = distance(d_Q_var.begin(), std::find(d_Q_var.begin(), d_Q_var.end(), Q_var));
@@ -858,8 +855,7 @@ AdvDiffHierarchyIntegrator::preprocessIntegrateHierarchy(double current_time, do
     // Build the priority mapping, which determines which variables are reset first
     std::multimap<int, Pointer<CellVariable<NDIM, double> > > priority_Q_map;
     unsigned int l = 0;
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit, ++l)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit, ++l)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         const int priority = d_Q_reset_priority[l];
@@ -1001,9 +997,7 @@ AdvDiffHierarchyIntegrator::getMaximumTimeStepSizeSpecialized()
             const Index<NDIM>& iupper = patch_box.upper();
             const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
             const double* const dx = patch_geom->getDx();
-            for (std::vector<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin();
-                 cit != d_u_var.end();
-                 ++cit)
+            for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
             {
                 Pointer<FaceVariable<NDIM, double> > u_var = *cit;
                 Pointer<FaceData<NDIM, double> > u_data = patch->getPatchData(u_var, getCurrentContext());
@@ -1052,8 +1046,7 @@ AdvDiffHierarchyIntegrator::initializeCompositeHierarchyDataSpecialized(double i
     // Build the priority mapping, which determines which variables are reset first
     std::multimap<int, Pointer<CellVariable<NDIM, double> > > priority_Q_map;
     unsigned int l = 0;
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit, ++l)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit, ++l)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         const int priority = d_Q_reset_priority[l];
@@ -1061,9 +1054,7 @@ AdvDiffHierarchyIntegrator::initializeCompositeHierarchyDataSpecialized(double i
     }
 
     // Reset the desired transported quantities.
-    for (std::multimap<int, Pointer<CellVariable<NDIM, double> > >::iterator it = priority_Q_map.begin();
-         it != priority_Q_map.end();
-         ++it)
+    for (auto it = priority_Q_map.begin(); it != priority_Q_map.end(); ++it)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = it->second;
         const int Q_current_idx = var_db->mapVariableAndContextToIndex(Q_var, getCurrentContext());
@@ -1110,8 +1101,7 @@ AdvDiffHierarchyIntegrator::resetHierarchyConfigurationSpecialized(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     d_hier_bdry_fill_ops.resize(d_Q_var.size());
     unsigned int l = 0;
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit, ++l)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit, ++l)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         const int Q_scratch_idx = var_db->mapVariableAndContextToIndex(Q_var, getScratchContext());
@@ -1136,8 +1126,7 @@ AdvDiffHierarchyIntegrator::resetHierarchyConfigurationSpecialized(
     d_rhs_vecs.resize(d_Q_var.size());
     l = 0;
     const int wgt_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit, ++l)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit, ++l)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         const std::string& name = Q_var->getName();
@@ -1182,8 +1171,7 @@ AdvDiffHierarchyIntegrator::registerVariables()
 {
     const IntVector<NDIM> cell_ghosts = CELLG;
     const IntVector<NDIM> face_ghosts = FACEG;
-    for (std::vector<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin(); cit != d_u_var.end();
-         ++cit)
+    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
     {
         Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         int u_current_idx, u_new_idx, u_scratch_idx;
@@ -1196,8 +1184,7 @@ AdvDiffHierarchyIntegrator::registerVariables()
                          "CONSERVATIVE_LINEAR_REFINE",
                          d_u_fcn[u_var]);
     }
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         int Q_current_idx, Q_new_idx, Q_scratch_idx;
@@ -1214,8 +1201,7 @@ AdvDiffHierarchyIntegrator::registerVariables()
         if (d_visit_writer)
             d_visit_writer->registerPlotQuantity(Q_var->getName(), Q_depth == 1 ? "SCALAR" : "VECTOR", Q_current_idx);
     }
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_F_var.begin(); cit != d_F_var.end();
-         ++cit)
+    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > F_var = *cit;
         int F_current_idx, F_new_idx, F_scratch_idx;
@@ -1232,9 +1218,7 @@ AdvDiffHierarchyIntegrator::registerVariables()
         if (d_visit_writer)
             d_visit_writer->registerPlotQuantity(F_var->getName(), F_depth == 1 ? "SCALAR" : "VECTOR", F_current_idx);
     }
-    for (std::vector<Pointer<SideVariable<NDIM, double> > >::const_iterator cit = d_diffusion_coef_var.begin();
-         cit != d_diffusion_coef_var.end();
-         ++cit)
+    for (auto cit = d_diffusion_coef_var.begin(); cit != d_diffusion_coef_var.end(); ++cit)
     {
         Pointer<SideVariable<NDIM, double> > D_var = *cit;
         int D_current_idx, D_new_idx, D_scratch_idx;
@@ -1247,17 +1231,13 @@ AdvDiffHierarchyIntegrator::registerVariables()
                          "CONSERVATIVE_LINEAR_REFINE",
                          d_diffusion_coef_fcn[D_var]);
     }
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_rhs_var.begin();
-         cit != d_Q_rhs_var.end();
-         ++cit)
+    for (auto cit = d_Q_rhs_var.begin(); cit != d_Q_rhs_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_rhs_var = *cit;
         int Q_rhs_scratch_idx;
         registerVariable(Q_rhs_scratch_idx, Q_rhs_var, cell_ghosts, getScratchContext());
     }
-    for (std::vector<Pointer<SideVariable<NDIM, double> > >::const_iterator cit = d_diffusion_coef_rhs_var.begin();
-         cit != d_diffusion_coef_rhs_var.end();
-         ++cit)
+    for (auto cit = d_diffusion_coef_rhs_var.begin(); cit != d_diffusion_coef_rhs_var.end(); ++cit)
     {
         Pointer<SideVariable<NDIM, double> > D_rhs_var = *cit;
         int D_rhs_scratch_idx;

--- a/src/adv_diff/AdvDiffPhysicalBoundaryUtilities.cpp
+++ b/src/adv_diff/AdvDiffPhysicalBoundaryUtilities.cpp
@@ -83,7 +83,7 @@ AdvDiffPhysicalBoundaryUtilities::setPhysicalBoundaryConditions(Pointer<CellData
     // Setup any extended Robin BC coef objects.
     for (int depth = 0; depth < Q_data->getDepth(); ++depth)
     {
-        ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[depth]);
+        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[depth]);
         if (extended_bc_coef)
         {
             extended_bc_coef->clearTargetPatchDataIndex();
@@ -120,7 +120,7 @@ AdvDiffPhysicalBoundaryUtilities::setPhysicalBoundaryConditions(Pointer<CellData
             if (bc_coefs[depth] == nullptr) continue;
 
             bc_coefs[depth]->setBcCoefs(acoef_data, bcoef_data, gcoef_data, nullptr, *patch, trimmed_bdry_box, fill_time);
-            ExtendedRobinBcCoefStrategy* extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[depth]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coefs[depth]);
             if (homogeneous_bc && !extended_bc_coef) gcoef_data->fillAll(0.0);
             for (Box<NDIM>::Iterator bc(bc_coef_box); bc; bc++)
             {

--- a/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
@@ -239,8 +239,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeHierarchyIntegrator(
     }
 
     // Register variables with the hyperbolic level integrator.
-    for (std::vector<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin(); cit != d_u_var.end();
-         ++cit)
+    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
     {
         Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         d_hyp_patch_ops->registerAdvectionVelocity(u_var);
@@ -249,8 +248,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeHierarchyIntegrator(
     }
 
     const IntVector<NDIM> cell_ghosts = CELLG;
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_F_var.begin(); cit != d_F_var.end();
-         ++cit)
+    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > F_var = *cit;
         d_hyp_level_integrator->registerVariable(F_var,
@@ -261,9 +259,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeHierarchyIntegrator(
                                                  "CONSERVATIVE_LINEAR_REFINE");
     }
 
-    for (std::vector<Pointer<SideVariable<NDIM, double> > >::const_iterator cit = d_diffusion_coef_var.begin();
-         cit != d_diffusion_coef_var.end();
-         ++cit)
+    for (auto cit = d_diffusion_coef_var.begin(); cit != d_diffusion_coef_var.end(); ++cit)
     {
         Pointer<SideVariable<NDIM, double> > D_var = *cit;
         d_hyp_level_integrator->registerVariable(D_var,
@@ -276,18 +272,14 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeHierarchyIntegrator(
         registerVariable(D_scratch_idx, D_var, cell_ghosts, getScratchContext());
     }
 
-    for (std::vector<Pointer<SideVariable<NDIM, double> > >::const_iterator cit = d_diffusion_coef_rhs_var.begin();
-         cit != d_diffusion_coef_rhs_var.end();
-         ++cit)
+    for (auto cit = d_diffusion_coef_rhs_var.begin(); cit != d_diffusion_coef_rhs_var.end(); ++cit)
     {
         Pointer<SideVariable<NDIM, double> > D_rhs_var = *cit;
         int D_rhs_scratch_idx;
         registerVariable(D_rhs_scratch_idx, D_rhs_var, cell_ghosts, getScratchContext());
     }
 
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_rhs_var.begin();
-         cit != d_Q_rhs_var.end();
-         ++cit)
+    for (auto cit = d_Q_rhs_var.begin(); cit != d_Q_rhs_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_rhs_var = *cit;
         int Q_rhs_scratch_idx;
@@ -295,8 +287,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeHierarchyIntegrator(
         d_hyp_patch_ops->registerSourceTerm(Q_rhs_var);
     }
 
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         int Q_scratch_idx;
@@ -359,8 +350,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
     }
 
     // Compute any time-dependent source terms at time-level n.
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_F_var.begin(); cit != d_F_var.end();
-         ++cit)
+    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > F_var = *cit;
         Pointer<CartGridFunction> F_fcn = d_F_fcn[F_var];
@@ -372,9 +362,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
     }
 
     // Compute any time-dependent variable diffusion coefficients at time-level n.
-    for (std::vector<Pointer<SideVariable<NDIM, double> > >::const_iterator cit = d_diffusion_coef_var.begin();
-         cit != d_diffusion_coef_var.end();
-         ++cit)
+    for (auto cit = d_diffusion_coef_var.begin(); cit != d_diffusion_coef_var.end(); ++cit)
     {
         Pointer<SideVariable<NDIM, double> > D_var = *cit;
         Pointer<CartGridFunction> D_fcn = d_diffusion_coef_fcn[D_var];
@@ -388,8 +376,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
     // Predict the advective terms and synchronize them across all levels of the
     // patch hierarchy.
     unsigned int l = 0;
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit, ++l)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit, ++l)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellVariable<NDIM, double> > F_var = d_Q_F_map[Q_var];
@@ -470,8 +457,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
     }
 
     // Compute any time-dependent source terms at time-level n+1/2.
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_F_var.begin(); cit != d_F_var.end();
-         ++cit, ++l)
+    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit, ++l)
     {
         Pointer<CellVariable<NDIM, double> > F_var = *cit;
         Pointer<CartGridFunction> F_fcn = d_F_fcn[F_var];
@@ -483,9 +469,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
     }
 
     // Compute any time-dependent variable diffusion coefficients at time-level n+1/2.
-    for (std::vector<Pointer<SideVariable<NDIM, double> > >::const_iterator cit = d_diffusion_coef_var.begin();
-         cit != d_diffusion_coef_var.end();
-         ++cit, ++l)
+    for (auto cit = d_diffusion_coef_var.begin(); cit != d_diffusion_coef_var.end(); ++cit, ++l)
     {
         Pointer<SideVariable<NDIM, double> > D_var = *cit;
         Pointer<CartGridFunction> D_fcn = d_diffusion_coef_fcn[D_var];
@@ -507,8 +491,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
 
     // Solve for Q(n+1).
     l = 0;
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit, ++l)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit, ++l)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellVariable<NDIM, double> > F_var = d_Q_F_map[Q_var];
@@ -790,9 +773,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeLevelDataSpecialized(
     {
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-        for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_F_var.begin();
-             cit != d_F_var.end();
-             ++cit)
+        for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
         {
             Pointer<CellVariable<NDIM, double> > F_var = *cit;
             const int F_idx = var_db->mapVariableAndContextToIndex(F_var, getCurrentContext());
@@ -816,9 +797,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeLevelDataSpecialized(
         }
 
         // Set the initial value of any variable diffusion coefficient
-        for (std::vector<Pointer<SideVariable<NDIM, double> > >::const_iterator cit = d_diffusion_coef_var.begin();
-             cit != d_diffusion_coef_var.end();
-             ++cit)
+        for (auto cit = d_diffusion_coef_var.begin(); cit != d_diffusion_coef_var.end(); ++cit)
         {
             Pointer<SideVariable<NDIM, double> > D_var = *cit;
             const int D_idx = var_db->mapVariableAndContextToIndex(D_var, getCurrentContext());

--- a/src/adv_diff/AdvDiffPredictorCorrectorHyperbolicPatchOps.cpp
+++ b/src/adv_diff/AdvDiffPredictorCorrectorHyperbolicPatchOps.cpp
@@ -210,8 +210,7 @@ AdvDiffPredictorCorrectorHyperbolicPatchOps::conservativeDifferenceOnPatch(Patch
     const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch.getPatchGeometry();
     const double* const dx = patch_geom->getDx();
 
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellData<NDIM, double> > Q_data = patch.getPatchData(Q_var, getDataContext());
@@ -389,8 +388,7 @@ AdvDiffPredictorCorrectorHyperbolicPatchOps::preprocessAdvanceLevelState(const P
     if (!d_compute_init_velocity) return;
 
     // Update the advection velocity (or velocities).
-    for (std::set<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin(); cit != d_u_var.end();
-         ++cit)
+    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
     {
         Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         if (d_u_fcn[u_var] && d_u_fcn[u_var]->isTimeDependent())
@@ -414,8 +412,7 @@ AdvDiffPredictorCorrectorHyperbolicPatchOps::postprocessAdvanceLevelState(const 
     if (!d_compute_final_velocity) return;
 
     // Update the advection velocity (or velocities).
-    for (std::set<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin(); cit != d_u_var.end();
-         ++cit)
+    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
     {
         Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         if (d_u_fcn[u_var] && d_u_fcn[u_var]->isTimeDependent())

--- a/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
@@ -377,7 +377,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::getConvectiveOperator(Pointer<CellVariab
 void
 AdvDiffSemiImplicitHierarchyIntegrator::setConvectiveOperatorsNeedInit()
 {
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::iterator it = d_Q_var.begin(); it != d_Q_var.end(); ++it)
+    for (auto it = d_Q_var.begin(); it != d_Q_var.end(); ++it)
     {
         setConvectiveOperatorNeedsInit(*it);
     }
@@ -413,8 +413,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<Pa
     AdvDiffHierarchyIntegrator::registerVariables();
 
     // Setup the convective operators.
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         getConvectiveOperator(Q_var);
@@ -422,8 +421,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<Pa
 
     // Register additional variables required for present time stepping algorithm.
     const IntVector<NDIM> cell_ghosts = CELLG;
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellDataFactory<NDIM, double> > Q_factory = Q_var->getPatchDataFactory();
@@ -464,9 +462,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::getNumberOfCycles() const
     int num_cycles = d_num_cycles;
     if (MathUtilities<double>::equalEps(d_integrator_time, d_start_time))
     {
-        for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin();
-             cit != d_Q_var.end();
-             ++cit)
+        for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
         {
             Pointer<CellVariable<NDIM, double> > Q_var = *cit;
             if (!d_Q_u_map.find(Q_var)->second) continue;
@@ -513,8 +509,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
     }
 
     // Update the advection velocity.
-    for (std::vector<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin(); cit != d_u_var.end();
-         ++cit)
+    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
     {
         Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         const int u_current_idx = var_db->mapVariableAndContextToIndex(u_var, getCurrentContext());
@@ -533,9 +528,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
     }
 
     // Update the diffusion coefficient
-    for (std::vector<Pointer<SideVariable<NDIM, double> > >::const_iterator cit = d_diffusion_coef_var.begin();
-         cit != d_diffusion_coef_var.end();
-         ++cit)
+    for (auto cit = d_diffusion_coef_var.begin(); cit != d_diffusion_coef_var.end(); ++cit)
     {
         Pointer<SideVariable<NDIM, double> > D_var = *cit;
         Pointer<CartGridFunction> D_fcn = d_diffusion_coef_fcn[D_var];
@@ -548,8 +541,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
 
     // Setup the operators and solvers and compute the right-hand-side terms.
     unsigned int l = 0;
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit, ++l)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit, ++l)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellVariable<NDIM, double> > Q_rhs_var = d_Q_Q_rhs_map[Q_var];
@@ -726,8 +718,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchy(const double current_
 
     // Perform a single step of fixed point iteration.
     unsigned int l = 0;
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit, ++l)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit, ++l)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellVariable<NDIM, double> > F_var = d_Q_F_map[Q_var];
@@ -743,9 +734,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchy(const double current_
         // Update the advection velocity.
         if (cycle_num > 0)
         {
-            for (std::vector<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin();
-                 cit != d_u_var.end();
-                 ++cit)
+            for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
             {
                 Pointer<FaceVariable<NDIM, double> > u_var = *cit;
                 const int u_current_idx = var_db->mapVariableAndContextToIndex(u_var, getCurrentContext());
@@ -948,8 +937,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::resetHierarchyConfigurationSpecialized(
     const int finest_hier_level = hierarchy->getFinestLevelNumber();
     d_hier_fc_data_ops->setPatchHierarchy(hierarchy);
     d_hier_fc_data_ops->resetLevels(0, finest_hier_level);
-    for (std::vector<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         d_Q_convective_op_needs_init[Q_var] = true;

--- a/src/advect/AdvectorPredictorCorrectorHyperbolicPatchOps.cpp
+++ b/src/advect/AdvectorPredictorCorrectorHyperbolicPatchOps.cpp
@@ -494,8 +494,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::registerModelVariables(HyperbolicL
 #endif
     d_integrator = integrator;
 
-    for (std::set<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin(); cit != d_u_var.end();
-         ++cit)
+    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
     {
         Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         d_integrator->registerVariable(u_var,
@@ -506,8 +505,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::registerModelVariables(HyperbolicL
                                        "CONSERVATIVE_LINEAR_REFINE");
     }
 
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_F_var.begin(); cit != d_F_var.end();
-         ++cit)
+    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > F_var = *cit;
         d_integrator->registerVariable(F_var,
@@ -518,8 +516,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::registerModelVariables(HyperbolicL
                                        "CONSERVATIVE_LINEAR_REFINE");
     }
 
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellDataFactory<NDIM, double> > Q_factory = Q_var->getPatchDataFactory();
@@ -604,9 +601,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::initializeDataOnPatch(Patch<NDIM>&
     if (initial_time)
     {
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-        for (std::set<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin();
-             cit != d_u_var.end();
-             ++cit)
+        for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
         {
             Pointer<FaceVariable<NDIM, double> > u_var = *cit;
             const int u_idx = var_db->mapVariableAndContextToIndex(u_var, getDataContext());
@@ -622,9 +617,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::initializeDataOnPatch(Patch<NDIM>&
             }
         }
 
-        for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_F_var.begin();
-             cit != d_F_var.end();
-             ++cit)
+        for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
         {
             Pointer<CellVariable<NDIM, double> > F_var = *cit;
             const int F_idx = var_db->mapVariableAndContextToIndex(F_var, getDataContext());
@@ -640,9 +633,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::initializeDataOnPatch(Patch<NDIM>&
             }
         }
 
-        for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin();
-             cit != d_Q_var.end();
-             ++cit)
+        for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
         {
             Pointer<CellVariable<NDIM, double> > Q_var = *cit;
             const int Q_idx = var_db->mapVariableAndContextToIndex(Q_var, getDataContext());
@@ -667,8 +658,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::computeStableDtOnPatch(Patch<NDIM>
                                                                      const double /*dt_time*/)
 {
     double stable_dt = std::numeric_limits<double>::max();
-    for (std::set<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin(); cit != d_u_var.end();
-         ++cit)
+    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
     {
         Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         Pointer<FaceData<NDIM, double> > u_data = patch.getPatchData(u_var, getDataContext());
@@ -687,8 +677,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::computeFluxesOnPatch(Patch<NDIM>& 
 
     PatchFaceDataOpsReal<NDIM, double> patch_fc_data_ops;
 
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<FaceVariable<NDIM, double> > u_var = d_Q_u_map[Q_var];
@@ -725,9 +714,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::computeFluxesOnPatch(Patch<NDIM>& 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     if (d_compute_half_velocity)
     {
-        for (std::set<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin();
-             cit != d_u_var.end();
-             ++cit)
+        for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
         {
             Pointer<FaceVariable<NDIM, double> > u_var = *cit;
             if (d_u_fcn[u_var] && d_u_fcn[u_var]->isTimeDependent())
@@ -739,8 +726,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::computeFluxesOnPatch(Patch<NDIM>& 
     }
 
     // Compute fluxes and other face-centered quantities.
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<FaceVariable<NDIM, double> > u_var = d_Q_u_map[Q_var];
@@ -783,8 +769,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::conservativeDifferenceOnPatch(Patc
     const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch.getPatchGeometry();
     const double* const dx = patch_geom->getDx();
 
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<FaceVariable<NDIM, double> > u_var = d_Q_u_map[Q_var];
@@ -944,8 +929,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::preprocessAdvanceLevelState(const 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
 
     // Update the source term.
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_F_var.begin(); cit != d_F_var.end();
-         ++cit)
+    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > F_var = *cit;
         if (d_F_fcn[F_var] && d_F_fcn[F_var]->isTimeDependent())
@@ -958,8 +942,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::preprocessAdvanceLevelState(const 
     if (!d_compute_init_velocity) return;
 
     // Update the advection velocity.
-    for (std::set<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin(); cit != d_u_var.end();
-         ++cit)
+    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
     {
         Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         if (d_u_fcn[u_var] && d_u_fcn[u_var]->isTimeDependent())
@@ -988,8 +971,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::postprocessAdvanceLevelState(const
 
     // Update the values of any time-dependent source terms and add the values
     // of all source terms to the advected quantities.
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellVariable<NDIM, double> > F_var = d_Q_F_map[Q_var];
@@ -1023,8 +1005,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::postprocessAdvanceLevelState(const
     if (!d_compute_final_velocity) return;
 
     // Update the advection velocity.
-    for (std::set<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin(); cit != d_u_var.end();
-         ++cit)
+    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
     {
         Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         if (d_u_fcn[u_var] && d_u_fcn[u_var]->isTimeDependent())
@@ -1092,9 +1073,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::tagGradientDetectorCells(Patch<NDI
             if (time_allowed)
             {
                 // Check for tags that have already been set in a previous step.
-                for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin();
-                     cit != d_Q_var.end();
-                     ++cit)
+                for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
                 {
                     Pointer<CellVariable<NDIM, double> > Q_var = *cit;
                     Pointer<CellData<NDIM, double> > Q_data = patch.getPatchData(Q_var, getDataContext());
@@ -1132,9 +1111,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::tagGradientDetectorCells(Patch<NDI
 
             if (time_allowed)
             {
-                for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin();
-                     cit != d_Q_var.end();
-                     ++cit)
+                for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
                 {
                     Pointer<CellVariable<NDIM, double> > Q_var = *cit;
                     Pointer<CellData<NDIM, double> > Q_data = patch.getPatchData(Q_var, getDataContext());
@@ -1211,8 +1188,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::setPhysicalBoundaryConditions(Patc
     // Extrapolate the interior data to set the ghost cell values for the state
     // variables and for any forcing terms.
     ComponentSelector u_patch_data_indices;
-    for (std::set<Pointer<FaceVariable<NDIM, double> > >::const_iterator cit = d_u_var.begin(); cit != d_u_var.end();
-         ++cit)
+    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
     {
         Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         const int u_data_idx = var_db->mapVariableAndContextToIndex(u_var, d_integrator->getScratchContext());
@@ -1223,15 +1199,13 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::setPhysicalBoundaryConditions(Patc
     d_extrap_bc_helper.setPhysicalBoundaryConditions(patch, fill_time, ghost_width_to_fill);
 
     ComponentSelector patch_data_indices;
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_F_var.begin(); cit != d_F_var.end();
-         ++cit)
+    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > F_var = *cit;
         const int F_data_idx = var_db->mapVariableAndContextToIndex(F_var, d_integrator->getScratchContext());
         patch_data_indices.setFlag(F_data_idx);
     }
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         const int Q_data_idx = var_db->mapVariableAndContextToIndex(Q_var, d_integrator->getScratchContext());
@@ -1357,8 +1331,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::setInflowBoundaryConditions(Patch<
     // boundaries only.
     const Box<NDIM>& patch_box = patch.getBox();
     const double* const dx = pgeom->getDx();
-    for (std::set<Pointer<CellVariable<NDIM, double> > >::const_iterator cit = d_Q_var.begin(); cit != d_Q_var.end();
-         ++cit)
+    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
     {
         Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<FaceVariable<NDIM, double> > u_var = d_Q_u_map[Q_var];
@@ -1373,8 +1346,7 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::setInflowBoundaryConditions(Patch<
         // Setup any extended Robin BC coef objects.
         for (int depth = 0; depth < q_integral_data->getDepth(); ++depth)
         {
-            ExtendedRobinBcCoefStrategy* extended_bc_coef =
-                dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_Q_bc_coef[Q_var][depth]);
+            auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_Q_bc_coef[Q_var][depth]);
             if (extended_bc_coef)
             {
                 extended_bc_coef->setTargetPatchDataIndex(Q_data_idx);

--- a/src/navier_stokes/INSCollocatedConvectiveOperatorManager.cpp
+++ b/src/navier_stokes/INSCollocatedConvectiveOperatorManager.cpp
@@ -107,7 +107,7 @@ INSCollocatedConvectiveOperatorManager::allocateOperator(const std::string& oper
                                                          const ConvectiveDifferencingType difference_form,
                                                          const std::vector<RobinBcCoefStrategy<NDIM>*>& bc_coefs) const
 {
-    std::map<std::string, OperatorMaker>::const_iterator it = d_operator_maker_map.find(operator_type);
+    auto it = d_operator_maker_map.find(operator_type);
     if (it == d_operator_maker_map.end())
     {
         TBOX_ERROR("INSCollocatedConvectiveOperatorManager::allocateOperator():\n"

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1903,7 +1903,7 @@ INSCollocatedHierarchyIntegrator::regridProjection()
     regrid_projection_solver->setHomogeneousBc(true);
     regrid_projection_solver->setSolutionTime(d_integrator_time);
     regrid_projection_solver->setTimeInterval(d_integrator_time, d_integrator_time);
-    LinearSolver* p_regrid_projection_solver = dynamic_cast<LinearSolver*>(regrid_projection_solver.getPointer());
+    auto p_regrid_projection_solver = dynamic_cast<LinearSolver*>(regrid_projection_solver.getPointer());
     if (p_regrid_projection_solver)
     {
         p_regrid_projection_solver->setInitialGuessNonzero(false);
@@ -2141,13 +2141,12 @@ INSCollocatedHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double c
     // Setup boundary conditions objects.
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        INSIntermediateVelocityBcCoef* U_star_bc_coef =
-            dynamic_cast<INSIntermediateVelocityBcCoef*>(d_U_star_bc_coefs[d]);
+        auto U_star_bc_coef = dynamic_cast<INSIntermediateVelocityBcCoef*>(d_U_star_bc_coefs[d]);
         U_star_bc_coef->setPhysicalBcCoefs(d_bc_coefs);
         U_star_bc_coef->setSolutionTime(new_time);
         U_star_bc_coef->setTimeInterval(current_time, new_time);
     }
-    INSProjectionBcCoef* Phi_bc_coef = dynamic_cast<INSProjectionBcCoef*>(d_Phi_bc_coef);
+    auto Phi_bc_coef = dynamic_cast<INSProjectionBcCoef*>(d_Phi_bc_coef);
     Phi_bc_coef->setPhysicalBcCoefs(d_bc_coefs);
     Phi_bc_coef->setSolutionTime(0.5 * (current_time + new_time));
     Phi_bc_coef->setTimeInterval(current_time, new_time);
@@ -2169,7 +2168,7 @@ INSCollocatedHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double c
         d_velocity_solver->setPhysicalBcCoefs(d_U_star_bc_coefs);
         d_velocity_solver->setSolutionTime(new_time);
         d_velocity_solver->setTimeInterval(current_time, new_time);
-        LinearSolver* p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
+        auto p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
         if (d_velocity_solver_needs_init)
         {
             if (d_enable_logging)
@@ -2192,7 +2191,7 @@ INSCollocatedHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double c
         d_pressure_solver->setPhysicalBcCoef(d_Phi_bc_coef);
         d_pressure_solver->setSolutionTime(half_time);
         d_pressure_solver->setTimeInterval(current_time, new_time);
-        LinearSolver* p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
+        auto p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
         if (d_pressure_solver_needs_init)
         {
             if (d_enable_logging)

--- a/src/navier_stokes/INSCollocatedVelocityBcCoef.cpp
+++ b/src/navier_stokes/INSCollocatedVelocityBcCoef.cpp
@@ -108,7 +108,7 @@ INSCollocatedVelocityBcCoef::setStokesSpecifications(const StokesSpecifications*
     StokesBcCoefStrategy::setStokesSpecifications(problem_coefs);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setStokesSpecifications(problem_coefs);
     }
     return;
@@ -120,7 +120,7 @@ INSCollocatedVelocityBcCoef::setTargetVelocityPatchDataIndex(int u_target_data_i
     StokesBcCoefStrategy::setTargetVelocityPatchDataIndex(u_target_data_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetVelocityPatchDataIndex(u_target_data_idx);
     }
     return;
@@ -132,7 +132,7 @@ INSCollocatedVelocityBcCoef::clearTargetVelocityPatchDataIndex()
     StokesBcCoefStrategy::clearTargetVelocityPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetVelocityPatchDataIndex();
     }
     return;
@@ -144,7 +144,7 @@ INSCollocatedVelocityBcCoef::setTargetPressurePatchDataIndex(int p_target_data_i
     StokesBcCoefStrategy::setTargetPressurePatchDataIndex(p_target_data_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPressurePatchDataIndex(p_target_data_idx);
     }
     return;
@@ -156,7 +156,7 @@ INSCollocatedVelocityBcCoef::clearTargetPressurePatchDataIndex()
     StokesBcCoefStrategy::clearTargetPressurePatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPressurePatchDataIndex();
     }
     return;
@@ -192,7 +192,7 @@ INSCollocatedVelocityBcCoef::setTargetPatchDataIndex(int target_idx)
     StokesBcCoefStrategy::setTargetPatchDataIndex(target_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPatchDataIndex(target_idx);
     }
     return;
@@ -204,7 +204,7 @@ INSCollocatedVelocityBcCoef::clearTargetPatchDataIndex()
     StokesBcCoefStrategy::clearTargetPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPatchDataIndex();
     }
     return;
@@ -216,7 +216,7 @@ INSCollocatedVelocityBcCoef::setHomogeneousBc(bool homogeneous_bc)
     ExtendedRobinBcCoefStrategy::setHomogeneousBc(homogeneous_bc);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setHomogeneousBc(homogeneous_bc);
     }
     return;

--- a/src/navier_stokes/INSIntermediateVelocityBcCoef.cpp
+++ b/src/navier_stokes/INSIntermediateVelocityBcCoef.cpp
@@ -112,7 +112,7 @@ INSIntermediateVelocityBcCoef::setTargetPatchDataIndex(int target_idx)
     ExtendedRobinBcCoefStrategy::setTargetPatchDataIndex(target_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPatchDataIndex(target_idx);
     }
     return;
@@ -124,7 +124,7 @@ INSIntermediateVelocityBcCoef::clearTargetPatchDataIndex()
     ExtendedRobinBcCoefStrategy::clearTargetPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPatchDataIndex();
     }
     return;
@@ -136,7 +136,7 @@ INSIntermediateVelocityBcCoef::setHomogeneousBc(bool homogeneous_bc)
     ExtendedRobinBcCoefStrategy::setHomogeneousBc(homogeneous_bc);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setHomogeneousBc(homogeneous_bc);
     }
     return;

--- a/src/navier_stokes/INSProjectionBcCoef.cpp
+++ b/src/navier_stokes/INSProjectionBcCoef.cpp
@@ -114,7 +114,7 @@ INSProjectionBcCoef::setTargetPatchDataIndex(int target_idx)
     ExtendedRobinBcCoefStrategy::setTargetPatchDataIndex(target_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPatchDataIndex(target_idx);
     }
     return;
@@ -126,7 +126,7 @@ INSProjectionBcCoef::clearTargetPatchDataIndex()
     ExtendedRobinBcCoefStrategy::clearTargetPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPatchDataIndex();
     }
     return;
@@ -138,7 +138,7 @@ INSProjectionBcCoef::setHomogeneousBc(bool homogeneous_bc)
     ExtendedRobinBcCoefStrategy::setHomogeneousBc(homogeneous_bc);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setHomogeneousBc(homogeneous_bc);
     }
     return;

--- a/src/navier_stokes/INSStaggeredConvectiveOperatorManager.cpp
+++ b/src/navier_stokes/INSStaggeredConvectiveOperatorManager.cpp
@@ -113,7 +113,7 @@ INSStaggeredConvectiveOperatorManager::allocateOperator(const std::string& opera
                                                         const ConvectiveDifferencingType difference_form,
                                                         const std::vector<RobinBcCoefStrategy<NDIM>*>& bc_coefs) const
 {
-    std::map<std::string, OperatorMaker>::const_iterator it = d_operator_maker_map.find(operator_type);
+    auto it = d_operator_maker_map.find(operator_type);
     if (it == d_operator_maker_map.end())
     {
         TBOX_ERROR("INSStaggeredConvectiveOperatorManager::allocateOperator():\n"

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -2154,7 +2154,7 @@ INSStaggeredHierarchyIntegrator::regridProjection()
     regrid_projection_solver->setHomogeneousBc(true);
     regrid_projection_solver->setSolutionTime(d_integrator_time);
     regrid_projection_solver->setTimeInterval(d_integrator_time, d_integrator_time);
-    LinearSolver* p_regrid_projection_solver = dynamic_cast<LinearSolver*>(regrid_projection_solver.getPointer());
+    auto p_regrid_projection_solver = dynamic_cast<LinearSolver*>(regrid_projection_solver.getPointer());
     if (p_regrid_projection_solver)
     {
         p_regrid_projection_solver->setInitialGuessNonzero(false);
@@ -2409,26 +2409,25 @@ INSStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double cu
     // Setup boundary conditions objects.
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        INSStaggeredVelocityBcCoef* U_bc_coef = dynamic_cast<INSStaggeredVelocityBcCoef*>(d_U_bc_coefs[d]);
+        auto U_bc_coef = dynamic_cast<INSStaggeredVelocityBcCoef*>(d_U_bc_coefs[d]);
         U_bc_coef->setStokesSpecifications(&d_problem_coefs);
         U_bc_coef->setPhysicalBcCoefs(d_bc_coefs);
         U_bc_coef->setSolutionTime(new_time);
         U_bc_coef->setTimeInterval(current_time, new_time);
     }
-    INSStaggeredPressureBcCoef* P_bc_coef = dynamic_cast<INSStaggeredPressureBcCoef*>(d_P_bc_coef);
+    auto P_bc_coef = dynamic_cast<INSStaggeredPressureBcCoef*>(d_P_bc_coef);
     P_bc_coef->setStokesSpecifications(&d_problem_coefs);
     P_bc_coef->setPhysicalBcCoefs(d_bc_coefs);
     P_bc_coef->setSolutionTime(new_time);
     P_bc_coef->setTimeInterval(current_time, new_time);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        INSIntermediateVelocityBcCoef* U_star_bc_coef =
-            dynamic_cast<INSIntermediateVelocityBcCoef*>(d_U_star_bc_coefs[d]);
+        auto U_star_bc_coef = dynamic_cast<INSIntermediateVelocityBcCoef*>(d_U_star_bc_coefs[d]);
         U_star_bc_coef->setPhysicalBcCoefs(d_bc_coefs);
         U_star_bc_coef->setSolutionTime(new_time);
         U_star_bc_coef->setTimeInterval(current_time, new_time);
     }
-    INSProjectionBcCoef* Phi_bc_coef = dynamic_cast<INSProjectionBcCoef*>(d_Phi_bc_coef);
+    auto Phi_bc_coef = dynamic_cast<INSProjectionBcCoef*>(d_Phi_bc_coef);
     Phi_bc_coef->setPhysicalBcCoefs(d_bc_coefs);
     Phi_bc_coef->setSolutionTime(0.5 * (current_time + new_time));
     Phi_bc_coef->setTimeInterval(current_time, new_time);
@@ -2457,7 +2456,7 @@ INSStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double cu
                 plog << d_object_name << "::preprocessIntegrateHierarchy(): initializing "
                                          "velocity subdomain solver"
                      << std::endl;
-            LinearSolver* p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
+            auto p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
             if (p_velocity_solver)
             {
                 p_velocity_solver->setInitialGuessNonzero(false);
@@ -2480,7 +2479,7 @@ INSStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double cu
                 plog << d_object_name << "::preprocessIntegrateHierarchy(): initializing "
                                          "pressure subdomain solver"
                      << std::endl;
-            LinearSolver* p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
+            auto p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
             if (p_pressure_solver)
             {
                 p_pressure_solver->setInitialGuessNonzero(false);
@@ -2498,21 +2497,19 @@ INSStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double cu
     d_stokes_solver->setSolutionTime(new_time);
     d_stokes_solver->setTimeInterval(current_time, new_time);
     d_stokes_solver->setComponentsHaveNullspace(has_velocity_nullspace, has_pressure_nullspace);
-    LinearSolver* p_stokes_linear_solver = dynamic_cast<LinearSolver*>(d_stokes_solver.getPointer());
+    auto p_stokes_linear_solver = dynamic_cast<LinearSolver*>(d_stokes_solver.getPointer());
     if (!p_stokes_linear_solver)
     {
-        NewtonKrylovSolver* p_stokes_newton_solver = dynamic_cast<NewtonKrylovSolver*>(d_stokes_solver.getPointer());
+        auto p_stokes_newton_solver = dynamic_cast<NewtonKrylovSolver*>(d_stokes_solver.getPointer());
         if (p_stokes_newton_solver) p_stokes_linear_solver = p_stokes_newton_solver->getLinearSolver().getPointer();
     }
     if (p_stokes_linear_solver)
     {
-        StaggeredStokesBlockPreconditioner* p_stokes_block_pc =
-            dynamic_cast<StaggeredStokesBlockPreconditioner*>(p_stokes_linear_solver);
-        StaggeredStokesFACPreconditioner* p_stokes_fac_pc =
-            dynamic_cast<StaggeredStokesFACPreconditioner*>(p_stokes_linear_solver);
+        auto p_stokes_block_pc = dynamic_cast<StaggeredStokesBlockPreconditioner*>(p_stokes_linear_solver);
+        auto p_stokes_fac_pc = dynamic_cast<StaggeredStokesFACPreconditioner*>(p_stokes_linear_solver);
         if (!(p_stokes_block_pc || p_stokes_fac_pc))
         {
-            KrylovLinearSolver* p_stokes_krylov_solver = dynamic_cast<KrylovLinearSolver*>(p_stokes_linear_solver);
+            auto p_stokes_krylov_solver = dynamic_cast<KrylovLinearSolver*>(p_stokes_linear_solver);
             if (p_stokes_krylov_solver)
             {
                 p_stokes_block_pc = dynamic_cast<StaggeredStokesBlockPreconditioner*>(

--- a/src/navier_stokes/INSStaggeredPressureBcCoef.cpp
+++ b/src/navier_stokes/INSStaggeredPressureBcCoef.cpp
@@ -94,7 +94,7 @@ INSStaggeredPressureBcCoef::setStokesSpecifications(const StokesSpecifications* 
     StokesBcCoefStrategy::setStokesSpecifications(problem_coefs);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setStokesSpecifications(problem_coefs);
     }
     return;
@@ -106,7 +106,7 @@ INSStaggeredPressureBcCoef::setTargetVelocityPatchDataIndex(int u_target_data_id
     StokesBcCoefStrategy::setTargetVelocityPatchDataIndex(u_target_data_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetVelocityPatchDataIndex(u_target_data_idx);
     }
     return;
@@ -118,7 +118,7 @@ INSStaggeredPressureBcCoef::clearTargetVelocityPatchDataIndex()
     StokesBcCoefStrategy::clearTargetVelocityPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetVelocityPatchDataIndex();
     }
     return;
@@ -130,7 +130,7 @@ INSStaggeredPressureBcCoef::setTargetPressurePatchDataIndex(int p_target_data_id
     StokesBcCoefStrategy::setTargetPressurePatchDataIndex(p_target_data_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPressurePatchDataIndex(p_target_data_idx);
     }
     return;
@@ -142,7 +142,7 @@ INSStaggeredPressureBcCoef::clearTargetPressurePatchDataIndex()
     StokesBcCoefStrategy::clearTargetPressurePatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPressurePatchDataIndex();
     }
     return;
@@ -178,7 +178,7 @@ INSStaggeredPressureBcCoef::setTargetPatchDataIndex(int target_idx)
     StokesBcCoefStrategy::setTargetPatchDataIndex(target_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPatchDataIndex(target_idx);
     }
     return;
@@ -190,7 +190,7 @@ INSStaggeredPressureBcCoef::clearTargetPatchDataIndex()
     StokesBcCoefStrategy::clearTargetPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPatchDataIndex();
     }
     return;
@@ -202,7 +202,7 @@ INSStaggeredPressureBcCoef::setHomogeneousBc(bool homogeneous_bc)
     ExtendedRobinBcCoefStrategy::setHomogeneousBc(homogeneous_bc);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setHomogeneousBc(homogeneous_bc);
     }
     return;

--- a/src/navier_stokes/INSStaggeredVelocityBcCoef.cpp
+++ b/src/navier_stokes/INSStaggeredVelocityBcCoef.cpp
@@ -104,7 +104,7 @@ INSStaggeredVelocityBcCoef::setStokesSpecifications(const StokesSpecifications* 
     StokesBcCoefStrategy::setStokesSpecifications(problem_coefs);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setStokesSpecifications(problem_coefs);
     }
     return;
@@ -116,7 +116,7 @@ INSStaggeredVelocityBcCoef::setTargetVelocityPatchDataIndex(int u_target_data_id
     StokesBcCoefStrategy::setTargetVelocityPatchDataIndex(u_target_data_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetVelocityPatchDataIndex(u_target_data_idx);
     }
     return;
@@ -128,7 +128,7 @@ INSStaggeredVelocityBcCoef::clearTargetVelocityPatchDataIndex()
     StokesBcCoefStrategy::clearTargetVelocityPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetVelocityPatchDataIndex();
     }
     return;
@@ -140,7 +140,7 @@ INSStaggeredVelocityBcCoef::setTargetPressurePatchDataIndex(int p_target_data_id
     StokesBcCoefStrategy::setTargetPressurePatchDataIndex(p_target_data_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPressurePatchDataIndex(p_target_data_idx);
     }
     return;
@@ -152,7 +152,7 @@ INSStaggeredVelocityBcCoef::clearTargetPressurePatchDataIndex()
     StokesBcCoefStrategy::clearTargetPressurePatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPressurePatchDataIndex();
     }
     return;
@@ -188,7 +188,7 @@ INSStaggeredVelocityBcCoef::setTargetPatchDataIndex(int target_idx)
     StokesBcCoefStrategy::setTargetPatchDataIndex(target_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPatchDataIndex(target_idx);
     }
     return;
@@ -200,7 +200,7 @@ INSStaggeredVelocityBcCoef::clearTargetPatchDataIndex()
     StokesBcCoefStrategy::clearTargetPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPatchDataIndex();
     }
     return;
@@ -212,7 +212,7 @@ INSStaggeredVelocityBcCoef::setHomogeneousBc(bool homogeneous_bc)
     ExtendedRobinBcCoefStrategy::setHomogeneousBc(homogeneous_bc);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setHomogeneousBc(homogeneous_bc);
     }
     return;

--- a/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
@@ -1064,7 +1064,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::regridProjection()
     regrid_projection_solver->setHomogeneousBc(true);
     regrid_projection_solver->setSolutionTime(d_integrator_time);
     regrid_projection_solver->setTimeInterval(d_integrator_time, d_integrator_time);
-    LinearSolver* p_regrid_projection_solver = dynamic_cast<LinearSolver*>(regrid_projection_solver.getPointer());
+    auto p_regrid_projection_solver = dynamic_cast<LinearSolver*>(regrid_projection_solver.getPointer());
     if (p_regrid_projection_solver)
     {
         p_regrid_projection_solver->setInitialGuessNonzero(false);
@@ -1264,7 +1264,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::updateOperatorsAndSolvers(const d
                      << "::updateOperatorsAndSolvers`(): initializing "
                         "velocity subdomain solver"
                      << std::endl;
-            LinearSolver* p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
+            auto p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
             if (p_velocity_solver)
             {
                 p_velocity_solver->setInitialGuessNonzero(false);
@@ -1288,7 +1288,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::updateOperatorsAndSolvers(const d
                      << "::updateOperatorsAndSolvers(): initializing "
                         "pressure subdomain solver"
                      << std::endl;
-            LinearSolver* p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
+            auto p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
             if (p_pressure_solver)
             {
                 p_pressure_solver->setInitialGuessNonzero(false);
@@ -1307,23 +1307,20 @@ INSVCStaggeredConservativeHierarchyIntegrator::updateOperatorsAndSolvers(const d
     d_stokes_solver->setTimeInterval(current_time, new_time);
     d_stokes_solver->setComponentsHaveNullspace(has_velocity_nullspace, has_pressure_nullspace);
 
-    LinearSolver* p_stokes_linear_solver = dynamic_cast<LinearSolver*>(d_stokes_solver.getPointer());
+    auto p_stokes_linear_solver = dynamic_cast<LinearSolver*>(d_stokes_solver.getPointer());
     if (!p_stokes_linear_solver)
     {
-        NewtonKrylovSolver* p_stokes_newton_solver = dynamic_cast<NewtonKrylovSolver*>(d_stokes_solver.getPointer());
+        auto p_stokes_newton_solver = dynamic_cast<NewtonKrylovSolver*>(d_stokes_solver.getPointer());
         if (p_stokes_newton_solver) p_stokes_linear_solver = p_stokes_newton_solver->getLinearSolver().getPointer();
     }
     if (p_stokes_linear_solver)
     {
-        StaggeredStokesBlockPreconditioner* p_stokes_block_pc =
-            dynamic_cast<StaggeredStokesBlockPreconditioner*>(p_stokes_linear_solver);
-        StaggeredStokesFACPreconditioner* p_stokes_fac_pc =
-            dynamic_cast<StaggeredStokesFACPreconditioner*>(p_stokes_linear_solver);
-        VCStaggeredStokesProjectionPreconditioner* p_vc_stokes_proj_pc =
-            dynamic_cast<VCStaggeredStokesProjectionPreconditioner*>(p_stokes_linear_solver);
+        auto p_stokes_block_pc = dynamic_cast<StaggeredStokesBlockPreconditioner*>(p_stokes_linear_solver);
+        auto p_stokes_fac_pc = dynamic_cast<StaggeredStokesFACPreconditioner*>(p_stokes_linear_solver);
+        auto p_vc_stokes_proj_pc = dynamic_cast<VCStaggeredStokesProjectionPreconditioner*>(p_stokes_linear_solver);
         if (!(p_stokes_block_pc || p_stokes_fac_pc))
         {
-            KrylovLinearSolver* p_stokes_krylov_solver = dynamic_cast<KrylovLinearSolver*>(p_stokes_linear_solver);
+            auto p_stokes_krylov_solver = dynamic_cast<KrylovLinearSolver*>(p_stokes_linear_solver);
             if (p_stokes_krylov_solver)
             {
                 p_stokes_block_pc = dynamic_cast<StaggeredStokesBlockPreconditioner*>(

--- a/src/navier_stokes/INSVCStaggeredConservativeMassMomentumIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredConservativeMassMomentumIntegrator.cpp
@@ -1673,7 +1673,7 @@ INSVCStaggeredConservativeMassMomentumIntegrator::deallocateTimeIntegrator()
     }
 
     // Deallocate coarse-fine boundary object.
-    for (std::vector<CoarseFineBoundary<NDIM>*>::iterator it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
+    for (auto it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
     {
         delete (*it);
         (*it) = nullptr;

--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -1113,8 +1113,7 @@ INSVCStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHi
     }
 
     // Set the velocity subdomain solver interpolation type if necessary
-    IBTK::PETScKrylovLinearSolver* p_velocity_solver =
-        dynamic_cast<IBTK::PETScKrylovLinearSolver*>(d_velocity_solver.getPointer());
+    auto p_velocity_solver = dynamic_cast<IBTK::PETScKrylovLinearSolver*>(d_velocity_solver.getPointer());
     if (p_velocity_solver)
     {
         Pointer<PoissonFACPreconditioner> p_poisson_fac_pc = p_velocity_solver->getPreconditioner();
@@ -2089,13 +2088,13 @@ INSVCStaggeredHierarchyIntegrator::preprocessOperatorsAndSolvers(const double cu
     // Setup boundary conditions objects.
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        INSVCStaggeredVelocityBcCoef* U_bc_coef = dynamic_cast<INSVCStaggeredVelocityBcCoef*>(d_U_bc_coefs[d]);
+        auto U_bc_coef = dynamic_cast<INSVCStaggeredVelocityBcCoef*>(d_U_bc_coefs[d]);
         U_bc_coef->setStokesSpecifications(&d_problem_coefs);
         U_bc_coef->setPhysicalBcCoefs(d_bc_coefs);
         U_bc_coef->setSolutionTime(new_time);
         U_bc_coef->setTimeInterval(current_time, new_time);
     }
-    INSVCStaggeredPressureBcCoef* P_bc_coef = dynamic_cast<INSVCStaggeredPressureBcCoef*>(d_P_bc_coef);
+    auto P_bc_coef = dynamic_cast<INSVCStaggeredPressureBcCoef*>(d_P_bc_coef);
     P_bc_coef->setStokesSpecifications(&d_problem_coefs);
     P_bc_coef->setPhysicalBcCoefs(d_bc_coefs);
     P_bc_coef->setSolutionTime(new_time);
@@ -2103,13 +2102,12 @@ INSVCStaggeredHierarchyIntegrator::preprocessOperatorsAndSolvers(const double cu
     P_bc_coef->setViscosityInterpolationType(d_mu_vc_interp_type);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        INSIntermediateVelocityBcCoef* U_star_bc_coef =
-            dynamic_cast<INSIntermediateVelocityBcCoef*>(d_U_star_bc_coefs[d]);
+        auto U_star_bc_coef = dynamic_cast<INSIntermediateVelocityBcCoef*>(d_U_star_bc_coefs[d]);
         U_star_bc_coef->setPhysicalBcCoefs(d_bc_coefs);
         U_star_bc_coef->setSolutionTime(new_time);
         U_star_bc_coef->setTimeInterval(current_time, new_time);
     }
-    INSProjectionBcCoef* Phi_bc_coef = dynamic_cast<INSProjectionBcCoef*>(d_Phi_bc_coef);
+    auto Phi_bc_coef = dynamic_cast<INSProjectionBcCoef*>(d_Phi_bc_coef);
     Phi_bc_coef->setPhysicalBcCoefs(d_bc_coefs);
     Phi_bc_coef->setSolutionTime(0.5 * (current_time + new_time));
     Phi_bc_coef->setTimeInterval(current_time, new_time);

--- a/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
@@ -1131,7 +1131,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::regridProjection()
     regrid_projection_solver->setHomogeneousBc(true);
     regrid_projection_solver->setSolutionTime(d_integrator_time);
     regrid_projection_solver->setTimeInterval(d_integrator_time, d_integrator_time);
-    LinearSolver* p_regrid_projection_solver = dynamic_cast<LinearSolver*>(regrid_projection_solver.getPointer());
+    auto p_regrid_projection_solver = dynamic_cast<LinearSolver*>(regrid_projection_solver.getPointer());
     if (p_regrid_projection_solver)
     {
         p_regrid_projection_solver->setInitialGuessNonzero(false);
@@ -1395,7 +1395,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::updateOperatorsAndSolvers(cons
                      << "::updateOperatorsAndSolvers`(): initializing "
                         "velocity subdomain solver"
                      << std::endl;
-            LinearSolver* p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
+            auto p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
             if (p_velocity_solver)
             {
                 p_velocity_solver->setInitialGuessNonzero(false);
@@ -1419,7 +1419,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::updateOperatorsAndSolvers(cons
                      << "::updateOperatorsAndSolvers(): initializing "
                         "pressure subdomain solver"
                      << std::endl;
-            LinearSolver* p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
+            auto p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
             if (p_pressure_solver)
             {
                 p_pressure_solver->setInitialGuessNonzero(false);
@@ -1438,23 +1438,20 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::updateOperatorsAndSolvers(cons
     d_stokes_solver->setTimeInterval(current_time, new_time);
     d_stokes_solver->setComponentsHaveNullspace(has_velocity_nullspace, has_pressure_nullspace);
 
-    LinearSolver* p_stokes_linear_solver = dynamic_cast<LinearSolver*>(d_stokes_solver.getPointer());
+    auto p_stokes_linear_solver = dynamic_cast<LinearSolver*>(d_stokes_solver.getPointer());
     if (!p_stokes_linear_solver)
     {
-        NewtonKrylovSolver* p_stokes_newton_solver = dynamic_cast<NewtonKrylovSolver*>(d_stokes_solver.getPointer());
+        auto p_stokes_newton_solver = dynamic_cast<NewtonKrylovSolver*>(d_stokes_solver.getPointer());
         if (p_stokes_newton_solver) p_stokes_linear_solver = p_stokes_newton_solver->getLinearSolver().getPointer();
     }
     if (p_stokes_linear_solver)
     {
-        StaggeredStokesBlockPreconditioner* p_stokes_block_pc =
-            dynamic_cast<StaggeredStokesBlockPreconditioner*>(p_stokes_linear_solver);
-        StaggeredStokesFACPreconditioner* p_stokes_fac_pc =
-            dynamic_cast<StaggeredStokesFACPreconditioner*>(p_stokes_linear_solver);
-        VCStaggeredStokesProjectionPreconditioner* p_vc_stokes_proj_pc =
-            dynamic_cast<VCStaggeredStokesProjectionPreconditioner*>(p_stokes_linear_solver);
+        auto p_stokes_block_pc = dynamic_cast<StaggeredStokesBlockPreconditioner*>(p_stokes_linear_solver);
+        auto p_stokes_fac_pc = dynamic_cast<StaggeredStokesFACPreconditioner*>(p_stokes_linear_solver);
+        auto p_vc_stokes_proj_pc = dynamic_cast<VCStaggeredStokesProjectionPreconditioner*>(p_stokes_linear_solver);
         if (!(p_stokes_block_pc || p_stokes_fac_pc))
         {
-            KrylovLinearSolver* p_stokes_krylov_solver = dynamic_cast<KrylovLinearSolver*>(p_stokes_linear_solver);
+            auto p_stokes_krylov_solver = dynamic_cast<KrylovLinearSolver*>(p_stokes_linear_solver);
             if (p_stokes_krylov_solver)
             {
                 p_stokes_block_pc = dynamic_cast<StaggeredStokesBlockPreconditioner*>(

--- a/src/navier_stokes/INSVCStaggeredPressureBcCoef.cpp
+++ b/src/navier_stokes/INSVCStaggeredPressureBcCoef.cpp
@@ -97,7 +97,7 @@ INSVCStaggeredPressureBcCoef::setStokesSpecifications(const StokesSpecifications
     StokesBcCoefStrategy::setStokesSpecifications(problem_coefs);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setStokesSpecifications(problem_coefs);
     }
     return;
@@ -109,7 +109,7 @@ INSVCStaggeredPressureBcCoef::setTargetVelocityPatchDataIndex(int u_target_data_
     StokesBcCoefStrategy::setTargetVelocityPatchDataIndex(u_target_data_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetVelocityPatchDataIndex(u_target_data_idx);
     }
     return;
@@ -121,7 +121,7 @@ INSVCStaggeredPressureBcCoef::clearTargetVelocityPatchDataIndex()
     StokesBcCoefStrategy::clearTargetVelocityPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetVelocityPatchDataIndex();
     }
     return;
@@ -133,7 +133,7 @@ INSVCStaggeredPressureBcCoef::setTargetPressurePatchDataIndex(int p_target_data_
     StokesBcCoefStrategy::setTargetPressurePatchDataIndex(p_target_data_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPressurePatchDataIndex(p_target_data_idx);
     }
     return;
@@ -145,7 +145,7 @@ INSVCStaggeredPressureBcCoef::clearTargetPressurePatchDataIndex()
     StokesBcCoefStrategy::clearTargetPressurePatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPressurePatchDataIndex();
     }
     return;
@@ -181,7 +181,7 @@ INSVCStaggeredPressureBcCoef::setTargetPatchDataIndex(int target_idx)
     StokesBcCoefStrategy::setTargetPatchDataIndex(target_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPatchDataIndex(target_idx);
     }
     return;
@@ -193,7 +193,7 @@ INSVCStaggeredPressureBcCoef::clearTargetPatchDataIndex()
     StokesBcCoefStrategy::clearTargetPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPatchDataIndex();
     }
     return;
@@ -205,7 +205,7 @@ INSVCStaggeredPressureBcCoef::setHomogeneousBc(bool homogeneous_bc)
     ExtendedRobinBcCoefStrategy::setHomogeneousBc(homogeneous_bc);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setHomogeneousBc(homogeneous_bc);
     }
     return;

--- a/src/navier_stokes/INSVCStaggeredVelocityBcCoef.cpp
+++ b/src/navier_stokes/INSVCStaggeredVelocityBcCoef.cpp
@@ -106,7 +106,7 @@ INSVCStaggeredVelocityBcCoef::setStokesSpecifications(const StokesSpecifications
     StokesBcCoefStrategy::setStokesSpecifications(problem_coefs);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setStokesSpecifications(problem_coefs);
     }
     return;
@@ -118,7 +118,7 @@ INSVCStaggeredVelocityBcCoef::setTargetVelocityPatchDataIndex(int u_target_data_
     StokesBcCoefStrategy::setTargetVelocityPatchDataIndex(u_target_data_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetVelocityPatchDataIndex(u_target_data_idx);
     }
     return;
@@ -130,7 +130,7 @@ INSVCStaggeredVelocityBcCoef::clearTargetVelocityPatchDataIndex()
     StokesBcCoefStrategy::clearTargetVelocityPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetVelocityPatchDataIndex();
     }
     return;
@@ -142,7 +142,7 @@ INSVCStaggeredVelocityBcCoef::setTargetPressurePatchDataIndex(int p_target_data_
     StokesBcCoefStrategy::setTargetPressurePatchDataIndex(p_target_data_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPressurePatchDataIndex(p_target_data_idx);
     }
     return;
@@ -154,7 +154,7 @@ INSVCStaggeredVelocityBcCoef::clearTargetPressurePatchDataIndex()
     StokesBcCoefStrategy::clearTargetPressurePatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPressurePatchDataIndex();
     }
     return;
@@ -190,7 +190,7 @@ INSVCStaggeredVelocityBcCoef::setTargetPatchDataIndex(int target_idx)
     StokesBcCoefStrategy::setTargetPatchDataIndex(target_idx);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setTargetPatchDataIndex(target_idx);
     }
     return;
@@ -202,7 +202,7 @@ INSVCStaggeredVelocityBcCoef::clearTargetPatchDataIndex()
     StokesBcCoefStrategy::clearTargetPatchDataIndex();
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->clearTargetPatchDataIndex();
     }
     return;
@@ -214,7 +214,7 @@ INSVCStaggeredVelocityBcCoef::setHomogeneousBc(bool homogeneous_bc)
     ExtendedRobinBcCoefStrategy::setHomogeneousBc(homogeneous_bc);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
+        auto p_comp_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[d]);
         if (p_comp_bc_coef) p_comp_bc_coef->setHomogeneousBc(homogeneous_bc);
     }
     return;

--- a/src/navier_stokes/KrylovLinearSolverStaggeredStokesSolverInterface.cpp
+++ b/src/navier_stokes/KrylovLinearSolverStaggeredStokesSolverInterface.cpp
@@ -78,7 +78,7 @@ void
 KrylovLinearSolverStaggeredStokesSolverInterface::setVelocityPoissonSpecifications(
     const PoissonSpecifications& U_problem_coefs)
 {
-    KrylovLinearSolver* p_this = dynamic_cast<KrylovLinearSolver*>(this);
+    auto p_this = dynamic_cast<KrylovLinearSolver*>(this);
 #if !defined(NDEBUG)
     TBOX_ASSERT(p_this);
 #endif
@@ -94,7 +94,7 @@ void
 KrylovLinearSolverStaggeredStokesSolverInterface::setComponentsHaveNullspace(const bool has_velocity_nullspace,
                                                                              const bool has_pressure_nullspace)
 {
-    KrylovLinearSolver* p_this = dynamic_cast<KrylovLinearSolver*>(this);
+    auto p_this = dynamic_cast<KrylovLinearSolver*>(this);
 #if !defined(NDEBUG)
     TBOX_ASSERT(p_this);
 #endif
@@ -110,7 +110,7 @@ KrylovLinearSolverStaggeredStokesSolverInterface::setPhysicalBcCoefs(
     const std::vector<RobinBcCoefStrategy<NDIM>*>& U_bc_coefs,
     RobinBcCoefStrategy<NDIM>* P_bc_coef)
 {
-    KrylovLinearSolver* p_this = dynamic_cast<KrylovLinearSolver*>(this);
+    auto p_this = dynamic_cast<KrylovLinearSolver*>(this);
 #if !defined(NDEBUG)
     TBOX_ASSERT(p_this);
 #endif
@@ -126,7 +126,7 @@ void
 KrylovLinearSolverStaggeredStokesSolverInterface::setPhysicalBoundaryHelper(
     Pointer<StaggeredStokesPhysicalBoundaryHelper> bc_helper)
 {
-    KrylovLinearSolver* p_this = dynamic_cast<KrylovLinearSolver*>(this);
+    auto p_this = dynamic_cast<KrylovLinearSolver*>(this);
 #if !defined(NDEBUG)
     TBOX_ASSERT(p_this);
 #endif

--- a/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
@@ -538,7 +538,7 @@ StaggeredStokesBlockFactorizationPreconditioner::solvePressureSubsystem(SAMRAIVe
     else
     {
         d_pressure_solver->setHomogeneousBc(true);
-        LinearSolver* p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
+        auto p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
         if (p_pressure_solver) p_pressure_solver->setInitialGuessNonzero(initial_guess_nonzero);
         d_pressure_solver->solveSystem(*P_scratch_vec, F_P_vec); // P_scratch_idx := -inv(L_rho)*F_P
         d_pressure_data_ops->linearSum(
@@ -558,7 +558,7 @@ StaggeredStokesBlockFactorizationPreconditioner::solveVelocitySubsystem(SAMRAIVe
     //
     // No special treatment is needed for the steady-state case.
     d_velocity_solver->setHomogeneousBc(true);
-    LinearSolver* p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
+    auto p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
     if (p_velocity_solver) p_velocity_solver->setInitialGuessNonzero(initial_guess_nonzero);
     d_velocity_solver->solveSystem(U_vec, F_U_vec);
     return;

--- a/src/navier_stokes/StaggeredStokesBlockPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesBlockPreconditioner.cpp
@@ -213,7 +213,7 @@ void
 StaggeredStokesBlockPreconditioner::correctNullspace(Pointer<SAMRAIVectorReal<NDIM, double> > U_vec,
                                                      Pointer<SAMRAIVectorReal<NDIM, double> > P_vec)
 {
-    LinearSolver* p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
+    auto p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
     if (p_velocity_solver)
     {
         const std::vector<Pointer<SAMRAIVectorReal<NDIM, double> > >& U_nul_vecs =
@@ -231,7 +231,7 @@ StaggeredStokesBlockPreconditioner::correctNullspace(Pointer<SAMRAIVectorReal<ND
 #endif
     }
 
-    LinearSolver* p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
+    auto p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
     if (p_pressure_solver)
     {
         if (p_pressure_solver->getNullspaceContainsConstantVector())

--- a/src/navier_stokes/StaggeredStokesFACPreconditionerStrategy.cpp
+++ b/src/navier_stokes/StaggeredStokesFACPreconditionerStrategy.cpp
@@ -550,13 +550,13 @@ StaggeredStokesFACPreconditionerStrategy::solveCoarsestLevel(SAMRAIVectorReal<ND
         d_coarse_solver->setSolutionTime(d_solution_time);
         d_coarse_solver->setTimeInterval(d_current_time, d_new_time);
         d_coarse_solver->setComponentsHaveNullspace(d_has_velocity_nullspace, d_has_pressure_nullspace);
-        LinearSolver* p_coarse_solver = dynamic_cast<LinearSolver*>(d_coarse_solver.getPointer());
+        auto p_coarse_solver = dynamic_cast<LinearSolver*>(d_coarse_solver.getPointer());
 
         if (p_coarse_solver)
         {
             bool initial_guess_nonzero = true;
-            PETScKrylovLinearSolver* p_petsc_solver = dynamic_cast<PETScKrylovLinearSolver*>(p_coarse_solver);
-            PETScLevelSolver* p_petsc_level_solver = dynamic_cast<PETScLevelSolver*>(p_coarse_solver);
+            auto p_petsc_solver = dynamic_cast<PETScKrylovLinearSolver*>(p_coarse_solver);
+            auto p_petsc_level_solver = dynamic_cast<PETScLevelSolver*>(p_coarse_solver);
             if (p_petsc_solver || p_petsc_level_solver)
             {
                 const KSP& petsc_ksp =

--- a/src/navier_stokes/StaggeredStokesLevelRelaxationFACOperator.cpp
+++ b/src/navier_stokes/StaggeredStokesLevelRelaxationFACOperator.cpp
@@ -263,13 +263,13 @@ StaggeredStokesLevelRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, do
         level_solver->setSolutionTime(d_solution_time);
         level_solver->setTimeInterval(d_current_time, d_new_time);
         level_solver->setComponentsHaveNullspace(d_has_velocity_nullspace, d_has_pressure_nullspace);
-        LinearSolver* p_level_solver = dynamic_cast<LinearSolver*>(level_solver.getPointer());
+        auto p_level_solver = dynamic_cast<LinearSolver*>(level_solver.getPointer());
         if (p_level_solver)
         {
             bool initial_guess_nonzero = true;
 
-            PETScKrylovLinearSolver* p_petsc_solver = dynamic_cast<PETScKrylovLinearSolver*>(p_level_solver);
-            PETScLevelSolver* p_petsc_level_solver = dynamic_cast<PETScLevelSolver*>(p_level_solver);
+            auto p_petsc_solver = dynamic_cast<PETScKrylovLinearSolver*>(p_level_solver);
+            auto p_petsc_level_solver = dynamic_cast<PETScLevelSolver*>(p_level_solver);
 
             if (p_petsc_solver || p_petsc_level_solver)
             {

--- a/src/navier_stokes/StaggeredStokesOperator.cpp
+++ b/src/navier_stokes/StaggeredStokesOperator.cpp
@@ -118,12 +118,10 @@ StaggeredStokesOperator::StaggeredStokesOperator(const std::string& object_name,
     // boundary conditions for the pressure.
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        LocationIndexRobinBcCoefs<NDIM>* p_default_U_bc_coef =
-            dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_U_bc_coef);
+        auto p_default_U_bc_coef = dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_U_bc_coef);
         p_default_U_bc_coef->setBoundaryValue(2 * d, 0.0);
         p_default_U_bc_coef->setBoundaryValue(2 * d + 1, 0.0);
-        LocationIndexRobinBcCoefs<NDIM>* p_default_P_bc_coef =
-            dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_P_bc_coef);
+        auto p_default_P_bc_coef = dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_P_bc_coef);
         p_default_P_bc_coef->setBoundarySlope(2 * d, 0.0);
         p_default_P_bc_coef->setBoundarySlope(2 * d + 1, 0.0);
     }

--- a/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
@@ -368,8 +368,7 @@ StaggeredStokesPETScMatUtilities::constructPatchLevelMACStokesOp(
 
                 // Set the boundary condition coefficients.
                 static const bool homogeneous_bc = true;
-                ExtendedRobinBcCoefStrategy* extended_bc_coef =
-                    dynamic_cast<ExtendedRobinBcCoefStrategy*>(u_bc_coefs[axis]);
+                auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(u_bc_coefs[axis]);
                 if (extended_bc_coef)
                 {
                     extended_bc_coef->clearTargetPatchDataIndex();
@@ -471,8 +470,7 @@ StaggeredStokesPETScMatUtilities::constructPatchLevelMACStokesOp(
 
                 // Set the boundary condition coefficients.
                 static const bool homogeneous_bc = true;
-                ExtendedRobinBcCoefStrategy* extended_bc_coef =
-                    dynamic_cast<ExtendedRobinBcCoefStrategy*>(u_bc_coefs[axis]);
+                auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(u_bc_coefs[axis]);
                 if (extended_bc_coef)
                 {
                     extended_bc_coef->clearTargetPatchDataIndex();

--- a/src/navier_stokes/StaggeredStokesPhysicalBoundaryHelper.cpp
+++ b/src/navier_stokes/StaggeredStokesPhysicalBoundaryHelper.cpp
@@ -133,7 +133,7 @@ StaggeredStokesPhysicalBoundaryHelper::enforceNormalVelocityBoundaryConditions(
                                                              *patch,
                                                              trimmed_bdry_box,
                                                              fill_time);
-                    ExtendedRobinBcCoefStrategy* const extended_bc_coef =
+                    auto const extended_bc_coef =
                         dynamic_cast<ExtendedRobinBcCoefStrategy*>(u_bc_coefs[bdry_normal_axis]);
                     if (homogeneous_bc && !extended_bc_coef) gcoef_data->fillAll(0.0);
                     for (Box<NDIM>::Iterator it(bc_coef_box); it; it++)
@@ -261,26 +261,26 @@ StaggeredStokesPhysicalBoundaryHelper::setupBcCoefObjects(const std::vector<Robi
 #endif
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        ExtendedRobinBcCoefStrategy* extended_u_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(u_bc_coefs[d]);
+        auto extended_u_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(u_bc_coefs[d]);
         if (extended_u_bc_coef)
         {
             extended_u_bc_coef->clearTargetPatchDataIndex();
             extended_u_bc_coef->setHomogeneousBc(homogeneous_bc);
         }
-        StokesBcCoefStrategy* stokes_u_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(u_bc_coefs[d]);
+        auto stokes_u_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(u_bc_coefs[d]);
         if (stokes_u_bc_coef)
         {
             stokes_u_bc_coef->setTargetVelocityPatchDataIndex(u_target_data_idx);
             stokes_u_bc_coef->setTargetPressurePatchDataIndex(p_target_data_idx);
         }
     }
-    ExtendedRobinBcCoefStrategy* extended_p_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(p_bc_coef);
+    auto extended_p_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(p_bc_coef);
     if (extended_p_bc_coef)
     {
         extended_p_bc_coef->clearTargetPatchDataIndex();
         extended_p_bc_coef->setHomogeneousBc(homogeneous_bc);
     }
-    StokesBcCoefStrategy* stokes_p_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(p_bc_coef);
+    auto stokes_p_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(p_bc_coef);
     if (stokes_p_bc_coef)
     {
         stokes_p_bc_coef->setTargetVelocityPatchDataIndex(u_target_data_idx);
@@ -298,14 +298,14 @@ StaggeredStokesPhysicalBoundaryHelper::resetBcCoefObjects(const std::vector<Robi
 #endif
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        StokesBcCoefStrategy* stokes_u_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(u_bc_coefs[d]);
+        auto stokes_u_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(u_bc_coefs[d]);
         if (stokes_u_bc_coef)
         {
             stokes_u_bc_coef->clearTargetVelocityPatchDataIndex();
             stokes_u_bc_coef->clearTargetPressurePatchDataIndex();
         }
     }
-    StokesBcCoefStrategy* stokes_p_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(p_bc_coef);
+    auto stokes_p_bc_coef = dynamic_cast<StokesBcCoefStrategy*>(p_bc_coef);
     if (stokes_p_bc_coef)
     {
         stokes_p_bc_coef->clearTargetVelocityPatchDataIndex();

--- a/src/navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
@@ -236,7 +236,7 @@ StaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, doub
     //
     // An approximate Helmholtz solver is used.
     d_velocity_solver->setHomogeneousBc(true);
-    LinearSolver* p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
+    auto p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
     if (p_velocity_solver) p_velocity_solver->setInitialGuessNonzero(false);
     d_velocity_solver->solveSystem(*U_vec, *F_U_vec);
 
@@ -285,7 +285,7 @@ StaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, doub
                          F_P_idx,
                          F_P_cc_var);
     d_pressure_solver->setHomogeneousBc(true);
-    LinearSolver* p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
+    auto p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
     p_pressure_solver->setInitialGuessNonzero(false);
     d_pressure_solver->solveSystem(*Phi_scratch_vec, *F_Phi_vec);
     if (steady_state)

--- a/src/navier_stokes/StaggeredStokesSolver.cpp
+++ b/src/navier_stokes/StaggeredStokesSolver.cpp
@@ -70,12 +70,10 @@ StaggeredStokesSolver::StaggeredStokesSolver()
     // boundary conditions for the pressure.
     for (unsigned int d = 0; d < NDIM; ++d)
     {
-        LocationIndexRobinBcCoefs<NDIM>* p_default_U_bc_coef =
-            dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_U_bc_coef);
+        auto p_default_U_bc_coef = dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_U_bc_coef);
         p_default_U_bc_coef->setBoundaryValue(2 * d, 0.0);
         p_default_U_bc_coef->setBoundaryValue(2 * d + 1, 0.0);
-        LocationIndexRobinBcCoefs<NDIM>* p_default_P_bc_coef =
-            dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_P_bc_coef);
+        auto p_default_P_bc_coef = dynamic_cast<LocationIndexRobinBcCoefs<NDIM>*>(d_default_P_bc_coef);
         p_default_P_bc_coef->setBoundarySlope(2 * d, 0.0);
         p_default_P_bc_coef->setBoundarySlope(2 * d + 1, 0.0);
     }

--- a/src/navier_stokes/StaggeredStokesSolverManager.cpp
+++ b/src/navier_stokes/StaggeredStokesSolverManager.cpp
@@ -127,7 +127,7 @@ StaggeredStokesSolverManager::allocateSolver(const std::string& solver_type,
                                              Pointer<Database> solver_input_db,
                                              const std::string& solver_default_options_prefix) const
 {
-    std::map<std::string, SolverMaker>::const_iterator it = d_solver_maker_map.find(solver_type);
+    auto it = d_solver_maker_map.find(solver_type);
     if (it == d_solver_maker_map.end())
     {
         TBOX_ERROR("CCPoissonSolverManager::allocateSolver():\n"

--- a/src/navier_stokes/VCStaggeredStokesProjectionPreconditioner.cpp
+++ b/src/navier_stokes/VCStaggeredStokesProjectionPreconditioner.cpp
@@ -237,7 +237,7 @@ VCStaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, do
     //
     // An approximate Helmholtz solver is used.
     d_velocity_solver->setHomogeneousBc(true);
-    LinearSolver* p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
+    auto p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
     if (p_velocity_solver) p_velocity_solver->setInitialGuessNonzero(false);
     d_velocity_solver->solveSystem(*U_vec, *F_U_vec);
 
@@ -287,7 +287,7 @@ VCStaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, do
                          F_P_idx,
                          F_P_cc_var);
     d_pressure_solver->setHomogeneousBc(true);
-    LinearSolver* p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
+    auto p_pressure_solver = dynamic_cast<LinearSolver*>(d_pressure_solver.getPointer());
     p_pressure_solver->setInitialGuessNonzero(false);
     d_pressure_solver->solveSystem(*Phi_scratch_vec, *F_Phi_vec);
 

--- a/src/utilities/RNG.cpp
+++ b/src/utilities/RNG.cpp
@@ -280,7 +280,7 @@ RNG::parallel_seed(int global_seed)
 
             // Insert the unique seeds into the seed vector.
             unsigned i = 0;
-            for (std::set<int>::const_iterator cit = seed_set.begin(); cit != seed_set.end(); ++cit, ++i)
+            for (auto cit = seed_set.begin(); cit != seed_set.end(); ++cit, ++i)
             {
                 seeds[i] = *cit;
             }


### PR DESCRIPTION
Clang-tidy changes of auto.

This also uses auto for certain uses of Box and Pointer with the following classes:
`Patch`
`GridGeometry`
`PatchGeometry`
`PatchData`
`BoxTree`
`ArrayData`
`BoxGeometry`
`BoxOverlap`
`CoarsenOperator`
`RefineOperator`
`CoarsenSchedule`
`RefineSchedule`
`Variable`
`BoundaryBox`

The script to make the changes is located in `scripts/convert_to_c++11`