### PR TITLE
Remove unused destructors, part 1.

### DIFF
--- a/include/ibamr/IBFECentroidPostProcessor.h
+++ b/include/ibamr/IBFECentroidPostProcessor.h
@@ -55,11 +55,6 @@ public:
     IBFECentroidPostProcessor(std::string name, IBTK::FEDataManager* fe_data_manager);
 
     /*!
-     * Destructor.
-     */
-    ~IBFECentroidPostProcessor();
-
-    /*!
      * Register a scalar-valued variable for reconstruction.
      *
      * \note This method checks that the requested FE family and order are valid

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -36,6 +36,7 @@
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include <fstream>
+#include <memory>
 
 #include "boost/multi_array.hpp"
 #include "ibamr/IBFEMethod.h"
@@ -65,11 +66,6 @@ public:
      * \brief Constructor.
      */
     IBFEInstrumentPanel(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db, int part);
-
-    /*!
-     * \brief Destructor.
-     */
-    ~IBFEInstrumentPanel();
 
     /*!
      * \brief Get data from input file.
@@ -102,7 +98,7 @@ public:
      * \return The instrument dump interval
      */
     int getInstrumentDumpInterval() const;
-    
+
     /*!
      * \return The name of the directory for output
      */
@@ -231,14 +227,14 @@ private:
     std::vector<std::vector<libMesh::dof_id_type> > d_node_dof_IDs;
 
     /*!
-     * \brief contains pointers to the equation systems for the meter mesh.
+     * \brief Equation systems for the meter meshes.
      */
-    std::vector<libMesh::EquationSystems*> d_meter_systems;
+    std::vector<std::unique_ptr<libMesh::EquationSystems>> d_meter_systems;
 
     /*!
-     * \brief vector of meter mesh pointers.
+     * \brief vector of meter meshes.
      */
-    std::vector<libMesh::SerialMesh*> d_meter_meshes;
+    std::vector<std::unique_ptr<libMesh::SerialMesh>> d_meter_meshes;
 
     /*!
      * \brief names for each meter mesh.

--- a/include/ibamr/IBFEPostProcessor.h
+++ b/include/ibamr/IBFEPostProcessor.h
@@ -201,7 +201,7 @@ public:
     /*!
      * Virtual destructor.
      */
-    virtual ~IBFEPostProcessor();
+    virtual ~IBFEPostProcessor() = default;
 
     /*!
      * Register a scalar-valued variable for reconstruction.

--- a/include/ibamr/IBSpringForceSpec.h
+++ b/include/ibamr/IBSpringForceSpec.h
@@ -122,11 +122,6 @@ public:
                       const std::vector<std::vector<double> >& parameters);
 
     /*!
-     * \brief Destructor.
-     */
-    ~IBSpringForceSpec();
-
-    /*!
      * \return The number of springs attached to the master node.
      */
     unsigned int getNumberOfSprings() const;

--- a/include/ibamr/IBStandardForceGen.h
+++ b/include/ibamr/IBStandardForceGen.h
@@ -89,11 +89,6 @@ public:
         SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db = SAMRAI::tbox::Pointer<SAMRAI::tbox::Database>());
 
     /*!
-     * \brief Destructor.
-     */
-    ~IBStandardForceGen();
-
-    /*!
      * \brief Register a spring force specification function with the force
      * generator.
      *

--- a/include/ibamr/IBStrategy.h
+++ b/include/ibamr/IBStrategy.h
@@ -126,11 +126,6 @@ public:
     IBStrategy();
 
     /*!
-     * \brief Virtual destructor.
-     */
-    virtual ~IBStrategy();
-
-    /*!
      * Register the IBHierarchyIntegrator object that is using this strategy
      * class.
      *

--- a/include/ibamr/IBStrategySet.h
+++ b/include/ibamr/IBStrategySet.h
@@ -106,11 +106,6 @@ public:
     } // IBStrategySet
 
     /*!
-     * \brief Destructor.
-     */
-    ~IBStrategySet();
-
-    /*!
      * Register the IBHierarchyIntegrator object that is using this strategy
      * class.
      */

--- a/include/ibamr/IBTargetPointForceSpec.h
+++ b/include/ibamr/IBTargetPointForceSpec.h
@@ -99,11 +99,6 @@ public:
                            const IBTK::Point& X_target = IBTK::Point::Zero());
 
     /*!
-     * \brief Destructor.
-     */
-    ~IBTargetPointForceSpec();
-
-    /*!
      * \return A const reference to the master node index.
      */
     const int& getMasterNodeIndex() const;

--- a/include/ibamr/RelaxationLSMethod.h
+++ b/include/ibamr/RelaxationLSMethod.h
@@ -100,11 +100,6 @@ public:
                        bool register_for_restart = true);
 
     /*!
-     * \brief Destructor.
-     */
-    virtual ~RelaxationLSMethod();
-
-    /*!
      * \name Implementation of IBAMR::LSInitStrategy interface.
      */
     //\{

--- a/include/ibamr/private/IBSpringForceSpec-inl.h
+++ b/include/ibamr/private/IBSpringForceSpec-inl.h
@@ -88,12 +88,6 @@ inline IBSpringForceSpec::IBSpringForceSpec(const int master_idx,
     return;
 } // IBSpringForceSpec
 
-inline IBSpringForceSpec::~IBSpringForceSpec()
-{
-    // intentionally blank
-    return;
-} // ~IBSpringForceSpec
-
 inline unsigned int
 IBSpringForceSpec::getNumberOfSprings() const
 {

--- a/include/ibamr/private/IBTargetPointForceSpec-inl.h
+++ b/include/ibamr/private/IBTargetPointForceSpec-inl.h
@@ -71,12 +71,6 @@ inline IBTargetPointForceSpec::IBTargetPointForceSpec(const int master_idx,
     return;
 } // IBTargetPointForceSpec
 
-inline IBTargetPointForceSpec::~IBTargetPointForceSpec()
-{
-    // intentionally blank
-    return;
-} // ~IBTargetPointForceSpec
-
 inline const int&
 IBTargetPointForceSpec::getMasterNodeIndex() const
 {

--- a/src/IB/IBFECentroidPostProcessor.cpp
+++ b/src/IB/IBFECentroidPostProcessor.cpp
@@ -114,12 +114,6 @@ IBFECentroidPostProcessor::IBFECentroidPostProcessor(std::string name, FEDataMan
     return;
 } // IBFECentroidPostProcessor
 
-IBFECentroidPostProcessor::~IBFECentroidPostProcessor()
-{
-    // intentionally blank
-    return;
-} // ~IBFECentroidPostProcessor
-
 void
 IBFECentroidPostProcessor::registerScalarVariable(const std::string& name,
                                                   libMesh::FEFamily fe_family,

--- a/src/IB/IBFEPostProcessor.cpp
+++ b/src/IB/IBFEPostProcessor.cpp
@@ -87,12 +87,6 @@ IBFEPostProcessor::IBFEPostProcessor(std::string name, FEDataManager* fe_data_ma
     return;
 } // IBFEPostProcessor
 
-IBFEPostProcessor::~IBFEPostProcessor()
-{
-    // intentionally blank
-    return;
-} // ~IBFEPostProcessor
-
 void
 IBFEPostProcessor::registerScalarVariable(const std::string& name,
                                           libMesh::FEFamily fe_family,

--- a/src/IB/IBStandardForceGen.cpp
+++ b/src/IB/IBStandardForceGen.cpp
@@ -141,12 +141,6 @@ IBStandardForceGen::IBStandardForceGen(Pointer<Database> input_db)
     return;
 } // IBStandardForceGen
 
-IBStandardForceGen::~IBStandardForceGen()
-{
-    // intentionally blank
-    return;
-} // ~IBStandardForceGen
-
 void
 IBStandardForceGen::registerSpringForceFunction(const int force_fcn_index,
                                                 const SpringForceFcnPtr spring_force_fcn_ptr,

--- a/src/IB/IBStrategy.cpp
+++ b/src/IB/IBStrategy.cpp
@@ -96,12 +96,6 @@ IBStrategy::IBStrategy() : d_ib_solver(nullptr), d_use_fixed_coupling_ops(false)
     return;
 } // IBStrategy
 
-IBStrategy::~IBStrategy()
-{
-    // intentionally blank
-    return;
-} // ~IBStrategy
-
 void
 IBStrategy::registerIBHierarchyIntegrator(IBHierarchyIntegrator* ib_solver)
 {

--- a/src/IB/IBStrategySet.cpp
+++ b/src/IB/IBStrategySet.cpp
@@ -80,12 +80,6 @@ namespace IBAMR
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
-IBStrategySet::~IBStrategySet()
-{
-    // intentionally blank
-    return;
-} // ~IBStrategySet
-
 void
 IBStrategySet::registerIBHierarchyIntegrator(IBHierarchyIntegrator* ib_solver)
 {

--- a/src/level_set/RelaxationLSMethod.cpp
+++ b/src/level_set/RelaxationLSMethod.cpp
@@ -244,11 +244,6 @@ RelaxationLSMethod::RelaxationLSMethod(std::string object_name, Pointer<Database
     return;
 } // RelaxationLSMethod
 
-RelaxationLSMethod::~RelaxationLSMethod()
-{
-    return;
-} // ~RelaxationLSMethod
-
 void
 RelaxationLSMethod::initializeLSData(int D_idx,
                                      Pointer<HierarchyMathOps> hier_math_ops,
@@ -314,7 +309,7 @@ RelaxationLSMethod::initializeLSData(int D_idx,
         var_db->registerVariableAndContext(D_var, var_db->getContext(d_object_name + "::COPY"), cell_ghosts);
     const int H_init_idx =
         var_db->registerVariableAndContext(D_var, var_db->getContext(d_object_name + "::H_INIT"), cell_ghosts);
-    const int H_scratch_idx = 
+    const int H_scratch_idx =
         var_db->registerVariableAndContext(D_var, var_db->getContext(d_object_name + "::H_SCRATCH"), no_ghosts);
 
     // Heaviside variables


### PR DESCRIPTION
We have a lot of empty destructor implementations (hundreds). This commit gets rid of a few.

I checked that, in all cases, we will not end up converting a destructor from virtual to non-virtual; all classes with virtual destructors here already have a base class with a virtual destructor.