### PR TITLE
Mark more destructors as virtual.

### DIFF
--- a/ibtk/include/ibtk/AppInitializer.h
+++ b/ibtk/include/ibtk/AppInitializer.h
@@ -65,7 +65,7 @@ public:
      * Destructor for class AppInitializer frees the SAMRAI manager objects
      * used to set up input and restart databases.
      */
-    ~AppInitializer();
+    virtual ~AppInitializer();
 
     /*!
      * Return a pointer to the input database.

--- a/ibtk/include/ibtk/EdgeDataSynchronization.h
+++ b/ibtk/include/ibtk/EdgeDataSynchronization.h
@@ -141,7 +141,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~EdgeDataSynchronization();
+    virtual ~EdgeDataSynchronization();
 
     /*!
      * \brief Setup the hierarchy synchronization operator to perform the

--- a/ibtk/include/ibtk/FaceDataSynchronization.h
+++ b/ibtk/include/ibtk/FaceDataSynchronization.h
@@ -140,7 +140,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~FaceDataSynchronization();
+    virtual ~FaceDataSynchronization();
 
     /*!
      * \brief Setup the hierarchy synchronization operator to perform the

--- a/ibtk/include/ibtk/HierarchyGhostCellInterpolation.h
+++ b/ibtk/include/ibtk/HierarchyGhostCellInterpolation.h
@@ -283,7 +283,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~HierarchyGhostCellInterpolation();
+    virtual ~HierarchyGhostCellInterpolation();
 
     /*!
      * \brief Specify whether the boundary conditions are homogeneous.

--- a/ibtk/include/ibtk/HierarchyMathOps.h
+++ b/ibtk/include/ibtk/HierarchyMathOps.h
@@ -113,7 +113,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~HierarchyMathOps();
+    virtual ~HierarchyMathOps();
 
     /*!
      * \name Methods to set the hierarchy and range of levels.

--- a/ibtk/include/ibtk/LMarker.h
+++ b/ibtk/include/ibtk/LMarker.h
@@ -87,7 +87,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~LMarker();
+    virtual ~LMarker();
 
     /*!
      * \brief Assignment operator.

--- a/ibtk/include/ibtk/LMesh.h
+++ b/ibtk/include/ibtk/LMesh.h
@@ -65,7 +65,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~LMesh();
+    virtual ~LMesh();
 
     /*!
      * \brief Return a const reference to the set of local LNode objects.

--- a/ibtk/include/ibtk/LSet.h
+++ b/ibtk/include/ibtk/LSet.h
@@ -130,7 +130,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~LSet();
+    virtual ~LSet();
 
     /*!
      * \brief Assignment operator.

--- a/ibtk/include/ibtk/NodeDataSynchronization.h
+++ b/ibtk/include/ibtk/NodeDataSynchronization.h
@@ -141,7 +141,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~NodeDataSynchronization();
+    virtual ~NodeDataSynchronization();
 
     /*!
      * \brief Setup the hierarchy synchronization operator to perform the

--- a/ibtk/include/ibtk/ParallelEdgeMap.h
+++ b/ibtk/include/ibtk/ParallelEdgeMap.h
@@ -59,7 +59,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~ParallelEdgeMap();
+    virtual ~ParallelEdgeMap();
 
     /*!
      * \brief Add an edge to the edge map.

--- a/ibtk/include/ibtk/ParallelMap.h
+++ b/ibtk/include/ibtk/ParallelMap.h
@@ -72,7 +72,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~ParallelMap();
+    virtual ~ParallelMap();
 
     /*!
      * \brief Assignment operator.

--- a/ibtk/include/ibtk/ParallelSet.h
+++ b/ibtk/include/ibtk/ParallelSet.h
@@ -66,7 +66,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~ParallelSet();
+    virtual ~ParallelSet();
 
     /*!
      * \brief Assignment operator.

--- a/ibtk/include/ibtk/PatchMathOps.h
+++ b/ibtk/include/ibtk/PatchMathOps.h
@@ -84,7 +84,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~PatchMathOps();
+    virtual ~PatchMathOps();
 
     /*!
      * \name Mathematical operations.

--- a/ibtk/include/ibtk/SideDataSynchronization.h
+++ b/ibtk/include/ibtk/SideDataSynchronization.h
@@ -140,7 +140,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~SideDataSynchronization();
+    virtual ~SideDataSynchronization();
 
     /*!
      * \brief Setup the hierarchy synchronization operator to perform the

--- a/ibtk/include/ibtk/StaggeredPhysicalBoundaryHelper.h
+++ b/ibtk/include/ibtk/StaggeredPhysicalBoundaryHelper.h
@@ -92,7 +92,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~StaggeredPhysicalBoundaryHelper();
+    virtual ~StaggeredPhysicalBoundaryHelper();
 
     /*!
      * \brief Copy data to u_data_out_idx from u_data_in_idx at Dirichlet

--- a/include/ibamr/CIBMobilitySolver.h
+++ b/include/ibamr/CIBMobilitySolver.h
@@ -103,7 +103,7 @@ public:
     /*!
      * \brief Destructor for this class.
      */
-    ~CIBMobilitySolver();
+    virtual ~CIBMobilitySolver();
 
     /*!
      * \brief Set the time at which the solution is to be evaluated.

--- a/include/ibamr/CIBSaddlePointSolver.h
+++ b/include/ibamr/CIBSaddlePointSolver.h
@@ -138,7 +138,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~CIBSaddlePointSolver();
+    virtual ~CIBSaddlePointSolver();
 
     /*!
      * \brief Set the KSP type.

--- a/include/ibamr/DirectMobilitySolver.h
+++ b/include/ibamr/DirectMobilitySolver.h
@@ -80,7 +80,7 @@ public:
     /*!
      * \brief Destructor for this class.
      */
-    ~DirectMobilitySolver();
+    virtual ~DirectMobilitySolver();
 
     /*!
      * \brief Register a prototypical structure with a particular mobility

--- a/include/ibamr/IBFEDirectForcingKinematics.h
+++ b/include/ibamr/IBFEDirectForcingKinematics.h
@@ -86,7 +86,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~IBFEDirectForcingKinematics();
+    virtual ~IBFEDirectForcingKinematics();
 
     /*!
      * \brief Typedef specifying interface for specifying rigid body velocities.

--- a/include/ibamr/IBInstrumentPanel.h
+++ b/include/ibamr/IBInstrumentPanel.h
@@ -86,7 +86,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~IBInstrumentPanel();
+    virtual ~IBInstrumentPanel();
 
     /*!
      * \return A const reference to the vector of instrument names.

--- a/include/ibamr/IBKirchhoffRodForceGen.h
+++ b/include/ibamr/IBKirchhoffRodForceGen.h
@@ -81,7 +81,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~IBKirchhoffRodForceGen();
+    virtual ~IBKirchhoffRodForceGen();
 
     /*!
      * \brief Setup the data needed to compute the beam forces on the specified

--- a/include/ibamr/KrylovFreeBodyMobilitySolver.h
+++ b/include/ibamr/KrylovFreeBodyMobilitySolver.h
@@ -83,7 +83,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~KrylovFreeBodyMobilitySolver();
+    virtual ~KrylovFreeBodyMobilitySolver();
 
     /*!
      * \brief Set the mobility solver for this class.

--- a/include/ibamr/KrylovMobilitySolver.h
+++ b/include/ibamr/KrylovMobilitySolver.h
@@ -90,7 +90,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    ~KrylovMobilitySolver();
+    virtual ~KrylovMobilitySolver();
 
     /*!
      * \brief Set the KSP type.

--- a/include/ibamr/StokesSpecifications.h
+++ b/include/ibamr/StokesSpecifications.h
@@ -73,7 +73,7 @@ public:
     /*!
      * \brief Destructor.
      */
-    inline ~StokesSpecifications()
+    virtual inline ~StokesSpecifications()
     {
         // intentionally blank
         return;


### PR DESCRIPTION
From the discussion in #365: lets fix this before we forget.

These destructors are, presently, already virtual because we inherit from `tbox::DescribedClass`. However, this class was removed in SAMRAI 3, so we will need to do explicitly make them virtual when we require SAMRAI 3 in the future.