### PR TITLE
Prefer range based for loops.

### DIFF
--- a/ibtk/include/ibtk/FEDataInterpolation.h
+++ b/ibtk/include/ibtk/FEDataInterpolation.h
@@ -58,9 +58,8 @@ public:
     inline void attachQuadratureRule(libMesh::QBase* qrule)
     {
         d_qrule = qrule;
-        for (size_t k = 0; k < d_fe.size(); ++k)
+        for (auto fe : d_fe)
         {
-            SAMRAI::tbox::Pointer<libMesh::FEBase> fe = d_fe[k];
             if (fe)
             {
                 fe->attach_quadrature_rule(d_qrule);
@@ -72,9 +71,8 @@ public:
     inline void attachQuadratureRuleFace(libMesh::QBase* qrule_face)
     {
         d_qrule_face = qrule_face;
-        for (size_t k = 0; k < d_fe_face.size(); ++k)
+        for (auto fe_face : d_fe_face)
         {
-            SAMRAI::tbox::Pointer<libMesh::FEBase> fe_face = d_fe_face[k];
             if (fe_face)
             {
                 fe_face->attach_quadrature_rule(d_qrule_face);

--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -617,9 +617,8 @@ intersect_line_with_edge(std::vector<std::pair<double, libMesh::Point> >& t_vals
         }
 
         // Look for intersections within the element interior.
-        for (unsigned int k = 0; k < u_vals.size(); ++k)
+        for (const auto& u : u_vals)
         {
-            double u = u_vals[k];
             if (u >= -1.0 - tol && u <= 1.0 + tol)
             {
                 is_interior_intersection = (u >= -1.0 && u <= 1.0);
@@ -767,9 +766,8 @@ intersect_line_with_face(std::vector<std::pair<double, libMesh::Point> >& t_vals
             }
         }
 
-        for (unsigned int k = 0; k < v_vals.size(); ++k)
+        for (const auto& v : v_vals)
         {
-            double v = v_vals[k];
             if (v >= 0.0 - tol && v <= 1.0 + tol)
             {
                 double u;

--- a/ibtk/include/ibtk/private/LDataManager-inl.h
+++ b/ibtk/include/ibtk/private/LDataManager-inl.h
@@ -165,11 +165,9 @@ LDataManager::getLagrangianStructureNames(const int level_number) const
     TBOX_ASSERT(d_coarsest_ln <= level_number && d_finest_ln >= level_number);
 #endif
     std::vector<std::string> ret_val;
-    for (std::map<int, std::string>::const_iterator cit(d_strct_id_to_strct_name_map[level_number].begin());
-         cit != d_strct_id_to_strct_name_map[level_number].end();
-         ++cit)
+    for (const auto& map : d_strct_id_to_strct_name_map[level_number])
     {
-        ret_val.push_back(cit->second);
+        ret_val.push_back(map.second);
     }
     return ret_val;
 } // getLagrangianStructureNames
@@ -181,11 +179,9 @@ LDataManager::getLagrangianStructureIDs(const int level_number) const
     TBOX_ASSERT(d_coarsest_ln <= level_number && d_finest_ln >= level_number);
 #endif
     std::vector<int> ret_val;
-    for (std::map<std::string, int>::const_iterator cit(d_strct_name_to_strct_id_map[level_number].begin());
-         cit != d_strct_name_to_strct_id_map[level_number].end();
-         ++cit)
+    for (const auto& map : d_strct_name_to_strct_id_map[level_number])
     {
-        ret_val.push_back(cit->second);
+        ret_val.push_back(map.second);
     }
     return ret_val;
 } // getLagrangianStructureIDs

--- a/ibtk/include/ibtk/private/LNode-inl.h
+++ b/ibtk/include/ibtk/private/LNode-inl.h
@@ -102,10 +102,9 @@ inline void
 LNode::registerPeriodicShift(const SAMRAI::hier::IntVector<NDIM>& offset, const Vector& displacement)
 {
     LNodeIndex::registerPeriodicShift(offset, displacement);
-    for (std::vector<SAMRAI::tbox::Pointer<Streamable> >::iterator it = d_node_data.begin(); it != d_node_data.end();
-         ++it)
+    for (const auto& node : d_node_data)
     {
-        (*it)->registerPeriodicShift(offset, displacement);
+        node->registerPeriodicShift(offset, displacement);
     }
     return;
 } // registerPeriodicShift

--- a/ibtk/include/ibtk/private/StreamableManager-inl.h
+++ b/ibtk/include/ibtk/private/StreamableManager-inl.h
@@ -56,9 +56,9 @@ inline size_t
 StreamableManager::getDataStreamSize(const std::vector<SAMRAI::tbox::Pointer<Streamable> >& data_items) const
 {
     size_t size = SAMRAI::tbox::AbstractStream::sizeofInt();
-    for (unsigned int k = 0; k < data_items.size(); ++k)
+    for (const auto& data_item : data_items)
     {
-        size += getDataStreamSize(data_items[k]);
+        size += getDataStreamSize(data_item);
     }
     return size;
 } // getDataStreamSize
@@ -81,9 +81,9 @@ StreamableManager::packStream(SAMRAI::tbox::AbstractStream& stream,
 {
     const int num_data = static_cast<int>(data_items.size());
     stream.pack(&num_data, 1);
-    for (unsigned int k = 0; k < data_items.size(); ++k)
+    for (auto& data_item : data_items)
     {
-        packStream(stream, data_items[k]);
+        packStream(stream, data_item);
     }
     return;
 } // packStream
@@ -107,9 +107,9 @@ StreamableManager::unpackStream(SAMRAI::tbox::AbstractStream& stream,
     int num_data;
     stream.unpack(&num_data, 1);
     data_items.resize(num_data);
-    for (unsigned int k = 0; k < data_items.size(); ++k)
+    for (auto& data_item : data_items)
     {
-        data_items[k] = unpackStream(stream, offset);
+        data_item = unpackStream(stream, offset);
     }
     std::vector<SAMRAI::tbox::Pointer<Streamable> >(data_items).swap(data_items); // trim-to-fit
     return;

--- a/ibtk/src/boundary/HierarchyGhostCellInterpolation.cpp
+++ b/ibtk/src/boundary/HierarchyGhostCellInterpolation.cpp
@@ -208,12 +208,12 @@ HierarchyGhostCellInterpolation::initializeOperatorState(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     bool registered_coarsen_op = false;
     d_coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const std::string& coarsen_op_name = d_transaction_comps[comp_idx].d_coarsen_op_name;
+        const std::string& coarsen_op_name = transaction_comp.d_coarsen_op_name;
         if (coarsen_op_name != "NONE")
         {
-            const int src_data_idx = d_transaction_comps[comp_idx].d_src_data_idx;
+            const int src_data_idx = transaction_comp.d_src_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(src_data_idx, var);
 #if !defined(NDEBUG)
@@ -334,9 +334,9 @@ HierarchyGhostCellInterpolation::initializeOperatorState(
 
         const std::vector<RobinBcCoefStrategy<NDIM>*>& robin_bc_coefs = d_transaction_comps[comp_idx].d_robin_bc_coefs;
         bool null_bc_coefs = true;
-        for (auto cit = robin_bc_coefs.begin(); cit != robin_bc_coefs.end(); ++cit)
+        for (const auto& robin_bc_coef : robin_bc_coefs)
         {
-            if (*cit) null_bc_coefs = false;
+            if (robin_bc_coef) null_bc_coefs = false;
         }
         if (!null_bc_coefs && cc_var)
         {
@@ -414,12 +414,12 @@ HierarchyGhostCellInterpolation::resetTransactionComponents(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     bool registered_coarsen_op = false;
     d_coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const std::string& coarsen_op_name = d_transaction_comps[comp_idx].d_coarsen_op_name;
+        const std::string& coarsen_op_name = transaction_comp.d_coarsen_op_name;
         if (coarsen_op_name != "NONE")
         {
-            const int src_data_idx = d_transaction_comps[comp_idx].d_src_data_idx;
+            const int src_data_idx = transaction_comp.d_src_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(src_data_idx, var);
 #if !defined(NDEBUG)
@@ -514,9 +514,9 @@ HierarchyGhostCellInterpolation::resetTransactionComponents(
         const std::vector<RobinBcCoefStrategy<NDIM>*>& robin_bc_coefs = d_transaction_comps[comp_idx].d_robin_bc_coefs;
 #if !defined(NDEBUG)
         bool null_bc_coefs = true;
-        for (auto cit = robin_bc_coefs.begin(); cit != robin_bc_coefs.end(); ++cit)
+        for (const auto& robin_bc_coef : robin_bc_coefs)
         {
-            if (*cit) null_bc_coefs = false;
+            if (robin_bc_coef) null_bc_coefs = false;
         }
 #endif
         if (d_cc_robin_bc_ops[comp_idx])

--- a/ibtk/src/boundary/cf_interface/CartCellDoubleLinearCFInterpolation.cpp
+++ b/ibtk/src/boundary/cf_interface/CartCellDoubleLinearCFInterpolation.cpp
@@ -150,9 +150,8 @@ CartCellDoubleLinearCFInterpolation::postprocessRefine(Patch<NDIM>& fine,
                                                        const Box<NDIM>& fine_box,
                                                        const IntVector<NDIM>& ratio)
 {
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_index : d_patch_data_indices)
     {
-        const int& patch_data_index = *cit;
         d_refine_op->refine(fine, coarse, patch_data_index, patch_data_index, fine_box, ratio);
     }
     return;
@@ -235,16 +234,16 @@ void
 CartCellDoubleLinearCFInterpolation::clearPatchHierarchy()
 {
     d_hierarchy.setNull();
-    for (auto it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
+    for (auto& cf_boundary : d_cf_boundary)
     {
-        delete (*it);
-        (*it) = nullptr;
+        delete cf_boundary;
+        cf_boundary = nullptr;
     }
     d_cf_boundary.clear();
-    for (auto it = d_domain_boxes.begin(); it != d_domain_boxes.end(); ++it)
+    for (auto& domain_box : d_domain_boxes)
     {
-        delete (*it);
-        (*it) = nullptr;
+        delete domain_box;
+        domain_box = nullptr;
     }
     d_domain_boxes.clear();
     d_periodic_shift.clear();
@@ -281,9 +280,8 @@ CartCellDoubleLinearCFInterpolation::computeNormalExtension(Patch<NDIM>& patch,
     if (n_cf_bdry_codim1_boxes == 0) return;
 
     // Get the patch data.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_index : d_patch_data_indices)
     {
-        const int& patch_data_index = *cit;
         Pointer<CellData<NDIM, double> > data = patch.getPatchData(patch_data_index);
 #if !defined(NDEBUG)
         TBOX_ASSERT(data);

--- a/ibtk/src/boundary/cf_interface/CartCellDoubleQuadraticCFInterpolation.cpp
+++ b/ibtk/src/boundary/cf_interface/CartCellDoubleQuadraticCFInterpolation.cpp
@@ -159,9 +159,9 @@ coarsen(const Index<NDIM>& index, const IntVector<NDIM>& ratio)
 inline bool
 bdry_boxes_contain_index(const Index<NDIM>& i, const std::vector<const BoundaryBox<NDIM>*>& patch_cf_bdry_boxes)
 {
-    for (auto cit = patch_cf_bdry_boxes.begin(); cit != patch_cf_bdry_boxes.end(); ++cit)
+    for (const auto& patch_cf_bdry_box : patch_cf_bdry_boxes)
     {
-        const BoundaryBox<NDIM>& bdry_box = *(*cit);
+        const BoundaryBox<NDIM>& bdry_box = *patch_cf_bdry_box;
         if (bdry_box.getBox().contains(i)) return true;
     }
     return false;
@@ -273,9 +273,8 @@ CartCellDoubleQuadraticCFInterpolation::postprocessRefine(Patch<NDIM>& fine,
     // boundary box information.
     if (!fine.inHierarchy())
     {
-        for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+        for (int patch_data_index : d_patch_data_indices)
         {
-            const int& patch_data_index = *cit;
             d_refine_op->refine(fine, coarse, patch_data_index, patch_data_index, fine_box, ratio);
         }
         return;
@@ -372,16 +371,16 @@ void
 CartCellDoubleQuadraticCFInterpolation::clearPatchHierarchy()
 {
     d_hierarchy.setNull();
-    for (auto it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
+    for (auto& cf_boundary : d_cf_boundary)
     {
-        delete (*it);
-        (*it) = nullptr;
+        delete cf_boundary;
+        cf_boundary = nullptr;
     }
     d_cf_boundary.clear();
-    for (auto it = d_domain_boxes.begin(); it != d_domain_boxes.end(); ++it)
+    for (auto& domain_box : d_domain_boxes)
     {
-        delete (*it);
-        (*it) = nullptr;
+        delete domain_box;
+        domain_box = nullptr;
     }
     d_domain_boxes.clear();
     d_periodic_shift.clear();
@@ -463,9 +462,8 @@ CartCellDoubleQuadraticCFInterpolation::postprocessRefine_expensive(Patch<NDIM>&
     if (patch_cf_bdry_boxes.empty()) return;
 
     // Get the patch data.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (int patch_data_index : d_patch_data_indices)
     {
-        const int& patch_data_index = *cit;
         Pointer<CellData<NDIM, double> > fdata = fine.getPatchData(patch_data_index);
         Pointer<CellData<NDIM, double> > cdata = coarse.getPatchData(patch_data_index);
 #if !defined(NDEBUG)
@@ -498,9 +496,9 @@ CartCellDoubleQuadraticCFInterpolation::postprocessRefine_expensive(Patch<NDIM>&
         // we perform coarse interpolation in all directions.
         const BoxArray<NDIM>& domain_boxes = *d_domain_boxes[fine_patch_level_num];
         const IntVector<NDIM>& periodic_shift = d_periodic_shift[fine_patch_level_num];
-        for (auto cit = patch_cf_bdry_boxes.begin(); cit != patch_cf_bdry_boxes.end(); ++cit)
+        for (const auto& patch_cf_bdry_box : patch_cf_bdry_boxes)
         {
-            const BoundaryBox<NDIM>& bdry_box = *(*cit);
+            const BoundaryBox<NDIM>& bdry_box = *patch_cf_bdry_box;
             const Box<NDIM> bc_fill_box = pgeom_fine->getBoundaryFillBox(bdry_box, patch_box_fine, ghost_width_to_fill);
 
             const int bdry_type = bdry_box.getBoundaryType();
@@ -627,9 +625,8 @@ CartCellDoubleQuadraticCFInterpolation::postprocessRefine_optimized(Patch<NDIM>&
     if (cf_bdry_codim1_boxes.size() == 0) return;
 
     // Get the patch data.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_index : d_patch_data_indices)
     {
-        const int& patch_data_index = *cit;
         Pointer<CellData<NDIM, double> > fdata = fine.getPatchData(patch_data_index);
         Pointer<CellData<NDIM, double> > cdata = coarse.getPatchData(patch_data_index);
 #if !defined(NDEBUG)
@@ -744,9 +741,8 @@ CartCellDoubleQuadraticCFInterpolation::computeNormalExtension_expensive(Patch<N
 #endif
 
     // Get the patch data.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_index : d_patch_data_indices)
     {
-        const int& patch_data_index = *cit;
         Pointer<CellData<NDIM, double> > data = patch.getPatchData(patch_data_index);
 #if !defined(NDEBUG)
         TBOX_ASSERT(data);
@@ -835,9 +831,8 @@ CartCellDoubleQuadraticCFInterpolation::computeNormalExtension_optimized(Patch<N
     if (n_cf_bdry_codim1_boxes == 0) return;
 
     // Get the patch data.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (int patch_data_index : d_patch_data_indices)
     {
-        const int& patch_data_index = *cit;
         Pointer<CellData<NDIM, double> > data = patch.getPatchData(patch_data_index);
 #if !defined(NDEBUG)
         TBOX_ASSERT(data);

--- a/ibtk/src/boundary/cf_interface/CartSideDoubleQuadraticCFInterpolation.cpp
+++ b/ibtk/src/boundary/cf_interface/CartSideDoubleQuadraticCFInterpolation.cpp
@@ -233,9 +233,8 @@ CartSideDoubleQuadraticCFInterpolation::postprocessRefine(Patch<NDIM>& fine,
     // boundary box information.
     if (!fine.inHierarchy())
     {
-        for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+        for (const auto& patch_data_index : d_patch_data_indices)
         {
-            const int& patch_data_index = *cit;
             d_refine_op->refine(fine, coarse, patch_data_index, patch_data_index, fine_box, ratio);
         }
         return;
@@ -259,9 +258,8 @@ CartSideDoubleQuadraticCFInterpolation::postprocessRefine(Patch<NDIM>& fine,
     if (cf_bdry_codim1_boxes.size() == 0) return;
 
     // Get the patch data.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_index : d_patch_data_indices)
     {
-        const int& patch_data_index = *cit;
         Pointer<SideData<NDIM, double> > fdata = fine.getPatchData(patch_data_index);
         Pointer<SideData<NDIM, double> > cdata = coarse.getPatchData(patch_data_index);
         Pointer<SideData<NDIM, int> > indicator_data = fine.getPatchData(d_sc_indicator_idx);
@@ -451,10 +449,10 @@ void
 CartSideDoubleQuadraticCFInterpolation::clearPatchHierarchy()
 {
     d_hierarchy.setNull();
-    for (auto it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
+    for (auto& cf_boundary : d_cf_boundary)
     {
-        delete (*it);
-        (*it) = nullptr;
+        delete cf_boundary;
+        cf_boundary = nullptr;
     }
     d_cf_boundary.clear();
     return;
@@ -495,9 +493,8 @@ CartSideDoubleQuadraticCFInterpolation::computeNormalExtension(Patch<NDIM>& patc
     if (n_cf_bdry_codim1_boxes == 0) return;
 
     // Get the patch data.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_index : d_patch_data_indices)
     {
-        const int& patch_data_index = *cit;
         Pointer<SideData<NDIM, double> > data = patch.getPatchData(patch_data_index);
         SideData<NDIM, double> data_copy(data->getBox(), data->getDepth(), data->getGhostCellWidth());
         data_copy.copyOnBox(*data, data->getGhostBox());

--- a/ibtk/src/boundary/physical_boundary/CartCellRobinPhysBdryOp.cpp
+++ b/ibtk/src/boundary/physical_boundary/CartCellRobinPhysBdryOp.cpp
@@ -281,9 +281,8 @@ CartCellRobinPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
 
     // Ensure the target patch data corresponds to a cell centered variable and
     // that the proper number of boundary condition objects have been provided.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         Pointer<CellData<NDIM, double> > patch_data = patch.getPatchData(patch_data_idx);
         if (!patch_data)
         {
@@ -315,25 +314,22 @@ CartCellRobinPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
     static const bool adjoint_op = false;
     const Array<BoundaryBox<NDIM> > physical_codim1_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim1Boxes(patch);
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1(
             patch_data_idx, physical_codim1_boxes, fill_time, ghost_width_to_fill, patch, adjoint_op);
     }
     const Array<BoundaryBox<NDIM> > physical_codim2_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim2Boxes(patch);
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim2(patch_data_idx, physical_codim2_boxes, ghost_width_to_fill, patch, adjoint_op);
     }
 #if (NDIM > 2)
     const Array<BoundaryBox<NDIM> > physical_codim3_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim3Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim3(patch_data_idx, physical_codim3_boxes, ghost_width_to_fill, patch, adjoint_op);
     }
 #endif
@@ -355,9 +351,8 @@ CartCellRobinPhysBdryOp::accumulateFromPhysicalBoundaryData(Patch<NDIM>& patch,
 
     // Ensure the target patch data corresponds to a cell centered variable and
     // that the proper number of boundary condition objects have been provided.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         Pointer<CellData<NDIM, double> > patch_data = patch.getPatchData(patch_data_idx);
         if (!patch_data)
         {
@@ -390,24 +385,21 @@ CartCellRobinPhysBdryOp::accumulateFromPhysicalBoundaryData(Patch<NDIM>& patch,
 #if (NDIM > 2)
     const Array<BoundaryBox<NDIM> > physical_codim3_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim3Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim3(patch_data_idx, physical_codim3_boxes, ghost_width_to_fill, patch, adjoint_op);
     }
 #endif
     const Array<BoundaryBox<NDIM> > physical_codim2_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim2Boxes(patch);
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim2(patch_data_idx, physical_codim2_boxes, ghost_width_to_fill, patch, adjoint_op);
     }
     const Array<BoundaryBox<NDIM> > physical_codim1_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim1Boxes(patch);
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1(
             patch_data_idx, physical_codim1_boxes, fill_time, ghost_width_to_fill, patch, adjoint_op);
     }

--- a/ibtk/src/boundary/physical_boundary/CartExtrapPhysBdryOp.cpp
+++ b/ibtk/src/boundary/physical_boundary/CartExtrapPhysBdryOp.cpp
@@ -361,9 +361,8 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_cell(
 
     // Set the physical boundary conditions for the specified patch data
     // indices.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         Pointer<Variable<NDIM> > var;
         var_db->mapIndexToVariable(patch_data_idx, var);
@@ -374,11 +373,11 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_cell(
         const Box<NDIM>& ghost_box = patch_data->getGhostBox();
 
         // Loop over the boundary fill boxes and extrapolate the data.
-        for (auto it = bdry_fill_boxes.begin(); it != bdry_fill_boxes.end(); ++it)
+        for (const auto& bdry_fill_box_pair : bdry_fill_boxes)
         {
-            const Box<NDIM>& bdry_fill_box = it->first;
-            const unsigned int location_index = it->second.first;
-            const int codim = it->second.second;
+            const Box<NDIM>& bdry_fill_box = bdry_fill_box_pair.first;
+            const unsigned int location_index = bdry_fill_box_pair.second.first;
+            const int codim = bdry_fill_box_pair.second.second;
 #if (NDIM == 2)
             const std::array<bool, NDIM> is_lower = { { PhysicalBoundaryUtilities::isLower(location_index, codim, 0),
                                                           PhysicalBoundaryUtilities::isLower(
@@ -464,9 +463,8 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_face(
 
     // Set the physical boundary conditions for the specified patch data
     // indices.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         Pointer<Variable<NDIM> > var;
         var_db->mapIndexToVariable(patch_data_idx, var);
@@ -476,11 +474,11 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_face(
         const Box<NDIM>& ghost_box = patch_data->getGhostBox();
 
         // Loop over the boundary fill boxes and extrapolate the data.
-        for (auto it = bdry_fill_boxes.begin(); it != bdry_fill_boxes.end(); ++it)
+        for (const auto& bdry_fill_box_pair : bdry_fill_boxes)
         {
-            const Box<NDIM>& bdry_fill_box = it->first;
-            const unsigned int location_index = it->second.first;
-            const int codim = it->second.second;
+            const Box<NDIM>& bdry_fill_box = bdry_fill_box_pair.first;
+            const unsigned int location_index = bdry_fill_box_pair.second.first;
+            const int codim = bdry_fill_box_pair.second.second;
 #if (NDIM == 2)
             const std::array<bool, NDIM> is_lower = { { PhysicalBoundaryUtilities::isLower(location_index, codim, 0),
                                                           PhysicalBoundaryUtilities::isLower(
@@ -574,9 +572,8 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_node(
 
     // Set the physical boundary conditions for the specified patch data
     // indices.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (int patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         Pointer<Variable<NDIM> > var;
         var_db->mapIndexToVariable(patch_data_idx, var);
@@ -586,11 +583,11 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_node(
         const Box<NDIM>& ghost_box = patch_data->getGhostBox();
 
         // Loop over the boundary fill boxes and extrapolate the data.
-        for (auto it = bdry_fill_boxes.begin(); it != bdry_fill_boxes.end(); ++it)
+        for (const auto& bdry_fill_box_pair : bdry_fill_boxes)
         {
-            const Box<NDIM>& bdry_fill_box = it->first;
-            const unsigned int location_index = it->second.first;
-            const int codim = it->second.second;
+            const Box<NDIM>& bdry_fill_box = bdry_fill_box_pair.first;
+            const unsigned int location_index = bdry_fill_box_pair.second.first;
+            const int codim = bdry_fill_box_pair.second.second;
 #if (NDIM == 2)
             const std::array<bool, NDIM> is_lower = { { PhysicalBoundaryUtilities::isLower(location_index, codim, 0),
                                                           PhysicalBoundaryUtilities::isLower(
@@ -676,9 +673,8 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_side(
 
     // Set the physical boundary conditions for the specified patch data
     // indices.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         Pointer<Variable<NDIM> > var;
         var_db->mapIndexToVariable(patch_data_idx, var);
@@ -688,11 +684,11 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions_side(
         const Box<NDIM>& ghost_box = patch_data->getGhostBox();
 
         // Loop over the boundary fill boxes and extrapolate the data.
-        for (auto it = bdry_fill_boxes.begin(); it != bdry_fill_boxes.end(); ++it)
+        for (const auto& bdry_fill_box_map : bdry_fill_boxes)
         {
-            const Box<NDIM>& bdry_fill_box = it->first;
-            const unsigned int location_index = it->second.first;
-            const int codim = it->second.second;
+            const Box<NDIM>& bdry_fill_box = bdry_fill_box_map.first;
+            const unsigned int location_index = bdry_fill_box_map.second.first;
+            const int codim = bdry_fill_box_map.second.second;
 #if (NDIM == 2)
             const std::array<bool, NDIM> is_lower = { { PhysicalBoundaryUtilities::isLower(location_index, codim, 0),
                                                           PhysicalBoundaryUtilities::isLower(

--- a/ibtk/src/boundary/physical_boundary/CartSideRobinPhysBdryOp.cpp
+++ b/ibtk/src/boundary/physical_boundary/CartSideRobinPhysBdryOp.cpp
@@ -365,9 +365,8 @@ CartSideRobinPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
 
     // Ensure the target patch data corresponds to a side centered variable and
     // that the proper number of boundary condition objects have been provided.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         Pointer<SideData<NDIM, double> > patch_data = patch.getPatchData(patch_data_idx);
         if (!patch_data)
         {
@@ -399,31 +398,27 @@ CartSideRobinPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
     static const bool adjoint_op = false;
     const Array<BoundaryBox<NDIM> > physical_codim1_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim1Boxes(patch);
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1Normal(
             patch_data_idx, physical_codim1_boxes, fill_time, ghost_width_to_fill, patch, adjoint_op);
     }
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1Transverse(
             patch_data_idx, physical_codim1_boxes, fill_time, ghost_width_to_fill, patch, adjoint_op);
     }
     const Array<BoundaryBox<NDIM> > physical_codim2_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim2Boxes(patch);
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim2(patch_data_idx, physical_codim2_boxes, ghost_width_to_fill, patch, adjoint_op);
     }
 #if (NDIM > 2)
     const Array<BoundaryBox<NDIM> > physical_codim3_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim3Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim3(patch_data_idx, physical_codim3_boxes, ghost_width_to_fill, patch, adjoint_op);
     }
 #endif
@@ -445,9 +440,8 @@ CartSideRobinPhysBdryOp::accumulateFromPhysicalBoundaryData(Patch<NDIM>& patch,
 
     // Ensure the target patch data corresponds to a side centered variable and
     // that the proper number of boundary condition objects have been provided.
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         Pointer<SideData<NDIM, double> > patch_data = patch.getPatchData(patch_data_idx);
         if (!patch_data)
         {
@@ -480,30 +474,26 @@ CartSideRobinPhysBdryOp::accumulateFromPhysicalBoundaryData(Patch<NDIM>& patch,
 #if (NDIM > 2)
     const Array<BoundaryBox<NDIM> > physical_codim3_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim3Boxes(patch);
-    for (std::set<int>::const_iterator cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim3(patch_data_idx, physical_codim3_boxes, ghost_width_to_fill, patch, adjoint_op);
     }
 #endif
     const Array<BoundaryBox<NDIM> > physical_codim2_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim2Boxes(patch);
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim2(patch_data_idx, physical_codim2_boxes, ghost_width_to_fill, patch, adjoint_op);
     }
     const Array<BoundaryBox<NDIM> > physical_codim1_boxes =
         PhysicalBoundaryUtilities::getPhysicalBoundaryCodim1Boxes(patch);
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1Transverse(
             patch_data_idx, physical_codim1_boxes, fill_time, ghost_width_to_fill, patch, adjoint_op);
     }
-    for (auto cit = d_patch_data_indices.begin(); cit != d_patch_data_indices.end(); ++cit)
+    for (const auto& patch_data_idx : d_patch_data_indices)
     {
-        const int patch_data_idx = (*cit);
         fillGhostCellValuesCodim1Normal(
             patch_data_idx, physical_codim1_boxes, fill_time, ghost_width_to_fill, patch, adjoint_op);
     }

--- a/ibtk/src/boundary/physical_boundary/muParserRobinBcCoefs.cpp
+++ b/ibtk/src/boundary/physical_boundary/muParserRobinBcCoefs.cpp
@@ -244,12 +244,12 @@ muParserRobinBcCoefs::muParserRobinBcCoefs(const std::string& object_name,
     const double pi = 3.1415926535897932384626433832795;
     const double* const xLower = grid_geom->getXLower();
     const double* const xUpper = grid_geom->getXUpper();
-    for (auto cit = all_parsers.begin(); cit != all_parsers.end(); ++cit)
+    for (const auto& parser : all_parsers)
     {
         // Various names for pi.
-        (*cit)->DefineConst("pi", pi);
-        (*cit)->DefineConst("Pi", pi);
-        (*cit)->DefineConst("PI", pi);
+        parser->DefineConst("pi", pi);
+        parser->DefineConst("Pi", pi);
+        parser->DefineConst("PI", pi);
 
         // The extents of the domain.
         for (unsigned int d = 0; d < NDIM; ++d)
@@ -258,77 +258,77 @@ muParserRobinBcCoefs::muParserRobinBcCoefs(const std::string& object_name,
             stream << d;
             const std::string postfix = stream.str();
 
-            (*cit)->DefineConst("X_LOWER" + postfix, xLower[d]);
-            (*cit)->DefineConst("X_lower" + postfix, xLower[d]);
-            (*cit)->DefineConst("x_lower" + postfix, xLower[d]);
-            (*cit)->DefineConst("x_LOWER" + postfix, xLower[d]);
-            (*cit)->DefineConst("X_Lower" + postfix, xLower[d]);
-            (*cit)->DefineConst("X_lower" + postfix, xLower[d]);
-            (*cit)->DefineConst("XLower" + postfix, xLower[d]);
-            (*cit)->DefineConst("Xlower" + postfix, xLower[d]);
-            (*cit)->DefineConst("x_Lower" + postfix, xLower[d]);
-            (*cit)->DefineConst("x_lower" + postfix, xLower[d]);
-            (*cit)->DefineConst("xLower" + postfix, xLower[d]);
-            (*cit)->DefineConst("xlower" + postfix, xLower[d]);
+            parser->DefineConst("X_LOWER" + postfix, xLower[d]);
+            parser->DefineConst("X_lower" + postfix, xLower[d]);
+            parser->DefineConst("x_lower" + postfix, xLower[d]);
+            parser->DefineConst("x_LOWER" + postfix, xLower[d]);
+            parser->DefineConst("X_Lower" + postfix, xLower[d]);
+            parser->DefineConst("X_lower" + postfix, xLower[d]);
+            parser->DefineConst("XLower" + postfix, xLower[d]);
+            parser->DefineConst("Xlower" + postfix, xLower[d]);
+            parser->DefineConst("x_Lower" + postfix, xLower[d]);
+            parser->DefineConst("x_lower" + postfix, xLower[d]);
+            parser->DefineConst("xLower" + postfix, xLower[d]);
+            parser->DefineConst("xlower" + postfix, xLower[d]);
 
-            (*cit)->DefineConst("X_LOWER_" + postfix, xLower[d]);
-            (*cit)->DefineConst("X_lower_" + postfix, xLower[d]);
-            (*cit)->DefineConst("x_lower_" + postfix, xLower[d]);
-            (*cit)->DefineConst("x_LOWER_" + postfix, xLower[d]);
-            (*cit)->DefineConst("X_Lower_" + postfix, xLower[d]);
-            (*cit)->DefineConst("X_lower_" + postfix, xLower[d]);
-            (*cit)->DefineConst("XLower_" + postfix, xLower[d]);
-            (*cit)->DefineConst("Xlower_" + postfix, xLower[d]);
-            (*cit)->DefineConst("x_Lower_" + postfix, xLower[d]);
-            (*cit)->DefineConst("x_lower_" + postfix, xLower[d]);
-            (*cit)->DefineConst("xLower_" + postfix, xLower[d]);
-            (*cit)->DefineConst("xlower_" + postfix, xLower[d]);
+            parser->DefineConst("X_LOWER_" + postfix, xLower[d]);
+            parser->DefineConst("X_lower_" + postfix, xLower[d]);
+            parser->DefineConst("x_lower_" + postfix, xLower[d]);
+            parser->DefineConst("x_LOWER_" + postfix, xLower[d]);
+            parser->DefineConst("X_Lower_" + postfix, xLower[d]);
+            parser->DefineConst("X_lower_" + postfix, xLower[d]);
+            parser->DefineConst("XLower_" + postfix, xLower[d]);
+            parser->DefineConst("Xlower_" + postfix, xLower[d]);
+            parser->DefineConst("x_Lower_" + postfix, xLower[d]);
+            parser->DefineConst("x_lower_" + postfix, xLower[d]);
+            parser->DefineConst("xLower_" + postfix, xLower[d]);
+            parser->DefineConst("xlower_" + postfix, xLower[d]);
 
-            (*cit)->DefineConst("X_UPPER" + postfix, xUpper[d]);
-            (*cit)->DefineConst("X_upper" + postfix, xUpper[d]);
-            (*cit)->DefineConst("x_upper" + postfix, xUpper[d]);
-            (*cit)->DefineConst("x_UPPER" + postfix, xUpper[d]);
-            (*cit)->DefineConst("X_Upper" + postfix, xUpper[d]);
-            (*cit)->DefineConst("X_upper" + postfix, xUpper[d]);
-            (*cit)->DefineConst("XUpper" + postfix, xUpper[d]);
-            (*cit)->DefineConst("Xupper" + postfix, xUpper[d]);
-            (*cit)->DefineConst("x_Upper" + postfix, xUpper[d]);
-            (*cit)->DefineConst("x_upper" + postfix, xUpper[d]);
-            (*cit)->DefineConst("xUpper" + postfix, xUpper[d]);
-            (*cit)->DefineConst("xupper" + postfix, xUpper[d]);
+            parser->DefineConst("X_UPPER" + postfix, xUpper[d]);
+            parser->DefineConst("X_upper" + postfix, xUpper[d]);
+            parser->DefineConst("x_upper" + postfix, xUpper[d]);
+            parser->DefineConst("x_UPPER" + postfix, xUpper[d]);
+            parser->DefineConst("X_Upper" + postfix, xUpper[d]);
+            parser->DefineConst("X_upper" + postfix, xUpper[d]);
+            parser->DefineConst("XUpper" + postfix, xUpper[d]);
+            parser->DefineConst("Xupper" + postfix, xUpper[d]);
+            parser->DefineConst("x_Upper" + postfix, xUpper[d]);
+            parser->DefineConst("x_upper" + postfix, xUpper[d]);
+            parser->DefineConst("xUpper" + postfix, xUpper[d]);
+            parser->DefineConst("xupper" + postfix, xUpper[d]);
 
-            (*cit)->DefineConst("X_UPPER_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("X_upper_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("x_upper_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("x_UPPER_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("X_Upper_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("X_upper_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("XUpper_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("Xupper_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("x_Upper_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("x_upper_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("xUpper_" + postfix, xUpper[d]);
-            (*cit)->DefineConst("xupper_" + postfix, xUpper[d]);
+            parser->DefineConst("X_UPPER_" + postfix, xUpper[d]);
+            parser->DefineConst("X_upper_" + postfix, xUpper[d]);
+            parser->DefineConst("x_upper_" + postfix, xUpper[d]);
+            parser->DefineConst("x_UPPER_" + postfix, xUpper[d]);
+            parser->DefineConst("X_Upper_" + postfix, xUpper[d]);
+            parser->DefineConst("X_upper_" + postfix, xUpper[d]);
+            parser->DefineConst("XUpper_" + postfix, xUpper[d]);
+            parser->DefineConst("Xupper_" + postfix, xUpper[d]);
+            parser->DefineConst("x_Upper_" + postfix, xUpper[d]);
+            parser->DefineConst("x_upper_" + postfix, xUpper[d]);
+            parser->DefineConst("xUpper_" + postfix, xUpper[d]);
+            parser->DefineConst("xupper_" + postfix, xUpper[d]);
         }
 
         // User-provided constants.
-        for (auto map_cit = d_constants.begin(); map_cit != d_constants.end(); ++map_cit)
+        for (const auto& constant : d_constants)
         {
-            (*cit)->DefineConst(map_cit->first, map_cit->second);
+            parser->DefineConst(constant.first, constant.second);
         }
 
         // Variables.
-        (*cit)->DefineVar("T", &d_parser_time);
-        (*cit)->DefineVar("t", &d_parser_time);
+        parser->DefineVar("T", &d_parser_time);
+        parser->DefineVar("t", &d_parser_time);
         for (unsigned int d = 0; d < NDIM; ++d)
         {
             std::ostringstream stream;
             stream << d;
             const std::string postfix = stream.str();
-            (*cit)->DefineVar("X" + postfix, d_parser_posn.data() + d);
-            (*cit)->DefineVar("x" + postfix, d_parser_posn.data() + d);
-            (*cit)->DefineVar("X_" + postfix, d_parser_posn.data() + d);
-            (*cit)->DefineVar("x_" + postfix, d_parser_posn.data() + d);
+            parser->DefineVar("X" + postfix, d_parser_posn.data() + d);
+            parser->DefineVar("x" + postfix, d_parser_posn.data() + d);
+            parser->DefineVar("X_" + postfix, d_parser_posn.data() + d);
+            parser->DefineVar("x_" + postfix, d_parser_posn.data() + d);
         }
     }
     return;

--- a/ibtk/src/lagrangian/FEDataInterpolation.cpp
+++ b/ibtk/src/lagrangian/FEDataInterpolation.cpp
@@ -225,9 +225,9 @@ FEDataInterpolation::init(const bool use_IB_ghosted_vecs)
         const System& system = *d_systems[system_idx];
         const DofMap& system_dof_map = system.get_dof_map();
         const std::vector<int>& all_vars = d_system_all_vars[system_idx];
-        for (unsigned int k = 0; k < all_vars.size(); ++k)
+        for (const auto& var : all_vars)
         {
-            fe_type_set.insert(system_dof_map.variable_type(all_vars[k]));
+            fe_type_set.insert(system_dof_map.variable_type(var));
         }
     }
     const size_t num_noninterp_systems = d_noninterp_systems.size();
@@ -236,9 +236,9 @@ FEDataInterpolation::init(const bool use_IB_ghosted_vecs)
         const System& system = *d_noninterp_systems[system_idx];
         const DofMap& system_dof_map = system.get_dof_map();
         const std::vector<int>& all_vars = d_noninterp_system_all_vars[system_idx];
-        for (unsigned int k = 0; k < all_vars.size(); ++k)
+        for (const auto& var : all_vars)
         {
-            fe_type_set.insert(system_dof_map.variable_type(all_vars[k]));
+            fe_type_set.insert(system_dof_map.variable_type(var));
         }
     }
     d_fe_types.assign(fe_type_set.begin(), fe_type_set.end());
@@ -291,17 +291,17 @@ FEDataInterpolation::init(const bool use_IB_ghosted_vecs)
         const DofMap& system_dof_map = system.get_dof_map();
 
         const std::vector<int>& phi_vars = d_noninterp_system_phi_vars[system_idx];
-        for (unsigned int k = 0; k < phi_vars.size(); ++k)
+        for (const auto& phi_var : phi_vars)
         {
-            const FEType& fe_type = system_dof_map.variable_type(phi_vars[k]);
+            const FEType& fe_type = system_dof_map.variable_type(phi_var);
             const size_t fe_type_idx = getFETypeIndex(fe_type);
             d_eval_phi[fe_type_idx] = true;
         }
 
         const std::vector<int>& dphi_vars = d_noninterp_system_dphi_vars[system_idx];
-        for (unsigned int k = 0; k < dphi_vars.size(); ++k)
+        for (const auto& dphi_var : dphi_vars)
         {
-            const FEType& fe_type = system_dof_map.variable_type(dphi_vars[k]);
+            const FEType& fe_type = system_dof_map.variable_type(dphi_var);
             const size_t fe_type_idx = getFETypeIndex(fe_type);
             d_eval_dphi[fe_type_idx] = true;
         }

--- a/ibtk/src/lagrangian/LEInteractor.cpp
+++ b/ibtk/src/lagrangian/LEInteractor.cpp
@@ -1740,9 +1740,9 @@ LEInteractor::interpolate(double* const Q_data,
                         periodic_shifts,
                         interp_fcn,
                         axis);
-            for (unsigned int k = 0; k < local_indices.size(); ++k)
+            for (const auto& local_index : local_indices)
             {
-                Q_data[NDIM * local_indices[k] + axis] = Q_data_axis[local_indices[k]];
+                Q_data[NDIM * local_index + axis] = Q_data_axis[local_index];
             }
         }
     }
@@ -1832,9 +1832,9 @@ LEInteractor::interpolate(double* const Q_data,
                         periodic_shifts,
                         interp_fcn,
                         axis);
-            for (unsigned int k = 0; k < local_indices.size(); ++k)
+            for (const auto& local_index : local_indices)
             {
-                Q_data[NDIM * local_indices[k] + axis] = Q_data_axis[local_indices[k]];
+                Q_data[NDIM * local_index + axis] = Q_data_axis[local_index];
             }
         }
     }
@@ -2327,9 +2327,9 @@ LEInteractor::interpolate(double* const Q_data,
                         periodic_shifts,
                         interp_fcn,
                         axis);
-            for (unsigned int k = 0; k < local_indices.size(); ++k)
+            for (const auto& local_index : local_indices)
             {
-                Q_data[NDIM * local_indices[k] + axis] = Q_data_axis[local_indices[k]];
+                Q_data[NDIM * local_index + axis] = Q_data_axis[local_index];
             }
         }
     }
@@ -2561,9 +2561,9 @@ LEInteractor::interpolate(double* const Q_data,
                         periodic_shifts,
                         interp_fcn,
                         axis);
-            for (unsigned int k = 0; k < local_indices.size(); ++k)
+            for (const auto& local_index : local_indices)
             {
-                Q_data[NDIM * local_indices[k] + axis] = Q_data_axis[local_indices[k]];
+                Q_data[NDIM * local_index + axis] = Q_data_axis[local_index];
             }
         }
     }
@@ -2920,9 +2920,9 @@ LEInteractor::spread(Pointer<SideData<NDIM, double> > q_data,
             }
             x_lower_axis[axis] -= 0.5 * dx[axis];
             x_upper_axis[axis] += 0.5 * dx[axis];
-            for (unsigned int k = 0; k < local_indices.size(); ++k)
+            for (const auto& local_index : local_indices)
             {
-                Q_data_axis[local_indices[k]] = Q_data[NDIM * local_indices[k] + axis];
+                Q_data_axis[local_index] = Q_data[NDIM * local_index + axis];
             }
             spread(q_data->getPointer(axis),
                    SideGeometry<NDIM>::toSideBox(q_data->getBox(), axis),
@@ -3012,9 +3012,9 @@ LEInteractor::spread(Pointer<EdgeData<NDIM, double> > q_data,
                     x_upper_axis[d] += 0.5 * dx[d];
                 }
             }
-            for (unsigned int k = 0; k < local_indices.size(); ++k)
+            for (const auto& local_index : local_indices)
             {
-                Q_data_axis[local_indices[k]] = Q_data[NDIM * local_indices[k] + axis];
+                Q_data_axis[local_index] = Q_data[NDIM * local_index + axis];
             }
             spread(q_data->getPointer(axis),
                    EdgeGeometry<NDIM>::toEdgeBox(q_data->getBox(), axis),
@@ -3503,9 +3503,9 @@ LEInteractor::spread(Pointer<SideData<NDIM, double> > q_data,
             }
             x_lower_axis[axis] -= 0.5 * dx[axis];
             x_upper_axis[axis] += 0.5 * dx[axis];
-            for (unsigned int k = 0; k < local_indices.size(); ++k)
+            for (const auto& local_index : local_indices)
             {
-                Q_data_axis[local_indices[k]] = Q_data[NDIM * local_indices[k] + axis];
+                Q_data_axis[local_index] = Q_data[NDIM * local_index + axis];
             }
             spread(q_data->getPointer(axis),
                    SideGeometry<NDIM>::toSideBox(q_data->getBox(), axis),
@@ -3730,9 +3730,9 @@ LEInteractor::spread(Pointer<EdgeData<NDIM, double> > q_data,
                     x_upper_axis[axis] += 0.5 * dx[axis];
                 }
             }
-            for (unsigned int k = 0; k < local_indices.size(); ++k)
+            for (const auto& local_index : local_indices)
             {
-                Q_data_axis[local_indices[k]] = Q_data[NDIM * local_indices[k] + axis];
+                Q_data_axis[local_index] = Q_data[NDIM * local_index + axis];
             }
             spread(q_data->getPointer(axis),
                    EdgeGeometry<NDIM>::toEdgeBox(q_data->getBox(), axis),

--- a/ibtk/src/math/PETScMatUtilities.cpp
+++ b/ibtk/src/math/PETScMatUtilities.cpp
@@ -972,7 +972,7 @@ PETScMatUtilities::constructPatchLevelSCInterpOp(Mat& mat,
 
         // Construct the interpolation weights for this IB point.
         std::vector<double> w[NDIM];
-        for (int d = 0; d < NDIM; ++d) w[d].resize(interp_stencil);
+        for (auto& vec : w) vec.resize(interp_stencil);
         int stencil_box_nvals = 1;
         for (unsigned int d = 0; d < NDIM; ++d) stencil_box_nvals *= interp_stencil;
         std::vector<double> stencil_box_vals(stencil_box_nvals);
@@ -1186,15 +1186,15 @@ PETScMatUtilities::constructPatchLevelASMSubdomains(std::vector<IS>& is_overlap,
                                                     Pointer<CoarseFineBoundary<NDIM> > cf_boundary)
 {
     int ierr;
-    for (unsigned int k = 0; k < is_overlap.size(); ++k)
+    for (auto& is : is_overlap)
     {
-        ierr = ISDestroy(&is_overlap[k]);
+        ierr = ISDestroy(&is);
         IBTK_CHKERRQ(ierr);
     }
     is_overlap.clear();
-    for (unsigned int k = 0; k < is_nonoverlap.size(); ++k)
+    for (auto& is : is_nonoverlap)
     {
-        ierr = ISDestroy(&is_nonoverlap[k]);
+        ierr = ISDestroy(&is);
         IBTK_CHKERRQ(ierr);
     }
     is_nonoverlap.clear();

--- a/ibtk/src/refine_ops/LMarkerRefine.cpp
+++ b/ibtk/src/refine_ops/LMarkerRefine.cpp
@@ -143,9 +143,8 @@ LMarkerRefine::refine(Patch<NDIM>& fine,
         if (coarse_box.contains(coarse_i))
         {
             const LMarkerSet& coarse_mark_set = it();
-            for (auto cit = coarse_mark_set.begin(); cit != coarse_mark_set.end(); ++cit)
+            for (const auto& coarse_mark : coarse_mark_set)
             {
-                const LMarkerSet::value_type& coarse_mark = *cit;
                 const Point& X = coarse_mark->getPosition();
                 const IntVector<NDIM>& offset = coarse_mark->getPeriodicOffset();
                 std::array<double, NDIM> X_shifted;

--- a/ibtk/src/solvers/impls/BGaussSeidelPreconditioner.cpp
+++ b/ibtk/src/solvers/impls/BGaussSeidelPreconditioner.cpp
@@ -290,18 +290,18 @@ BGaussSeidelPreconditioner::deallocateSolverState()
     if (!d_is_initialized) return;
 
     // Deallocate the component preconditioners.
-    for (auto it = d_pc_map.begin(); it != d_pc_map.end(); ++it)
+    for (const auto& linearSolver_pair : d_pc_map)
     {
-        it->second->deallocateSolverState();
+        linearSolver_pair.second->deallocateSolverState();
     }
 
     // Deallocate the component operators.
-    for (auto it = d_linear_ops_map.begin(); it != d_linear_ops_map.end(); ++it)
+    for (auto& linearSolverVec_pair : d_linear_ops_map)
     {
-        std::vector<Pointer<LinearOperator> >& comp_linear_ops = it->second;
-        for (auto comp_it = comp_linear_ops.begin(); comp_it != comp_linear_ops.end(); ++comp_it)
+        std::vector<Pointer<LinearOperator> >& comp_linear_ops = linearSolverVec_pair.second;
+        for (auto& comp_linear_op : comp_linear_ops)
         {
-            if (*comp_it) (*comp_it)->deallocateOperatorState();
+            if (comp_linear_op) comp_linear_op->deallocateOperatorState();
         }
     }
 

--- a/ibtk/src/solvers/impls/BJacobiPreconditioner.cpp
+++ b/ibtk/src/solvers/impls/BJacobiPreconditioner.cpp
@@ -171,9 +171,9 @@ BJacobiPreconditioner::initializeSolverState(const SAMRAIVectorReal<NDIM, double
     // Initialize the component preconditioners.
     const std::string& x_name = x.getName();
     const std::string& b_name = b.getName();
-    for (auto it = d_pc_map.begin(); it != d_pc_map.end(); ++it)
+    for (const auto& linearSolver_pair : d_pc_map)
     {
-        const int comp = it->first;
+        const int comp = linearSolver_pair.first;
         SAMRAIVectorReal<NDIM, double> x_comp(x_name + "_component", hierarchy, coarsest_ln, finest_ln);
         x_comp.addComponent(
             x.getComponentVariable(comp), x.getComponentDescriptorIndex(comp), x.getControlVolumeIndex(comp));
@@ -194,9 +194,9 @@ BJacobiPreconditioner::deallocateSolverState()
     if (!d_is_initialized) return;
 
     // Deallocate the component preconditioners.
-    for (auto it = d_pc_map.begin(); it != d_pc_map.end(); ++it)
+    for (const auto& linearSolver_pair : d_pc_map)
     {
-        const int comp = it->first;
+        const int comp = linearSolver_pair.first;
         d_pc_map[comp]->deallocateSolverState();
     }
 

--- a/ibtk/src/solvers/impls/CCPoissonBoxRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonBoxRelaxationFACOperator.cpp
@@ -412,10 +412,10 @@ CCPoissonBoxRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, double>& e
             if (update_local_data)
             {
                 const std::map<int, Box<NDIM> > neighbor_overlap = d_patch_neighbor_overlap[level_num][patch_counter];
-                for (auto cit = neighbor_overlap.begin(); cit != neighbor_overlap.end(); ++cit)
+                for (const auto& pair : neighbor_overlap)
                 {
-                    const int src_patch_num = cit->first;
-                    const Box<NDIM>& overlap = cit->second;
+                    const int src_patch_num = pair.first;
+                    const Box<NDIM>& overlap = pair.second;
                     Pointer<Patch<NDIM> > src_patch = level->getPatch(src_patch_num);
                     Pointer<CellData<NDIM, double> > src_error_data = error.getComponentPatchData(0, *src_patch);
                     error_data->getArrayData().copy(src_error_data->getArrayData(), overlap, IntVector<NDIM>(0));
@@ -746,30 +746,26 @@ CCPoissonBoxRelaxationFACOperator::deallocateOperatorStateSpecialized(const int 
     int ierr;
     for (int ln = coarsest_reset_ln; ln <= std::min(d_finest_ln, finest_reset_ln); ++ln)
     {
-        for (auto it = d_patch_vec_e[ln].begin(); it != d_patch_vec_e[ln].end(); ++it)
+        for (auto& e : d_patch_vec_e[ln])
         {
-            Vec& e = *it;
             ierr = VecDestroy(&e);
             IBTK_CHKERRQ(ierr);
         }
         d_patch_vec_e[ln].clear();
-        for (auto it = d_patch_vec_f[ln].begin(); it != d_patch_vec_f[ln].end(); ++it)
+        for (auto& f : d_patch_vec_f[ln])
         {
-            Vec& f = *it;
             ierr = VecDestroy(&f);
             IBTK_CHKERRQ(ierr);
         }
         d_patch_vec_f[ln].clear();
-        for (auto it = d_patch_mat[ln].begin(); it != d_patch_mat[ln].end(); ++it)
+        for (auto& A : d_patch_mat[ln])
         {
-            Mat& A = *it;
             ierr = MatDestroy(&A);
             IBTK_CHKERRQ(ierr);
         }
         d_patch_mat[ln].clear();
-        for (auto it = d_patch_ksp[ln].begin(); it != d_patch_ksp[ln].end(); ++it)
+        for (auto& ksp : d_patch_ksp[ln])
         {
-            KSP& ksp = *it;
             ierr = KSPDestroy(&ksp);
             IBTK_CHKERRQ(ierr);
         }

--- a/ibtk/src/solvers/impls/CCPoissonPointRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonPointRelaxationFACOperator.cpp
@@ -518,10 +518,10 @@ CCPoissonPointRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, double>&
             if (update_local_data)
             {
                 const std::map<int, Box<NDIM> > neighbor_overlap = d_patch_neighbor_overlap[level_num][patch_counter];
-                for (auto cit = neighbor_overlap.begin(); cit != neighbor_overlap.end(); ++cit)
+                for (const auto& pair : neighbor_overlap)
                 {
-                    const int src_patch_num = cit->first;
-                    const Box<NDIM>& overlap = cit->second;
+                    const int src_patch_num = pair.first;
+                    const Box<NDIM>& overlap = pair.second;
                     Pointer<Patch<NDIM> > src_patch = level->getPatch(src_patch_num);
                     Pointer<CellData<NDIM, double> > src_error_data = error.getComponentPatchData(0, *src_patch);
                     error_data->getArrayData().copy(src_error_data->getArrayData(), overlap, IntVector<NDIM>(0));

--- a/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
@@ -754,9 +754,8 @@ PETScKrylovLinearSolver::resetMatNullspace()
             nullspace_vecs.push_back(d_petsc_nullspace_basis_vecs[k]);
         }
 
-        for (unsigned int k = 0; k < nullspace_vecs.size(); ++k)
+        for (const auto& petsc_nvec : nullspace_vecs)
         {
-            Vec petsc_nvec = nullspace_vecs[k];
             double norm;
             ierr = VecNorm(petsc_nvec, NORM_2, &norm);
             IBTK_CHKERRQ(ierr);
@@ -804,9 +803,9 @@ PETScKrylovLinearSolver::deallocateNullspaceData()
     {
         PETScSAMRAIVectorReal::destroyPETScVector(d_petsc_nullspace_constant_vec);
     }
-    for (unsigned int k = 0; k < d_petsc_nullspace_basis_vecs.size(); ++k)
+    for (const auto& petsc_nullspace_basis_vec : d_petsc_nullspace_basis_vecs)
     {
-        PETScSAMRAIVectorReal::destroyPETScVector(d_petsc_nullspace_basis_vecs[k]);
+        PETScSAMRAIVectorReal::destroyPETScVector(petsc_nullspace_basis_vec);
     }
     d_petsc_nullspace_constant_vec = nullptr;
     d_petsc_nullspace_basis_vecs.clear();

--- a/ibtk/src/solvers/impls/PETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScLevelSolver.cpp
@@ -80,15 +80,15 @@ generate_petsc_is_from_std_is(std::vector<std::set<int> >& overlap_std,
 {
     // Destroy old IS'es and generate new ones.
     int ierr;
-    for (unsigned int k = 0; k < overlap_petsc.size(); ++k)
+    for (auto& is : overlap_petsc)
     {
-        ierr = ISDestroy(&overlap_petsc[k]);
+        ierr = ISDestroy(&is);
         IBTK_CHKERRQ(ierr);
     }
     overlap_petsc.clear();
-    for (unsigned int k = 0; k < nonoverlap_petsc.size(); ++k)
+    for (auto& is : nonoverlap_petsc)
     {
-        ierr = ISDestroy(&nonoverlap_petsc[k]);
+        ierr = ISDestroy(&is);
         IBTK_CHKERRQ(ierr);
     }
     nonoverlap_petsc.clear();
@@ -168,14 +168,14 @@ PETScLevelSolver::~PETScLevelSolver()
     }
 
     int ierr;
-    for (size_t i = 0; i < d_nonoverlap_is.size(); ++i)
+    for (auto& is : d_nonoverlap_is)
     {
-        ierr = ISDestroy(&d_nonoverlap_is[i]);
+        ierr = ISDestroy(&is);
         IBTK_CHKERRQ(ierr);
     }
-    for (size_t i = 0; i < d_overlap_is.size(); ++i)
+    for (auto& is : d_overlap_is)
     {
-        ierr = ISDestroy(&d_overlap_is[i]);
+        ierr = ISDestroy(&is);
         IBTK_CHKERRQ(ierr);
     }
     return;
@@ -433,9 +433,9 @@ PETScLevelSolver::initializeSolverState(const SAMRAIVectorReal<NDIM, double>& x,
         const int n_fields = static_cast<int>(field_is.size());
 
         // Destroy old IS'es and generate new ones.
-        for (unsigned int k = 0; k < d_field_is.size(); ++k)
+        for (auto& is : d_field_is)
         {
-            ierr = ISDestroy(&d_field_is[k]);
+            ierr = ISDestroy(&is);
             IBTK_CHKERRQ(ierr);
         }
         d_field_is.clear();

--- a/ibtk/src/solvers/impls/PoissonFACPreconditionerStrategy.cpp
+++ b/ibtk/src/solvers/impls/PoissonFACPreconditionerStrategy.cpp
@@ -584,9 +584,9 @@ PoissonFACPreconditionerStrategy::xeqScheduleProlongation(const int dst_idx, con
     d_bc_op->setPatchDataIndex(dst_idx);
     d_bc_op->setPhysicalBcCoefs(d_bc_coefs);
     d_bc_op->setHomogeneousBc(true);
-    for (unsigned int k = 0; k < d_bc_coefs.size(); ++k)
+    for (const auto& bc_coef : d_bc_coefs)
     {
-        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
+        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coef);
         if (extended_bc_coef)
         {
             extended_bc_coef->setTargetPatchDataIndex(dst_idx);
@@ -598,9 +598,9 @@ PoissonFACPreconditionerStrategy::xeqScheduleProlongation(const int dst_idx, con
     refiner.resetSchedule(d_prolongation_refine_schedules[dst_ln]);
     d_prolongation_refine_schedules[dst_ln]->fillData(d_solution_time);
     d_prolongation_refine_algorithm->resetSchedule(d_prolongation_refine_schedules[dst_ln]);
-    for (unsigned int k = 0; k < d_bc_coefs.size(); ++k)
+    for (const auto& bc_coef : d_bc_coefs)
     {
-        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
+        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coef);
         if (extended_bc_coef) extended_bc_coef->clearTargetPatchDataIndex();
     }
     return;
@@ -623,9 +623,9 @@ PoissonFACPreconditionerStrategy::xeqScheduleGhostFillNoCoarse(const int dst_idx
     d_bc_op->setPatchDataIndex(dst_idx);
     d_bc_op->setPhysicalBcCoefs(d_bc_coefs);
     d_bc_op->setHomogeneousBc(true);
-    for (unsigned int k = 0; k < d_bc_coefs.size(); ++k)
+    for (const auto& bc_coef : d_bc_coefs)
     {
-        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
+        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coef);
         if (extended_bc_coef)
         {
             extended_bc_coef->setTargetPatchDataIndex(dst_idx);
@@ -637,9 +637,9 @@ PoissonFACPreconditionerStrategy::xeqScheduleGhostFillNoCoarse(const int dst_idx
     refiner.resetSchedule(d_ghostfill_nocoarse_refine_schedules[dst_ln]);
     d_ghostfill_nocoarse_refine_schedules[dst_ln]->fillData(d_solution_time);
     d_ghostfill_nocoarse_refine_algorithm->resetSchedule(d_ghostfill_nocoarse_refine_schedules[dst_ln]);
-    for (unsigned int k = 0; k < d_bc_coefs.size(); ++k)
+    for (const auto& bc_coef : d_bc_coefs)
     {
-        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(d_bc_coefs[k]);
+        auto extended_bc_coef = dynamic_cast<ExtendedRobinBcCoefStrategy*>(bc_coef);
         if (extended_bc_coef) extended_bc_coef->clearTargetPatchDataIndex();
     }
     return;

--- a/ibtk/src/solvers/impls/SCPoissonHypreLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonHypreLevelSolver.cpp
@@ -953,18 +953,18 @@ void
 SCPoissonHypreLevelSolver::deallocateHypreData()
 {
     if (d_graph) HYPRE_SStructGraphDestroy(d_graph);
-    for (int var = 0; var < NVARS; ++var)
+    for (const auto& var : d_stencil)
     {
-        if (d_stencil[var]) HYPRE_SStructStencilDestroy(d_stencil[var]);
+        if (var) HYPRE_SStructStencilDestroy(var);
     }
     if (d_grid) HYPRE_SStructGridDestroy(d_grid);
     if (d_matrix) HYPRE_SStructMatrixDestroy(d_matrix);
     if (d_sol_vec) HYPRE_SStructVectorDestroy(d_sol_vec);
     if (d_rhs_vec) HYPRE_SStructVectorDestroy(d_rhs_vec);
     d_grid = nullptr;
-    for (int var = 0; var < NVARS; ++var)
+    for (auto& var : d_stencil)
     {
-        d_stencil[var] = nullptr;
+        var = nullptr;
     }
     d_matrix = nullptr;
     d_sol_vec = nullptr;

--- a/ibtk/src/solvers/impls/SCPoissonPointRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonPointRelaxationFACOperator.cpp
@@ -509,10 +509,10 @@ SCPoissonPointRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, double>&
                 {
                     const std::map<int, Box<NDIM> > neighbor_overlap =
                         d_patch_neighbor_overlap[level_num][patch_counter][axis];
-                    for (auto cit = neighbor_overlap.begin(); cit != neighbor_overlap.end(); ++cit)
+                    for (const auto& pair : neighbor_overlap)
                     {
-                        const int src_patch_num = cit->first;
-                        const Box<NDIM>& overlap = cit->second;
+                        const int src_patch_num = pair.first;
+                        const Box<NDIM>& overlap = pair.second;
                         Pointer<Patch<NDIM> > src_patch = level->getPatch(src_patch_num);
                         Pointer<SideData<NDIM, double> > src_error_data = error.getComponentPatchData(0, *src_patch);
                         error_data->getArrayData(axis)

--- a/ibtk/src/solvers/impls/VCSCViscousOpPointRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/VCSCViscousOpPointRelaxationFACOperator.cpp
@@ -531,10 +531,10 @@ VCSCViscousOpPointRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, doub
                 {
                     const std::map<int, Box<NDIM> > neighbor_overlap =
                         d_patch_neighbor_overlap[level_num][patch_counter][axis];
-                    for (auto cit = neighbor_overlap.begin(); cit != neighbor_overlap.end(); ++cit)
+                    for (const auto& pair : neighbor_overlap)
                     {
-                        const int src_patch_num = cit->first;
-                        const Box<NDIM>& overlap = cit->second;
+                        const int src_patch_num = pair.first;
+                        const Box<NDIM>& overlap = pair.second;
                         Pointer<Patch<NDIM> > src_patch = level->getPatch(src_patch_num);
                         Pointer<SideData<NDIM, double> > src_error_data = error.getComponentPatchData(0, *src_patch);
                         error_data->getArrayData(axis).copy(

--- a/ibtk/src/utilities/AppInitializer.cpp
+++ b/ibtk/src/utilities/AppInitializer.cpp
@@ -232,9 +232,9 @@ AppInitializer::AppInitializer(int argc, char* argv[], const std::string& defaul
         }
     }
 
-    for (unsigned int i = 0; i < d_viz_writers.size(); i++)
+    for (const auto& viz_writer : d_viz_writers)
     {
-        if (d_viz_writers[i] == "VisIt")
+        if (viz_writer == "VisIt")
         {
             int visit_number_procs_per_file = 1;
             if (main_db->keyExists("visit_number_procs_per_file"))
@@ -243,17 +243,17 @@ AppInitializer::AppInitializer(int argc, char* argv[], const std::string& defaul
                 new VisItDataWriter<NDIM>("VisItDataWriter", d_viz_dump_dirname, visit_number_procs_per_file);
         }
 
-        if (d_viz_writers[i] == "Silo")
+        if (viz_writer == "Silo")
         {
             d_silo_data_writer = new LSiloDataWriter("LSiloDataWriter", d_viz_dump_dirname);
         }
 
-        if (d_viz_writers[i] == "ExodusII")
+        if (viz_writer == "ExodusII")
         {
             if (main_db->keyExists("exodus_filename")) d_exodus_filename = main_db->getString("exodus_filename");
         }
 
-        if (d_viz_writers[i] == "GMV")
+        if (viz_writer == "GMV")
         {
             if (main_db->keyExists("gmv_filename")) d_gmv_filename = main_db->getString("gmv_filename");
         }

--- a/ibtk/src/utilities/CartGridFunctionSet.cpp
+++ b/ibtk/src/utilities/CartGridFunctionSet.cpp
@@ -101,9 +101,9 @@ CartGridFunctionSet::addFunction(Pointer<CartGridFunction> fcn)
 bool
 CartGridFunctionSet::isTimeDependent() const
 {
-    for (unsigned int k = 0; k < d_fcns.size(); ++k)
+    for (const auto& fcn : d_fcns)
     {
-        if (d_fcns[k]->isTimeDependent()) return true;
+        if (fcn->isTimeDependent()) return true;
     }
     return false;
 } // isTimeDependent

--- a/ibtk/src/utilities/CoarsenPatchStrategySet.cpp
+++ b/ibtk/src/utilities/CoarsenPatchStrategySet.cpp
@@ -58,9 +58,9 @@ CoarsenPatchStrategySet::~CoarsenPatchStrategySet()
 {
     if (d_managed)
     {
-        for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+        for (const auto& strategy : d_strategy_set)
         {
-            delete (*it);
+            delete strategy;
         }
     }
     return;
@@ -70,9 +70,9 @@ IntVector<NDIM>
 CoarsenPatchStrategySet::getCoarsenOpStencilWidth() const
 {
     IntVector<NDIM> width = 0;
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        width = IntVector<NDIM>::max(width, (*it)->getCoarsenOpStencilWidth());
+        width = IntVector<NDIM>::max(width, strategy->getCoarsenOpStencilWidth());
     }
     return width;
 } // getCoarsenOpStencilWidth
@@ -83,9 +83,9 @@ CoarsenPatchStrategySet::preprocessCoarsen(Patch<NDIM>& coarse,
                                            const Box<NDIM>& coarse_box,
                                            const IntVector<NDIM>& ratio)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->preprocessCoarsen(coarse, fine, coarse_box, ratio);
+        strategy->preprocessCoarsen(coarse, fine, coarse_box, ratio);
     }
     return;
 } // preprocessCoarsen
@@ -96,9 +96,9 @@ CoarsenPatchStrategySet::postprocessCoarsen(Patch<NDIM>& coarse,
                                             const Box<NDIM>& coarse_box,
                                             const IntVector<NDIM>& ratio)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->postprocessCoarsen(coarse, fine, coarse_box, ratio);
+        strategy->postprocessCoarsen(coarse, fine, coarse_box, ratio);
     }
     return;
 } // postprocessCoarsen

--- a/ibtk/src/utilities/EdgeDataSynchronization.cpp
+++ b/ibtk/src/utilities/EdgeDataSynchronization.cpp
@@ -122,12 +122,12 @@ EdgeDataSynchronization::initializeOperatorState(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     bool registered_coarsen_op = false;
     d_coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const std::string& coarsen_op_name = d_transaction_comps[comp_idx].d_coarsen_op_name;
+        const std::string& coarsen_op_name = transaction_comp.d_coarsen_op_name;
         if (coarsen_op_name != "NONE")
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
 #if !defined(NDEBUG)
@@ -160,9 +160,9 @@ EdgeDataSynchronization::initializeOperatorState(
     for (unsigned int axis = 0; axis < NDIM; ++axis)
     {
         d_refine_alg[axis] = new RefineAlgorithm<NDIM>();
-        for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+        for (const auto& transaction_comp : d_transaction_comps)
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
             Pointer<EdgeVariable<NDIM, double> > ec_var = var;
@@ -231,12 +231,12 @@ EdgeDataSynchronization::resetTransactionComponents(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     bool registered_coarsen_op = false;
     d_coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const std::string& coarsen_op_name = d_transaction_comps[comp_idx].d_coarsen_op_name;
+        const std::string& coarsen_op_name = transaction_comp.d_coarsen_op_name;
         if (coarsen_op_name != "NONE")
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
 #if !defined(NDEBUG)
@@ -265,9 +265,9 @@ EdgeDataSynchronization::resetTransactionComponents(
     for (unsigned int axis = 0; axis < NDIM; ++axis)
     {
         d_refine_alg[axis] = new RefineAlgorithm<NDIM>();
-        for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+        for (const auto& transaction_comp : d_transaction_comps)
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
             Pointer<EdgeVariable<NDIM, double> > ec_var = var;

--- a/ibtk/src/utilities/FaceDataSynchronization.cpp
+++ b/ibtk/src/utilities/FaceDataSynchronization.cpp
@@ -122,12 +122,12 @@ FaceDataSynchronization::initializeOperatorState(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     bool registered_coarsen_op = false;
     d_coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const std::string& coarsen_op_name = d_transaction_comps[comp_idx].d_coarsen_op_name;
+        const std::string& coarsen_op_name = transaction_comp.d_coarsen_op_name;
         if (coarsen_op_name != "NONE")
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
 #if !defined(NDEBUG)
@@ -158,9 +158,9 @@ FaceDataSynchronization::initializeOperatorState(
 
     // Setup cached refine algorithms and schedules.
     d_refine_alg = new RefineAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+        const int data_idx = transaction_comp.d_data_idx;
         Pointer<Variable<NDIM> > var;
         var_db->mapIndexToVariable(data_idx, var);
         Pointer<FaceVariable<NDIM, double> > fc_var = var;
@@ -228,12 +228,12 @@ FaceDataSynchronization::resetTransactionComponents(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     bool registered_coarsen_op = false;
     d_coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const std::string& coarsen_op_name = d_transaction_comps[comp_idx].d_coarsen_op_name;
+        const std::string& coarsen_op_name = transaction_comp.d_coarsen_op_name;
         if (coarsen_op_name != "NONE")
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
 #if !defined(NDEBUG)
@@ -260,9 +260,9 @@ FaceDataSynchronization::resetTransactionComponents(
 
     // Reset cached refine algorithms and schedules.
     d_refine_alg = new RefineAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+        const int data_idx = transaction_comp.d_data_idx;
         Pointer<Variable<NDIM> > var;
         var_db->mapIndexToVariable(data_idx, var);
         Pointer<FaceVariable<NDIM, double> > fc_var = var;

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -184,19 +184,19 @@ HierarchyIntegrator::~HierarchyIntegrator()
         d_registered_for_restart = false;
     }
 
-    for (auto it = d_ghostfill_strategies.begin(); it != d_ghostfill_strategies.end(); ++it)
+    for (const auto& ghostfill_strategy : d_ghostfill_strategies)
     {
-        delete it->second;
+        delete ghostfill_strategy.second;
     }
 
-    for (auto it = d_prolong_strategies.begin(); it != d_prolong_strategies.end(); ++it)
+    for (const auto& prolong_strategy : d_prolong_strategies)
     {
-        delete it->second;
+        delete prolong_strategy.second;
     }
 
-    for (auto it = d_coarsen_strategies.begin(); it != d_coarsen_strategies.end(); ++it)
+    for (const auto& coarsen_strategy : d_coarsen_strategies)
     {
-        delete it->second;
+        delete coarsen_strategy.second;
     }
     return;
 } // ~HierarchyIntegrator
@@ -396,9 +396,9 @@ double
 HierarchyIntegrator::getMinimumTimeStepSize()
 {
     double dt = getMinimumTimeStepSizeSpecialized();
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        dt = std::max(dt, (*it)->getMinimumTimeStepSize());
+        dt = std::max(dt, child_integrator->getMinimumTimeStepSize());
     }
     return std::min(dt, d_end_time - d_integrator_time);
 } // getMinimumTimeStepSize
@@ -407,9 +407,9 @@ double
 HierarchyIntegrator::getMaximumTimeStepSize()
 {
     double dt = getMaximumTimeStepSizeSpecialized();
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        dt = std::min(dt, (*it)->getMaximumTimeStepSize());
+        dt = std::min(dt, child_integrator->getMaximumTimeStepSize());
     }
     return std::min(dt, d_end_time - d_integrator_time);
 } // getMaximumTimeStepSize
@@ -418,9 +418,9 @@ void
 HierarchyIntegrator::synchronizeHierarchyData(VariableContextType ctx_type)
 {
     synchronizeHierarchyDataSpecialized(ctx_type);
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        (*it)->synchronizeHierarchyData(ctx_type);
+        child_integrator->synchronizeHierarchyData(ctx_type);
     }
     return;
 } // synchronizeHierarchyData
@@ -429,9 +429,9 @@ void
 HierarchyIntegrator::resetTimeDependentHierarchyData(const double new_time)
 {
     resetTimeDependentHierarchyDataSpecialized(new_time);
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        (*it)->resetTimeDependentHierarchyData(new_time);
+        child_integrator->resetTimeDependentHierarchyData(new_time);
     }
     return;
 } // resetTimeDependentHierarchyData
@@ -440,9 +440,9 @@ void
 HierarchyIntegrator::resetIntegratorToPreadvanceState()
 {
     resetIntegratorToPreadvanceStateSpecialized();
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        (*it)->resetIntegratorToPreadvanceState();
+        child_integrator->resetIntegratorToPreadvanceState();
     }
     return;
 } // resetIntegratorToPreadvanceState
@@ -558,9 +558,9 @@ void
 HierarchyIntegrator::registerVisItDataWriter(Pointer<VisItDataWriter<NDIM> > visit_writer)
 {
     d_visit_writer = visit_writer;
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        (*it)->registerVisItDataWriter(visit_writer);
+        child_integrator->registerVisItDataWriter(visit_writer);
     }
     return;
 } // registerVisItDataWriter
@@ -575,9 +575,9 @@ void
 HierarchyIntegrator::setupPlotData()
 {
     setupPlotDataSpecialized();
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        (*it)->setupPlotData();
+        child_integrator->setupPlotData();
     }
     return;
 } // setupPlotData
@@ -709,9 +709,9 @@ HierarchyIntegrator::initializeCompositeHierarchyData(double init_data_time, boo
     initializeCompositeHierarchyDataSpecialized(init_data_time, initial_time);
 
     // Initialize data associated with any child integrators.
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        (*it)->initializeCompositeHierarchyData(init_data_time, initial_time);
+        child_integrator->initializeCompositeHierarchyData(init_data_time, initial_time);
     }
     return;
 } // initializeCompositeHierarchyData
@@ -775,9 +775,8 @@ HierarchyIntegrator::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> 
     if (initial_time)
     {
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-        for (auto cit = d_state_variables.begin(); cit != d_state_variables.end(); ++cit)
+        for (const auto& var : d_state_variables)
         {
-            Pointer<Variable<NDIM> > var = *cit;
             const int var_current_idx = var_db->mapVariableAndContextToIndex(var, getCurrentContext());
             Pointer<CartGridFunction> var_init = d_state_var_init_fcns[var];
             if (var_init)
@@ -814,9 +813,9 @@ HierarchyIntegrator::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> 
         base_hierarchy, level_number, init_data_time, can_be_refined, initial_time, base_old_level, allocate_data);
 
     // Initialize data associated with any child integrators.
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        (*it)->initializeLevelData(
+        child_integrator->initializeLevelData(
             base_hierarchy, level_number, init_data_time, can_be_refined, initial_time, base_old_level, allocate_data);
     }
     return;
@@ -849,55 +848,55 @@ HierarchyIntegrator::resetHierarchyConfiguration(const Pointer<BasePatchHierarch
 
     // If we have added or removed a level, resize the communication schedule
     // vectors.
-    for (auto it = d_ghostfill_algs.begin(); it != d_ghostfill_algs.end(); ++it)
+    for (const auto& ghostfill_alg : d_ghostfill_algs)
     {
-        d_ghostfill_scheds[it->first].resize(finest_hier_level + 1);
+        d_ghostfill_scheds[ghostfill_alg.first].resize(finest_hier_level + 1);
     }
 
-    for (auto it = d_prolong_algs.begin(); it != d_prolong_algs.end(); ++it)
+    for (const auto& prolong_alg : d_prolong_algs)
     {
-        d_prolong_scheds[it->first].resize(finest_hier_level + 1);
+        d_prolong_scheds[prolong_alg.first].resize(finest_hier_level + 1);
     }
 
-    for (auto it = d_coarsen_algs.begin(); it != d_coarsen_algs.end(); ++it)
+    for (const auto& coarsen_alg : d_coarsen_algs)
     {
-        d_coarsen_scheds[it->first].resize(finest_hier_level + 1);
+        d_coarsen_scheds[coarsen_alg.first].resize(finest_hier_level + 1);
     }
 
     // (Re)build ghost cell filling communication schedules.  These are created
     // for all levels in the hierarchy.
-    for (auto it = d_ghostfill_algs.begin(); it != d_ghostfill_algs.end(); ++it)
+    for (const auto& ghostfill_alg : d_ghostfill_algs)
     {
         for (int ln = coarsest_level; ln <= std::min(finest_level + 1, finest_hier_level); ++ln)
         {
             Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(ln);
-            d_ghostfill_scheds[it->first][ln] =
-                it->second->createSchedule(level, ln - 1, hierarchy, d_ghostfill_strategies[it->first]);
+            d_ghostfill_scheds[ghostfill_alg.first][ln] = ghostfill_alg.second->createSchedule(
+                level, ln - 1, hierarchy, d_ghostfill_strategies[ghostfill_alg.first]);
         }
     }
 
     // (Re)build data prolongation communication schedules.  These are set only for levels
     // >= 1.
-    for (auto it = d_prolong_algs.begin(); it != d_prolong_algs.end(); ++it)
+    for (const auto& prolong_alg : d_prolong_algs)
     {
         for (int ln = std::max(coarsest_level, 1); ln <= std::min(finest_level + 1, finest_level); ++ln)
         {
             Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(ln);
-            d_prolong_scheds[it->first][ln] = it->second->createSchedule(
-                level, Pointer<PatchLevel<NDIM> >(), ln - 1, hierarchy, d_prolong_strategies[it->first]);
+            d_prolong_scheds[prolong_alg.first][ln] = prolong_alg.second->createSchedule(
+                level, Pointer<PatchLevel<NDIM> >(), ln - 1, hierarchy, d_prolong_strategies[prolong_alg.first]);
         }
     }
 
     // (Re)build coarsen communication schedules.  These are set only for levels
     // >= 1.
-    for (auto it = d_coarsen_algs.begin(); it != d_coarsen_algs.end(); ++it)
+    for (const auto& coarsen_alg : d_coarsen_algs)
     {
         for (int ln = std::max(coarsest_level, 1); ln <= std::min(finest_level + 1, finest_level); ++ln)
         {
             Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(ln);
             Pointer<PatchLevel<NDIM> > coarser_level = hierarchy->getPatchLevel(ln - 1);
-            d_coarsen_scheds[it->first][ln] =
-                it->second->createSchedule(coarser_level, level, d_coarsen_strategies[it->first]);
+            d_coarsen_scheds[coarsen_alg.first][ln] =
+                coarsen_alg.second->createSchedule(coarser_level, level, d_coarsen_strategies[coarsen_alg.first]);
         }
     }
 
@@ -905,9 +904,9 @@ HierarchyIntegrator::resetHierarchyConfiguration(const Pointer<BasePatchHierarch
     resetHierarchyConfigurationSpecialized(base_hierarchy, coarsest_level, finest_level);
 
     // Reset data associated with any child integrators.
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        (*it)->resetHierarchyConfiguration(base_hierarchy, coarsest_level, finest_level);
+        child_integrator->resetHierarchyConfiguration(base_hierarchy, coarsest_level, finest_level);
     }
     return;
 } // resetHierarchyConfiguration
@@ -945,9 +944,9 @@ HierarchyIntegrator::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM
         hierarchy, level_number, error_data_time, tag_index, initial_time, uses_richardson_extrapolation_too);
 
     // ALlow child integrators to tag cells for refinement.
-    for (auto it = d_child_integrators.begin(); it != d_child_integrators.end(); ++it)
+    for (const auto& child_integrator : d_child_integrators)
     {
-        (*it)->applyGradientDetector(
+        child_integrator->applyGradientDetector(
             hierarchy, level_number, error_data_time, tag_index, initial_time, uses_richardson_extrapolation_too);
     }
     return;
@@ -1212,9 +1211,8 @@ HierarchyIntegrator::resetTimeDependentHierarchyDataSpecialized(const double new
 
     // Swap PatchData<NDIM> pointers between the current and new contexts.
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    for (auto sv = d_state_variables.begin(); sv != d_state_variables.end(); ++sv)
+    for (const auto& v : d_state_variables)
     {
-        const Pointer<Variable<NDIM> >& v = *sv;
         const int src_idx = var_db->mapVariableAndContextToIndex(v, getNewContext());
         const int dst_idx = var_db->mapVariableAndContextToIndex(v, getCurrentContext());
         for (int ln = coarsest_ln; ln <= finest_ln; ++ln)

--- a/ibtk/src/utilities/NodeDataSynchronization.cpp
+++ b/ibtk/src/utilities/NodeDataSynchronization.cpp
@@ -122,12 +122,12 @@ NodeDataSynchronization::initializeOperatorState(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     bool registered_coarsen_op = false;
     d_coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const std::string& coarsen_op_name = d_transaction_comps[comp_idx].d_coarsen_op_name;
+        const std::string& coarsen_op_name = transaction_comp.d_coarsen_op_name;
         if (coarsen_op_name != "NONE")
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
 #if !defined(NDEBUG)
@@ -160,9 +160,9 @@ NodeDataSynchronization::initializeOperatorState(
     for (unsigned int axis = 0; axis < NDIM; ++axis)
     {
         d_refine_alg[axis] = new RefineAlgorithm<NDIM>();
-        for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+        for (const auto& transaction_comp : d_transaction_comps)
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
             Pointer<NodeVariable<NDIM, double> > nc_var = var;
@@ -231,12 +231,12 @@ NodeDataSynchronization::resetTransactionComponents(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     bool registered_coarsen_op = false;
     d_coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const std::string& coarsen_op_name = d_transaction_comps[comp_idx].d_coarsen_op_name;
+        const std::string& coarsen_op_name = transaction_comp.d_coarsen_op_name;
         if (coarsen_op_name != "NONE")
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
 #if !defined(NDEBUG)
@@ -265,9 +265,9 @@ NodeDataSynchronization::resetTransactionComponents(
     for (unsigned int axis = 0; axis < NDIM; ++axis)
     {
         d_refine_alg[axis] = new RefineAlgorithm<NDIM>();
-        for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+        for (const auto& transaction_comp : d_transaction_comps)
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
             Pointer<NodeVariable<NDIM, double> > nc_var = var;

--- a/ibtk/src/utilities/ParallelEdgeMap.cpp
+++ b/ibtk/src/utilities/ParallelEdgeMap.cpp
@@ -153,16 +153,15 @@ ParallelEdgeMap::communicateData()
     }
 
     using multimap_iterator = std::multimap<int, std::pair<int, int> >::iterator;
-    using multimap_const_iterator = std::multimap<int, std::pair<int, int> >::const_iterator;
-    for (auto cit = d_pending_additions.begin(); cit != d_pending_additions.end(); ++cit)
+    for (const auto& pending_addition : d_pending_additions)
     {
-        d_edge_map.insert(std::make_pair(cit->first, cit->second));
+        d_edge_map.insert(std::make_pair(pending_addition.first, pending_addition.second));
     }
 
-    for (auto cit = d_pending_removals.begin(); cit != d_pending_removals.end(); ++cit)
+    for (const auto& pending_removal : d_pending_removals)
     {
-        int mastr_idx = cit->first;
-        const std::pair<int, int>& link = cit->second;
+        int mastr_idx = pending_removal.first;
+        const std::pair<int, int>& link = pending_removal.second;
 
         bool found_link = false;
 

--- a/ibtk/src/utilities/ParallelMap.cpp
+++ b/ibtk/src/utilities/ParallelMap.cpp
@@ -121,10 +121,10 @@ ParallelMap::communicateData()
         // broadcast by each process.
         std::vector<int> keys_to_send;
         std::vector<tbox::Pointer<Streamable> > data_items_to_send;
-        for (auto cit = d_pending_additions.begin(); cit != d_pending_additions.end(); ++cit)
+        for (const auto& pending_addition : d_pending_additions)
         {
-            keys_to_send.push_back(cit->first);
-            data_items_to_send.push_back(cit->second);
+            keys_to_send.push_back(pending_addition.first);
+            data_items_to_send.push_back(pending_addition.second);
         }
         std::vector<int> data_sz(size, 0);
         data_sz[rank] = static_cast<int>(tbox::AbstractStream::sizeofInt() * keys_to_send.size() +

--- a/ibtk/src/utilities/RefinePatchStrategySet.cpp
+++ b/ibtk/src/utilities/RefinePatchStrategySet.cpp
@@ -56,9 +56,9 @@ RefinePatchStrategySet::~RefinePatchStrategySet()
 {
     if (d_managed)
     {
-        for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+        for (const auto& strategy : d_strategy_set)
         {
-            delete (*it);
+            delete strategy;
         }
     }
     return;
@@ -69,9 +69,9 @@ RefinePatchStrategySet::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
                                                       const double fill_time,
                                                       const IntVector<NDIM>& ghost_width_to_fill)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->setPhysicalBoundaryConditions(patch, fill_time, ghost_width_to_fill);
+        strategy->setPhysicalBoundaryConditions(patch, fill_time, ghost_width_to_fill);
     }
     return;
 } // setPhysicalBoundaryConditions
@@ -80,9 +80,9 @@ IntVector<NDIM>
 RefinePatchStrategySet::getRefineOpStencilWidth() const
 {
     IntVector<NDIM> width = 0;
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        width = IntVector<NDIM>::max(width, (*it)->getRefineOpStencilWidth());
+        width = IntVector<NDIM>::max(width, strategy->getRefineOpStencilWidth());
     }
     return width;
 } // getRefineOpStencilWidth()
@@ -93,9 +93,9 @@ RefinePatchStrategySet::preprocessRefine(Patch<NDIM>& fine,
                                          const Box<NDIM>& fine_box,
                                          const IntVector<NDIM>& ratio)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->preprocessRefine(fine, coarse, fine_box, ratio);
+        strategy->preprocessRefine(fine, coarse, fine_box, ratio);
     }
     return;
 } // preprocessRefine
@@ -106,9 +106,9 @@ RefinePatchStrategySet::postprocessRefine(Patch<NDIM>& fine,
                                           const Box<NDIM>& fine_box,
                                           const IntVector<NDIM>& ratio)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->postprocessRefine(fine, coarse, fine_box, ratio);
+        strategy->postprocessRefine(fine, coarse, fine_box, ratio);
     }
     return;
 } // postprocessRefine
@@ -119,9 +119,9 @@ RefinePatchStrategySet::preprocessRefineBoxes(Patch<NDIM>& fine,
                                               const BoxList<NDIM>& fine_boxes,
                                               const IntVector<NDIM>& ratio)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->preprocessRefineBoxes(fine, coarse, fine_boxes, ratio);
+        strategy->preprocessRefineBoxes(fine, coarse, fine_boxes, ratio);
     }
     return;
 } // preprocessRefineBoxes
@@ -132,9 +132,9 @@ RefinePatchStrategySet::postprocessRefineBoxes(Patch<NDIM>& fine,
                                                const BoxList<NDIM>& fine_boxes,
                                                const IntVector<NDIM>& ratio)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->postprocessRefineBoxes(fine, coarse, fine_boxes, ratio);
+        strategy->postprocessRefineBoxes(fine, coarse, fine_boxes, ratio);
     }
     return;
 } // postprocessRefineBoxes

--- a/ibtk/src/utilities/SideDataSynchronization.cpp
+++ b/ibtk/src/utilities/SideDataSynchronization.cpp
@@ -127,12 +127,12 @@ SideDataSynchronization::initializeOperatorState(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     bool registered_coarsen_op = false;
     d_coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const std::string& coarsen_op_name = d_transaction_comps[comp_idx].d_coarsen_op_name;
+        const std::string& coarsen_op_name = transaction_comp.d_coarsen_op_name;
         if (coarsen_op_name != "NONE")
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
 #if !defined(NDEBUG)
@@ -163,9 +163,9 @@ SideDataSynchronization::initializeOperatorState(
 
     // Setup cached refine algorithms and schedules.
     d_refine_alg = new RefineAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+        const int data_idx = transaction_comp.d_data_idx;
         Pointer<Variable<NDIM> > var;
         var_db->mapIndexToVariable(data_idx, var);
         Pointer<SideVariable<NDIM, double> > sc_var = var;
@@ -233,12 +233,12 @@ SideDataSynchronization::resetTransactionComponents(
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     bool registered_coarsen_op = false;
     d_coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const std::string& coarsen_op_name = d_transaction_comps[comp_idx].d_coarsen_op_name;
+        const std::string& coarsen_op_name = transaction_comp.d_coarsen_op_name;
         if (coarsen_op_name != "NONE")
         {
-            const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+            const int data_idx = transaction_comp.d_data_idx;
             Pointer<Variable<NDIM> > var;
             var_db->mapIndexToVariable(data_idx, var);
 #if !defined(NDEBUG)
@@ -265,9 +265,9 @@ SideDataSynchronization::resetTransactionComponents(
 
     // Reset cached refine algorithms and schedules.
     d_refine_alg = new RefineAlgorithm<NDIM>();
-    for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
+    for (const auto& transaction_comp : d_transaction_comps)
     {
-        const int data_idx = d_transaction_comps[comp_idx].d_data_idx;
+        const int data_idx = transaction_comp.d_data_idx;
         Pointer<Variable<NDIM> > var;
         var_db->mapIndexToVariable(data_idx, var);
         Pointer<SideVariable<NDIM, double> > sc_var = var;

--- a/ibtk/src/utilities/StandardTagAndInitStrategySet.cpp
+++ b/ibtk/src/utilities/StandardTagAndInitStrategySet.cpp
@@ -58,9 +58,9 @@ StandardTagAndInitStrategySet::~StandardTagAndInitStrategySet()
 {
     if (d_managed)
     {
-        for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+        for (const auto& strategy : d_strategy_set)
         {
-            delete (*it);
+            delete strategy;
         }
     }
     return;
@@ -72,9 +72,9 @@ StandardTagAndInitStrategySet::getLevelDt(const Pointer<BasePatchLevel<NDIM> > l
                                           const bool initial_time)
 {
     double dt = std::numeric_limits<double>::max();
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        dt = std::min(dt, (*it)->getLevelDt(level, dt_time, initial_time));
+        dt = std::min(dt, strategy->getLevelDt(level, dt_time, initial_time));
     }
     return dt;
 } // getLevelDt
@@ -89,10 +89,11 @@ StandardTagAndInitStrategySet::advanceLevel(const Pointer<BasePatchLevel<NDIM> >
                                             const bool regrid_advance)
 {
     double dt = std::numeric_limits<double>::max();
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
         dt = std::min(
-            dt, (*it)->advanceLevel(level, hierarchy, current_time, new_time, first_step, last_step, regrid_advance));
+            dt,
+            strategy->advanceLevel(level, hierarchy, current_time, new_time, first_step, last_step, regrid_advance));
     }
     return dt;
 } // advanceLevel
@@ -102,9 +103,9 @@ StandardTagAndInitStrategySet::resetTimeDependentData(const Pointer<BasePatchLev
                                                       const double new_time,
                                                       const bool can_be_refined)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->resetTimeDependentData(level, new_time, can_be_refined);
+        strategy->resetTimeDependentData(level, new_time, can_be_refined);
     }
     return;
 } // resetTimeDependentData
@@ -112,9 +113,9 @@ StandardTagAndInitStrategySet::resetTimeDependentData(const Pointer<BasePatchLev
 void
 StandardTagAndInitStrategySet::resetDataToPreadvanceState(const Pointer<BasePatchLevel<NDIM> > level)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->resetDataToPreadvanceState(level);
+        strategy->resetDataToPreadvanceState(level);
     }
     return;
 } // resetDataToPreadvanceState
@@ -128,9 +129,9 @@ StandardTagAndInitStrategySet::initializeLevelData(const Pointer<BasePatchHierar
                                                    const Pointer<BasePatchLevel<NDIM> > old_level,
                                                    const bool allocate_data)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->initializeLevelData(
+        strategy->initializeLevelData(
             hierarchy, level_number, init_data_time, can_be_refined, initial_time, old_level, allocate_data);
     }
     return;
@@ -141,9 +142,9 @@ StandardTagAndInitStrategySet::resetHierarchyConfiguration(const Pointer<BasePat
                                                            const int coarsest_level,
                                                            const int finest_level)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->resetHierarchyConfiguration(hierarchy, coarsest_level, finest_level);
+        strategy->resetHierarchyConfiguration(hierarchy, coarsest_level, finest_level);
     }
     return;
 } // resetHierarchyConfiguration
@@ -156,9 +157,9 @@ StandardTagAndInitStrategySet::applyGradientDetector(const Pointer<BasePatchHier
                                                      const bool initial_time,
                                                      const bool uses_richardson_extrapolation_too)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->applyGradientDetector(
+        strategy->applyGradientDetector(
             hierarchy, level_number, error_data_time, tag_index, initial_time, uses_richardson_extrapolation_too);
     }
     return;
@@ -173,9 +174,9 @@ StandardTagAndInitStrategySet::applyRichardsonExtrapolation(const Pointer<PatchL
                                                             const bool initial_time,
                                                             const bool uses_gradient_detector_too)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->applyRichardsonExtrapolation(
+        strategy->applyRichardsonExtrapolation(
             level, error_data_time, tag_index, deltat, error_coarsen_ratio, initial_time, uses_gradient_detector_too);
     }
     return;
@@ -188,9 +189,9 @@ StandardTagAndInitStrategySet::coarsenDataForRichardsonExtrapolation(const Point
                                                                      const double coarsen_data_time,
                                                                      const bool before_advance)
 {
-    for (auto it = d_strategy_set.begin(); it != d_strategy_set.end(); ++it)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*it)->coarsenDataForRichardsonExtrapolation(
+        strategy->coarsenDataForRichardsonExtrapolation(
             hierarchy, level_number, coarser_level, coarsen_data_time, before_advance);
     }
     return;

--- a/ibtk/src/utilities/muParserCartGridFunction.cpp
+++ b/ibtk/src/utilities/muParserCartGridFunction.cpp
@@ -202,12 +202,12 @@ muParserCartGridFunction::muParserCartGridFunction(const std::string& object_nam
     const double pi = 3.1415926535897932384626433832795;
     const double* const x_lower = grid_geom->getXLower();
     const double* const x_upper = grid_geom->getXUpper();
-    for (auto it = d_parsers.begin(); it != d_parsers.end(); ++it)
+    for (auto& parser : d_parsers)
     {
         // Various names for pi.
-        it->DefineConst("pi", pi);
-        it->DefineConst("Pi", pi);
-        it->DefineConst("PI", pi);
+        parser.DefineConst("pi", pi);
+        parser.DefineConst("Pi", pi);
+        parser.DefineConst("PI", pi);
 
         // The extents of the domain.
         for (unsigned int d = 0; d < NDIM; ++d)
@@ -216,77 +216,77 @@ muParserCartGridFunction::muParserCartGridFunction(const std::string& object_nam
             stream << d;
             const std::string postfix = stream.str();
 
-            it->DefineConst("X_LOWER" + postfix, x_lower[d]);
-            it->DefineConst("X_lower" + postfix, x_lower[d]);
-            it->DefineConst("x_lower" + postfix, x_lower[d]);
-            it->DefineConst("x_LOWER" + postfix, x_lower[d]);
-            it->DefineConst("X_Lower" + postfix, x_lower[d]);
-            it->DefineConst("X_lower" + postfix, x_lower[d]);
-            it->DefineConst("XLower" + postfix, x_lower[d]);
-            it->DefineConst("Xlower" + postfix, x_lower[d]);
-            it->DefineConst("x_Lower" + postfix, x_lower[d]);
-            it->DefineConst("x_lower" + postfix, x_lower[d]);
-            it->DefineConst("xLower" + postfix, x_lower[d]);
-            it->DefineConst("xlower" + postfix, x_lower[d]);
+            parser.DefineConst("X_LOWER" + postfix, x_lower[d]);
+            parser.DefineConst("X_lower" + postfix, x_lower[d]);
+            parser.DefineConst("x_lower" + postfix, x_lower[d]);
+            parser.DefineConst("x_LOWER" + postfix, x_lower[d]);
+            parser.DefineConst("X_Lower" + postfix, x_lower[d]);
+            parser.DefineConst("X_lower" + postfix, x_lower[d]);
+            parser.DefineConst("XLower" + postfix, x_lower[d]);
+            parser.DefineConst("Xlower" + postfix, x_lower[d]);
+            parser.DefineConst("x_Lower" + postfix, x_lower[d]);
+            parser.DefineConst("x_lower" + postfix, x_lower[d]);
+            parser.DefineConst("xLower" + postfix, x_lower[d]);
+            parser.DefineConst("xlower" + postfix, x_lower[d]);
 
-            it->DefineConst("X_LOWER_" + postfix, x_lower[d]);
-            it->DefineConst("X_lower_" + postfix, x_lower[d]);
-            it->DefineConst("x_lower_" + postfix, x_lower[d]);
-            it->DefineConst("x_LOWER_" + postfix, x_lower[d]);
-            it->DefineConst("X_Lower_" + postfix, x_lower[d]);
-            it->DefineConst("X_lower_" + postfix, x_lower[d]);
-            it->DefineConst("XLower_" + postfix, x_lower[d]);
-            it->DefineConst("Xlower_" + postfix, x_lower[d]);
-            it->DefineConst("x_Lower_" + postfix, x_lower[d]);
-            it->DefineConst("x_lower_" + postfix, x_lower[d]);
-            it->DefineConst("xLower_" + postfix, x_lower[d]);
-            it->DefineConst("xlower_" + postfix, x_lower[d]);
+            parser.DefineConst("X_LOWER_" + postfix, x_lower[d]);
+            parser.DefineConst("X_lower_" + postfix, x_lower[d]);
+            parser.DefineConst("x_lower_" + postfix, x_lower[d]);
+            parser.DefineConst("x_LOWER_" + postfix, x_lower[d]);
+            parser.DefineConst("X_Lower_" + postfix, x_lower[d]);
+            parser.DefineConst("X_lower_" + postfix, x_lower[d]);
+            parser.DefineConst("XLower_" + postfix, x_lower[d]);
+            parser.DefineConst("Xlower_" + postfix, x_lower[d]);
+            parser.DefineConst("x_Lower_" + postfix, x_lower[d]);
+            parser.DefineConst("x_lower_" + postfix, x_lower[d]);
+            parser.DefineConst("xLower_" + postfix, x_lower[d]);
+            parser.DefineConst("xlower_" + postfix, x_lower[d]);
 
-            it->DefineConst("X_UPPER" + postfix, x_upper[d]);
-            it->DefineConst("X_upper" + postfix, x_upper[d]);
-            it->DefineConst("x_upper" + postfix, x_upper[d]);
-            it->DefineConst("x_UPPER" + postfix, x_upper[d]);
-            it->DefineConst("X_Upper" + postfix, x_upper[d]);
-            it->DefineConst("X_upper" + postfix, x_upper[d]);
-            it->DefineConst("XUpper" + postfix, x_upper[d]);
-            it->DefineConst("Xupper" + postfix, x_upper[d]);
-            it->DefineConst("x_Upper" + postfix, x_upper[d]);
-            it->DefineConst("x_upper" + postfix, x_upper[d]);
-            it->DefineConst("xUpper" + postfix, x_upper[d]);
-            it->DefineConst("xupper" + postfix, x_upper[d]);
+            parser.DefineConst("X_UPPER" + postfix, x_upper[d]);
+            parser.DefineConst("X_upper" + postfix, x_upper[d]);
+            parser.DefineConst("x_upper" + postfix, x_upper[d]);
+            parser.DefineConst("x_UPPER" + postfix, x_upper[d]);
+            parser.DefineConst("X_Upper" + postfix, x_upper[d]);
+            parser.DefineConst("X_upper" + postfix, x_upper[d]);
+            parser.DefineConst("XUpper" + postfix, x_upper[d]);
+            parser.DefineConst("Xupper" + postfix, x_upper[d]);
+            parser.DefineConst("x_Upper" + postfix, x_upper[d]);
+            parser.DefineConst("x_upper" + postfix, x_upper[d]);
+            parser.DefineConst("xUpper" + postfix, x_upper[d]);
+            parser.DefineConst("xupper" + postfix, x_upper[d]);
 
-            it->DefineConst("X_UPPER_" + postfix, x_upper[d]);
-            it->DefineConst("X_upper_" + postfix, x_upper[d]);
-            it->DefineConst("x_upper_" + postfix, x_upper[d]);
-            it->DefineConst("x_UPPER_" + postfix, x_upper[d]);
-            it->DefineConst("X_Upper_" + postfix, x_upper[d]);
-            it->DefineConst("X_upper_" + postfix, x_upper[d]);
-            it->DefineConst("XUpper_" + postfix, x_upper[d]);
-            it->DefineConst("Xupper_" + postfix, x_upper[d]);
-            it->DefineConst("x_Upper_" + postfix, x_upper[d]);
-            it->DefineConst("x_upper_" + postfix, x_upper[d]);
-            it->DefineConst("xUpper_" + postfix, x_upper[d]);
-            it->DefineConst("xupper_" + postfix, x_upper[d]);
+            parser.DefineConst("X_UPPER_" + postfix, x_upper[d]);
+            parser.DefineConst("X_upper_" + postfix, x_upper[d]);
+            parser.DefineConst("x_upper_" + postfix, x_upper[d]);
+            parser.DefineConst("x_UPPER_" + postfix, x_upper[d]);
+            parser.DefineConst("X_Upper_" + postfix, x_upper[d]);
+            parser.DefineConst("X_upper_" + postfix, x_upper[d]);
+            parser.DefineConst("XUpper_" + postfix, x_upper[d]);
+            parser.DefineConst("Xupper_" + postfix, x_upper[d]);
+            parser.DefineConst("x_Upper_" + postfix, x_upper[d]);
+            parser.DefineConst("x_upper_" + postfix, x_upper[d]);
+            parser.DefineConst("xUpper_" + postfix, x_upper[d]);
+            parser.DefineConst("xupper_" + postfix, x_upper[d]);
         }
 
         // User-provided constants.
-        for (auto map_cit = d_constants.begin(); map_cit != d_constants.end(); ++map_cit)
+        for (const auto& constant : d_constants)
         {
-            it->DefineConst(map_cit->first, map_cit->second);
+            parser.DefineConst(constant.first, constant.second);
         }
 
         // Variables.
-        it->DefineVar("T", &d_parser_time);
-        it->DefineVar("t", &d_parser_time);
+        parser.DefineVar("T", &d_parser_time);
+        parser.DefineVar("t", &d_parser_time);
         for (unsigned int d = 0; d < NDIM; ++d)
         {
             std::ostringstream stream;
             stream << d;
             const std::string postfix = stream.str();
-            it->DefineVar("X" + postfix, &(d_parser_posn[d]));
-            it->DefineVar("x" + postfix, &(d_parser_posn[d]));
-            it->DefineVar("X_" + postfix, &(d_parser_posn[d]));
-            it->DefineVar("x_" + postfix, &(d_parser_posn[d]));
+            parser.DefineVar("X" + postfix, &(d_parser_posn[d]));
+            parser.DefineVar("x" + postfix, &(d_parser_posn[d]));
+            parser.DefineVar("X_" + postfix, &(d_parser_posn[d]));
+            parser.DefineVar("x_" + postfix, &(d_parser_posn[d]));
         }
     }
     return;

--- a/src/IB/CIBFEMethod.cpp
+++ b/src/IB/CIBFEMethod.cpp
@@ -860,9 +860,9 @@ CIBFEMethod::copyVecToArray(Vec b,
 
     // Wrap the raw data in a PETSc Vec.
     PetscInt total_nodes = 0;
-    for (unsigned k = 0; k < struct_ids.size(); ++k)
+    for (unsigned int struct_id : struct_ids)
     {
-        total_nodes += getNumberOfNodes(struct_ids[k]);
+        total_nodes += getNumberOfNodes(struct_id);
     }
     PetscInt size = total_nodes * data_depth;
     int rank = SAMRAI_MPI::getRank();
@@ -877,9 +877,8 @@ CIBFEMethod::copyVecToArray(Vec b,
 
     // Scatter values
     PetscInt offset = 0;
-    for (unsigned k = 0; k < struct_ids.size(); ++k)
+    for (unsigned int struct_id : struct_ids)
     {
-        const unsigned struct_id = struct_ids[k];
         PetscInt nodes = getNumberOfNodes(struct_id);
         PetscInt size_vec = nodes * data_depth;
 
@@ -918,9 +917,9 @@ CIBFEMethod::copyArrayToVec(Vec b,
 
     // Wrap the raw data in a PETSc Vec.
     PetscInt total_nodes = 0;
-    for (unsigned k = 0; k < struct_ids.size(); ++k)
+    for (unsigned int struct_id : struct_ids)
     {
-        total_nodes += getNumberOfNodes(struct_ids[k]);
+        total_nodes += getNumberOfNodes(struct_id);
     }
     PetscInt size = total_nodes * data_depth;
     int rank = SAMRAI_MPI::getRank();
@@ -935,9 +934,8 @@ CIBFEMethod::copyArrayToVec(Vec b,
 
     // Scatter values
     PetscInt offset = 0;
-    for (unsigned k = 0; k < struct_ids.size(); ++k)
+    for (unsigned int struct_id : struct_ids)
     {
-        const unsigned struct_id = struct_ids[k];
         PetscInt nodes = getNumberOfNodes(struct_id);
         PetscInt size_vec = nodes * data_depth;
 

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -550,9 +550,8 @@ CIBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy,
 
         const Pointer<LMesh> mesh = d_l_data_manager->getLMesh(struct_ln);
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int local_idx = node_idx->getLocalPETScIndex();
             const Vector& displacement_0 = node_idx->getInitialPeriodicDisplacement();
             double* const X0_unshifted = &X0_unshifted_data_array[local_idx][0];
@@ -680,9 +679,8 @@ CIBMethod::forwardEulerStep(double current_time, double new_time)
 #if !defined(NDEBUG)
         TBOX_ASSERT(structs_on_this_ln == d_num_rigid_parts);
 #endif
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
             const int local_idx = node_idx->getLocalPETScIndex();
             double* const X_half = &X_half_array[local_idx][0];
@@ -801,9 +799,8 @@ CIBMethod::midpointStep(double current_time, double new_time)
         TBOX_ASSERT(structs_on_this_ln == d_num_rigid_parts);
 #endif
 
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
             const int local_idx = node_idx->getLocalPETScIndex();
             double* const X_new = &X_new_array[local_idx][0];
@@ -1130,9 +1127,8 @@ CIBMethod::setRigidBodyVelocity(const unsigned int part, const RigidDOFVector& U
         const Pointer<LMesh> mesh = d_l_data_manager->getLMesh(struct_ln);
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
         const std::pair<int, int>& part_idx_range = d_struct_lag_idx_range[part];
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
             if (part_idx_range.first <= lag_idx && lag_idx < part_idx_range.second)
             {
@@ -1186,9 +1182,8 @@ CIBMethod::computeNetRigidGeneralizedForce(const unsigned int part, Vec L, Rigid
     F.setZero();
     const Pointer<LMesh> mesh = d_l_data_manager->getLMesh(struct_ln);
     const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (const auto& node_idx : local_nodes)
     {
-        const LNode* const node_idx = *cit;
         const int lag_idx = node_idx->getLagrangianIndex();
         const int local_idx = node_idx->getLocalPETScIndex();
         const double* const P = &p_data_array[local_idx][0];
@@ -1392,9 +1387,9 @@ CIBMethod::constructMobilityMatrix(const std::string& /*mat_name*/,
 
     // Get the size of matrix.
     unsigned num_nodes = 0;
-    for (unsigned i = 0; i < prototype_struct_ids.size(); ++i)
+    for (const auto& prototype_struct_id : prototype_struct_ids)
     {
-        num_nodes += getNumberOfNodes(prototype_struct_ids[i]);
+        num_nodes += getNumberOfNodes(prototype_struct_id);
     }
     const int size = num_nodes * NDIM;
 
@@ -1491,9 +1486,9 @@ CIBMethod::constructGeometricMatrix(const std::string& /*mat_name*/,
 
     // Get the size of matrix
     unsigned num_nodes = 0;
-    for (unsigned i = 0; i < prototype_struct_ids.size(); ++i)
+    for (const auto& prototype_struct_id : prototype_struct_ids)
     {
-        num_nodes += getNumberOfNodes(prototype_struct_ids[i]);
+        num_nodes += getNumberOfNodes(prototype_struct_id);
     }
     int row_size = num_nodes * NDIM;
     int col_size = s_max_free_dofs * static_cast<int>(prototype_struct_ids.size());
@@ -1773,9 +1768,8 @@ CIBMethod::computeCOMOfStructures(std::vector<Eigen::Vector3d>& center_of_mass, 
         TBOX_ASSERT(structs_on_this_ln == d_num_rigid_parts);
 #endif
 
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
             const int local_idx = node_idx->getLocalPETScIndex();
             const double* const X = &X_data_array[local_idx][0];
@@ -1828,9 +1822,8 @@ CIBMethod::setRegularizationWeight(const int level_number)
         const std::pair<int, int>& lag_idx_range = d_struct_lag_idx_range[struct_no];
         if (d_reg_filename[struct_no].empty())
         {
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -1895,9 +1888,8 @@ CIBMethod::setRegularizationWeight(const int level_number)
             }
         }
 
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
             if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
             {
@@ -1998,9 +1990,8 @@ CIBMethod::setInitialLambda(const int level_number)
             }
         }
 
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
             if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
             {

--- a/src/IB/CIBSaddlePointSolver.cpp
+++ b/src/IB/CIBSaddlePointSolver.cpp
@@ -639,16 +639,16 @@ CIBSaddlePointSolver::initializeStokesSolver(const SAMRAIVectorReal<NDIM, double
     const bool has_velocity_nullspace = d_normalize_velocity && MathUtilities<double>::equalEps(rho, 0.0);
     const bool has_pressure_nullspace = d_normalize_pressure;
 
-    for (unsigned int k = 0; k < d_nul_vecs.size(); ++k)
+    for (const auto& nul_vec : d_nul_vecs)
     {
-        if (d_nul_vecs[k]) d_nul_vecs[k]->freeVectorComponents();
+        if (nul_vec) nul_vec->freeVectorComponents();
     }
     const int n_nul_vecs = (has_pressure_nullspace ? 1 : 0) + (has_velocity_nullspace ? NDIM : 0);
     d_nul_vecs.resize(n_nul_vecs);
 
-    for (unsigned int k = 0; k < d_U_nul_vecs.size(); ++k)
+    for (const auto& U_nul_vec : d_U_nul_vecs)
     {
-        if (d_U_nul_vecs[k]) d_U_nul_vecs[k]->freeVectorComponents();
+        if (U_nul_vec) U_nul_vec->freeVectorComponents();
     }
     const int n_U_nul_vecs = (has_velocity_nullspace ? NDIM : 0);
     d_U_nul_vecs.resize(n_U_nul_vecs);

--- a/src/IB/ConstraintIBMethod.cpp
+++ b/src/IB/ConstraintIBMethod.cpp
@@ -114,9 +114,9 @@ public:
         const std::vector<std::pair<int, int> >& range = struct_param.getLagIdxRange();
 
         bool is_in_range = false;
-        for (unsigned int i = 0; i < range.size(); ++i)
+        for (const auto& idx : range)
         {
-            if (struct_to_find_range.first == range[i].first && struct_to_find_range.second == range[i].second)
+            if (struct_to_find_range.first == idx.first && struct_to_find_range.second == idx.second)
             {
                 is_in_range = true;
                 break;
@@ -964,9 +964,8 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
             double X_com_current[NDIM] = { 0.0 }, X_com_new[NDIM] = { 0.0 };
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -1065,9 +1064,8 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
             Inertia_current.setZero();
             Inertia_new.setZero();
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -1228,9 +1226,8 @@ ConstraintIBMethod::calculateMomentumOfKinematicsVelocity(const int position_han
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
         const std::vector<std::vector<double> >& def_vel = ptr_ib_kinematics->getKinematicsVelocity(ln);
 
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int lag_idx = node_idx->getLagrangianIndex();
             if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
             {
@@ -1288,9 +1285,8 @@ ConstraintIBMethod::calculateMomentumOfKinematicsVelocity(const int position_han
             const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
             const std::vector<std::vector<double> >& def_vel = ptr_ib_kinematics->getKinematicsVelocity(ln);
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -1522,9 +1518,8 @@ ConstraintIBMethod::calculateRigidTranslationalMomentum()
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
             double U_rigid[NDIM] = { 0.0 };
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -1615,9 +1610,8 @@ ConstraintIBMethod::calculateRigidRotationalMomentum()
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
             double Omega_rigid[3] = { 0.0 };
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -1719,9 +1713,8 @@ ConstraintIBMethod::calculateCurrentLagrangianVelocity()
             const StructureParameters& struct_param = ptr_ib_kinematics->getStructureParameters();
             const std::vector<std::vector<double> >& current_vel = ptr_ib_kinematics->getKinematicsVelocity(ln);
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
 
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
@@ -1826,9 +1819,8 @@ ConstraintIBMethod::correctVelocityOnLagrangianMesh()
             const StructureParameters& struct_param = ptr_ib_kinematics->getStructureParameters();
             const std::vector<std::vector<double> >& new_vel = ptr_ib_kinematics->getKinematicsVelocity(ln);
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -2119,9 +2111,8 @@ ConstraintIBMethod::updateStructurePositionEulerStep()
             const std::string position_update_method = struct_param.getPositionUpdateMethod();
             const std::vector<std::vector<double> >& current_shape = ptr_ib_kinematics->getShape(ln);
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -2223,9 +2214,8 @@ ConstraintIBMethod::updateStructurePositionMidPointStep()
             const std::string position_update_method = struct_param.getPositionUpdateMethod();
             const std::vector<std::vector<double> >& new_shape = ptr_ib_kinematics->getShape(ln);
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -2470,9 +2460,8 @@ ConstraintIBMethod::calculateDrag()
             const int location_struct_handle =
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -2555,9 +2544,8 @@ ConstraintIBMethod::calculateTorque()
             const int location_struct_handle =
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -2664,9 +2652,8 @@ ConstraintIBMethod::calculatePower()
             const int location_struct_handle =
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -2740,9 +2727,8 @@ ConstraintIBMethod::calculateStructureMomentum()
             const int location_struct_handle =
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
@@ -2802,9 +2788,8 @@ ConstraintIBMethod::calculateStructureRotationalMomentum()
             const int location_struct_handle =
                 find_struct_handle_position(d_ib_kinematics.begin(), d_ib_kinematics.end(), ptr_ib_kinematics);
 
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const int lag_idx = node_idx->getLagrangianIndex();
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -425,9 +425,8 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
     // on all the processes.
     for (int jj = 0; jj < d_nodeset_IDs_for_meters.size(); ++jj)
     {
-        for (auto it = temp_node_dof_ID_sets[jj].begin(); it != temp_node_dof_ID_sets[jj].end(); ++it)
+        for (const auto& node_id : temp_node_dof_ID_sets[jj])
         {
-            const dof_id_type node_id = *it;
             temp_node_dof_IDs[jj].push_back(node_id);
             const Node* node = &mesh->node_ref(node_id);
             temp_nodes[jj].push_back(*node);

--- a/src/IB/IBFEPostProcessor.cpp
+++ b/src/IB/IBFEPostProcessor.cpp
@@ -221,9 +221,9 @@ void
 IBFEPostProcessor::initializeFEData()
 {
     if (d_fe_data_initialized) return;
-    for (unsigned int k = 0; k < d_var_systems.size(); ++k)
+    for (const auto& var_system : d_var_systems)
     {
-        System& system = *d_var_systems[k];
+        System& system = *var_system;
         system.assemble_before_solve = false;
         system.assemble();
     }

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -567,9 +567,9 @@ IBFESurfaceMethod::interpolateVelocity(const int u_data_idx,
 
         // Communicate any unsynchronized ghost data and extract the underlying
         // solution data.
-        for (unsigned int k = 0; k < u_ghost_fill_scheds.size(); ++k)
+        for (const auto& u_ghost_fill_sched : u_ghost_fill_scheds)
         {
-            if (u_ghost_fill_scheds[k]) u_ghost_fill_scheds[k]->fillData(data_time);
+            if (u_ghost_fill_sched) u_ghost_fill_sched->fillData(data_time);
         }
 
         X_ghost_vec->close();
@@ -1664,10 +1664,10 @@ IBFESurfaceMethod::imposeJumpConditions(const int f_data_idx,
 #if (NDIM == 3)
                     intersect_line_with_face(intersections, static_cast<Face*>(elem), r, q, tolerance);
 #endif
-                    for (unsigned int k = 0; k < intersections.size(); ++k)
+                    for (const auto& intersection : intersections)
                     {
-                        const libMesh::Point x = r + intersections[k].first * q;
-                        const libMesh::Point& xi = intersections[k].second;
+                        const libMesh::Point x = r + intersection.first * q;
+                        const libMesh::Point& xi = intersection.second;
                         SideIndex<NDIM> i_s(i_c, axis, 0);
                         i_s(axis) = boost::math::iround((x(axis) - x_lower[axis]) / dx[axis]) + patch_lower[axis];
                         if (extended_box.contains(i_s))

--- a/src/IB/IBHydrodynamicForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicForceEvaluator.cpp
@@ -324,9 +324,9 @@ IBHydrodynamicForceEvaluator::computeLaggedMomentumIntegral(
     // Whether or not the simulation has adaptive mesh refinement
     const bool amr_case = (coarsest_ln != finest_ln);
 
-    for (auto it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
+    for (auto& hydro_obj : d_hydro_objs)
     {
-        IBHydrodynamicForceObject& fobj = it->second;
+        IBHydrodynamicForceObject& fobj = hydro_obj.second;
 
         // Compute the momentum integral:= (rho * u * dv) for the previous time step (integral is over new control
         // volume)
@@ -493,9 +493,9 @@ IBHydrodynamicForceEvaluator::computeHydrodynamicForce(int u_idx,
     // Whether or not the simulation has adaptive mesh refinement
     const bool amr_case = (coarsest_ln != finest_ln);
 
-    for (auto it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
+    for (auto& hydro_obj : d_hydro_objs)
     {
-        IBHydrodynamicForceObject& fobj = it->second;
+        IBHydrodynamicForceObject& fobj = hydro_obj.second;
 
         // Compute the momentum integral:= (rho * u * dv)
         fobj.P_box_new.setZero();
@@ -790,9 +790,9 @@ IBHydrodynamicForceEvaluator::computeHydrodynamicForce(int u_idx,
 void
 IBHydrodynamicForceEvaluator::postprocessIntegrateData(double /*current_time*/, double new_time)
 {
-    for (auto it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
+    for (auto& hydro_obj : d_hydro_objs)
     {
-        IBHydrodynamicForceObject& force_obj = it->second;
+        IBHydrodynamicForceObject& force_obj = hydro_obj.second;
 
         // Output drag and torque to stream
         if (SAMRAI_MPI::getRank() == 0)
@@ -822,10 +822,10 @@ IBHydrodynamicForceEvaluator::postprocessIntegrateData(double /*current_time*/, 
 void
 IBHydrodynamicForceEvaluator::putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db)
 {
-    for (auto it = d_hydro_objs.begin(); it != d_hydro_objs.end(); ++it)
+    for (const auto& hydro_obj : d_hydro_objs)
     {
-        int strct_id = it->first;
-        const IBHydrodynamicForceObject& force_obj = it->second;
+        int strct_id = hydro_obj.first;
+        const IBHydrodynamicForceObject& force_obj = hydro_obj.second;
 
         std::ostringstream F, T, P, L, P_box, L_box, X_lo, X_hi, r_or, vol_curr;
         F << "F_" << strct_id;

--- a/src/IB/IBInstrumentPanel.cpp
+++ b/src/IB/IBInstrumentPanel.cpp
@@ -629,9 +629,8 @@ IBInstrumentPanel::initializeHierarchyIndependentData(const Pointer<PatchHierarc
         {
             const Pointer<LMesh> mesh = l_data_manager->getLMesh(ln);
             const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const IBInstrumentationSpec* const spec = node_idx->getNodeDataItem<IBInstrumentationSpec>();
                 if (spec)
                 {
@@ -774,9 +773,8 @@ IBInstrumentPanel::initializeHierarchyDependentData(const Pointer<PatchHierarchy
             // Store the local positions of the perimeter nodes.
             const Pointer<LMesh> mesh = l_data_manager->getLMesh(ln);
             const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const IBInstrumentationSpec* const spec = node_idx->getNodeDataItem<IBInstrumentationSpec>();
                 if (spec)
                 {
@@ -1138,9 +1136,8 @@ IBInstrumentPanel::readInstrumentData(const int U_data_idx,
             // Store the local velocities of the perimeter nodes.
             const Pointer<LMesh> mesh = l_data_manager->getLMesh(ln);
             const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-            for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+            for (const auto& node_idx : local_nodes)
             {
-                const LNode* const node_idx = *cit;
                 const IBInstrumentationSpec* const spec = node_idx->getNodeDataItem<IBInstrumentationSpec>();
                 if (spec)
                 {

--- a/src/IB/IBKirchhoffRodForceGen.cpp
+++ b/src/IB/IBKirchhoffRodForceGen.cpp
@@ -98,19 +98,19 @@ IBKirchhoffRodForceGen::IBKirchhoffRodForceGen(Pointer<Database> input_db)
 IBKirchhoffRodForceGen::~IBKirchhoffRodForceGen()
 {
     int ierr;
-    for (auto it = d_D_next_mats.begin(); it != d_D_next_mats.end(); ++it)
+    for (auto& D_next_mat : d_D_next_mats)
     {
-        if (*it)
+        if (D_next_mat)
         {
-            ierr = MatDestroy(&*it);
+            ierr = MatDestroy(&D_next_mat);
             IBTK_CHKERRQ(ierr);
         }
     }
-    for (auto it = d_X_next_mats.begin(); it != d_X_next_mats.end(); ++it)
+    for (auto& X_next_mat : d_X_next_mats)
     {
-        if (*it)
+        if (X_next_mat)
         {
-            ierr = MatDestroy(&*it);
+            ierr = MatDestroy(&X_next_mat);
             IBTK_CHKERRQ(ierr);
         }
     }
@@ -174,9 +174,8 @@ IBKirchhoffRodForceGen::initializeLevelData(const Pointer<PatchHierarchy<NDIM> >
 
     // Determine the "next" node indices for all rods associated with the
     // present MPI process.
-    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (const auto& node_idx : local_nodes)
     {
-        const LNode* const node_idx = *cit;
         const IBRodForceSpec* const force_spec = node_idx->getNodeDataItem<IBRodForceSpec>();
         if (force_spec)
         {

--- a/src/IB/IBLagrangianForceStrategySet.cpp
+++ b/src/IB/IBLagrangianForceStrategySet.cpp
@@ -61,9 +61,9 @@ IBLagrangianForceStrategySet::~IBLagrangianForceStrategySet()
 void
 IBLagrangianForceStrategySet::setTimeInterval(const double current_time, const double new_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->setTimeInterval(current_time, new_time);
+        strategy->setTimeInterval(current_time, new_time);
     }
     return;
 } // setTimeInterval
@@ -75,9 +75,9 @@ IBLagrangianForceStrategySet::initializeLevelData(const Pointer<PatchHierarchy<N
                                                   const bool initial_time,
                                                   LDataManager* const l_data_manager)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->initializeLevelData(hierarchy, level_number, init_data_time, initial_time, l_data_manager);
+        strategy->initializeLevelData(hierarchy, level_number, init_data_time, initial_time, l_data_manager);
     }
     return;
 } // initializeLevelData
@@ -91,9 +91,9 @@ IBLagrangianForceStrategySet::computeLagrangianForce(Pointer<LData> F_data,
                                                      const double data_time,
                                                      LDataManager* const l_data_manager)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->computeLagrangianForce(F_data, X_data, U_data, hierarchy, level_number, data_time, l_data_manager);
+        strategy->computeLagrangianForce(F_data, X_data, U_data, hierarchy, level_number, data_time, l_data_manager);
     }
     return;
 } // computeLagrangianForce
@@ -106,9 +106,9 @@ IBLagrangianForceStrategySet::computeLagrangianForceJacobianNonzeroStructure(
     const int level_number,
     LDataManager* const l_data_manager)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->computeLagrangianForceJacobianNonzeroStructure(d_nnz, o_nnz, hierarchy, level_number, l_data_manager);
+        strategy->computeLagrangianForceJacobianNonzeroStructure(d_nnz, o_nnz, hierarchy, level_number, l_data_manager);
     }
     return;
 } // computeLagrangianForceJacobianNonzeroStructure
@@ -125,18 +125,18 @@ IBLagrangianForceStrategySet::computeLagrangianForceJacobian(Mat& J_mat,
                                                              const double data_time,
                                                              LDataManager* const l_data_manager)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->computeLagrangianForceJacobian(J_mat,
-                                               MAT_FLUSH_ASSEMBLY,
-                                               X_coef,
-                                               X_data,
-                                               U_coef,
-                                               U_data,
-                                               hierarchy,
-                                               level_number,
-                                               data_time,
-                                               l_data_manager);
+        strategy->computeLagrangianForceJacobian(J_mat,
+                                                 MAT_FLUSH_ASSEMBLY,
+                                                 X_coef,
+                                                 X_data,
+                                                 U_coef,
+                                                 U_data,
+                                                 hierarchy,
+                                                 level_number,
+                                                 data_time,
+                                                 l_data_manager);
     }
     if (assembly_type != MAT_FLUSH_ASSEMBLY)
     {
@@ -158,9 +158,10 @@ IBLagrangianForceStrategySet::computeLagrangianEnergy(Pointer<LData> X_data,
                                                       LDataManager* const l_data_manager)
 {
     double ret_val = 0.0;
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        ret_val += (*cit)->computeLagrangianEnergy(X_data, U_data, hierarchy, level_number, data_time, l_data_manager);
+        ret_val +=
+            strategy->computeLagrangianEnergy(X_data, U_data, hierarchy, level_number, data_time, l_data_manager);
     }
     return ret_val;
 } // computeLagrangianEnergy

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -1172,9 +1172,9 @@ IBMethod::spreadFluidSource(const int q_data_idx,
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
     {
         Q_sum = std::accumulate(d_Q_src[ln].begin(), d_Q_src[ln].end(), Q_sum);
-        for (unsigned int k = 0; k < d_Q_src[ln].size(); ++k)
+        for (const auto& Q_src : d_Q_src[ln])
         {
-            Q_max = std::max(Q_max, std::abs(d_Q_src[ln][k]));
+            Q_max = std::max(Q_max, std::abs(Q_src));
         }
     }
     const double q_total = getPressureHierarchyDataOps()->integral(q_data_idx, wgt_idx);
@@ -1556,9 +1556,8 @@ IBMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > hierarchy,
 
         const Pointer<LMesh> mesh = d_l_data_manager->getLMesh(ln);
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const IBAnchorPointSpec* const anchor_point_spec = node_idx->getNodeDataItem<IBAnchorPointSpec>();
             if (anchor_point_spec)
             {
@@ -1929,12 +1928,11 @@ IBMethod::resetAnchorPointValues(std::vector<Pointer<LData> > U_data, const int 
         double* U_arr;
         ierr = VecGetArray(U_vec, &U_arr);
         IBTK_CHKERRQ(ierr);
-        for (auto cit = d_anchor_point_local_idxs[ln].begin(); cit != d_anchor_point_local_idxs[ln].end(); ++cit)
+        for (const auto& idx : d_anchor_point_local_idxs[ln])
         {
-            const int& i = *cit;
             for (int d = 0; d < depth; ++d)
             {
-                U_arr[depth * i + d] = 0.0;
+                U_arr[depth * idx + d] = 0.0;
             }
         }
         ierr = VecRestoreArray(U_vec, &U_arr);

--- a/src/IB/IBRedundantInitializer.cpp
+++ b/src/IB/IBRedundantInitializer.cpp
@@ -403,9 +403,9 @@ IBRedundantInitializer::initializeSprings()
 
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
-                for (auto it = d_spring_edge_map[ln][j].begin(); it != d_spring_edge_map[ln][j].end(); ++it)
+                for (const auto& edge_pair : d_spring_edge_map[ln][j])
                 {
-                    Edge& e = it->second;
+                    const Edge& e = edge_pair.second;
                     const SpringSpec& spec = d_spring_spec_data[ln][j][e];
                     if ((e.first < min_idx) || (e.first > max_idx))
                     {
@@ -419,7 +419,7 @@ IBRedundantInitializer::initializeSprings()
                                                  << " and structure number " << j << ":\n"
                                                  << e.second << " is not a valid index.");
                     }
-                    if (it->first > e.second)
+                    if (edge_pair.first > e.second)
                     {
                         TBOX_ERROR(d_object_name << ":\n Error on level " << ln << " and structure number " << j
                                                  << ".\n Master index must be lower than the slave index for springs.");
@@ -458,9 +458,9 @@ IBRedundantInitializer::initializeXSprings()
                 d_init_xspring_on_level_fcn(j, ln, d_xspring_edge_map[ln][j], d_xspring_spec_data[ln][j]);
                 const int min_idx = 0;
                 const int max_idx = std::accumulate(d_num_vertex[ln].begin(), d_num_vertex[ln].end(), 0);
-                for (auto it = d_xspring_edge_map[ln][j].begin(); it != d_xspring_edge_map[ln][j].end(); ++it)
+                for (const auto& edge_pair : d_xspring_edge_map[ln][j])
                 {
-                    Edge& e = it->second;
+                    const Edge& e = edge_pair.second;
                     const XSpringSpec& spec = d_xspring_spec_data[ln][j][e];
                     if ((e.first < min_idx) || (e.first > max_idx))
                     {
@@ -474,7 +474,7 @@ IBRedundantInitializer::initializeXSprings()
                                                  << " and structure number " << j << ":\n"
                                                  << e.second << " is not a valid index.");
                     }
-                    if (it->first > e.second)
+                    if (edge_pair.first > e.second)
                     {
                         TBOX_ERROR(d_object_name
                                    << ":\n Error on level " << ln << " and structure number " << j
@@ -514,9 +514,9 @@ IBRedundantInitializer::initializeBeams()
 
                 const int min_idx = 0;
                 const int max_idx = d_num_vertex[ln][j];
-                for (auto it = d_beam_spec_data[ln][j].begin(); it != d_beam_spec_data[ln][j].end(); ++it)
+                for (const auto& spec_pair : d_beam_spec_data[ln][j])
                 {
-                    const BeamSpec& e = it->second;
+                    const BeamSpec& e = spec_pair.second;
                     const std::pair<int, int>& idxs = e.neighbor_idxs;
                     if ((idxs.first < min_idx) || (idxs.first > max_idx))
                     {
@@ -534,7 +534,8 @@ IBRedundantInitializer::initializeBeams()
                     {
                         TBOX_ERROR(d_object_name << ":\n Invalid bending rigidity encountered on level " << ln
                                                  << " and structure number " << j << ":\n"
-                                                 << e.bend_rigidity << " for index " << it->first << " is negative");
+                                                 << e.bend_rigidity << " for index " << spec_pair.first
+                                                 << " is negative");
                     }
                 }
             }
@@ -563,15 +564,16 @@ IBRedundantInitializer::initializeTargetPts()
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
                 d_target_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
-                for (auto it = tg_pt_spec.begin(); it != tg_pt_spec.end(); ++it)
+                for (const auto& spec_pair : tg_pt_spec)
                 {
-                    if ((it->first < min_idx) || (it->first > max_idx))
+                    const int& idx = spec_pair.first;
+                    if ((idx < min_idx) || (idx > max_idx))
                     {
                         TBOX_ERROR(d_object_name << ":\n Invalid target point index on level " << ln
                                                  << " and structure number " << j << ": \n"
-                                                 << it->first);
+                                                 << idx);
                     }
-                    const TargetSpec& tg_spec = it->second;
+                    const TargetSpec& tg_spec = spec_pair.second;
                     if (tg_spec.stiffness < 0.0)
                     {
                         TBOX_ERROR(d_object_name << ":\n Invalid target point stiffness encountered on level " << ln
@@ -584,7 +586,7 @@ IBRedundantInitializer::initializeTargetPts()
                                                  << " and structure number " << j << ": \n"
                                                  << tg_spec.damping << " is negative");
                     }
-                    d_target_spec_data[ln][j][it->first] = tg_spec;
+                    d_target_spec_data[ln][j][idx] = tg_spec;
                 }
             }
         }
@@ -649,9 +651,9 @@ IBRedundantInitializer::initializeDirectorAndRods()
                         }
                     }
                 }
-                for (auto it = d_rod_edge_map[ln][j].begin(); it != d_rod_edge_map[ln][j].end(); ++it)
+                for (const auto& edge_pair : d_rod_edge_map[ln][j])
                 {
-                    const Edge& e = it->second;
+                    const Edge& e = edge_pair.second;
                     const RodSpec& rod_spec = d_rod_spec_data[ln][j][e];
                     const std::array<double, IBRodForceSpec::NUM_MATERIAL_PARAMS> parameters = rod_spec.properties;
                     if ((e.first < min_idx) || (e.first > max_idx))
@@ -734,15 +736,16 @@ IBRedundantInitializer::initializeBoundaryMass()
                 d_bdry_mass_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
-                for (auto it = bdry_map.begin(); it != bdry_map.end(); ++it)
+                for (const auto& spec_pair : bdry_map)
                 {
-                    if ((it->first < min_idx) || (it->first > max_idx))
+                    const int& idx = spec_pair.first;
+                    if ((idx < min_idx) || (idx > max_idx))
                     {
                         TBOX_ERROR(d_object_name << ":\n Invalid massive point index on level " << ln
                                                  << " and structure number " << j << ": \n"
-                                                 << it->first);
+                                                 << idx);
                     }
-                    const BdryMassSpec& bdry_mass_spec = it->second;
+                    const BdryMassSpec& bdry_mass_spec = spec_pair.second;
                     if (bdry_mass_spec.bdry_mass < 0.0)
                     {
                         TBOX_ERROR(d_object_name << ":\n Invalid boundary mass encountered on level " << ln
@@ -755,7 +758,7 @@ IBRedundantInitializer::initializeBoundaryMass()
                                                  << " and structure number " << j << ": \n"
                                                  << bdry_mass_spec.stiffness << " is negative");
                     }
-                    d_bdry_mass_spec_data[ln][j][it->first] = bdry_mass_spec;
+                    d_bdry_mass_spec_data[ln][j][idx] = bdry_mass_spec;
                 }
             }
         }
@@ -788,15 +791,16 @@ IBRedundantInitializer::initializeAnchorPts()
                 d_anchor_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
-                for (auto it = anchor_map.begin(); it != anchor_map.end(); ++it)
+                for (const auto& anchor_pair : anchor_map)
                 {
-                    if ((it->first < min_idx) || (it->first > max_idx))
+                    const int& anchor_pt = anchor_pair.first;
+                    if ((anchor_pt < min_idx) || (anchor_pt > max_idx))
                     {
                         TBOX_ERROR(d_object_name << ":\n Invalid anchor point index on level " << ln
                                                  << " and structure number " << j << ": \n"
-                                                 << it->first);
+                                                 << anchor_pt);
                     }
-                    d_anchor_spec_data[ln][j][it->first] = it->second;
+                    d_anchor_spec_data[ln][j][anchor_pt] = anchor_pair.second;
                 }
             }
         }
@@ -828,7 +832,7 @@ IBRedundantInitializer::initializeInstrumentationData()
                 d_init_instrumentation_on_level_fcn(j, ln, new_names, d_instrument_idx[ln][j]);
                 std::vector<bool> encountered_instrument_idx;
                 std::map<int, std::vector<bool> > encountered_node_idxs;
-                for (auto i = new_names.begin(); i != new_names.end(); ++i) instrument_names.push_back(*i);
+                for (const auto& new_name : new_names) instrument_names.push_back(new_name);
                 const int min_idx = 0;
                 const int max_idx = d_num_vertex[ln][j];
                 for (auto it = d_instrument_idx[ln][j].begin(); it != d_instrument_idx[ln][j].end(); ++it)
@@ -928,8 +932,8 @@ IBRedundantInitializer::initializeSourceData()
                                              << source_names.size() << " is not equal to number of radii "
                                              << source_radii.size() << ".\n");
                 }
-                for (auto i = new_names.begin(); i != new_names.end(); ++i) source_names.push_back(*i);
-                for (auto i = new_radii.begin(); i != new_radii.end(); ++i) source_radii.push_back(*i);
+                for (const auto& new_name : new_names) source_names.push_back(new_name);
+                for (double& radius : new_radii) source_radii.push_back(radius);
                 num_source = new_names.size();
                 for (auto it = d_source_idx[ln][j].begin(); it != d_source_idx[ln][j].end(); ++it)
                 {
@@ -1011,9 +1015,8 @@ IBRedundantInitializer::initializeDataOnPatchLevel(const int lag_node_index_idx,
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(patch_vertices, patch, hierarchy);
         local_node_count += patch_vertices.size();
-        for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
+        for (const auto& point_idx : patch_vertices)
         {
-            const std::pair<int, int>& point_idx = (*it);
             const int lagrangian_idx = getCanonicalLagrangianIndex(point_idx, level_number) + global_index_offset;
             const int local_petsc_idx = ++local_idx + local_index_offset;
             const int global_petsc_idx = local_petsc_idx + global_index_offset;
@@ -1065,9 +1068,9 @@ IBRedundantInitializer::initializeDataOnPatchLevel(const int lag_node_index_idx,
             // vertex.
             std::vector<Pointer<Streamable> > node_data =
                 initializeNodeData(point_idx, global_index_offset, level_number);
-            for (auto it = node_data.begin(); it != node_data.end(); ++it)
+            for (const auto& node : node_data)
             {
-                (*it)->registerPeriodicShift(periodic_offset, periodic_displacement);
+                node->registerPeriodicShift(periodic_offset, periodic_displacement);
             }
 
             // Create or retrieve a pointer to the LNodeSet associated with the
@@ -1140,9 +1143,8 @@ IBRedundantInitializer::initializeMassDataOnPatchLevel(const unsigned int /*glob
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(patch_vertices, patch, hierarchy);
         local_node_count += patch_vertices.size();
-        for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
+        for (const auto& point_idx : patch_vertices)
         {
-            const std::pair<int, int>& point_idx = (*it);
             const int local_petsc_idx = ++local_idx + local_index_offset;
 
             // Initialize the mass and penalty stiffness coefficient
@@ -1202,9 +1204,8 @@ IBRedundantInitializer::initializeDirectorDataOnPatchLevel(const unsigned int /*
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(patch_vertices, patch, hierarchy);
         local_node_count += patch_vertices.size();
-        for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
+        for (const auto& point_idx : patch_vertices)
         {
-            const std::pair<int, int>& point_idx = (*it);
             const int local_petsc_idx = ++local_idx + local_index_offset;
 
             // Initialize the director corresponding to the present vertex.
@@ -1255,10 +1256,8 @@ IBRedundantInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarch
         {
             std::vector<std::pair<int, int> > patch_vertices;
             getPatchVerticesAtLevel(patch_vertices, patch, hierarchy, ln);
-            for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
+            for (const auto& point_idx : patch_vertices)
             {
-                const std::pair<int, int>& point_idx = (*it);
-
                 // Get the coordinates of the present vertex.
                 const Point& X = getShiftedVertexPosn(point_idx, ln, domain_x_lower, domain_x_upper, periodic_shift);
 

--- a/src/IB/IBStandardForceGen.cpp
+++ b/src/IB/IBStandardForceGen.cpp
@@ -79,9 +79,8 @@ resetLocalPETScIndices(std::vector<int>& inds, const int global_node_offset, con
 #if defined(NDEBUG)
     NULL_USE(num_local_nodes);
 #endif
-    for (auto it = inds.begin(); it != inds.end(); ++it)
+    for (int& idx : inds)
     {
-        int& idx = *it;
 #if !defined(NDEBUG)
         TBOX_ASSERT(idx >= global_node_offset && idx < global_node_offset + num_local_nodes);
 #endif
@@ -96,9 +95,8 @@ resetLocalOrNonlocalPETScIndices(std::vector<int>& inds,
                                  const int num_local_nodes,
                                  const std::vector<int>& nonlocal_petsc_idxs)
 {
-    for (auto it = inds.begin(); it != inds.end(); ++it)
+    for (int& idx : inds)
     {
-        int& idx = *it;
         if (idx >= global_node_offset && idx < global_node_offset + num_local_nodes)
         {
             // A local node.
@@ -785,9 +783,8 @@ IBStandardForceGen::initializeSpringLevelData(std::set<int>& nonlocal_petsc_idx_
 
     // Determine how many springs are associated with the present MPI process.
     unsigned int num_springs = 0;
-    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (const auto& node_idx : local_nodes)
     {
-        const LNode* const node_idx = *cit;
         const IBSpringForceSpec* const force_spec = node_idx->getNodeDataItem<IBSpringForceSpec>();
         if (force_spec) num_springs += force_spec->getNumberOfSprings();
     }
@@ -805,9 +802,8 @@ IBStandardForceGen::initializeSpringLevelData(std::set<int>& nonlocal_petsc_idx_
 
     // Setup the data structures used to compute spring forces.
     int current_spring = 0;
-    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (const auto& node_idx : local_nodes)
     {
-        const LNode* const node_idx = *cit;
         const IBSpringForceSpec* const force_spec = node_idx->getNodeDataItem<IBSpringForceSpec>();
         if (!force_spec) continue;
 
@@ -851,9 +847,8 @@ IBStandardForceGen::initializeSpringLevelData(std::set<int>& nonlocal_petsc_idx_
     // NOTE: Only slave nodes can be "off processor".  Master nodes are
     // guaranteed to be "on processor".
     const int global_node_offset = l_data_manager->getGlobalNodeOffset(level_number);
-    for (unsigned int k = 0; k < petsc_slave_node_idxs.size(); ++k)
+    for (int idx : petsc_slave_node_idxs)
     {
-        const int idx = petsc_slave_node_idxs[k];
         if (UNLIKELY(idx < global_node_offset || idx >= global_node_offset + num_local_nodes))
         {
             nonlocal_petsc_idx_set.insert(idx);
@@ -1005,9 +1000,8 @@ IBStandardForceGen::initializeBeamLevelData(std::set<int>& nonlocal_petsc_idx_se
 
     // Determine how many beams are associated with the present MPI process.
     unsigned int num_beams = 0;
-    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (const auto& node_idx : local_nodes)
     {
-        const LNode* const node_idx = *cit;
         const IBBeamForceSpec* const force_spec = node_idx->getNodeDataItem<IBBeamForceSpec>();
         if (force_spec) num_beams += force_spec->getNumberOfBeams();
     }
@@ -1022,9 +1016,8 @@ IBStandardForceGen::initializeBeamLevelData(std::set<int>& nonlocal_petsc_idx_se
 
     // Setup the data structures used to compute beam forces.
     int current_beam = 0;
-    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (const auto& node_idx : local_nodes)
     {
-        const LNode* const node_idx = *cit;
         const IBBeamForceSpec* const force_spec = node_idx->getNodeDataItem<IBBeamForceSpec>();
         if (!force_spec) continue;
 
@@ -1071,17 +1064,15 @@ IBStandardForceGen::initializeBeamLevelData(std::set<int>& nonlocal_petsc_idx_se
     //
     // NOTE: Only neighbor nodes can be "off processor".  Master nodes are
     // guaranteed to be "on processor".
-    for (auto cit = petsc_next_node_idxs.begin(); cit != petsc_next_node_idxs.end(); ++cit)
+    for (int idx : petsc_next_node_idxs)
     {
-        const int idx = *cit;
         if (idx < global_node_offset || idx >= global_node_offset + num_local_nodes)
         {
             nonlocal_petsc_idx_set.insert(idx);
         }
     }
-    for (auto cit = petsc_prev_node_idxs.begin(); cit != petsc_prev_node_idxs.end(); ++cit)
+    for (int idx : petsc_prev_node_idxs)
     {
-        const int idx = *cit;
         if (idx < global_node_offset || idx >= global_node_offset + num_local_nodes)
         {
             nonlocal_petsc_idx_set.insert(idx);
@@ -1223,9 +1214,8 @@ IBStandardForceGen::initializeTargetPointLevelData(std::set<int>& /*nonlocal_pet
     // Determine how many target points are associated with the present MPI
     // process.
     unsigned int num_target_points = 0;
-    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (const auto& node_idx : local_nodes)
     {
-        const LNode* const node_idx = *cit;
         const IBTargetPointForceSpec* const force_spec = node_idx->getNodeDataItem<IBTargetPointForceSpec>();
         if (force_spec) num_target_points += 1;
     }
@@ -1240,9 +1230,8 @@ IBStandardForceGen::initializeTargetPointLevelData(std::set<int>& /*nonlocal_pet
 
     // Setup the data structures used to compute target point forces.
     int current_target_point = 0;
-    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (const auto& node_idx : local_nodes)
     {
-        const LNode* const node_idx = *cit;
         const IBTargetPointForceSpec* const force_spec = node_idx->getNodeDataItem<IBTargetPointForceSpec>();
         if (!force_spec) continue;
         petsc_global_node_idxs[current_target_point] = petsc_node_idxs[current_target_point] =

--- a/src/IB/IBStandardSourceGen.cpp
+++ b/src/IB/IBStandardSourceGen.cpp
@@ -178,9 +178,8 @@ IBStandardSourceGen::initializeLevelData(const Pointer<PatchHierarchy<NDIM> > /*
     std::fill(d_num_perimeter_nodes[level_number].begin(), d_num_perimeter_nodes[level_number].end(), 0);
     const Pointer<LMesh> mesh = l_data_manager->getLMesh(level_number);
     const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (const auto& node_idx : local_nodes)
     {
-        const LNode* const node_idx = *cit;
         const IBSourceSpec* const spec = node_idx->getNodeDataItem<IBSourceSpec>();
         if (!spec) continue;
         const int source_idx = spec->getSourceIndex();
@@ -227,9 +226,8 @@ IBStandardSourceGen::getSourceLocations(std::vector<Point>& X_src,
     const double* const X_node = X_data->getLocalFormVecArray()->data();
     const Pointer<LMesh> mesh = l_data_manager->getLMesh(level_number);
     const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
-    for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+    for (const auto& node_idx : local_nodes)
     {
-        const LNode* const node_idx = *cit;
         const IBSourceSpec* const spec = node_idx->getNodeDataItem<IBSourceSpec>();
         if (!spec) continue;
         const int& petsc_idx = node_idx->getLocalPETScIndex();

--- a/src/IB/IBStrategySet.cpp
+++ b/src/IB/IBStrategySet.cpp
@@ -89,9 +89,9 @@ IBStrategySet::~IBStrategySet()
 void
 IBStrategySet::registerIBHierarchyIntegrator(IBHierarchyIntegrator* ib_solver)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->registerIBHierarchyIntegrator(ib_solver);
+        strategy->registerIBHierarchyIntegrator(ib_solver);
     }
     return;
 } // registerIBHierarchyIntegrator
@@ -99,9 +99,9 @@ IBStrategySet::registerIBHierarchyIntegrator(IBHierarchyIntegrator* ib_solver)
 void
 IBStrategySet::registerEulerianVariables()
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->registerEulerianVariables();
+        strategy->registerEulerianVariables();
     }
     return;
 } // registerEulerianVariables
@@ -109,9 +109,9 @@ IBStrategySet::registerEulerianVariables()
 void
 IBStrategySet::registerEulerianCommunicationAlgorithms()
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->registerEulerianCommunicationAlgorithms();
+        strategy->registerEulerianCommunicationAlgorithms();
     }
     return;
 } // registerEulerianCommunicationAlgorithms
@@ -120,9 +120,9 @@ const IntVector<NDIM>&
 IBStrategySet::getMinimumGhostCellWidth() const
 {
     static IntVector<NDIM> ghost_cell_width = 0;
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        ghost_cell_width = IntVector<NDIM>::max(ghost_cell_width, (*cit)->getMinimumGhostCellWidth());
+        ghost_cell_width = IntVector<NDIM>::max(ghost_cell_width, strategy->getMinimumGhostCellWidth());
     }
     return ghost_cell_width;
 } // getMinimumGhostCellWidth
@@ -130,9 +130,9 @@ IBStrategySet::getMinimumGhostCellWidth() const
 void
 IBStrategySet::setupTagBuffer(Array<int>& tag_buffer, Pointer<GriddingAlgorithm<NDIM> > gridding_alg) const
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->setupTagBuffer(tag_buffer, gridding_alg);
+        strategy->setupTagBuffer(tag_buffer, gridding_alg);
     }
     return;
 } // setupTagBuffer
@@ -140,9 +140,9 @@ IBStrategySet::setupTagBuffer(Array<int>& tag_buffer, Pointer<GriddingAlgorithm<
 void
 IBStrategySet::preprocessIntegrateData(double current_time, double new_time, int num_cycles)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->preprocessIntegrateData(current_time, new_time, num_cycles);
+        strategy->preprocessIntegrateData(current_time, new_time, num_cycles);
     }
     return;
 } // preprocessIntegrateData
@@ -150,9 +150,9 @@ IBStrategySet::preprocessIntegrateData(double current_time, double new_time, int
 void
 IBStrategySet::postprocessIntegrateData(double current_time, double new_time, int num_cycles)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->postprocessIntegrateData(current_time, new_time, num_cycles);
+        strategy->postprocessIntegrateData(current_time, new_time, num_cycles);
     }
     return;
 } // postprocessIntegrateData
@@ -160,9 +160,9 @@ IBStrategySet::postprocessIntegrateData(double current_time, double new_time, in
 void
 IBStrategySet::updateFixedLEOperators()
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->updateFixedLEOperators();
+        strategy->updateFixedLEOperators();
     }
     return;
 } // updateFixedLEOperators
@@ -173,9 +173,9 @@ IBStrategySet::interpolateVelocity(int u_data_idx,
                                    const std::vector<Pointer<RefineSchedule<NDIM> > >& u_ghost_fill_scheds,
                                    double data_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->interpolateVelocity(u_data_idx, u_synch_scheds, u_ghost_fill_scheds, data_time);
+        strategy->interpolateVelocity(u_data_idx, u_synch_scheds, u_ghost_fill_scheds, data_time);
     }
     return;
 } // interpolateVelocity
@@ -183,9 +183,9 @@ IBStrategySet::interpolateVelocity(int u_data_idx,
 void
 IBStrategySet::IBStrategySet::forwardEulerStep(double current_time, double new_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->forwardEulerStep(current_time, new_time);
+        strategy->forwardEulerStep(current_time, new_time);
     }
     return;
 } // eulerStep
@@ -193,9 +193,9 @@ IBStrategySet::IBStrategySet::forwardEulerStep(double current_time, double new_t
 void
 IBStrategySet::midpointStep(double current_time, double new_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->midpointStep(current_time, new_time);
+        strategy->midpointStep(current_time, new_time);
     }
     return;
 } // midpointStep
@@ -203,9 +203,9 @@ IBStrategySet::midpointStep(double current_time, double new_time)
 void
 IBStrategySet::trapezoidalStep(double current_time, double new_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->trapezoidalStep(current_time, new_time);
+        strategy->trapezoidalStep(current_time, new_time);
     }
     return;
 } // trapezoidalStep
@@ -213,9 +213,9 @@ IBStrategySet::trapezoidalStep(double current_time, double new_time)
 void
 IBStrategySet::computeLagrangianForce(double data_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->computeLagrangianForce(data_time);
+        strategy->computeLagrangianForce(data_time);
     }
     return;
 } // computeLagrangianForce
@@ -226,9 +226,9 @@ IBStrategySet::spreadForce(int f_data_idx,
                            const std::vector<Pointer<RefineSchedule<NDIM> > >& f_prolongation_scheds,
                            double data_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->spreadForce(f_data_idx, f_phys_bdry_op, f_prolongation_scheds, data_time);
+        strategy->spreadForce(f_data_idx, f_phys_bdry_op, f_prolongation_scheds, data_time);
     }
     return;
 } // spreadForce
@@ -237,9 +237,9 @@ bool
 IBStrategySet::hasFluidSources() const
 {
     bool has_fluid_sources = false;
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        has_fluid_sources = has_fluid_sources || (*cit)->hasFluidSources();
+        has_fluid_sources = has_fluid_sources || strategy->hasFluidSources();
     }
     return has_fluid_sources;
 } // hasFluidSources
@@ -247,9 +247,9 @@ IBStrategySet::hasFluidSources() const
 void
 IBStrategySet::computeLagrangianFluidSource(double data_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->computeLagrangianFluidSource(data_time);
+        strategy->computeLagrangianFluidSource(data_time);
     }
     return;
 } // computeLagrangianFluidSource
@@ -260,9 +260,9 @@ IBStrategySet::spreadFluidSource(int q_data_idx,
                                  const std::vector<Pointer<RefineSchedule<NDIM> > >& q_prolongation_scheds,
                                  double data_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->spreadFluidSource(q_data_idx, q_phys_bdry_op, q_prolongation_scheds, data_time);
+        strategy->spreadFluidSource(q_data_idx, q_phys_bdry_op, q_prolongation_scheds, data_time);
     }
     return;
 } // spreadFluidSource
@@ -273,9 +273,9 @@ IBStrategySet::interpolatePressure(int p_data_idx,
                                    const std::vector<Pointer<RefineSchedule<NDIM> > >& p_ghost_fill_scheds,
                                    double data_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->interpolatePressure(p_data_idx, p_synch_scheds, p_ghost_fill_scheds, data_time);
+        strategy->interpolatePressure(p_data_idx, p_synch_scheds, p_ghost_fill_scheds, data_time);
     }
     return;
 } // interpolatePressure
@@ -283,9 +283,9 @@ IBStrategySet::interpolatePressure(int p_data_idx,
 void
 IBStrategySet::preprocessSolveFluidEquations(double current_time, double new_time, int cycle_num)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->preprocessSolveFluidEquations(current_time, new_time, cycle_num);
+        strategy->preprocessSolveFluidEquations(current_time, new_time, cycle_num);
     }
     return;
 } // preprocessSolveFluidEquations
@@ -293,9 +293,9 @@ IBStrategySet::preprocessSolveFluidEquations(double current_time, double new_tim
 void
 IBStrategySet::postprocessSolveFluidEquations(double current_time, double new_time, int cycle_num)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->postprocessSolveFluidEquations(current_time, new_time, cycle_num);
+        strategy->postprocessSolveFluidEquations(current_time, new_time, cycle_num);
     }
     return;
 } // postprocessSolveFluidEquations
@@ -303,9 +303,9 @@ IBStrategySet::postprocessSolveFluidEquations(double current_time, double new_ti
 void
 IBStrategySet::postprocessData()
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->postprocessData();
+        strategy->postprocessData();
     }
     return;
 } // postprocessData
@@ -320,16 +320,16 @@ IBStrategySet::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy
                                         double init_data_time,
                                         bool initial_time)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->initializePatchHierarchy(hierarchy,
-                                         gridding_alg,
-                                         u_data_idx,
-                                         u_synch_scheds,
-                                         u_ghost_fill_scheds,
-                                         integrator_step,
-                                         init_data_time,
-                                         initial_time);
+        strategy->initializePatchHierarchy(hierarchy,
+                                           gridding_alg,
+                                           u_data_idx,
+                                           u_synch_scheds,
+                                           u_ghost_fill_scheds,
+                                           integrator_step,
+                                           init_data_time,
+                                           initial_time);
     }
     return;
 } // initializePatchHierarchy
@@ -337,9 +337,9 @@ IBStrategySet::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy
 void
 IBStrategySet::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, int workload_data_idx)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->registerLoadBalancer(load_balancer, workload_data_idx);
+        strategy->registerLoadBalancer(load_balancer, workload_data_idx);
     }
     return;
 } // registerLoadBalancer
@@ -347,9 +347,9 @@ IBStrategySet::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, 
 void
 IBStrategySet::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > hierarchy, int workload_data_idx)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->updateWorkloadEstimates(hierarchy, workload_data_idx);
+        strategy->updateWorkloadEstimates(hierarchy, workload_data_idx);
     }
     return;
 } // updateWorkloadEstimates
@@ -358,9 +358,9 @@ void
 IBStrategySet::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > hierarchy,
                                        Pointer<GriddingAlgorithm<NDIM> > gridding_alg)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->beginDataRedistribution(hierarchy, gridding_alg);
+        strategy->beginDataRedistribution(hierarchy, gridding_alg);
     }
     return;
 } // beginDataRedistribution
@@ -369,9 +369,9 @@ void
 IBStrategySet::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > hierarchy,
                                      Pointer<GriddingAlgorithm<NDIM> > gridding_alg)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->endDataRedistribution(hierarchy, gridding_alg);
+        strategy->endDataRedistribution(hierarchy, gridding_alg);
     }
     return;
 } // endDataRedistribution
@@ -385,9 +385,9 @@ IBStrategySet::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
                                    Pointer<BasePatchLevel<NDIM> > old_level,
                                    bool allocate_data)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->initializeLevelData(
+        strategy->initializeLevelData(
             hierarchy, level_number, init_data_time, can_be_refined, initial_time, old_level, allocate_data);
     }
     return;
@@ -398,9 +398,9 @@ IBStrategySet::resetHierarchyConfiguration(Pointer<BasePatchHierarchy<NDIM> > hi
                                            int coarsest_level,
                                            int finest_level)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->resetHierarchyConfiguration(hierarchy, coarsest_level, finest_level);
+        strategy->resetHierarchyConfiguration(hierarchy, coarsest_level, finest_level);
     }
     return;
 } // resetHierarchyConfiguration
@@ -413,9 +413,9 @@ IBStrategySet::applyGradientDetector(Pointer<BasePatchHierarchy<NDIM> > hierarch
                                      bool initial_time,
                                      bool uses_richardson_extrapolation_too)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->applyGradientDetector(
+        strategy->applyGradientDetector(
             hierarchy, level_number, error_data_time, tag_index, initial_time, uses_richardson_extrapolation_too);
     }
     return;
@@ -424,9 +424,9 @@ IBStrategySet::applyGradientDetector(Pointer<BasePatchHierarchy<NDIM> > hierarch
 void
 IBStrategySet::putToDatabase(Pointer<Database> db)
 {
-    for (auto cit = d_strategy_set.begin(); cit != d_strategy_set.end(); ++cit)
+    for (const auto& strategy : d_strategy_set)
     {
-        (*cit)->putToDatabase(db);
+        strategy->putToDatabase(db);
     }
     return;
 } // putToDatabase

--- a/src/IB/IMPInitializer.cpp
+++ b/src/IB/IMPInitializer.cpp
@@ -351,9 +351,8 @@ IMPInitializer::initializeDataOnPatchLevel(const int lag_node_index_idx,
         std::vector<std::pair<int, int> > patch_vertices;
         getPatchVertices(patch_vertices, patch, level_number, can_be_refined);
         local_node_count += patch_vertices.size();
-        for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
+        for (const auto& point_idx : patch_vertices)
         {
-            const std::pair<int, int>& point_idx = (*it);
             const int lagrangian_idx = getCanonicalLagrangianIndex(point_idx, level_number) + global_index_offset;
             const int local_petsc_idx = ++local_idx + local_index_offset;
             const int global_petsc_idx = local_petsc_idx + global_index_offset;
@@ -450,9 +449,8 @@ IMPInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarchy<NDIM> 
         {
             std::vector<std::pair<int, int> > patch_vertices;
             getPatchVertices(patch_vertices, patch, ln, can_be_refined);
-            for (auto it = patch_vertices.begin(); it != patch_vertices.end(); ++it)
+            for (const auto& point_idx : patch_vertices)
             {
-                const std::pair<int, int>& point_idx = (*it);
                 const libMesh::Point& X = getVertexPosn(point_idx, ln);
                 const CellIndex<NDIM> i = IndexUtilities::getCellIndex(&X(0), grid_geom, ratio);
                 if (patch_box.contains(i)) (*tag_data)(i) = 1;

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -475,9 +475,8 @@ IMPMethod::interpolateVelocity(const int u_data_idx,
                 const Index<NDIM>& i = *it;
                 LNodeSet* const node_set = idx_data->getItem(i);
                 if (!node_set) continue;
-                for (auto it = node_set->begin(); it != node_set->end(); ++it)
+                for (const auto& node_idx : *node_set)
                 {
-                    const LNode* const node_idx = *it;
                     const int local_idx = node_idx->getLocalPETScIndex();
                     const double* const X = &X_array[local_idx][0];
                     VectorValue<double> U;
@@ -583,9 +582,8 @@ IMPMethod::forwardEulerStep(const double current_time, const double new_time)
         boost::multi_array_ref<double, 2>& Grad_U_array = *(*Grad_U_data)[ln]->getVecArray();
         TensorValue<double> F_current, F_new, F_half, Grad_U;
         TensorValue<double> I(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int idx = node_idx->getGlobalPETScIndex();
             for (int i = 0; i < NDIM; ++i)
             {
@@ -640,9 +638,8 @@ IMPMethod::midpointStep(const double current_time, const double new_time)
         boost::multi_array_ref<double, 2>& Grad_U_array = *(*Grad_U_data)[ln]->getVecArray();
         TensorValue<double> F_current, F_new, Grad_U;
         TensorValue<double> I(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int idx = node_idx->getGlobalPETScIndex();
             for (int i = 0; i < NDIM; ++i)
             {
@@ -700,9 +697,8 @@ IMPMethod::trapezoidalStep(const double current_time, const double new_time)
         boost::multi_array_ref<double, 2>& Grad_U_new_array = *(*Grad_U_new_data)[ln]->getVecArray();
         TensorValue<double> F_current, F_new, Grad_U_current, Grad_U_new;
         TensorValue<double> I(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int idx = node_idx->getGlobalPETScIndex();
             for (int i = 0; i < NDIM; ++i)
             {
@@ -751,9 +747,8 @@ IMPMethod::computeLagrangianForce(const double data_time)
         boost::multi_array_ref<double, 2>& tau_array = *d_tau_data[ln]->getVecArray();
         TensorValue<double> FF, PP, tau;
         VectorValue<double> X, x;
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int idx = node_idx->getGlobalPETScIndex();
             auto mp_spec = node_idx->getNodeDataItem<MaterialPointSpec>();
             if (mp_spec && d_PK1_stress_fcn)
@@ -868,9 +863,8 @@ IMPMethod::spreadForce(const int f_data_idx,
                 const Index<NDIM>& i = *it;
                 LNodeSet* const node_set = idx_data->getItem(i);
                 if (!node_set) continue;
-                for (auto it = node_set->begin(); it != node_set->end(); ++it)
+                for (const auto& node_idx : *node_set)
                 {
-                    const LNode* const node_idx = *it;
                     auto mp_spec = node_idx->getNodeDataItem<MaterialPointSpec>();
                     if (!mp_spec) continue;
                     const double wgt = mp_spec->getWeight();
@@ -1064,9 +1058,8 @@ IMPMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
         boost::multi_array_ref<double, 2>& F_array = *F_data->getLocalFormVecArray();
         boost::multi_array_ref<double, 2>& tau_array = *tau_data->getLocalFormVecArray();
-        for (auto cit = local_nodes.begin(); cit != local_nodes.end(); ++cit)
+        for (const auto& node_idx : local_nodes)
         {
-            const LNode* const node_idx = *cit;
             const int idx = node_idx->getLocalPETScIndex();
             for (int i = 0; i < NDIM; ++i)
             {

--- a/src/IB/KrylovMobilitySolver.cpp
+++ b/src/IB/KrylovMobilitySolver.cpp
@@ -585,16 +585,16 @@ KrylovMobilitySolver::initializeStokesSolver(const SAMRAIVectorReal<NDIM, double
     const bool has_velocity_nullspace = d_normalize_velocity && MathUtilities<double>::equalEps(rho, 0.0);
     const bool has_pressure_nullspace = d_normalize_pressure;
 
-    for (unsigned int k = 0; k < d_nul_vecs.size(); ++k)
+    for (const auto& nul_vec : d_nul_vecs)
     {
-        if (d_nul_vecs[k]) d_nul_vecs[k]->freeVectorComponents();
+        if (nul_vec) nul_vec->freeVectorComponents();
     }
     const int n_nul_vecs = (has_pressure_nullspace ? 1 : 0) + (has_velocity_nullspace ? NDIM : 0);
     d_nul_vecs.resize(n_nul_vecs);
 
-    for (unsigned int k = 0; k < d_U_nul_vecs.size(); ++k)
+    for (const auto& U_nul_vec : d_U_nul_vecs)
     {
-        if (d_U_nul_vecs[k]) d_U_nul_vecs[k]->freeVectorComponents();
+        if (U_nul_vec) U_nul_vec->freeVectorComponents();
     }
     const int n_U_nul_vecs = (has_velocity_nullspace ? NDIM : 0);
     d_U_nul_vecs.resize(n_U_nul_vecs);

--- a/src/IB/NonbondedForceEvaluator.cpp
+++ b/src/IB/NonbondedForceEvaluator.cpp
@@ -202,16 +202,14 @@ NonbondedForceEvaluator::computeLagrangianForce(Pointer<LData> F_data,
                         // we have a set of nodes in the first cell and the search cell,
                         // add up forces
                         // and accumulate for the first cell.
-                        for (auto it = mstr_node_set->begin(); it != mstr_node_set->end(); ++it)
+                        for (const auto& mstr_node_idx : *mstr_node_set)
                         {
                             // master nodes
-                            LNodeSet::value_type& mstr_node_idx = *it;
                             const int mstr_lag_idx = mstr_node_idx->getLagrangianIndex();
                             const int mstr_petsc_idx = mstr_node_idx->getLocalPETScIndex();
 
-                            for (auto sit = search_node_set->begin(); sit != search_node_set->end(); ++sit)
+                            for (const auto& search_node_idx : *search_node_set)
                             {
-                                LNodeSet::value_type& search_node_idx = *sit;
                                 const int search_lag_idx = search_node_idx->getLagrangianIndex();
                                 const int search_petsc_idx = search_node_idx->getLocalPETScIndex();
                                 if (mstr_lag_idx < search_lag_idx)

--- a/src/IB/WallForceEvaluator.cpp
+++ b/src/IB/WallForceEvaluator.cpp
@@ -94,9 +94,9 @@ void
 WallForceEvaluator::registerWallForceFcn(Wall::WallForceFcnPtr wall_force_fcn)
 {
     // register the given force function pointer with all walls
-    for (auto wall_it = d_walls_vec.begin(); wall_it != d_walls_vec.end(); ++wall_it)
+    for (auto& wall_vec : d_walls_vec)
     { // iterate through walls
-        wall_it->registerWallForceFcn(wall_force_fcn);
+        wall_vec.registerWallForceFcn(wall_force_fcn);
     }
     return;
 } // registerWallForceFcn
@@ -130,11 +130,11 @@ WallForceEvaluator::computeLagrangianForce(Pointer<LData> F_data,
 
     const int lag_node_idx_current_idx = l_data_manager->getLNodePatchDescriptorIndex();
 
-    for (auto wall_it = d_walls_vec.begin(); wall_it != d_walls_vec.end(); ++wall_it)
+    for (auto& wall : d_walls_vec)
     { // iterate through walls
 
         // get axis (which direction the wall is normal to)
-        int axis = wall_it->getAxis();
+        int axis = wall.getAxis();
 
         Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
         const IntVector<NDIM>& ratio = level->getRatio();
@@ -146,7 +146,7 @@ WallForceEvaluator::computeLagrangianForce(Pointer<LData> F_data,
             const Box<NDIM>& patch_box = patch->getBox();
 
             // get just the area near the wall
-            const Box<NDIM> intersect_box = patch_box * Box<NDIM>::refine(wall_it->getForceArea(), ratio);
+            const Box<NDIM> intersect_box = patch_box * Box<NDIM>::refine(wall.getForceArea(), ratio);
 
             // iterate through cells in relevant area
             for (LNodeSetData::CellIterator scit(intersect_box); scit; scit++)
@@ -158,15 +158,14 @@ WallForceEvaluator::computeLagrangianForce(Pointer<LData> F_data,
                 // if particles exist in this cell, add forces to them
                 if (search_node_set)
                 {
-                    for (auto it = search_node_set->begin(); it != search_node_set->end(); ++it)
+                    for (const auto& particle_node_idx : *search_node_set)
                     {
                         // get node data
-                        LNodeSet::value_type& particle_node_idx = *it;
                         const int particle_petsc_idx = particle_node_idx->getLocalPETScIndex();
 
                         // get wall distance
-                        double wall_distance = lposition[particle_petsc_idx * NDIM + axis] - wall_it->getLocation();
-                        force[particle_petsc_idx * NDIM + axis] += wall_it->applyForce(wall_distance, eval_time);
+                        double wall_distance = lposition[particle_petsc_idx * NDIM + axis] - wall.getLocation();
+                        force[particle_petsc_idx * NDIM + axis] += wall.applyForce(wall_distance, eval_time);
                     } // iterate through nodes
                 }     // if search_node_set
             }         // iterate through cells in wall area

--- a/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
@@ -239,18 +239,16 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeHierarchyIntegrator(
     }
 
     // Register variables with the hyperbolic level integrator.
-    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+    for (const auto& u_var : d_u_var)
     {
-        Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         d_hyp_patch_ops->registerAdvectionVelocity(u_var);
         d_hyp_patch_ops->setAdvectionVelocityIsDivergenceFree(u_var, d_u_is_div_free[u_var]);
         if (d_u_fcn[u_var]) d_hyp_patch_ops->setAdvectionVelocityFunction(u_var, d_u_fcn[u_var]);
     }
 
     const IntVector<NDIM> cell_ghosts = CELLG;
-    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
+    for (const auto& F_var : d_F_var)
     {
-        Pointer<CellVariable<NDIM, double> > F_var = *cit;
         d_hyp_level_integrator->registerVariable(F_var,
                                                  cell_ghosts,
                                                  HyperbolicLevelIntegrator<NDIM>::TIME_DEP,
@@ -259,9 +257,8 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeHierarchyIntegrator(
                                                  "CONSERVATIVE_LINEAR_REFINE");
     }
 
-    for (auto cit = d_diffusion_coef_var.begin(); cit != d_diffusion_coef_var.end(); ++cit)
+    for (const auto& D_var : d_diffusion_coef_var)
     {
-        Pointer<SideVariable<NDIM, double> > D_var = *cit;
         d_hyp_level_integrator->registerVariable(D_var,
                                                  cell_ghosts,
                                                  HyperbolicLevelIntegrator<NDIM>::TIME_DEP,
@@ -272,24 +269,21 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeHierarchyIntegrator(
         registerVariable(D_scratch_idx, D_var, cell_ghosts, getScratchContext());
     }
 
-    for (auto cit = d_diffusion_coef_rhs_var.begin(); cit != d_diffusion_coef_rhs_var.end(); ++cit)
+    for (const auto& D_rhs_var : d_diffusion_coef_rhs_var)
     {
-        Pointer<SideVariable<NDIM, double> > D_rhs_var = *cit;
         int D_rhs_scratch_idx;
         registerVariable(D_rhs_scratch_idx, D_rhs_var, cell_ghosts, getScratchContext());
     }
 
-    for (auto cit = d_Q_rhs_var.begin(); cit != d_Q_rhs_var.end(); ++cit)
+    for (const auto& Q_rhs_var : d_Q_rhs_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_rhs_var = *cit;
         int Q_rhs_scratch_idx;
         registerVariable(Q_rhs_scratch_idx, Q_rhs_var, cell_ghosts, getScratchContext());
         d_hyp_patch_ops->registerSourceTerm(Q_rhs_var);
     }
 
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         int Q_scratch_idx;
         registerVariable(Q_scratch_idx, Q_var, cell_ghosts, getScratchContext());
         d_hyp_patch_ops->registerTransportedQuantity(Q_var);
@@ -350,9 +344,8 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
     }
 
     // Compute any time-dependent source terms at time-level n.
-    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
+    for (const auto& F_var : d_F_var)
     {
-        Pointer<CellVariable<NDIM, double> > F_var = *cit;
         Pointer<CartGridFunction> F_fcn = d_F_fcn[F_var];
         if (F_fcn && F_fcn->isTimeDependent())
         {
@@ -362,9 +355,8 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
     }
 
     // Compute any time-dependent variable diffusion coefficients at time-level n.
-    for (auto cit = d_diffusion_coef_var.begin(); cit != d_diffusion_coef_var.end(); ++cit)
+    for (const auto& D_var : d_diffusion_coef_var)
     {
-        Pointer<SideVariable<NDIM, double> > D_var = *cit;
         Pointer<CartGridFunction> D_fcn = d_diffusion_coef_fcn[D_var];
         if (D_fcn)
         {
@@ -659,9 +651,9 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::postprocessIntegrateHierarchy(cons
     // Determine the CFL number.
     double cfl_max = 0.0;
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    for (unsigned int k = 0; k < d_u_var.size(); ++k)
+    for (const auto& u_var : d_u_var)
     {
-        const int u_new_idx = var_db->mapVariableAndContextToIndex(d_u_var[k], getNewContext());
+        const int u_new_idx = var_db->mapVariableAndContextToIndex(u_var, getNewContext());
         PatchFaceDataOpsReal<NDIM, double> patch_fc_ops;
         for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
         {
@@ -773,9 +765,8 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeLevelDataSpecialized(
     {
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-        for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
+        for (const auto& F_var : d_F_var)
         {
-            Pointer<CellVariable<NDIM, double> > F_var = *cit;
             const int F_idx = var_db->mapVariableAndContextToIndex(F_var, getCurrentContext());
             Pointer<CartGridFunction> F_fcn = d_F_fcn[F_var];
             if (F_fcn)
@@ -797,9 +788,8 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeLevelDataSpecialized(
         }
 
         // Set the initial value of any variable diffusion coefficient
-        for (auto cit = d_diffusion_coef_var.begin(); cit != d_diffusion_coef_var.end(); ++cit)
+        for (const auto& D_var : d_diffusion_coef_var)
         {
-            Pointer<SideVariable<NDIM, double> > D_var = *cit;
             const int D_idx = var_db->mapVariableAndContextToIndex(D_var, getCurrentContext());
             Pointer<CartGridFunction> D_fcn = d_diffusion_coef_fcn[D_var];
             if (D_fcn)

--- a/src/adv_diff/AdvDiffPredictorCorrectorHyperbolicPatchOps.cpp
+++ b/src/adv_diff/AdvDiffPredictorCorrectorHyperbolicPatchOps.cpp
@@ -210,9 +210,8 @@ AdvDiffPredictorCorrectorHyperbolicPatchOps::conservativeDifferenceOnPatch(Patch
     const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch.getPatchGeometry();
     const double* const dx = patch_geom->getDx();
 
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellData<NDIM, double> > Q_data = patch.getPatchData(Q_var, getDataContext());
         Pointer<FaceVariable<NDIM, double> > u_var = d_Q_u_map[Q_var];
         if (u_var)
@@ -388,9 +387,8 @@ AdvDiffPredictorCorrectorHyperbolicPatchOps::preprocessAdvanceLevelState(const P
     if (!d_compute_init_velocity) return;
 
     // Update the advection velocity (or velocities).
-    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+    for (const auto& u_var : d_u_var)
     {
-        Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         if (d_u_fcn[u_var] && d_u_fcn[u_var]->isTimeDependent())
         {
             VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -412,9 +410,8 @@ AdvDiffPredictorCorrectorHyperbolicPatchOps::postprocessAdvanceLevelState(const 
     if (!d_compute_final_velocity) return;
 
     // Update the advection velocity (or velocities).
-    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+    for (const auto& u_var : d_u_var)
     {
-        Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         if (d_u_fcn[u_var] && d_u_fcn[u_var]->isTimeDependent())
         {
             VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
@@ -377,9 +377,9 @@ AdvDiffSemiImplicitHierarchyIntegrator::getConvectiveOperator(Pointer<CellVariab
 void
 AdvDiffSemiImplicitHierarchyIntegrator::setConvectiveOperatorsNeedInit()
 {
-    for (auto it = d_Q_var.begin(); it != d_Q_var.end(); ++it)
+    for (const auto& Q_var : d_Q_var)
     {
-        setConvectiveOperatorNeedsInit(*it);
+        setConvectiveOperatorNeedsInit(Q_var);
     }
     return;
 }
@@ -413,17 +413,15 @@ AdvDiffSemiImplicitHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<Pa
     AdvDiffHierarchyIntegrator::registerVariables();
 
     // Setup the convective operators.
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         getConvectiveOperator(Q_var);
     }
 
     // Register additional variables required for present time stepping algorithm.
     const IntVector<NDIM> cell_ghosts = CELLG;
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellDataFactory<NDIM, double> > Q_factory = Q_var->getPatchDataFactory();
         const int Q_depth = Q_factory->getDefaultDepth();
 
@@ -462,9 +460,8 @@ AdvDiffSemiImplicitHierarchyIntegrator::getNumberOfCycles() const
     int num_cycles = d_num_cycles;
     if (MathUtilities<double>::equalEps(d_integrator_time, d_start_time))
     {
-        for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+        for (const auto& Q_var : d_Q_var)
         {
-            Pointer<CellVariable<NDIM, double> > Q_var = *cit;
             if (!d_Q_u_map.find(Q_var)->second) continue;
             if (is_multistep_time_stepping_type(d_Q_convective_time_stepping_type.find(Q_var)->second) &&
                 d_Q_init_convective_time_stepping_type.find(Q_var)->second != FORWARD_EULER)
@@ -509,9 +506,8 @@ AdvDiffSemiImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
     }
 
     // Update the advection velocity.
-    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+    for (const auto& u_var : d_u_var)
     {
-        Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         const int u_current_idx = var_db->mapVariableAndContextToIndex(u_var, getCurrentContext());
         const int u_scratch_idx = var_db->mapVariableAndContextToIndex(u_var, getScratchContext());
         const int u_new_idx = var_db->mapVariableAndContextToIndex(u_var, getNewContext());
@@ -528,9 +524,8 @@ AdvDiffSemiImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
     }
 
     // Update the diffusion coefficient
-    for (auto cit = d_diffusion_coef_var.begin(); cit != d_diffusion_coef_var.end(); ++cit)
+    for (const auto& D_var : d_diffusion_coef_var)
     {
-        Pointer<SideVariable<NDIM, double> > D_var = *cit;
         Pointer<CartGridFunction> D_fcn = d_diffusion_coef_fcn[D_var];
         if (D_fcn)
         {
@@ -734,9 +729,8 @@ AdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchy(const double current_
         // Update the advection velocity.
         if (cycle_num > 0)
         {
-            for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+            for (const auto& u_var : d_u_var)
             {
-                Pointer<FaceVariable<NDIM, double> > u_var = *cit;
                 const int u_current_idx = var_db->mapVariableAndContextToIndex(u_var, getCurrentContext());
                 const int u_scratch_idx = var_db->mapVariableAndContextToIndex(u_var, getScratchContext());
                 const int u_new_idx = var_db->mapVariableAndContextToIndex(u_var, getNewContext());
@@ -894,9 +888,9 @@ AdvDiffSemiImplicitHierarchyIntegrator::postprocessIntegrateHierarchy(const doub
     // Determine the CFL number.
     double cfl_max = 0.0;
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    for (unsigned int k = 0; k < d_u_var.size(); ++k)
+    for (const auto& u_var : d_u_var)
     {
-        const int u_new_idx = var_db->mapVariableAndContextToIndex(d_u_var[k], getNewContext());
+        const int u_new_idx = var_db->mapVariableAndContextToIndex(u_var, getNewContext());
         PatchFaceDataOpsReal<NDIM, double> patch_fc_ops;
         for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
         {
@@ -937,9 +931,8 @@ AdvDiffSemiImplicitHierarchyIntegrator::resetHierarchyConfigurationSpecialized(
     const int finest_hier_level = hierarchy->getFinestLevelNumber();
     d_hier_fc_data_ops->setPatchHierarchy(hierarchy);
     d_hier_fc_data_ops->resetLevels(0, finest_hier_level);
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         d_Q_convective_op_needs_init[Q_var] = true;
     }
     AdvDiffHierarchyIntegrator::resetHierarchyConfigurationSpecialized(base_hierarchy, coarsest_level, finest_level);

--- a/src/advect/AdvectorPredictorCorrectorHyperbolicPatchOps.cpp
+++ b/src/advect/AdvectorPredictorCorrectorHyperbolicPatchOps.cpp
@@ -494,9 +494,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::registerModelVariables(HyperbolicL
 #endif
     d_integrator = integrator;
 
-    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+    for (const auto& u_var : d_u_var)
     {
-        Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         d_integrator->registerVariable(u_var,
                                        d_ghosts,
                                        HyperbolicLevelIntegrator<NDIM>::TIME_DEP,
@@ -505,9 +504,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::registerModelVariables(HyperbolicL
                                        "CONSERVATIVE_LINEAR_REFINE");
     }
 
-    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
+    for (const auto& F_var : d_F_var)
     {
-        Pointer<CellVariable<NDIM, double> > F_var = *cit;
         d_integrator->registerVariable(F_var,
                                        d_ghosts,
                                        HyperbolicLevelIntegrator<NDIM>::TIME_DEP,
@@ -516,9 +514,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::registerModelVariables(HyperbolicL
                                        "CONSERVATIVE_LINEAR_REFINE");
     }
 
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellDataFactory<NDIM, double> > Q_factory = Q_var->getPatchDataFactory();
         d_integrator->registerVariable(Q_var,
                                        d_ghosts,
@@ -601,9 +598,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::initializeDataOnPatch(Patch<NDIM>&
     if (initial_time)
     {
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-        for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+        for (const auto& u_var : d_u_var)
         {
-            Pointer<FaceVariable<NDIM, double> > u_var = *cit;
             const int u_idx = var_db->mapVariableAndContextToIndex(u_var, getDataContext());
             if (d_u_fcn[u_var])
             {
@@ -617,9 +613,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::initializeDataOnPatch(Patch<NDIM>&
             }
         }
 
-        for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
+        for (const auto& F_var : d_F_var)
         {
-            Pointer<CellVariable<NDIM, double> > F_var = *cit;
             const int F_idx = var_db->mapVariableAndContextToIndex(F_var, getDataContext());
             if (d_F_fcn[F_var])
             {
@@ -633,9 +628,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::initializeDataOnPatch(Patch<NDIM>&
             }
         }
 
-        for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+        for (const auto& Q_var : d_Q_var)
         {
-            Pointer<CellVariable<NDIM, double> > Q_var = *cit;
             const int Q_idx = var_db->mapVariableAndContextToIndex(Q_var, getDataContext());
             if (d_Q_init[Q_var])
             {
@@ -658,9 +652,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::computeStableDtOnPatch(Patch<NDIM>
                                                                      const double /*dt_time*/)
 {
     double stable_dt = std::numeric_limits<double>::max();
-    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+    for (const auto& u_var : d_u_var)
     {
-        Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         Pointer<FaceData<NDIM, double> > u_data = patch.getPatchData(u_var, getDataContext());
         stable_dt = std::min(stable_dt, d_explicit_predictor->computeStableDtOnPatch(*u_data, patch));
     }
@@ -677,9 +670,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::computeFluxesOnPatch(Patch<NDIM>& 
 
     PatchFaceDataOpsReal<NDIM, double> patch_fc_data_ops;
 
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<FaceVariable<NDIM, double> > u_var = d_Q_u_map[Q_var];
         Pointer<FaceData<NDIM, double> > q_integral_data = getQIntegralData(Q_var, patch, getDataContext());
         if (!u_var)
@@ -714,9 +706,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::computeFluxesOnPatch(Patch<NDIM>& 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     if (d_compute_half_velocity)
     {
-        for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+        for (const auto& u_var : d_u_var)
         {
-            Pointer<FaceVariable<NDIM, double> > u_var = *cit;
             if (d_u_fcn[u_var] && d_u_fcn[u_var]->isTimeDependent())
             {
                 const int u_idx = var_db->mapVariableAndContextToIndex(u_var, getDataContext());
@@ -726,9 +717,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::computeFluxesOnPatch(Patch<NDIM>& 
     }
 
     // Compute fluxes and other face-centered quantities.
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<FaceVariable<NDIM, double> > u_var = d_Q_u_map[Q_var];
 
         if (!u_var) continue;
@@ -769,9 +759,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::conservativeDifferenceOnPatch(Patc
     const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch.getPatchGeometry();
     const double* const dx = patch_geom->getDx();
 
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<FaceVariable<NDIM, double> > u_var = d_Q_u_map[Q_var];
 
         if (!u_var) continue;
@@ -929,9 +918,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::preprocessAdvanceLevelState(const 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
 
     // Update the source term.
-    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
+    for (const auto& F_var : d_F_var)
     {
-        Pointer<CellVariable<NDIM, double> > F_var = *cit;
         if (d_F_fcn[F_var] && d_F_fcn[F_var]->isTimeDependent())
         {
             const int F_idx = var_db->mapVariableAndContextToIndex(F_var, d_integrator->getScratchContext());
@@ -942,9 +930,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::preprocessAdvanceLevelState(const 
     if (!d_compute_init_velocity) return;
 
     // Update the advection velocity.
-    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+    for (const auto& u_var : d_u_var)
     {
-        Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         if (d_u_fcn[u_var] && d_u_fcn[u_var]->isTimeDependent())
         {
             const int u_idx = var_db->mapVariableAndContextToIndex(u_var, d_integrator->getScratchContext());
@@ -971,9 +958,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::postprocessAdvanceLevelState(const
 
     // Update the values of any time-dependent source terms and add the values
     // of all source terms to the advected quantities.
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<CellVariable<NDIM, double> > F_var = d_Q_F_map[Q_var];
         if (!F_var) continue;
         Pointer<CartGridFunction> F_fcn = d_F_fcn[F_var];
@@ -1005,9 +991,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::postprocessAdvanceLevelState(const
     if (!d_compute_final_velocity) return;
 
     // Update the advection velocity.
-    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+    for (const auto& u_var : d_u_var)
     {
-        Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         if (d_u_fcn[u_var] && d_u_fcn[u_var]->isTimeDependent())
         {
             const int u_idx = var_db->mapVariableAndContextToIndex(u_var, d_integrator->getNewContext());
@@ -1073,9 +1058,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::tagGradientDetectorCells(Patch<NDI
             if (time_allowed)
             {
                 // Check for tags that have already been set in a previous step.
-                for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+                for (const auto& Q_var : d_Q_var)
                 {
-                    Pointer<CellVariable<NDIM, double> > Q_var = *cit;
                     Pointer<CellData<NDIM, double> > Q_data = patch.getPatchData(Q_var, getDataContext());
                     for (int depth = 0; depth < Q_data->getDepth(); ++depth)
                     {
@@ -1111,9 +1095,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::tagGradientDetectorCells(Patch<NDI
 
             if (time_allowed)
             {
-                for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+                for (const auto& Q_var : d_Q_var)
                 {
-                    Pointer<CellVariable<NDIM, double> > Q_var = *cit;
                     Pointer<CellData<NDIM, double> > Q_data = patch.getPatchData(Q_var, getDataContext());
                     const IntVector<NDIM>& Q_ghost = Q_data->getGhostCellWidth();
                     for (int depth = 0; depth < Q_data->getDepth(); ++depth)
@@ -1188,9 +1171,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::setPhysicalBoundaryConditions(Patc
     // Extrapolate the interior data to set the ghost cell values for the state
     // variables and for any forcing terms.
     ComponentSelector u_patch_data_indices;
-    for (auto cit = d_u_var.begin(); cit != d_u_var.end(); ++cit)
+    for (const auto& u_var : d_u_var)
     {
-        Pointer<FaceVariable<NDIM, double> > u_var = *cit;
         const int u_data_idx = var_db->mapVariableAndContextToIndex(u_var, d_integrator->getScratchContext());
         u_patch_data_indices.setFlag(u_data_idx);
     }
@@ -1199,15 +1181,13 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::setPhysicalBoundaryConditions(Patc
     d_extrap_bc_helper.setPhysicalBoundaryConditions(patch, fill_time, ghost_width_to_fill);
 
     ComponentSelector patch_data_indices;
-    for (auto cit = d_F_var.begin(); cit != d_F_var.end(); ++cit)
+    for (const auto& F_var : d_F_var)
     {
-        Pointer<CellVariable<NDIM, double> > F_var = *cit;
         const int F_data_idx = var_db->mapVariableAndContextToIndex(F_var, d_integrator->getScratchContext());
         patch_data_indices.setFlag(F_data_idx);
     }
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         const int Q_data_idx = var_db->mapVariableAndContextToIndex(Q_var, d_integrator->getScratchContext());
         patch_data_indices.setFlag(Q_data_idx);
     }
@@ -1331,9 +1311,8 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::setInflowBoundaryConditions(Patch<
     // boundaries only.
     const Box<NDIM>& patch_box = patch.getBox();
     const double* const dx = pgeom->getDx();
-    for (auto cit = d_Q_var.begin(); cit != d_Q_var.end(); ++cit)
+    for (const auto& Q_var : d_Q_var)
     {
-        Pointer<CellVariable<NDIM, double> > Q_var = *cit;
         Pointer<FaceVariable<NDIM, double> > u_var = d_Q_u_map[Q_var];
 
         if (!u_var) continue;

--- a/src/level_set/FastSweepingLSMethod.cpp
+++ b/src/level_set/FastSweepingLSMethod.cpp
@@ -95,7 +95,7 @@ FastSweepingLSMethod::FastSweepingLSMethod(const std::string& object_name,
     d_abs_tol = 1e-5;
     d_enable_logging = false;
     d_consider_phys_bdry_wall = false;
-    for (int k = 0; k < 2 * NDIM; ++k) d_wall_location_idx[k] = 0;
+    for (int& wall_idx : d_wall_location_idx) wall_idx = 0;
 
     if (d_registered_for_restart) getFromRestart();
     if (!db.isNull()) getFromInput(db);

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -444,9 +444,9 @@ INSCollocatedHierarchyIntegrator::~INSCollocatedHierarchyIntegrator()
     if (d_U_adv_vec) d_U_adv_vec->freeVectorComponents();
     if (d_N_vec) d_N_vec->freeVectorComponents();
     if (d_Phi_rhs_vec) d_Phi_rhs_vec->freeVectorComponents();
-    for (unsigned int k = 0; k < d_U_nul_vecs.size(); ++k)
+    for (const auto& U_nul_vec : d_U_nul_vecs)
     {
-        if (d_U_nul_vecs[k]) d_U_nul_vecs[k]->freeVectorComponents();
+        if (U_nul_vec) U_nul_vec->freeVectorComponents();
     }
     return;
 } // ~INSCollocatedHierarchyIntegrator
@@ -2105,9 +2105,9 @@ INSCollocatedHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double c
         d_N_vec = d_U_scratch_vec->cloneVector(d_object_name + "::N_vec");
         d_Phi_rhs_vec = d_Phi_vec->cloneVector(d_object_name + "::Phi_rhs_vec");
 
-        for (unsigned int k = 0; k < d_U_nul_vecs.size(); ++k)
+        for (const auto& U_nul_vec : d_U_nul_vecs)
         {
-            if (d_U_nul_vecs[k]) d_U_nul_vecs[k]->freeVectorComponents();
+            if (U_nul_vec) U_nul_vec->freeVectorComponents();
         }
         const int n_U_nul_vecs = (has_velocity_nullspace ? NDIM : 0);
         d_U_nul_vecs.resize(n_U_nul_vecs);

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -605,13 +605,13 @@ INSStaggeredHierarchyIntegrator::~INSStaggeredHierarchyIntegrator()
     if (d_U_adv_vec) d_U_adv_vec->freeVectorComponents();
     if (d_N_vec) d_N_vec->freeVectorComponents();
     if (d_P_rhs_vec) d_P_rhs_vec->freeVectorComponents();
-    for (unsigned int k = 0; k < d_nul_vecs.size(); ++k)
+    for (const auto& nul_vec : d_nul_vecs)
     {
-        if (d_nul_vecs[k]) d_nul_vecs[k]->freeVectorComponents();
+        if (nul_vec) nul_vec->freeVectorComponents();
     }
-    for (unsigned int k = 0; k < d_U_nul_vecs.size(); ++k)
+    for (const auto& U_nul_vec : d_U_nul_vecs)
     {
-        if (d_U_nul_vecs[k]) d_U_nul_vecs[k]->freeVectorComponents();
+        if (U_nul_vec) U_nul_vec->freeVectorComponents();
     }
     return;
 } // ~INSStaggeredHierarchyIntegrator
@@ -1700,11 +1700,11 @@ void
 INSStaggeredHierarchyIntegrator::removeNullSpace(const Pointer<SAMRAIVectorReal<NDIM, double> >& sol_vec)
 {
     if (d_nul_vecs.empty()) return;
-    for (size_t k = 0; k < d_nul_vecs.size(); ++k)
+    for (const auto& nul_vec : d_nul_vecs)
     {
-        const double sol_dot_nul = sol_vec->dot(d_nul_vecs[k]);
-        const double nul_L2_norm = std::sqrt(d_nul_vecs[k]->dot(d_nul_vecs[k]));
-        sol_vec->axpy(-sol_dot_nul / nul_L2_norm, d_nul_vecs[k], sol_vec);
+        const double sol_dot_nul = sol_vec->dot(nul_vec);
+        const double nul_L2_norm = std::sqrt(nul_vec->dot(nul_vec));
+        sol_vec->axpy(-sol_dot_nul / nul_L2_norm, nul_vec, sol_vec);
     }
     return;
 }
@@ -2352,16 +2352,16 @@ INSStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double cu
         const int P_rhs_idx = d_P_rhs_vec->getComponentDescriptorIndex(0);
         d_rhs_vec->addComponent(d_P_var, P_rhs_idx, wgt_cc_idx, d_hier_cc_data_ops);
 
-        for (unsigned int k = 0; k < d_nul_vecs.size(); ++k)
+        for (const auto& nul_vec : d_nul_vecs)
         {
-            if (d_nul_vecs[k]) d_nul_vecs[k]->freeVectorComponents();
+            if (nul_vec) nul_vec->freeVectorComponents();
         }
         const int n_nul_vecs = (has_pressure_nullspace ? 1 : 0) + (has_velocity_nullspace ? NDIM : 0);
         d_nul_vecs.resize(n_nul_vecs);
 
-        for (unsigned int k = 0; k < d_U_nul_vecs.size(); ++k)
+        for (const auto& U_nul_vec : d_U_nul_vecs)
         {
-            if (d_U_nul_vecs[k]) d_U_nul_vecs[k]->freeVectorComponents();
+            if (U_nul_vec) U_nul_vec->freeVectorComponents();
         }
         const int n_U_nul_vecs = (has_velocity_nullspace ? NDIM : 0);
         d_U_nul_vecs.resize(n_U_nul_vecs);

--- a/src/navier_stokes/INSVCStaggeredConservativeMassMomentumIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredConservativeMassMomentumIntegrator.cpp
@@ -1673,10 +1673,10 @@ INSVCStaggeredConservativeMassMomentumIntegrator::deallocateTimeIntegrator()
     }
 
     // Deallocate coarse-fine boundary object.
-    for (auto it = d_cf_boundary.begin(); it != d_cf_boundary.end(); ++it)
+    for (auto& cf_boundary : d_cf_boundary)
     {
-        delete (*it);
-        (*it) = nullptr;
+        delete cf_boundary;
+        cf_boundary = nullptr;
     }
     d_cf_boundary.clear();
 

--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -564,13 +564,13 @@ INSVCStaggeredHierarchyIntegrator::~INSVCStaggeredHierarchyIntegrator()
     if (d_U_adv_vec) d_U_adv_vec->freeVectorComponents();
     if (d_N_vec) d_N_vec->freeVectorComponents();
     if (d_P_rhs_vec) d_P_rhs_vec->freeVectorComponents();
-    for (unsigned int k = 0; k < d_nul_vecs.size(); ++k)
+    for (const auto& nul_vec : d_nul_vecs)
     {
-        if (d_nul_vecs[k]) d_nul_vecs[k]->freeVectorComponents();
+        if (nul_vec) nul_vec->freeVectorComponents();
     }
-    for (unsigned int k = 0; k < d_U_nul_vecs.size(); ++k)
+    for (const auto& U_nul_vec : d_U_nul_vecs)
     {
-        if (d_U_nul_vecs[k]) d_U_nul_vecs[k]->freeVectorComponents();
+        if (U_nul_vec) U_nul_vec->freeVectorComponents();
     }
 
     return;
@@ -1390,11 +1390,11 @@ void
 INSVCStaggeredHierarchyIntegrator::removeNullSpace(const Pointer<SAMRAIVectorReal<NDIM, double> >& sol_vec)
 {
     if (d_nul_vecs.empty()) return;
-    for (size_t k = 0; k < d_nul_vecs.size(); ++k)
+    for (const auto& nul_vec : d_nul_vecs)
     {
-        const double sol_dot_nul = sol_vec->dot(d_nul_vecs[k]);
-        const double nul_L2_norm = std::sqrt(d_nul_vecs[k]->dot(d_nul_vecs[k]));
-        sol_vec->axpy(-sol_dot_nul / nul_L2_norm, d_nul_vecs[k], sol_vec);
+        const double sol_dot_nul = sol_vec->dot(nul_vec);
+        const double nul_L2_norm = std::sqrt(nul_vec->dot(nul_vec));
+        sol_vec->axpy(-sol_dot_nul / nul_L2_norm, nul_vec, sol_vec);
     }
     return;
 } // removeNullSpace
@@ -2031,16 +2031,16 @@ INSVCStaggeredHierarchyIntegrator::preprocessOperatorsAndSolvers(const double cu
         const int P_rhs_idx = d_P_rhs_vec->getComponentDescriptorIndex(0);
         d_rhs_vec->addComponent(d_P_var, P_rhs_idx, wgt_cc_idx, d_hier_cc_data_ops);
 
-        for (unsigned int k = 0; k < d_nul_vecs.size(); ++k)
+        for (const auto& nul_vec : d_nul_vecs)
         {
-            if (d_nul_vecs[k]) d_nul_vecs[k]->freeVectorComponents();
+            if (nul_vec) nul_vec->freeVectorComponents();
         }
         const int n_nul_vecs = (has_pressure_nullspace ? 1 : 0) + (has_velocity_nullspace ? NDIM : 0);
         d_nul_vecs.resize(n_nul_vecs);
 
-        for (unsigned int k = 0; k < d_U_nul_vecs.size(); ++k)
+        for (const auto& U_nul_vec : d_U_nul_vecs)
         {
-            if (d_U_nul_vecs[k]) d_U_nul_vecs[k]->freeVectorComponents();
+            if (U_nul_vec) U_nul_vec->freeVectorComponents();
         }
         const int n_U_nul_vecs = (has_velocity_nullspace ? NDIM : 0);
         d_U_nul_vecs.resize(n_U_nul_vecs);

--- a/src/navier_stokes/StaggeredStokesBlockPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesBlockPreconditioner.cpp
@@ -220,10 +220,10 @@ StaggeredStokesBlockPreconditioner::correctNullspace(Pointer<SAMRAIVectorReal<ND
             p_velocity_solver->getNullspaceBasisVectors();
         if (!U_nul_vecs.empty())
         {
-            for (unsigned int k = 0; k < U_nul_vecs.size(); ++k)
+            for (const auto& U_nul_vec : U_nul_vecs)
             {
-                const double alpha = U_vec->dot(U_nul_vecs[k]) / U_nul_vecs[k]->dot(U_nul_vecs[k]);
-                U_vec->axpy(-alpha, U_nul_vecs[k], U_vec);
+                const double alpha = U_vec->dot(U_nul_vec) / U_nul_vec->dot(U_nul_vec);
+                U_vec->axpy(-alpha, U_nul_vec, U_vec);
             }
         }
 #if !defined(NDEBUG)

--- a/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
@@ -614,14 +614,14 @@ StaggeredStokesPETScMatUtilities::constructPatchLevelASMSubdomains(std::vector<s
                                                                    Pointer<CoarseFineBoundary<NDIM> > /*cf_boundary*/)
 {
     // Clear previously stored index sets.
-    for (unsigned int k = 0; k < is_overlap.size(); ++k)
+    for (auto& k : is_overlap)
     {
-        is_overlap[k].clear();
+        k.clear();
     }
     is_overlap.clear();
-    for (unsigned int k = 0; k < is_nonoverlap.size(); ++k)
+    for (auto& k : is_nonoverlap)
     {
-        is_nonoverlap[k].clear();
+        k.clear();
     }
     is_nonoverlap.clear();
 
@@ -814,9 +814,9 @@ StaggeredStokesPETScMatUtilities::constructPatchLevelFields(
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM> > patch_level)
 {
     // Destroy the previously stored IS'es
-    for (unsigned int k = 0; k < is_field.size(); ++k)
+    for (auto& k : is_field)
     {
-        is_field[k].clear();
+        k.clear();
     }
     is_field.clear();
     is_field_name.clear();


### PR DESCRIPTION
This is a run of modernize-loop-convert with clang-tidy.

I'm still working on removing unused `typedef`'s, but I went ahead and opened this so changes can be reviewed.