### PR TITLE
Add versioning macros.

### DIFF
--- a/config/IBAMR_config.h.tmp.in
+++ b/config/IBAMR_config.h.tmp.in
@@ -209,3 +209,15 @@
 
 /* Version number of package */
 #undef VERSION
+
+/* Major version of IBAMR. */
+#undef VERSION_MAJOR
+
+/* Minor version of IBAMR. */
+#undef VERSION_MINOR
+
+/* Subminor version of IBAMR. */
+#undef VERSION_SUBMINOR
+
+/* Version check macro. */
+#define VERSION_GTE(major, minor, subminor) ((IBAMR_VERSION_MAJOR*10000 + IBAMR_VERSION_MINOR*100 + IBAMR_VERSION_SUBMINOR) >= (major)*10000 + (minor)*100 + (subminor))

--- a/configure
+++ b/configure
@@ -23434,6 +23434,32 @@ _ACEOF
 
 
 ###########################################################################
+# Version information (requires sed).
+###########################################################################
+ibamr_version_major=$($SED "s/^\([0-9]\+\)\..*/\1/" "$srcdir/VERSION")
+ibamr_version_minor=$($SED "s/^[^.]\+\.\([0-9]\+\)\.[0-9]\+.*/\1/" "$srcdir/VERSION")
+ibamr_version_subminor=$($SED "s/^[^.]\+\.[^.]\+\.\([0-9]\+\).*/\1/" "$srcdir/VERSION")
+
+cat >>confdefs.h <<_ACEOF
+#define VERSION_MAJOR $ibamr_version_major
+_ACEOF
+
+
+cat >>confdefs.h <<_ACEOF
+#define VERSION_MINOR $ibamr_version_minor
+_ACEOF
+
+
+cat >>confdefs.h <<_ACEOF
+#define VERSION_SUBMINOR $ibamr_version_subminor
+_ACEOF
+
+
+
+
+
+
+###########################################################################
 # Checks for optional and required third-party libraries.
 ###########################################################################
 

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,36 @@ CHECK_BUILTIN_EXPECT
 CHECK_BUILTIN_PREFETCH
 
 ###########################################################################
+# Version information (requires sed).
+###########################################################################
+dnl Since this is an M4 script we must use the quadrigraphs @<:@ and @:>@ for
+dnl brackets, i.e., for [ and ]
+ibamr_version_major=$($SED "s/^\(@<:@0-9@:>@\+\)\..*/\1/" "$srcdir/VERSION")
+ibamr_version_minor=$($SED "s/^@<:@^.@:>@\+\.\(@<:@0-9@:>@\+\)\.@<:@0-9@:>@\+.*/\1/" "$srcdir/VERSION")
+ibamr_version_subminor=$($SED "s/^@<:@^.@:>@\+\.@<:@^.@:>@\+\.\(@<:@0-9@:>@\+\).*/\1/" "$srcdir/VERSION")
+AC_DEFINE_UNQUOTED(VERSION_MAJOR, $ibamr_version_major, [Major version of IBAMR.])
+AC_DEFINE_UNQUOTED(VERSION_MINOR, $ibamr_version_minor, [Minor version of IBAMR.])
+AC_DEFINE_UNQUOTED(VERSION_SUBMINOR, $ibamr_version_subminor, [Subminor version of IBAMR.])
+
+dnl We have to use a funny name for the key to guarantee that it comes after
+dnl IBAMR_VERSION_SUBMINOR.
+dnl
+dnl TODO: Our code ignores backslashes when placing ifdef/endif guards around
+dnl individual macros: i.e., autoheader writes
+dnl     #define IBAMR_VERSION_GTE(...) ... \
+dnl     #endif
+dnl     ..... \
+dnl     .....
+dnl
+dnl which doesn't make any sense. Get around this by just putting everything on
+dnl one line. It is probably possible to fix this by editing
+dnl m4/ax_prefix_config_h.m4, circa line 173.
+AH_VERBATIM(VERSION_T_CHECK, [/* Version check macro. */
+#define VERSION_GTE(major, minor, subminor) ((IBAMR_VERSION_MAJOR*10000 + IBAMR_VERSION_MINOR*100 + IBAMR_VERSION_SUBMINOR) >= (major)*10000 + (minor)*100 + (subminor))])
+
+
+
+###########################################################################
 # Checks for optional and required third-party libraries.
 ###########################################################################
 PACKAGE_INITIALIZE_ENVIRONMENT

--- a/doc/news/changes/minor/20181031DavidWells
+++ b/doc/news/changes/minor/20181031DavidWells
@@ -1,0 +1,6 @@
+New: <code>IBAMR_config.h</code> now defines preprocessor constants
+<code>IBAMR_VERSION_MINOR</code>, <code>IBAMR_VERSION_MAJOR</code>, and
+<code>IBAMR_VERSION_SUBMINOR</code>, as well as the version check macro
+<code>IBAMR_VERSION_GTE</code>.
+<br>
+(David Wells, 2018/10/31)


### PR DESCRIPTION
This commit adds basic preprocessor constants and one function for doing version checks. One can now do things like
```cpp
#if IBAMR_VERSION_GTE(1, 0, 0)
    std::vector<MeshBase *> meshes;
#else
    std::vector<Mesh *> meshes;
#endif
```
for compatibility with the changes made in #368.

I really wish I had realized this was missing before the 0.3.0 release; better late than never, I suppose.