### PR TITLE
Don't delete a source file in make clean.

### DIFF
--- a/doc/news/changes/minor/20181024AaronBarrettDavidWells
+++ b/doc/news/changes/minor/20181024AaronBarrettDavidWells
@@ -1,0 +1,2 @@
+Fixed: The <code>clean</code> accidentally deleted a source file. This is now fixed.
+(Aaron Barrett and David Wells, 2018/10/24)

--- a/src/navier_stokes/fortran/Makefile.am
+++ b/src/navier_stokes/fortran/Makefile.am
@@ -8,7 +8,7 @@ EXTRA_DIST =                                                                    
   navier_stokes_staggered_helpers2d.f.m4          navier_stokes_staggered_helpers3d.f.m4     \
   navier_stokes_stabledt2d.f.m4                   navier_stokes_stabledt3d.f.m4              \
   navier_stokes_stochastic_forcing2d.f.m4         navier_stokes_stochastic_forcing3d.f.m4    \
-  navier_stokes_surface_tension_forcing2d.f.m4    navier_stokes_surface_tension_forcing2d.f
+  navier_stokes_surface_tension_forcing2d.f.m4    navier_stokes_surface_tension_forcing2d.f.m4
 BUILT_SOURCES =                                                                              \
   navier_stokes_bdryop2d.f                        navier_stokes_bdryop3d.f                   \
   navier_stokes_divsource2d.f                     navier_stokes_divsource3d.f                \
@@ -16,5 +16,5 @@ BUILT_SOURCES =                                                                 
   navier_stokes_staggered_helpers2d.f             navier_stokes_staggered_helpers3d.f        \
   navier_stokes_stabledt2d.f                      navier_stokes_stabledt3d.f                 \
   navier_stokes_stochastic_forcing2d.f            navier_stokes_stochastic_forcing3d.f       \
-  navier_stokes_surface_tension_forcing3d.f.m4    navier_stokes_surface_tension_forcing3d.f
+  navier_stokes_surface_tension_forcing3d.f       navier_stokes_surface_tension_forcing3d.f
 CLEANFILES = ${BUILT_SOURCES}

--- a/src/navier_stokes/fortran/Makefile.in
+++ b/src/navier_stokes/fortran/Makefile.in
@@ -445,7 +445,7 @@ EXTRA_DIST = \
   navier_stokes_staggered_helpers2d.f.m4          navier_stokes_staggered_helpers3d.f.m4     \
   navier_stokes_stabledt2d.f.m4                   navier_stokes_stabledt3d.f.m4              \
   navier_stokes_stochastic_forcing2d.f.m4         navier_stokes_stochastic_forcing3d.f.m4    \
-  navier_stokes_surface_tension_forcing2d.f.m4    navier_stokes_surface_tension_forcing2d.f
+  navier_stokes_surface_tension_forcing2d.f.m4    navier_stokes_surface_tension_forcing2d.f.m4
 
 BUILT_SOURCES = \
   navier_stokes_bdryop2d.f                        navier_stokes_bdryop3d.f                   \
@@ -454,7 +454,7 @@ BUILT_SOURCES = \
   navier_stokes_staggered_helpers2d.f             navier_stokes_staggered_helpers3d.f        \
   navier_stokes_stabledt2d.f                      navier_stokes_stabledt3d.f                 \
   navier_stokes_stochastic_forcing2d.f            navier_stokes_stochastic_forcing3d.f       \
-  navier_stokes_surface_tension_forcing3d.f.m4    navier_stokes_surface_tension_forcing3d.f
+  navier_stokes_surface_tension_forcing3d.f       navier_stokes_surface_tension_forcing3d.f
 
 CLEANFILES = ${BUILT_SOURCES}
 all: $(BUILT_SOURCES)


### PR DESCRIPTION
Fixes #373.

The `.f.m4` files are source files; the `.f` files are generated.