### PR TITLE
Remove forward declarations of boost::array.

### DIFF
--- a/ibtk/include/ibtk/SCPoissonPointRelaxationFACOperator.h
+++ b/ibtk/include/ibtk/SCPoissonPointRelaxationFACOperator.h
@@ -46,12 +46,6 @@
 #include "tbox/Database.h"
 #include "tbox/Pointer.h"
 
-namespace boost
-{
-template <class T, std::size_t N>
-class array;
-} // namespace boost
-
 namespace SAMRAI
 {
 namespace hier

--- a/include/ibamr/StaggeredStokesBoxRelaxationFACOperator.h
+++ b/include/ibamr/StaggeredStokesBoxRelaxationFACOperator.h
@@ -45,12 +45,6 @@
 #include "petscvec.h"
 #include "tbox/Pointer.h"
 
-namespace boost
-{
-template <class T, std::size_t N>
-class array;
-} // namespace boost
-
 namespace SAMRAI
 {
 namespace hier

--- a/include/ibamr/StaggeredStokesIBLevelRelaxationFACOperator.h
+++ b/include/ibamr/StaggeredStokesIBLevelRelaxationFACOperator.h
@@ -64,11 +64,6 @@
 #include "tbox/Database.h"
 #include "tbox/Pointer.h"
 
-namespace boost
-{
-template <class T, std::size_t N>
-class array;
-} // namespace boost
 namespace IBAMR
 {
 class StaggeredStokesPETScLevelSolver;

--- a/include/ibamr/StaggeredStokesLevelRelaxationFACOperator.h
+++ b/include/ibamr/StaggeredStokesLevelRelaxationFACOperator.h
@@ -46,11 +46,6 @@
 #include "petscvec.h"
 #include "tbox/Pointer.h"
 
-namespace boost
-{
-template <class T, std::size_t N>
-class array;
-} // namespace boost
 namespace SAMRAI
 {
 namespace hier


### PR DESCRIPTION
Tiny little cosmetic fix; we don't need forward declarations for `boost::array` since we don't use it any more.