### PR TITLE
Use delete on private special member functions.

### DIFF
--- a/ibtk/include/ibtk/AppInitializer.h
+++ b/ibtk/include/ibtk/AppInitializer.h
@@ -208,7 +208,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AppInitializer(const AppInitializer& from);
+    AppInitializer(const AppInitializer& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -219,7 +219,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AppInitializer& operator=(const AppInitializer& that);
+    AppInitializer& operator=(const AppInitializer& that) = delete;
 
     /*!
      * The input database.

--- a/ibtk/include/ibtk/BGaussSeidelPreconditioner.h
+++ b/ibtk/include/ibtk/BGaussSeidelPreconditioner.h
@@ -275,7 +275,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    BGaussSeidelPreconditioner();
+    BGaussSeidelPreconditioner() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -284,7 +284,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    BGaussSeidelPreconditioner(const BGaussSeidelPreconditioner& from);
+    BGaussSeidelPreconditioner(const BGaussSeidelPreconditioner& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -295,7 +295,7 @@ private:
      *
      * \return A reference to this object.
      */
-    BGaussSeidelPreconditioner& operator=(const BGaussSeidelPreconditioner& that);
+    BGaussSeidelPreconditioner& operator=(const BGaussSeidelPreconditioner& that) = delete;
 
     /*!
      * \brief Extract the individual components of a

--- a/ibtk/include/ibtk/BJacobiPreconditioner.h
+++ b/ibtk/include/ibtk/BJacobiPreconditioner.h
@@ -239,7 +239,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    BJacobiPreconditioner();
+    BJacobiPreconditioner() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -248,7 +248,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    BJacobiPreconditioner(const BJacobiPreconditioner& from);
+    BJacobiPreconditioner(const BJacobiPreconditioner& from) = delete;
 
     /*!
      * ]brief Assignment operator.
@@ -259,7 +259,7 @@ private:
      *
      * \return A reference to this object.
      */
-    BJacobiPreconditioner& operator=(const BJacobiPreconditioner& that);
+    BJacobiPreconditioner& operator=(const BJacobiPreconditioner& that) = delete;
 
     /*!
      * The component preconditioners.

--- a/ibtk/include/ibtk/CCLaplaceOperator.h
+++ b/ibtk/include/ibtk/CCLaplaceOperator.h
@@ -136,7 +136,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CCLaplaceOperator();
+    CCLaplaceOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -145,7 +145,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CCLaplaceOperator(const CCLaplaceOperator& from);
+    CCLaplaceOperator(const CCLaplaceOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -156,7 +156,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CCLaplaceOperator& operator=(const CCLaplaceOperator& that);
+    CCLaplaceOperator& operator=(const CCLaplaceOperator& that) = delete;
 
     // Operator parameters.
     int d_ncomp;

--- a/ibtk/include/ibtk/CCPoissonBoxRelaxationFACOperator.h
+++ b/ibtk/include/ibtk/CCPoissonBoxRelaxationFACOperator.h
@@ -244,7 +244,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CCPoissonBoxRelaxationFACOperator();
+    CCPoissonBoxRelaxationFACOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -253,7 +253,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CCPoissonBoxRelaxationFACOperator(const CCPoissonBoxRelaxationFACOperator& from);
+    CCPoissonBoxRelaxationFACOperator(const CCPoissonBoxRelaxationFACOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -264,7 +264,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CCPoissonBoxRelaxationFACOperator& operator=(const CCPoissonBoxRelaxationFACOperator& that);
+    CCPoissonBoxRelaxationFACOperator& operator=(const CCPoissonBoxRelaxationFACOperator& that) = delete;
 
     /*!
      * \brief Construct a matrix corresponding to a Laplace operator restricted

--- a/ibtk/include/ibtk/CCPoissonHypreLevelSolver.h
+++ b/ibtk/include/ibtk/CCPoissonHypreLevelSolver.h
@@ -257,7 +257,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CCPoissonHypreLevelSolver();
+    CCPoissonHypreLevelSolver() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -266,7 +266,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CCPoissonHypreLevelSolver(const CCPoissonHypreLevelSolver& from);
+    CCPoissonHypreLevelSolver(const CCPoissonHypreLevelSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -277,7 +277,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CCPoissonHypreLevelSolver& operator=(const CCPoissonHypreLevelSolver& that);
+    CCPoissonHypreLevelSolver& operator=(const CCPoissonHypreLevelSolver& that) = delete;
 
     /*!
      * \brief Functions to allocate, initialize, access, and deallocate hypre

--- a/ibtk/include/ibtk/CCPoissonLevelRelaxationFACOperator.h
+++ b/ibtk/include/ibtk/CCPoissonLevelRelaxationFACOperator.h
@@ -234,7 +234,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CCPoissonLevelRelaxationFACOperator();
+    CCPoissonLevelRelaxationFACOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -243,7 +243,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CCPoissonLevelRelaxationFACOperator(const CCPoissonLevelRelaxationFACOperator& from);
+    CCPoissonLevelRelaxationFACOperator(const CCPoissonLevelRelaxationFACOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -254,7 +254,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CCPoissonLevelRelaxationFACOperator& operator=(const CCPoissonLevelRelaxationFACOperator& that);
+    CCPoissonLevelRelaxationFACOperator& operator=(const CCPoissonLevelRelaxationFACOperator& that) = delete;
 
     /*
      * Level solvers and solver parameters.

--- a/ibtk/include/ibtk/CCPoissonPETScLevelSolver.h
+++ b/ibtk/include/ibtk/CCPoissonPETScLevelSolver.h
@@ -175,7 +175,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CCPoissonPETScLevelSolver();
+    CCPoissonPETScLevelSolver() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -184,7 +184,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CCPoissonPETScLevelSolver(const CCPoissonPETScLevelSolver& from);
+    CCPoissonPETScLevelSolver(const CCPoissonPETScLevelSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -195,7 +195,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CCPoissonPETScLevelSolver& operator=(const CCPoissonPETScLevelSolver& that);
+    CCPoissonPETScLevelSolver& operator=(const CCPoissonPETScLevelSolver& that) = delete;
 
     /*!
      * \name PETSc objects.

--- a/ibtk/include/ibtk/CCPoissonPointRelaxationFACOperator.h
+++ b/ibtk/include/ibtk/CCPoissonPointRelaxationFACOperator.h
@@ -242,7 +242,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CCPoissonPointRelaxationFACOperator();
+    CCPoissonPointRelaxationFACOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -251,7 +251,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CCPoissonPointRelaxationFACOperator(const CCPoissonPointRelaxationFACOperator& from);
+    CCPoissonPointRelaxationFACOperator(const CCPoissonPointRelaxationFACOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -262,7 +262,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CCPoissonPointRelaxationFACOperator& operator=(const CCPoissonPointRelaxationFACOperator& that);
+    CCPoissonPointRelaxationFACOperator& operator=(const CCPoissonPointRelaxationFACOperator& that) = delete;
 
     /*
      * Coarse level solvers and solver parameters.

--- a/ibtk/include/ibtk/CCPoissonSolverManager.h
+++ b/ibtk/include/ibtk/CCPoissonSolverManager.h
@@ -159,7 +159,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CCPoissonSolverManager(const CCPoissonSolverManager& from);
+    CCPoissonSolverManager(const CCPoissonSolverManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -170,7 +170,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CCPoissonSolverManager& operator=(const CCPoissonSolverManager& that);
+    CCPoissonSolverManager& operator=(const CCPoissonSolverManager& that) = delete;
 
     /*!
      * Static data members used to control access to and destruction of

--- a/ibtk/include/ibtk/CartCellDoubleBoundsPreservingConservativeLinearRefine.h
+++ b/ibtk/include/ibtk/CartCellDoubleBoundsPreservingConservativeLinearRefine.h
@@ -137,7 +137,7 @@ private:
      * \param from The value to copy to this object.
      */
     CartCellDoubleBoundsPreservingConservativeLinearRefine(
-        const CartCellDoubleBoundsPreservingConservativeLinearRefine& from);
+        const CartCellDoubleBoundsPreservingConservativeLinearRefine& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -149,7 +149,7 @@ private:
      * \return A reference to this object.
      */
     CartCellDoubleBoundsPreservingConservativeLinearRefine&
-    operator=(const CartCellDoubleBoundsPreservingConservativeLinearRefine& that);
+    operator=(const CartCellDoubleBoundsPreservingConservativeLinearRefine& that) = delete;
 
     /*!
      * The operator name.

--- a/ibtk/include/ibtk/CartCellDoubleCubicCoarsen.h
+++ b/ibtk/include/ibtk/CartCellDoubleCubicCoarsen.h
@@ -142,7 +142,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartCellDoubleCubicCoarsen(const CartCellDoubleCubicCoarsen& from);
+    CartCellDoubleCubicCoarsen(const CartCellDoubleCubicCoarsen& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -153,7 +153,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartCellDoubleCubicCoarsen& operator=(const CartCellDoubleCubicCoarsen& that);
+    CartCellDoubleCubicCoarsen& operator=(const CartCellDoubleCubicCoarsen& that) = delete;
 
     /*!
      * The operator name.

--- a/ibtk/include/ibtk/CartCellDoubleLinearCFInterpolation.h
+++ b/ibtk/include/ibtk/CartCellDoubleLinearCFInterpolation.h
@@ -218,7 +218,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartCellDoubleLinearCFInterpolation(const CartCellDoubleLinearCFInterpolation& from);
+    CartCellDoubleLinearCFInterpolation(const CartCellDoubleLinearCFInterpolation& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -229,7 +229,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartCellDoubleLinearCFInterpolation& operator=(const CartCellDoubleLinearCFInterpolation& that);
+    CartCellDoubleLinearCFInterpolation& operator=(const CartCellDoubleLinearCFInterpolation& that) = delete;
 
     /*!
      * The patch data indices corresponding to the "scratch" patch data that is

--- a/ibtk/include/ibtk/CartCellDoubleQuadraticCFInterpolation.h
+++ b/ibtk/include/ibtk/CartCellDoubleQuadraticCFInterpolation.h
@@ -219,7 +219,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartCellDoubleQuadraticCFInterpolation(const CartCellDoubleQuadraticCFInterpolation& from);
+    CartCellDoubleQuadraticCFInterpolation(const CartCellDoubleQuadraticCFInterpolation& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -230,7 +230,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartCellDoubleQuadraticCFInterpolation& operator=(const CartCellDoubleQuadraticCFInterpolation& that);
+    CartCellDoubleQuadraticCFInterpolation& operator=(const CartCellDoubleQuadraticCFInterpolation& that) = delete;
 
     /*!
      * \brief Implementations of postprocessRefine().

--- a/ibtk/include/ibtk/CartCellDoubleQuadraticRefine.h
+++ b/ibtk/include/ibtk/CartCellDoubleQuadraticRefine.h
@@ -133,7 +133,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartCellDoubleQuadraticRefine(const CartCellDoubleQuadraticRefine& from);
+    CartCellDoubleQuadraticRefine(const CartCellDoubleQuadraticRefine& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -144,7 +144,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartCellDoubleQuadraticRefine& operator=(const CartCellDoubleQuadraticRefine& that);
+    CartCellDoubleQuadraticRefine& operator=(const CartCellDoubleQuadraticRefine& that) = delete;
 
     /*!
      * The operator name.

--- a/ibtk/include/ibtk/CartCellRobinPhysBdryOp.h
+++ b/ibtk/include/ibtk/CartCellRobinPhysBdryOp.h
@@ -243,7 +243,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartCellRobinPhysBdryOp(const CartCellRobinPhysBdryOp& from);
+    CartCellRobinPhysBdryOp(const CartCellRobinPhysBdryOp& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -254,7 +254,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartCellRobinPhysBdryOp& operator=(const CartCellRobinPhysBdryOp& that);
+    CartCellRobinPhysBdryOp& operator=(const CartCellRobinPhysBdryOp& that) = delete;
 
     /*!
      * \brief Set the boundary conditions along the co-dimension one boundary.

--- a/ibtk/include/ibtk/CartExtrapPhysBdryOp.h
+++ b/ibtk/include/ibtk/CartExtrapPhysBdryOp.h
@@ -236,7 +236,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartExtrapPhysBdryOp(const CartExtrapPhysBdryOp& from);
+    CartExtrapPhysBdryOp(const CartExtrapPhysBdryOp& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -247,7 +247,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartExtrapPhysBdryOp& operator=(const CartExtrapPhysBdryOp& that);
+    CartExtrapPhysBdryOp& operator=(const CartExtrapPhysBdryOp& that) = delete;
 
     /*!
      * \brief The implementation of setPhysicalBoundaryConditions() for

--- a/ibtk/include/ibtk/CartGridFunction.h
+++ b/ibtk/include/ibtk/CartGridFunction.h
@@ -141,7 +141,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartGridFunction(const CartGridFunction& from);
+    CartGridFunction(const CartGridFunction& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -152,7 +152,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartGridFunction& operator=(const CartGridFunction& that);
+    CartGridFunction& operator=(const CartGridFunction& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/CartGridFunctionSet.h
+++ b/ibtk/include/ibtk/CartGridFunctionSet.h
@@ -148,7 +148,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartGridFunctionSet(const CartGridFunctionSet& from);
+    CartGridFunctionSet(const CartGridFunctionSet& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -159,7 +159,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartGridFunctionSet& operator=(const CartGridFunctionSet& that);
+    CartGridFunctionSet& operator=(const CartGridFunctionSet& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/CartSideDoubleCubicCoarsen.h
+++ b/ibtk/include/ibtk/CartSideDoubleCubicCoarsen.h
@@ -142,7 +142,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartSideDoubleCubicCoarsen(const CartSideDoubleCubicCoarsen& from);
+    CartSideDoubleCubicCoarsen(const CartSideDoubleCubicCoarsen& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -153,7 +153,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartSideDoubleCubicCoarsen& operator=(const CartSideDoubleCubicCoarsen& that);
+    CartSideDoubleCubicCoarsen& operator=(const CartSideDoubleCubicCoarsen& that) = delete;
 
     /*!
      * The operator name.

--- a/ibtk/include/ibtk/CartSideDoubleDivPreservingRefine.h
+++ b/ibtk/include/ibtk/CartSideDoubleDivPreservingRefine.h
@@ -171,7 +171,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CartSideDoubleDivPreservingRefine();
+    CartSideDoubleDivPreservingRefine() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -180,7 +180,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartSideDoubleDivPreservingRefine(const CartSideDoubleDivPreservingRefine& from);
+    CartSideDoubleDivPreservingRefine(const CartSideDoubleDivPreservingRefine& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -191,7 +191,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartSideDoubleDivPreservingRefine& operator=(const CartSideDoubleDivPreservingRefine& that);
+    CartSideDoubleDivPreservingRefine& operator=(const CartSideDoubleDivPreservingRefine& that) = delete;
 
     /*!
      * Patch data indices.

--- a/ibtk/include/ibtk/CartSideDoubleQuadraticCFInterpolation.h
+++ b/ibtk/include/ibtk/CartSideDoubleQuadraticCFInterpolation.h
@@ -218,7 +218,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartSideDoubleQuadraticCFInterpolation(const CartSideDoubleQuadraticCFInterpolation& from);
+    CartSideDoubleQuadraticCFInterpolation(const CartSideDoubleQuadraticCFInterpolation& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -229,7 +229,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartSideDoubleQuadraticCFInterpolation& operator=(const CartSideDoubleQuadraticCFInterpolation& that);
+    CartSideDoubleQuadraticCFInterpolation& operator=(const CartSideDoubleQuadraticCFInterpolation& that) = delete;
 
     /*!
      * The patch data indices corresponding to the "scratch" patch data that is

--- a/ibtk/include/ibtk/CartSideDoubleRT0Coarsen.h
+++ b/ibtk/include/ibtk/CartSideDoubleRT0Coarsen.h
@@ -134,7 +134,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartSideDoubleRT0Coarsen(const CartSideDoubleRT0Coarsen& from);
+    CartSideDoubleRT0Coarsen(const CartSideDoubleRT0Coarsen& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -145,7 +145,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartSideDoubleRT0Coarsen& operator=(const CartSideDoubleRT0Coarsen& that);
+    CartSideDoubleRT0Coarsen& operator=(const CartSideDoubleRT0Coarsen& that) = delete;
 
     /*!
      * The operator name.

--- a/ibtk/include/ibtk/CartSideDoubleSpecializedConstantRefine.h
+++ b/ibtk/include/ibtk/CartSideDoubleSpecializedConstantRefine.h
@@ -133,7 +133,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartSideDoubleSpecializedConstantRefine(const CartSideDoubleSpecializedConstantRefine& from);
+    CartSideDoubleSpecializedConstantRefine(const CartSideDoubleSpecializedConstantRefine& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -144,7 +144,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartSideDoubleSpecializedConstantRefine& operator=(const CartSideDoubleSpecializedConstantRefine& that);
+    CartSideDoubleSpecializedConstantRefine& operator=(const CartSideDoubleSpecializedConstantRefine& that) = delete;
 
     /*!
      * The operator name.

--- a/ibtk/include/ibtk/CartSideDoubleSpecializedLinearRefine.h
+++ b/ibtk/include/ibtk/CartSideDoubleSpecializedLinearRefine.h
@@ -134,7 +134,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartSideDoubleSpecializedLinearRefine(const CartSideDoubleSpecializedLinearRefine& from);
+    CartSideDoubleSpecializedLinearRefine(const CartSideDoubleSpecializedLinearRefine& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -145,7 +145,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartSideDoubleSpecializedLinearRefine& operator=(const CartSideDoubleSpecializedLinearRefine& that);
+    CartSideDoubleSpecializedLinearRefine& operator=(const CartSideDoubleSpecializedLinearRefine& that) = delete;
 
     /*!
      * The operator name.

--- a/ibtk/include/ibtk/CartSideRobinPhysBdryOp.h
+++ b/ibtk/include/ibtk/CartSideRobinPhysBdryOp.h
@@ -199,7 +199,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CartSideRobinPhysBdryOp(const CartSideRobinPhysBdryOp& from);
+    CartSideRobinPhysBdryOp(const CartSideRobinPhysBdryOp& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -210,7 +210,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CartSideRobinPhysBdryOp& operator=(const CartSideRobinPhysBdryOp& that);
+    CartSideRobinPhysBdryOp& operator=(const CartSideRobinPhysBdryOp& that) = delete;
 
     /*!
      * \brief Set the boundary conditions for normal components along the

--- a/ibtk/include/ibtk/CellNoCornersFillPattern.h
+++ b/ibtk/include/ibtk/CellNoCornersFillPattern.h
@@ -167,7 +167,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CellNoCornersFillPattern();
+    CellNoCornersFillPattern() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -176,7 +176,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CellNoCornersFillPattern(const CellNoCornersFillPattern& from);
+    CellNoCornersFillPattern(const CellNoCornersFillPattern& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -187,7 +187,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CellNoCornersFillPattern& operator=(const CellNoCornersFillPattern& that);
+    CellNoCornersFillPattern& operator=(const CellNoCornersFillPattern& that) = delete;
 
     SAMRAI::hier::IntVector<NDIM> d_stencil_width;
     const bool d_include_dst_patch_box;

--- a/ibtk/include/ibtk/CoarseFineBoundaryRefinePatchStrategy.h
+++ b/ibtk/include/ibtk/CoarseFineBoundaryRefinePatchStrategy.h
@@ -216,7 +216,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CoarseFineBoundaryRefinePatchStrategy(const CoarseFineBoundaryRefinePatchStrategy& from);
+    CoarseFineBoundaryRefinePatchStrategy(const CoarseFineBoundaryRefinePatchStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -227,7 +227,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CoarseFineBoundaryRefinePatchStrategy& operator=(const CoarseFineBoundaryRefinePatchStrategy& that);
+    CoarseFineBoundaryRefinePatchStrategy& operator=(const CoarseFineBoundaryRefinePatchStrategy& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/CoarsenPatchStrategySet.h
+++ b/ibtk/include/ibtk/CoarsenPatchStrategySet.h
@@ -135,7 +135,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CoarsenPatchStrategySet();
+    CoarsenPatchStrategySet() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -144,7 +144,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CoarsenPatchStrategySet(const CoarsenPatchStrategySet& from);
+    CoarsenPatchStrategySet(const CoarsenPatchStrategySet& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -155,7 +155,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CoarsenPatchStrategySet& operator=(const CoarsenPatchStrategySet& that);
+    CoarsenPatchStrategySet& operator=(const CoarsenPatchStrategySet& that) = delete;
 
     /*!
      * \brief The set of SAMRAI::xfer:CoarsenPatchStrategy objects.

--- a/ibtk/include/ibtk/CopyToRootSchedule.h
+++ b/ibtk/include/ibtk/CopyToRootSchedule.h
@@ -101,7 +101,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CopyToRootSchedule();
+    CopyToRootSchedule() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -110,7 +110,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CopyToRootSchedule(const CopyToRootSchedule& from);
+    CopyToRootSchedule(const CopyToRootSchedule& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -121,7 +121,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CopyToRootSchedule& operator=(const CopyToRootSchedule& that);
+    CopyToRootSchedule& operator=(const CopyToRootSchedule& that) = delete;
 
     void commonClassCtor();
 

--- a/ibtk/include/ibtk/CopyToRootTransaction.h
+++ b/ibtk/include/ibtk/CopyToRootTransaction.h
@@ -138,7 +138,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    CopyToRootTransaction();
+    CopyToRootTransaction() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -147,7 +147,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CopyToRootTransaction(const CopyToRootTransaction& from);
+    CopyToRootTransaction(const CopyToRootTransaction& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -158,7 +158,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CopyToRootTransaction& operator=(const CopyToRootTransaction& that);
+    CopyToRootTransaction& operator=(const CopyToRootTransaction& that) = delete;
 
     const int d_src_proc, d_dst_proc;
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM> > d_patch_level;

--- a/ibtk/include/ibtk/DebuggingUtilities.h
+++ b/ibtk/include/ibtk/DebuggingUtilities.h
@@ -145,7 +145,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    DebuggingUtilities();
+    DebuggingUtilities() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -154,7 +154,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    DebuggingUtilities(const DebuggingUtilities& from);
+    DebuggingUtilities(const DebuggingUtilities& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -165,7 +165,7 @@ private:
      *
      * \return A reference to this object.
      */
-    DebuggingUtilities& operator=(const DebuggingUtilities& that);
+    DebuggingUtilities& operator=(const DebuggingUtilities& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/EdgeDataSynchronization.h
+++ b/ibtk/include/ibtk/EdgeDataSynchronization.h
@@ -187,7 +187,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    EdgeDataSynchronization(const EdgeDataSynchronization& from);
+    EdgeDataSynchronization(const EdgeDataSynchronization& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -198,7 +198,7 @@ private:
      *
      * \return A reference to this object.
      */
-    EdgeDataSynchronization& operator=(const EdgeDataSynchronization& that);
+    EdgeDataSynchronization& operator=(const EdgeDataSynchronization& that) = delete;
 
     // Boolean indicating whether the operator is initialized.
     bool d_is_initialized;

--- a/ibtk/include/ibtk/EdgeSynchCopyFillPattern.h
+++ b/ibtk/include/ibtk/EdgeSynchCopyFillPattern.h
@@ -127,7 +127,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    EdgeSynchCopyFillPattern();
+    EdgeSynchCopyFillPattern() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -136,7 +136,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    EdgeSynchCopyFillPattern(const EdgeSynchCopyFillPattern& from);
+    EdgeSynchCopyFillPattern(const EdgeSynchCopyFillPattern& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -147,7 +147,7 @@ private:
      *
      * \return A reference to this object.
      */
-    EdgeSynchCopyFillPattern& operator=(const EdgeSynchCopyFillPattern& that);
+    EdgeSynchCopyFillPattern& operator=(const EdgeSynchCopyFillPattern& that) = delete;
 
     SAMRAI::hier::IntVector<NDIM> d_stencil_width;
     const unsigned int d_axis;

--- a/ibtk/include/ibtk/ExtendedRobinBcCoefStrategy.h
+++ b/ibtk/include/ibtk/ExtendedRobinBcCoefStrategy.h
@@ -103,7 +103,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    ExtendedRobinBcCoefStrategy(const ExtendedRobinBcCoefStrategy& from);
+    ExtendedRobinBcCoefStrategy(const ExtendedRobinBcCoefStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -114,7 +114,7 @@ private:
      *
      * \return A reference to this object.
      */
-    ExtendedRobinBcCoefStrategy& operator=(const ExtendedRobinBcCoefStrategy& that);
+    ExtendedRobinBcCoefStrategy& operator=(const ExtendedRobinBcCoefStrategy& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/FACPreconditioner.h
+++ b/ibtk/include/ibtk/FACPreconditioner.h
@@ -307,7 +307,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    FACPreconditioner();
+    FACPreconditioner() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -316,7 +316,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    FACPreconditioner(const FACPreconditioner& from);
+    FACPreconditioner(const FACPreconditioner& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -327,7 +327,7 @@ private:
      *
      * \return A reference to this object.
      */
-    FACPreconditioner& operator=(const FACPreconditioner& that);
+    FACPreconditioner& operator=(const FACPreconditioner& that) = delete;
 
     void getFromInput(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db);
 };

--- a/ibtk/include/ibtk/FACPreconditionerStrategy.h
+++ b/ibtk/include/ibtk/FACPreconditionerStrategy.h
@@ -270,7 +270,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    FACPreconditionerStrategy();
+    FACPreconditionerStrategy() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -279,7 +279,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    FACPreconditionerStrategy(const FACPreconditionerStrategy& from);
+    FACPreconditionerStrategy(const FACPreconditionerStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -290,7 +290,7 @@ private:
      *
      * \return A reference to this object.
      */
-    FACPreconditionerStrategy& operator=(const FACPreconditionerStrategy& that);
+    FACPreconditionerStrategy& operator=(const FACPreconditionerStrategy& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/FEDataInterpolation.h
+++ b/ibtk/include/ibtk/FEDataInterpolation.h
@@ -310,9 +310,9 @@ public:
     void interpolate(const libMesh::Elem* elem, unsigned int side);
 
 private:
-    FEDataInterpolation();
-    FEDataInterpolation(const FEDataInterpolation&);
-    FEDataInterpolation& operator=(const FEDataInterpolation&);
+    FEDataInterpolation() = delete;
+    FEDataInterpolation(const FEDataInterpolation&) = delete;
+    FEDataInterpolation& operator=(const FEDataInterpolation&) = delete;
 
     size_t getFETypeIndex(const libMesh::FEType& fe_type) const;
 

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -678,7 +678,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    FEDataManager();
+    FEDataManager() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -687,7 +687,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    FEDataManager(const FEDataManager& from);
+    FEDataManager(const FEDataManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -698,7 +698,7 @@ private:
      *
      * \return A reference to this object.
      */
-    FEDataManager& operator=(const FEDataManager& that);
+    FEDataManager& operator=(const FEDataManager& that) = delete;
 
     /*!
      * Compute the quadrature point counts in each cell of the level in which

--- a/ibtk/include/ibtk/FaceDataSynchronization.h
+++ b/ibtk/include/ibtk/FaceDataSynchronization.h
@@ -186,7 +186,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    FaceDataSynchronization(const FaceDataSynchronization& from);
+    FaceDataSynchronization(const FaceDataSynchronization& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -197,7 +197,7 @@ private:
      *
      * \return A reference to this object.
      */
-    FaceDataSynchronization& operator=(const FaceDataSynchronization& that);
+    FaceDataSynchronization& operator=(const FaceDataSynchronization& that) = delete;
 
     // Boolean indicating whether the operator is initialized.
     bool d_is_initialized;

--- a/ibtk/include/ibtk/FaceSynchCopyFillPattern.h
+++ b/ibtk/include/ibtk/FaceSynchCopyFillPattern.h
@@ -123,7 +123,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    FaceSynchCopyFillPattern(const FaceSynchCopyFillPattern& from);
+    FaceSynchCopyFillPattern(const FaceSynchCopyFillPattern& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -134,7 +134,7 @@ private:
      *
      * \return A reference to this object.
      */
-    FaceSynchCopyFillPattern& operator=(const FaceSynchCopyFillPattern& that);
+    FaceSynchCopyFillPattern& operator=(const FaceSynchCopyFillPattern& that) = delete;
 
     SAMRAI::hier::IntVector<NDIM> d_stencil_width;
 };

--- a/ibtk/include/ibtk/FixedSizedStream.h
+++ b/ibtk/include/ibtk/FixedSizedStream.h
@@ -289,7 +289,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    FixedSizedStream();
+    FixedSizedStream() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -298,7 +298,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    FixedSizedStream(const FixedSizedStream& from);
+    FixedSizedStream(const FixedSizedStream& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -309,7 +309,7 @@ private:
      *
      * \return A reference to this object.
      */
-    FixedSizedStream& operator=(const FixedSizedStream& that);
+    FixedSizedStream& operator=(const FixedSizedStream& that) = delete;
 
     /*!
      * \brief Return a pointer to buffer space and advance internal pointers to

--- a/ibtk/include/ibtk/GeneralOperator.h
+++ b/ibtk/include/ibtk/GeneralOperator.h
@@ -321,7 +321,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    GeneralOperator();
+    GeneralOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -330,7 +330,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    GeneralOperator(const GeneralOperator& from);
+    GeneralOperator(const GeneralOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -341,7 +341,7 @@ private:
      *
      * \return A reference to this object.
      */
-    GeneralOperator& operator=(const GeneralOperator& that);
+    GeneralOperator& operator=(const GeneralOperator& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/GeneralSolver.h
+++ b/ibtk/include/ibtk/GeneralSolver.h
@@ -355,7 +355,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    GeneralSolver(const GeneralSolver& from);
+    GeneralSolver(const GeneralSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -366,7 +366,7 @@ private:
      *
      * \return A reference to this object.
      */
-    GeneralSolver& operator=(const GeneralSolver& that);
+    GeneralSolver& operator=(const GeneralSolver& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/HierarchyGhostCellInterpolation.h
+++ b/ibtk/include/ibtk/HierarchyGhostCellInterpolation.h
@@ -345,7 +345,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    HierarchyGhostCellInterpolation(const HierarchyGhostCellInterpolation& from);
+    HierarchyGhostCellInterpolation(const HierarchyGhostCellInterpolation& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -356,7 +356,7 @@ private:
      *
      * \return A reference to this object.
      */
-    HierarchyGhostCellInterpolation& operator=(const HierarchyGhostCellInterpolation& that);
+    HierarchyGhostCellInterpolation& operator=(const HierarchyGhostCellInterpolation& that) = delete;
 
     // Boolean indicating whether the operator is initialized.
     bool d_is_initialized;

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -1002,7 +1002,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    HierarchyIntegrator(const HierarchyIntegrator& from);
+    HierarchyIntegrator(const HierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -1013,7 +1013,7 @@ private:
      *
      * \return A reference to this object.
      */
-    HierarchyIntegrator& operator=(const HierarchyIntegrator& that);
+    HierarchyIntegrator& operator=(const HierarchyIntegrator& that) = delete;
 
     /*!
      * Read input values from a given database.

--- a/ibtk/include/ibtk/HierarchyMathOps.h
+++ b/ibtk/include/ibtk/HierarchyMathOps.h
@@ -1376,7 +1376,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    HierarchyMathOps();
+    HierarchyMathOps() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -1385,7 +1385,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    HierarchyMathOps(const HierarchyMathOps& from);
+    HierarchyMathOps(const HierarchyMathOps& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -1396,7 +1396,7 @@ private:
      *
      * \return A reference to this object.
      */
-    HierarchyMathOps& operator=(const HierarchyMathOps& that);
+    HierarchyMathOps& operator=(const HierarchyMathOps& that) = delete;
 
     /*!
      * \brief Reset the coarsen operators.

--- a/ibtk/include/ibtk/IndexUtilities.h
+++ b/ibtk/include/ibtk/IndexUtilities.h
@@ -204,7 +204,7 @@ private:
      * \note This constructor is not implemented and should not be
      * used.
      */
-    IndexUtilities();
+    IndexUtilities() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -214,12 +214,12 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IndexUtilities(const IndexUtilities& from);
+    IndexUtilities(const IndexUtilities& from) = delete;
 
     /*!
      * \brief Unimplemented destructor.
      */
-    ~IndexUtilities();
+    ~IndexUtilities() = delete;
 
     /*!
      * \brief Assignment operator.
@@ -230,7 +230,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IndexUtilities& operator=(const IndexUtilities& that);
+    IndexUtilities& operator=(const IndexUtilities& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/JacobianOperator.h
+++ b/ibtk/include/ibtk/JacobianOperator.h
@@ -100,7 +100,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    JacobianOperator();
+    JacobianOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -109,7 +109,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    JacobianOperator(const JacobianOperator& from);
+    JacobianOperator(const JacobianOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -120,7 +120,7 @@ private:
      *
      * \return A reference to this object.
      */
-    JacobianOperator& operator=(const JacobianOperator& that);
+    JacobianOperator& operator=(const JacobianOperator& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/KrylovLinearSolver.h
+++ b/ibtk/include/ibtk/KrylovLinearSolver.h
@@ -141,7 +141,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    KrylovLinearSolver(const KrylovLinearSolver& from);
+    KrylovLinearSolver(const KrylovLinearSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -152,7 +152,7 @@ private:
      *
      * \return A reference to this object.
      */
-    KrylovLinearSolver& operator=(const KrylovLinearSolver& that);
+    KrylovLinearSolver& operator=(const KrylovLinearSolver& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/KrylovLinearSolverManager.h
+++ b/ibtk/include/ibtk/KrylovLinearSolverManager.h
@@ -122,7 +122,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    KrylovLinearSolverManager(const KrylovLinearSolverManager& from);
+    KrylovLinearSolverManager(const KrylovLinearSolverManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -133,7 +133,7 @@ private:
      *
      * \return A reference to this object.
      */
-    KrylovLinearSolverManager& operator=(const KrylovLinearSolverManager& that);
+    KrylovLinearSolverManager& operator=(const KrylovLinearSolverManager& that) = delete;
 
     /*!
      * Static data members used to control access to and destruction of

--- a/ibtk/include/ibtk/KrylovLinearSolverPoissonSolverInterface.h
+++ b/ibtk/include/ibtk/KrylovLinearSolverPoissonSolverInterface.h
@@ -115,7 +115,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    KrylovLinearSolverPoissonSolverInterface(const KrylovLinearSolverPoissonSolverInterface& from);
+    KrylovLinearSolverPoissonSolverInterface(const KrylovLinearSolverPoissonSolverInterface& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -126,7 +126,7 @@ private:
      *
      * \return A reference to this object.
      */
-    KrylovLinearSolverPoissonSolverInterface& operator=(const KrylovLinearSolverPoissonSolverInterface& that);
+    KrylovLinearSolverPoissonSolverInterface& operator=(const KrylovLinearSolverPoissonSolverInterface& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/LData.h
+++ b/ibtk/include/ibtk/LData.h
@@ -302,7 +302,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LData();
+    LData() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -311,7 +311,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LData(const LData& from);
+    LData(const LData& from) = delete;
 
     /*
      * Extract the array data.

--- a/ibtk/include/ibtk/LDataManager.h
+++ b/ibtk/include/ibtk/LDataManager.h
@@ -937,7 +937,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LDataManager(const LDataManager& from);
+    LDataManager(const LDataManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -948,7 +948,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LDataManager& operator=(const LDataManager& that);
+    LDataManager& operator=(const LDataManager& that) = delete;
 
     /*!
      * \brief Common implementation of scatterPETScToLagrangian() and

--- a/ibtk/include/ibtk/LEInteractor.h
+++ b/ibtk/include/ibtk/LEInteractor.h
@@ -1218,14 +1218,14 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LEInteractor();
+    LEInteractor() = delete;
 
     /*!
      * \brief Default destructor constructor.
      *
      * \note This destructor is not implemented and should not be used.
      */
-    ~LEInteractor();
+    ~LEInteractor() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -1234,7 +1234,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LEInteractor(const LEInteractor& from);
+    LEInteractor(const LEInteractor& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -1245,7 +1245,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LEInteractor& operator=(const LEInteractor& that);
+    LEInteractor& operator=(const LEInteractor& that) = delete;
 
     /*!
      * Implementation of the IB interpolation operation.

--- a/ibtk/include/ibtk/LIndexSetData.h
+++ b/ibtk/include/ibtk/LIndexSetData.h
@@ -163,7 +163,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LIndexSetData();
+    LIndexSetData() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -172,7 +172,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LIndexSetData(const LIndexSetData<T>& from);
+    LIndexSetData(const LIndexSetData<T>& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -183,7 +183,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LIndexSetData& operator=(const LIndexSetData<T>& that);
+    LIndexSetData& operator=(const LIndexSetData<T>& that) = delete;
 
     std::vector<int> d_lag_indices, d_interior_lag_indices, d_ghost_lag_indices;
     std::vector<int> d_global_petsc_indices, d_interior_global_petsc_indices, d_ghost_global_petsc_indices;

--- a/ibtk/include/ibtk/LIndexSetDataFactory.h
+++ b/ibtk/include/ibtk/LIndexSetDataFactory.h
@@ -126,7 +126,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LIndexSetDataFactory();
+    LIndexSetDataFactory() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -135,7 +135,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LIndexSetDataFactory(const LIndexSetDataFactory<T>& from);
+    LIndexSetDataFactory(const LIndexSetDataFactory<T>& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -146,7 +146,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LIndexSetDataFactory& operator=(const LIndexSetDataFactory<T>& that);
+    LIndexSetDataFactory& operator=(const LIndexSetDataFactory<T>& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/LIndexSetVariable.h
+++ b/ibtk/include/ibtk/LIndexSetVariable.h
@@ -84,7 +84,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LIndexSetVariable();
+    LIndexSetVariable() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -93,7 +93,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LIndexSetVariable(const LIndexSetVariable<T>& from);
+    LIndexSetVariable(const LIndexSetVariable<T>& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -104,7 +104,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LIndexSetVariable<T>& operator=(const LIndexSetVariable<T>& that);
+    LIndexSetVariable<T>& operator=(const LIndexSetVariable<T>& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/LInitStrategy.h
+++ b/ibtk/include/ibtk/LInitStrategy.h
@@ -218,7 +218,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LInitStrategy(const LInitStrategy& from);
+    LInitStrategy(const LInitStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -229,7 +229,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LInitStrategy& operator=(const LInitStrategy& that);
+    LInitStrategy& operator=(const LInitStrategy& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/LMarkerCoarsen.h
+++ b/ibtk/include/ibtk/LMarkerCoarsen.h
@@ -133,7 +133,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LMarkerCoarsen(const LMarkerCoarsen& from);
+    LMarkerCoarsen(const LMarkerCoarsen& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -144,7 +144,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LMarkerCoarsen& operator=(const LMarkerCoarsen& that);
+    LMarkerCoarsen& operator=(const LMarkerCoarsen& that) = delete;
 
     /*!
      * The operator name.

--- a/ibtk/include/ibtk/LMarkerRefine.h
+++ b/ibtk/include/ibtk/LMarkerRefine.h
@@ -133,7 +133,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LMarkerRefine(const LMarkerRefine& from);
+    LMarkerRefine(const LMarkerRefine& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -144,7 +144,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LMarkerRefine& operator=(const LMarkerRefine& that);
+    LMarkerRefine& operator=(const LMarkerRefine& that) = delete;
 
     /*!
      * The operator name.

--- a/ibtk/include/ibtk/LMarkerUtilities.h
+++ b/ibtk/include/ibtk/LMarkerUtilities.h
@@ -166,7 +166,7 @@ private:
      * \note This constructor is not implemented and should not be
      * used.
      */
-    LMarkerUtilities();
+    LMarkerUtilities() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -176,12 +176,12 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LMarkerUtilities(const LMarkerUtilities& from);
+    LMarkerUtilities(const LMarkerUtilities& from) = delete;
 
     /*!
      * \brief Unimplemented destructor.
      */
-    ~LMarkerUtilities();
+    ~LMarkerUtilities() = delete;
 
     /*!
      * \brief Assignment operator.
@@ -192,7 +192,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LMarkerUtilities& operator=(const LMarkerUtilities& that);
+    LMarkerUtilities& operator=(const LMarkerUtilities& that) = delete;
 
     /*!
      * Determine the number of markers in a patch.

--- a/ibtk/include/ibtk/LMesh.h
+++ b/ibtk/include/ibtk/LMesh.h
@@ -83,7 +83,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LMesh(const LMesh& from);
+    LMesh(const LMesh& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -94,7 +94,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LMesh& operator=(const LMesh& that);
+    LMesh& operator=(const LMesh& that) = delete;
 
     const std::string& d_object_name;
     const std::vector<LNode*> d_local_nodes;

--- a/ibtk/include/ibtk/LSetData.h
+++ b/ibtk/include/ibtk/LSetData.h
@@ -126,7 +126,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LSetData();
+    LSetData() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -135,7 +135,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LSetData(const LSetData<T>& from);
+    LSetData(const LSetData<T>& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -146,7 +146,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LSetData& operator=(const LSetData<T>& that);
+    LSetData& operator=(const LSetData<T>& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/LSetDataFactory.h
+++ b/ibtk/include/ibtk/LSetDataFactory.h
@@ -134,7 +134,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LSetDataFactory();
+    LSetDataFactory() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -143,7 +143,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LSetDataFactory(const LSetDataFactory<T>& from);
+    LSetDataFactory(const LSetDataFactory<T>& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -154,7 +154,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LSetDataFactory& operator=(const LSetDataFactory<T>& that);
+    LSetDataFactory& operator=(const LSetDataFactory<T>& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/LSetVariable.h
+++ b/ibtk/include/ibtk/LSetVariable.h
@@ -84,7 +84,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LSetVariable();
+    LSetVariable() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -93,7 +93,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LSetVariable(const LSetVariable<T>& from);
+    LSetVariable(const LSetVariable<T>& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -104,7 +104,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LSetVariable<T>& operator=(const LSetVariable<T>& that);
+    LSetVariable<T>& operator=(const LSetVariable<T>& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/LSiloDataWriter.h
+++ b/ibtk/include/ibtk/LSiloDataWriter.h
@@ -216,7 +216,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LSiloDataWriter();
+    LSiloDataWriter() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -225,7 +225,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LSiloDataWriter(const LSiloDataWriter& from);
+    LSiloDataWriter(const LSiloDataWriter& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -236,7 +236,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LSiloDataWriter& operator=(const LSiloDataWriter& that);
+    LSiloDataWriter& operator=(const LSiloDataWriter& that) = delete;
 
     /*!
      * \brief Build the VecScatter objects required to communicate data for

--- a/ibtk/include/ibtk/LTransaction.h
+++ b/ibtk/include/ibtk/LTransaction.h
@@ -224,7 +224,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LTransaction();
+    LTransaction() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -233,7 +233,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LTransaction(const LTransaction& from);
+    LTransaction(const LTransaction& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -244,7 +244,7 @@ private:
      *
      * \return A reference to this object.
      */
-    void operator=(const LTransaction& that);
+    void operator=(const LTransaction& that) = delete;
 
     std::vector<LTransactionComponent> d_src_item_set;
     int d_src_proc;

--- a/ibtk/include/ibtk/LaplaceOperator.h
+++ b/ibtk/include/ibtk/LaplaceOperator.h
@@ -126,7 +126,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LaplaceOperator();
+    LaplaceOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -135,7 +135,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LaplaceOperator(const LaplaceOperator& from);
+    LaplaceOperator(const LaplaceOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -146,7 +146,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LaplaceOperator& operator=(const LaplaceOperator& that);
+    LaplaceOperator& operator=(const LaplaceOperator& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/LinearOperator.h
+++ b/ibtk/include/ibtk/LinearOperator.h
@@ -99,7 +99,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    LinearOperator();
+    LinearOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -108,7 +108,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LinearOperator(const LinearOperator& from);
+    LinearOperator(const LinearOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -119,7 +119,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LinearOperator& operator=(const LinearOperator& that);
+    LinearOperator& operator=(const LinearOperator& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/LinearSolver.h
+++ b/ibtk/include/ibtk/LinearSolver.h
@@ -140,7 +140,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LinearSolver(const LinearSolver& from);
+    LinearSolver(const LinearSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -151,7 +151,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LinearSolver& operator=(const LinearSolver& that);
+    LinearSolver& operator=(const LinearSolver& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/NewtonKrylovSolver.h
+++ b/ibtk/include/ibtk/NewtonKrylovSolver.h
@@ -215,7 +215,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    NewtonKrylovSolver(const NewtonKrylovSolver& from);
+    NewtonKrylovSolver(const NewtonKrylovSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -226,7 +226,7 @@ private:
      *
      * \return A reference to this object.
      */
-    NewtonKrylovSolver& operator=(const NewtonKrylovSolver& that);
+    NewtonKrylovSolver& operator=(const NewtonKrylovSolver& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/NewtonKrylovSolverManager.h
+++ b/ibtk/include/ibtk/NewtonKrylovSolverManager.h
@@ -123,7 +123,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    NewtonKrylovSolverManager(const NewtonKrylovSolverManager& from);
+    NewtonKrylovSolverManager(const NewtonKrylovSolverManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -134,7 +134,7 @@ private:
      *
      * \return A reference to this object.
      */
-    NewtonKrylovSolverManager& operator=(const NewtonKrylovSolverManager& that);
+    NewtonKrylovSolverManager& operator=(const NewtonKrylovSolverManager& that) = delete;
 
     /*!
      * Static data members used to control access to and destruction of

--- a/ibtk/include/ibtk/NodeDataSynchronization.h
+++ b/ibtk/include/ibtk/NodeDataSynchronization.h
@@ -187,7 +187,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    NodeDataSynchronization(const NodeDataSynchronization& from);
+    NodeDataSynchronization(const NodeDataSynchronization& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -198,7 +198,7 @@ private:
      *
      * \return A reference to this object.
      */
-    NodeDataSynchronization& operator=(const NodeDataSynchronization& that);
+    NodeDataSynchronization& operator=(const NodeDataSynchronization& that) = delete;
 
     // Boolean indicating whether the operator is initialized.
     bool d_is_initialized;

--- a/ibtk/include/ibtk/NodeSynchCopyFillPattern.h
+++ b/ibtk/include/ibtk/NodeSynchCopyFillPattern.h
@@ -127,7 +127,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    NodeSynchCopyFillPattern();
+    NodeSynchCopyFillPattern() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -136,7 +136,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    NodeSynchCopyFillPattern(const NodeSynchCopyFillPattern& from);
+    NodeSynchCopyFillPattern(const NodeSynchCopyFillPattern& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -147,7 +147,7 @@ private:
      *
      * \return A reference to this object.
      */
-    NodeSynchCopyFillPattern& operator=(const NodeSynchCopyFillPattern& that);
+    NodeSynchCopyFillPattern& operator=(const NodeSynchCopyFillPattern& that) = delete;
 
     SAMRAI::hier::IntVector<NDIM> d_stencil_width;
     const unsigned int d_axis;

--- a/ibtk/include/ibtk/NormOps.h
+++ b/ibtk/include/ibtk/NormOps.h
@@ -76,7 +76,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    NormOps();
+    NormOps() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -85,7 +85,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    NormOps(const NormOps& from);
+    NormOps(const NormOps& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -96,7 +96,7 @@ private:
      *
      * \return A reference to this object.
      */
-    NormOps& operator=(const NormOps& that);
+    NormOps& operator=(const NormOps& that) = delete;
 
     /*!
      * \brief Compute the local L1 norm.

--- a/ibtk/include/ibtk/PETScKrylovLinearSolver.h
+++ b/ibtk/include/ibtk/PETScKrylovLinearSolver.h
@@ -316,7 +316,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScKrylovLinearSolver();
+    PETScKrylovLinearSolver() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -325,7 +325,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScKrylovLinearSolver(const PETScKrylovLinearSolver& from);
+    PETScKrylovLinearSolver(const PETScKrylovLinearSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -336,7 +336,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScKrylovLinearSolver& operator=(const PETScKrylovLinearSolver& that);
+    PETScKrylovLinearSolver& operator=(const PETScKrylovLinearSolver& that) = delete;
 
     /*!
      * \brief Common routine used by all class constructors.

--- a/ibtk/include/ibtk/PETScKrylovPoissonSolver.h
+++ b/ibtk/include/ibtk/PETScKrylovPoissonSolver.h
@@ -80,7 +80,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScKrylovPoissonSolver();
+    PETScKrylovPoissonSolver() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -89,7 +89,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScKrylovPoissonSolver(const PETScKrylovPoissonSolver& from);
+    PETScKrylovPoissonSolver(const PETScKrylovPoissonSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -100,7 +100,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScKrylovPoissonSolver& operator=(const PETScKrylovPoissonSolver& that);
+    PETScKrylovPoissonSolver& operator=(const PETScKrylovPoissonSolver& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/PETScLevelSolver.h
+++ b/ibtk/include/ibtk/PETScLevelSolver.h
@@ -352,7 +352,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScLevelSolver& operator=(const PETScLevelSolver& that);
+    PETScLevelSolver& operator=(const PETScLevelSolver& that) = delete;
 
     /*!
      * \brief Apply the preconditioner to \a x and store the result in \a y.

--- a/ibtk/include/ibtk/PETScMFFDJacobianOperator.h
+++ b/ibtk/include/ibtk/PETScMFFDJacobianOperator.h
@@ -189,7 +189,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScMFFDJacobianOperator();
+    PETScMFFDJacobianOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -198,7 +198,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScMFFDJacobianOperator(const PETScMFFDJacobianOperator& from);
+    PETScMFFDJacobianOperator(const PETScMFFDJacobianOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -209,7 +209,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScMFFDJacobianOperator& operator=(const PETScMFFDJacobianOperator& that);
+    PETScMFFDJacobianOperator& operator=(const PETScMFFDJacobianOperator& that) = delete;
 
     static PetscErrorCode FormFunction_SAMRAI(void* p_ctx, Vec x, Vec f);
 

--- a/ibtk/include/ibtk/PETScMatLOWrapper.h
+++ b/ibtk/include/ibtk/PETScMatLOWrapper.h
@@ -192,7 +192,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScMatLOWrapper();
+    PETScMatLOWrapper() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -201,7 +201,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScMatLOWrapper(const PETScMatLOWrapper& from);
+    PETScMatLOWrapper(const PETScMatLOWrapper& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -212,7 +212,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScMatLOWrapper& operator=(const PETScMatLOWrapper& that);
+    PETScMatLOWrapper& operator=(const PETScMatLOWrapper& that) = delete;
 
     const Mat d_petsc_mat;
     SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double> > d_x, d_y, d_z;

--- a/ibtk/include/ibtk/PETScMatUtilities.h
+++ b/ibtk/include/ibtk/PETScMatUtilities.h
@@ -232,7 +232,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScMatUtilities();
+    PETScMatUtilities() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -241,7 +241,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScMatUtilities(const PETScMatUtilities& from);
+    PETScMatUtilities(const PETScMatUtilities& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -252,7 +252,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScMatUtilities& operator=(const PETScMatUtilities& that);
+    PETScMatUtilities& operator=(const PETScMatUtilities& that) = delete;
 
     /*!
      * \brief Construct a parallel PETSc Mat object corresponding to cc-data

--- a/ibtk/include/ibtk/PETScNewtonKrylovSolver.h
+++ b/ibtk/include/ibtk/PETScNewtonKrylovSolver.h
@@ -299,7 +299,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScNewtonKrylovSolver();
+    PETScNewtonKrylovSolver() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -308,7 +308,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScNewtonKrylovSolver(const PETScNewtonKrylovSolver& from);
+    PETScNewtonKrylovSolver(const PETScNewtonKrylovSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -319,7 +319,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScNewtonKrylovSolver& operator=(const PETScNewtonKrylovSolver& that);
+    PETScNewtonKrylovSolver& operator=(const PETScNewtonKrylovSolver& that) = delete;
 
     /*!
      * \brief Common routine used by all class constructors.

--- a/ibtk/include/ibtk/PETScPCLSWrapper.h
+++ b/ibtk/include/ibtk/PETScPCLSWrapper.h
@@ -266,7 +266,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScPCLSWrapper();
+    PETScPCLSWrapper() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -275,7 +275,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScPCLSWrapper(const PETScPCLSWrapper& from);
+    PETScPCLSWrapper(const PETScPCLSWrapper& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -286,7 +286,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScPCLSWrapper& operator=(const PETScPCLSWrapper& that);
+    PETScPCLSWrapper& operator=(const PETScPCLSWrapper& that) = delete;
 
     const PC d_petsc_pc;
     SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double> > d_x, d_b;

--- a/ibtk/include/ibtk/PETScSAMRAIVectorReal.h
+++ b/ibtk/include/ibtk/PETScSAMRAIVectorReal.h
@@ -171,7 +171,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScSAMRAIVectorReal();
+    PETScSAMRAIVectorReal() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -180,7 +180,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScSAMRAIVectorReal(const PETScSAMRAIVectorReal& from);
+    PETScSAMRAIVectorReal(const PETScSAMRAIVectorReal& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -191,7 +191,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScSAMRAIVectorReal& operator=(const PETScSAMRAIVectorReal& that);
+    PETScSAMRAIVectorReal& operator=(const PETScSAMRAIVectorReal& that) = delete;
 
     static PetscErrorCode VecDuplicate_SAMRAI(Vec v, Vec* newv);
 

--- a/ibtk/include/ibtk/PETScSNESFunctionGOWrapper.h
+++ b/ibtk/include/ibtk/PETScSNESFunctionGOWrapper.h
@@ -178,7 +178,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScSNESFunctionGOWrapper();
+    PETScSNESFunctionGOWrapper() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -187,7 +187,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScSNESFunctionGOWrapper(const PETScSNESFunctionGOWrapper& from);
+    PETScSNESFunctionGOWrapper(const PETScSNESFunctionGOWrapper& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -198,7 +198,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScSNESFunctionGOWrapper& operator=(const PETScSNESFunctionGOWrapper& that);
+    PETScSNESFunctionGOWrapper& operator=(const PETScSNESFunctionGOWrapper& that) = delete;
 
     const SNES d_petsc_snes;
     PetscErrorCode (*const d_petsc_snes_form_func)(SNES, Vec, Vec, void*);

--- a/ibtk/include/ibtk/PETScSNESJacobianJOWrapper.h
+++ b/ibtk/include/ibtk/PETScSNESJacobianJOWrapper.h
@@ -225,7 +225,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScSNESJacobianJOWrapper();
+    PETScSNESJacobianJOWrapper() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -234,7 +234,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScSNESJacobianJOWrapper(const PETScSNESJacobianJOWrapper& from);
+    PETScSNESJacobianJOWrapper(const PETScSNESJacobianJOWrapper& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -245,7 +245,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScSNESJacobianJOWrapper& operator=(const PETScSNESJacobianJOWrapper& that);
+    PETScSNESJacobianJOWrapper& operator=(const PETScSNESJacobianJOWrapper& that) = delete;
 
     const SNES d_petsc_snes;
     Mat d_petsc_snes_jac;

--- a/ibtk/include/ibtk/PETScVecUtilities.h
+++ b/ibtk/include/ibtk/PETScVecUtilities.h
@@ -150,7 +150,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScVecUtilities();
+    PETScVecUtilities() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -159,7 +159,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScVecUtilities(const PETScVecUtilities& from);
+    PETScVecUtilities(const PETScVecUtilities& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -170,7 +170,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScVecUtilities& operator=(const PETScVecUtilities& that);
+    PETScVecUtilities& operator=(const PETScVecUtilities& that) = delete;
 
     /*!
      * \brief Implementation of copyToPatchLevelVec() for cell-centered data.

--- a/ibtk/include/ibtk/ParallelEdgeMap.h
+++ b/ibtk/include/ibtk/ParallelEdgeMap.h
@@ -108,7 +108,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    ParallelEdgeMap(const ParallelEdgeMap& from);
+    ParallelEdgeMap(const ParallelEdgeMap& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -119,7 +119,7 @@ private:
      *
      * \return A reference to this object.
      */
-    ParallelEdgeMap& operator=(const ParallelEdgeMap& that);
+    ParallelEdgeMap& operator=(const ParallelEdgeMap& that) = delete;
 
     // Member data.
     std::multimap<int, std::pair<int, int> > d_edge_map;

--- a/ibtk/include/ibtk/PatchMathOps.h
+++ b/ibtk/include/ibtk/PatchMathOps.h
@@ -750,7 +750,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PatchMathOps(const PatchMathOps& from);
+    PatchMathOps(const PatchMathOps& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -761,7 +761,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PatchMathOps& operator=(const PatchMathOps& that);
+    PatchMathOps& operator=(const PatchMathOps& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/PhysicalBoundaryUtilities.h
+++ b/ibtk/include/ibtk/PhysicalBoundaryUtilities.h
@@ -122,7 +122,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PhysicalBoundaryUtilities();
+    PhysicalBoundaryUtilities() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -131,12 +131,12 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PhysicalBoundaryUtilities(const PhysicalBoundaryUtilities& from);
+    PhysicalBoundaryUtilities(const PhysicalBoundaryUtilities& from) = delete;
 
     /*!
      * \brief Destructor.
      */
-    ~PhysicalBoundaryUtilities();
+    ~PhysicalBoundaryUtilities() = delete;
 
     /*!
      * \brief Assignment operator.
@@ -147,7 +147,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PhysicalBoundaryUtilities& operator=(const PhysicalBoundaryUtilities& that);
+    PhysicalBoundaryUtilities& operator=(const PhysicalBoundaryUtilities& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/PoissonFACPreconditioner.h
+++ b/ibtk/include/ibtk/PoissonFACPreconditioner.h
@@ -124,7 +124,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PoissonFACPreconditioner();
+    PoissonFACPreconditioner() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -133,7 +133,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PoissonFACPreconditioner(const PoissonFACPreconditioner& from);
+    PoissonFACPreconditioner(const PoissonFACPreconditioner& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -144,7 +144,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PoissonFACPreconditioner& operator=(const PoissonFACPreconditioner& that);
+    PoissonFACPreconditioner& operator=(const PoissonFACPreconditioner& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/PoissonFACPreconditionerStrategy.h
+++ b/ibtk/include/ibtk/PoissonFACPreconditionerStrategy.h
@@ -485,7 +485,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PoissonFACPreconditionerStrategy();
+    PoissonFACPreconditionerStrategy() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -494,7 +494,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PoissonFACPreconditionerStrategy(const PoissonFACPreconditionerStrategy& from);
+    PoissonFACPreconditionerStrategy(const PoissonFACPreconditionerStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -505,7 +505,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PoissonFACPreconditionerStrategy& operator=(const PoissonFACPreconditionerStrategy& that);
+    PoissonFACPreconditionerStrategy& operator=(const PoissonFACPreconditionerStrategy& that) = delete;
 
     /*!
      * \name Various refine and coarsen objects.

--- a/ibtk/include/ibtk/PoissonSolver.h
+++ b/ibtk/include/ibtk/PoissonSolver.h
@@ -117,7 +117,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PoissonSolver(const PoissonSolver& from);
+    PoissonSolver(const PoissonSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -128,7 +128,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PoissonSolver& operator=(const PoissonSolver& that);
+    PoissonSolver& operator=(const PoissonSolver& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/PoissonUtilities.h
+++ b/ibtk/include/ibtk/PoissonUtilities.h
@@ -241,7 +241,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PoissonUtilities();
+    PoissonUtilities() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -250,7 +250,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PoissonUtilities(const PoissonUtilities& from);
+    PoissonUtilities(const PoissonUtilities& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -261,7 +261,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PoissonUtilities& operator=(const PoissonUtilities& that);
+    PoissonUtilities& operator=(const PoissonUtilities& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/RefinePatchStrategySet.h
+++ b/ibtk/include/ibtk/RefinePatchStrategySet.h
@@ -198,7 +198,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    RefinePatchStrategySet();
+    RefinePatchStrategySet() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -207,7 +207,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    RefinePatchStrategySet(const RefinePatchStrategySet& from);
+    RefinePatchStrategySet(const RefinePatchStrategySet& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -218,7 +218,7 @@ private:
      *
      * \return A reference to this object.
      */
-    RefinePatchStrategySet& operator=(const RefinePatchStrategySet& that);
+    RefinePatchStrategySet& operator=(const RefinePatchStrategySet& that) = delete;
 
     /*!
      * \brief The set of SAMRAI::xfer:RefinePatchStrategy objects.

--- a/ibtk/include/ibtk/RobinPhysBdryPatchStrategy.h
+++ b/ibtk/include/ibtk/RobinPhysBdryPatchStrategy.h
@@ -227,7 +227,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    RobinPhysBdryPatchStrategy(const RobinPhysBdryPatchStrategy& from);
+    RobinPhysBdryPatchStrategy(const RobinPhysBdryPatchStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -238,7 +238,7 @@ private:
      *
      * \return A reference to this object.
      */
-    RobinPhysBdryPatchStrategy& operator=(const RobinPhysBdryPatchStrategy& that);
+    RobinPhysBdryPatchStrategy& operator=(const RobinPhysBdryPatchStrategy& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/SCLaplaceOperator.h
+++ b/ibtk/include/ibtk/SCLaplaceOperator.h
@@ -160,7 +160,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    SCLaplaceOperator();
+    SCLaplaceOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -169,7 +169,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    SCLaplaceOperator(const SCLaplaceOperator& from);
+    SCLaplaceOperator(const SCLaplaceOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -180,7 +180,7 @@ private:
      *
      * \return A reference to this object.
      */
-    SCLaplaceOperator& operator=(const SCLaplaceOperator& that);
+    SCLaplaceOperator& operator=(const SCLaplaceOperator& that) = delete;
 
 };
 } // namespace IBTK

--- a/ibtk/include/ibtk/SCPoissonHypreLevelSolver.h
+++ b/ibtk/include/ibtk/SCPoissonHypreLevelSolver.h
@@ -254,7 +254,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    SCPoissonHypreLevelSolver();
+    SCPoissonHypreLevelSolver() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -263,7 +263,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    SCPoissonHypreLevelSolver(const SCPoissonHypreLevelSolver& from);
+    SCPoissonHypreLevelSolver(const SCPoissonHypreLevelSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -274,7 +274,7 @@ private:
      *
      * \return A reference to this object.
      */
-    SCPoissonHypreLevelSolver& operator=(const SCPoissonHypreLevelSolver& that);
+    SCPoissonHypreLevelSolver& operator=(const SCPoissonHypreLevelSolver& that) = delete;
 
     /*!
      * \brief Functions to allocate, initialize, access, and deallocate hypre

--- a/ibtk/include/ibtk/SCPoissonPETScLevelSolver.h
+++ b/ibtk/include/ibtk/SCPoissonPETScLevelSolver.h
@@ -186,7 +186,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    SCPoissonPETScLevelSolver();
+    SCPoissonPETScLevelSolver() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -195,7 +195,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    SCPoissonPETScLevelSolver(const SCPoissonPETScLevelSolver& from);
+    SCPoissonPETScLevelSolver(const SCPoissonPETScLevelSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -206,7 +206,7 @@ private:
      *
      * \return A reference to this object.
      */
-    SCPoissonPETScLevelSolver& operator=(const SCPoissonPETScLevelSolver& that);
+    SCPoissonPETScLevelSolver& operator=(const SCPoissonPETScLevelSolver& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/SCPoissonPointRelaxationFACOperator.h
+++ b/ibtk/include/ibtk/SCPoissonPointRelaxationFACOperator.h
@@ -252,7 +252,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    SCPoissonPointRelaxationFACOperator();
+    SCPoissonPointRelaxationFACOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -261,7 +261,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    SCPoissonPointRelaxationFACOperator(const SCPoissonPointRelaxationFACOperator& from);
+    SCPoissonPointRelaxationFACOperator(const SCPoissonPointRelaxationFACOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -272,7 +272,7 @@ private:
      *
      * \return A reference to this object.
      */
-    SCPoissonPointRelaxationFACOperator& operator=(const SCPoissonPointRelaxationFACOperator& that);
+    SCPoissonPointRelaxationFACOperator& operator=(const SCPoissonPointRelaxationFACOperator& that) = delete;
 
 };
 } // namespace IBTK

--- a/ibtk/include/ibtk/SCPoissonSolverManager.h
+++ b/ibtk/include/ibtk/SCPoissonSolverManager.h
@@ -157,7 +157,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    SCPoissonSolverManager(const SCPoissonSolverManager& from);
+    SCPoissonSolverManager(const SCPoissonSolverManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -168,7 +168,7 @@ private:
      *
      * \return A reference to this object.
      */
-    SCPoissonSolverManager& operator=(const SCPoissonSolverManager& that);
+    SCPoissonSolverManager& operator=(const SCPoissonSolverManager& that) = delete;
 
     /*!
      * Static data members used to control access to and destruction of

--- a/ibtk/include/ibtk/SideDataSynchronization.h
+++ b/ibtk/include/ibtk/SideDataSynchronization.h
@@ -186,7 +186,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    SideDataSynchronization(const SideDataSynchronization& from);
+    SideDataSynchronization(const SideDataSynchronization& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -197,7 +197,7 @@ private:
      *
      * \return A reference to this object.
      */
-    SideDataSynchronization& operator=(const SideDataSynchronization& that);
+    SideDataSynchronization& operator=(const SideDataSynchronization& that) = delete;
 
     // Boolean indicating whether the operator is initialized.
     bool d_is_initialized;

--- a/ibtk/include/ibtk/SideNoCornersFillPattern.h
+++ b/ibtk/include/ibtk/SideNoCornersFillPattern.h
@@ -167,7 +167,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    SideNoCornersFillPattern();
+    SideNoCornersFillPattern() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -176,7 +176,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    SideNoCornersFillPattern(const SideNoCornersFillPattern& from);
+    SideNoCornersFillPattern(const SideNoCornersFillPattern& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -187,7 +187,7 @@ private:
      *
      * \return A reference to this object.
      */
-    SideNoCornersFillPattern& operator=(const SideNoCornersFillPattern& that);
+    SideNoCornersFillPattern& operator=(const SideNoCornersFillPattern& that) = delete;
 
     SAMRAI::hier::IntVector<NDIM> d_stencil_width;
     const bool d_include_dst_patch_box;

--- a/ibtk/include/ibtk/SideSynchCopyFillPattern.h
+++ b/ibtk/include/ibtk/SideSynchCopyFillPattern.h
@@ -123,7 +123,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    SideSynchCopyFillPattern(const SideSynchCopyFillPattern& from);
+    SideSynchCopyFillPattern(const SideSynchCopyFillPattern& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -134,7 +134,7 @@ private:
      *
      * \return A reference to this object.
      */
-    SideSynchCopyFillPattern& operator=(const SideSynchCopyFillPattern& that);
+    SideSynchCopyFillPattern& operator=(const SideSynchCopyFillPattern& that) = delete;
 
     SAMRAI::hier::IntVector<NDIM> d_stencil_width;
 };

--- a/ibtk/include/ibtk/StaggeredPhysicalBoundaryHelper.h
+++ b/ibtk/include/ibtk/StaggeredPhysicalBoundaryHelper.h
@@ -174,7 +174,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredPhysicalBoundaryHelper(const StaggeredPhysicalBoundaryHelper& from);
+    StaggeredPhysicalBoundaryHelper(const StaggeredPhysicalBoundaryHelper& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -185,7 +185,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredPhysicalBoundaryHelper& operator=(const StaggeredPhysicalBoundaryHelper& that);
+    StaggeredPhysicalBoundaryHelper& operator=(const StaggeredPhysicalBoundaryHelper& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/StandardTagAndInitStrategySet.h
+++ b/ibtk/include/ibtk/StandardTagAndInitStrategySet.h
@@ -315,7 +315,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StandardTagAndInitStrategySet();
+    StandardTagAndInitStrategySet() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -324,7 +324,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StandardTagAndInitStrategySet(const StandardTagAndInitStrategySet& from);
+    StandardTagAndInitStrategySet(const StandardTagAndInitStrategySet& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -335,7 +335,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StandardTagAndInitStrategySet& operator=(const StandardTagAndInitStrategySet& that);
+    StandardTagAndInitStrategySet& operator=(const StandardTagAndInitStrategySet& that) = delete;
 
     /*!
      * \brief The set of SAMRAI::xfer:StandardTagAndInitStrategy objects.

--- a/ibtk/include/ibtk/Streamable.h
+++ b/ibtk/include/ibtk/Streamable.h
@@ -119,7 +119,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    Streamable(const Streamable& from);
+    Streamable(const Streamable& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -130,7 +130,7 @@ private:
      *
      * \return A reference to this object.
      */
-    Streamable& operator=(const Streamable& that);
+    Streamable& operator=(const Streamable& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/StreamableFactory.h
+++ b/ibtk/include/ibtk/StreamableFactory.h
@@ -117,7 +117,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StreamableFactory(const StreamableFactory& from);
+    StreamableFactory(const StreamableFactory& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -128,7 +128,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StreamableFactory& operator=(const StreamableFactory& that);
+    StreamableFactory& operator=(const StreamableFactory& that) = delete;
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/StreamableManager.h
+++ b/ibtk/include/ibtk/StreamableManager.h
@@ -190,7 +190,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StreamableManager(const StreamableManager& from);
+    StreamableManager(const StreamableManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -201,7 +201,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StreamableManager& operator=(const StreamableManager& that);
+    StreamableManager& operator=(const StreamableManager& that) = delete;
 
     /*!
      * Static data members used to control access to and destruction of

--- a/ibtk/include/ibtk/VCSCViscousOpPointRelaxationFACOperator.h
+++ b/ibtk/include/ibtk/VCSCViscousOpPointRelaxationFACOperator.h
@@ -190,7 +190,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    VCSCViscousOpPointRelaxationFACOperator();
+    VCSCViscousOpPointRelaxationFACOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -199,7 +199,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    VCSCViscousOpPointRelaxationFACOperator(const VCSCViscousOpPointRelaxationFACOperator& from);
+    VCSCViscousOpPointRelaxationFACOperator(const VCSCViscousOpPointRelaxationFACOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -210,7 +210,7 @@ private:
      *
      * \return A reference to this object.
      */
-    VCSCViscousOpPointRelaxationFACOperator& operator=(const VCSCViscousOpPointRelaxationFACOperator& that);
+    VCSCViscousOpPointRelaxationFACOperator& operator=(const VCSCViscousOpPointRelaxationFACOperator& that) = delete;
 
     /*
      * The interpolation type to be used in computing the variable coefficient viscous Laplacian.

--- a/ibtk/include/ibtk/VCSCViscousOperator.h
+++ b/ibtk/include/ibtk/VCSCViscousOperator.h
@@ -139,7 +139,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    VCSCViscousOperator();
+    VCSCViscousOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -148,7 +148,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    VCSCViscousOperator(const VCSCViscousOperator& from);
+    VCSCViscousOperator(const VCSCViscousOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -159,7 +159,7 @@ private:
      *
      * \return A reference to this object.
      */
-    VCSCViscousOperator& operator=(const VCSCViscousOperator& that);
+    VCSCViscousOperator& operator=(const VCSCViscousOperator& that) = delete;
 
     /*
      * The interpolation type to be used in computing the variable coefficient viscous Laplacian.

--- a/ibtk/include/ibtk/VCSCViscousPETScLevelSolver.h
+++ b/ibtk/include/ibtk/VCSCViscousPETScLevelSolver.h
@@ -154,7 +154,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    VCSCViscousPETScLevelSolver();
+    VCSCViscousPETScLevelSolver() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -163,7 +163,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    VCSCViscousPETScLevelSolver(const VCSCViscousPETScLevelSolver& from);
+    VCSCViscousPETScLevelSolver(const VCSCViscousPETScLevelSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -174,7 +174,7 @@ private:
      *
      * \return A reference to this object.
      */
-    VCSCViscousPETScLevelSolver& operator=(const VCSCViscousPETScLevelSolver& that);
+    VCSCViscousPETScLevelSolver& operator=(const VCSCViscousPETScLevelSolver& that) = delete;
 
     /*
      * The interpolation type to be used for viscosity

--- a/ibtk/include/ibtk/muParserCartGridFunction.h
+++ b/ibtk/include/ibtk/muParserCartGridFunction.h
@@ -117,7 +117,7 @@ private:
      * \note This constructor is not implemented and should not be
      * used.
      */
-    muParserCartGridFunction();
+    muParserCartGridFunction() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -126,7 +126,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    muParserCartGridFunction(const muParserCartGridFunction& from);
+    muParserCartGridFunction(const muParserCartGridFunction& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -137,7 +137,7 @@ private:
      *
      * \return A reference to this object.
      */
-    muParserCartGridFunction& operator=(const muParserCartGridFunction& that);
+    muParserCartGridFunction& operator=(const muParserCartGridFunction& that) = delete;
 
     /*!
      * The Cartesian grid geometry object provides the extents of the

--- a/ibtk/include/ibtk/muParserRobinBcCoefs.h
+++ b/ibtk/include/ibtk/muParserRobinBcCoefs.h
@@ -158,7 +158,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    muParserRobinBcCoefs();
+    muParserRobinBcCoefs() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -167,7 +167,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    muParserRobinBcCoefs(const muParserRobinBcCoefs& from);
+    muParserRobinBcCoefs(const muParserRobinBcCoefs& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -178,7 +178,7 @@ private:
      *
      * \return A reference to this object.
      */
-    muParserRobinBcCoefs& operator=(const muParserRobinBcCoefs& that);
+    muParserRobinBcCoefs& operator=(const muParserRobinBcCoefs& that) = delete;
 
     /*!
      * Current time value used by the mu::Parser instances.

--- a/include/ibamr/AdvDiffCUIConvectiveOperator.h
+++ b/include/ibamr/AdvDiffCUIConvectiveOperator.h
@@ -183,7 +183,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvDiffCUIConvectiveOperator();
+    AdvDiffCUIConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -192,7 +192,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffCUIConvectiveOperator(const AdvDiffCUIConvectiveOperator& from);
+    AdvDiffCUIConvectiveOperator(const AdvDiffCUIConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -203,7 +203,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffCUIConvectiveOperator& operator=(const AdvDiffCUIConvectiveOperator& that);
+    AdvDiffCUIConvectiveOperator& operator=(const AdvDiffCUIConvectiveOperator& that) = delete;
 
     // Data communication algorithms, operators, and schedules.
     SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenAlgorithm<NDIM> > d_coarsen_alg;

--- a/include/ibamr/AdvDiffCenteredConvectiveOperator.h
+++ b/include/ibamr/AdvDiffCenteredConvectiveOperator.h
@@ -171,7 +171,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvDiffCenteredConvectiveOperator();
+    AdvDiffCenteredConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -180,7 +180,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffCenteredConvectiveOperator(const AdvDiffCenteredConvectiveOperator& from);
+    AdvDiffCenteredConvectiveOperator(const AdvDiffCenteredConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -191,7 +191,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffCenteredConvectiveOperator& operator=(const AdvDiffCenteredConvectiveOperator& that);
+    AdvDiffCenteredConvectiveOperator& operator=(const AdvDiffCenteredConvectiveOperator& that) = delete;
 
     // Data communication algorithms, operators, and schedules.
     SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenAlgorithm<NDIM> > d_coarsen_alg;

--- a/include/ibamr/AdvDiffConvectiveOperatorManager.h
+++ b/include/ibamr/AdvDiffConvectiveOperatorManager.h
@@ -138,7 +138,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffConvectiveOperatorManager(const AdvDiffConvectiveOperatorManager& from);
+    AdvDiffConvectiveOperatorManager(const AdvDiffConvectiveOperatorManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -149,7 +149,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffConvectiveOperatorManager& operator=(const AdvDiffConvectiveOperatorManager& that);
+    AdvDiffConvectiveOperatorManager& operator=(const AdvDiffConvectiveOperatorManager& that) = delete;
 
     /*!
      * Static data members used to control access to and destruction of

--- a/include/ibamr/AdvDiffHierarchyIntegrator.h
+++ b/include/ibamr/AdvDiffHierarchyIntegrator.h
@@ -626,7 +626,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvDiffHierarchyIntegrator();
+    AdvDiffHierarchyIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -635,7 +635,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffHierarchyIntegrator(const AdvDiffHierarchyIntegrator& from);
+    AdvDiffHierarchyIntegrator(const AdvDiffHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -646,7 +646,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffHierarchyIntegrator& operator=(const AdvDiffHierarchyIntegrator& that);
+    AdvDiffHierarchyIntegrator& operator=(const AdvDiffHierarchyIntegrator& that) = delete;
 
     /*!
      * Read input values from a given database.

--- a/include/ibamr/AdvDiffPPMConvectiveOperator.h
+++ b/include/ibamr/AdvDiffPPMConvectiveOperator.h
@@ -175,7 +175,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvDiffPPMConvectiveOperator();
+    AdvDiffPPMConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -184,7 +184,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffPPMConvectiveOperator(const AdvDiffPPMConvectiveOperator& from);
+    AdvDiffPPMConvectiveOperator(const AdvDiffPPMConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -195,7 +195,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffPPMConvectiveOperator& operator=(const AdvDiffPPMConvectiveOperator& that);
+    AdvDiffPPMConvectiveOperator& operator=(const AdvDiffPPMConvectiveOperator& that) = delete;
 
     // Data communication algorithms, operators, and schedules.
     SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenAlgorithm<NDIM> > d_coarsen_alg;

--- a/include/ibamr/AdvDiffPhysicalBoundaryUtilities.h
+++ b/include/ibamr/AdvDiffPhysicalBoundaryUtilities.h
@@ -89,7 +89,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvDiffPhysicalBoundaryUtilities();
+    AdvDiffPhysicalBoundaryUtilities() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -98,7 +98,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffPhysicalBoundaryUtilities(const AdvDiffPhysicalBoundaryUtilities& from);
+    AdvDiffPhysicalBoundaryUtilities(const AdvDiffPhysicalBoundaryUtilities& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -109,7 +109,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffPhysicalBoundaryUtilities& operator=(const AdvDiffPhysicalBoundaryUtilities& that);
+    AdvDiffPhysicalBoundaryUtilities& operator=(const AdvDiffPhysicalBoundaryUtilities& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/AdvDiffPredictorCorrectorHierarchyIntegrator.h
+++ b/include/ibamr/AdvDiffPredictorCorrectorHierarchyIntegrator.h
@@ -217,7 +217,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvDiffPredictorCorrectorHierarchyIntegrator();
+    AdvDiffPredictorCorrectorHierarchyIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -226,7 +226,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffPredictorCorrectorHierarchyIntegrator(const AdvDiffPredictorCorrectorHierarchyIntegrator& from);
+    AdvDiffPredictorCorrectorHierarchyIntegrator(const AdvDiffPredictorCorrectorHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -237,7 +237,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffPredictorCorrectorHierarchyIntegrator& operator=(const AdvDiffPredictorCorrectorHierarchyIntegrator& that);
+    AdvDiffPredictorCorrectorHierarchyIntegrator& operator=(const AdvDiffPredictorCorrectorHierarchyIntegrator& that) = delete;
 
     /*
      * The SAMRAI::algs::HyperbolicLevelIntegrator supplies generic operations

--- a/include/ibamr/AdvDiffPredictorCorrectorHyperbolicPatchOps.h
+++ b/include/ibamr/AdvDiffPredictorCorrectorHyperbolicPatchOps.h
@@ -155,7 +155,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvDiffPredictorCorrectorHyperbolicPatchOps();
+    AdvDiffPredictorCorrectorHyperbolicPatchOps() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -164,7 +164,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffPredictorCorrectorHyperbolicPatchOps(const AdvDiffPredictorCorrectorHyperbolicPatchOps& from);
+    AdvDiffPredictorCorrectorHyperbolicPatchOps(const AdvDiffPredictorCorrectorHyperbolicPatchOps& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -175,7 +175,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffPredictorCorrectorHyperbolicPatchOps& operator=(const AdvDiffPredictorCorrectorHyperbolicPatchOps& that);
+    AdvDiffPredictorCorrectorHyperbolicPatchOps& operator=(const AdvDiffPredictorCorrectorHyperbolicPatchOps& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h
+++ b/include/ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h
@@ -361,7 +361,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvDiffSemiImplicitHierarchyIntegrator();
+    AdvDiffSemiImplicitHierarchyIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -370,7 +370,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffSemiImplicitHierarchyIntegrator(const AdvDiffSemiImplicitHierarchyIntegrator& from);
+    AdvDiffSemiImplicitHierarchyIntegrator(const AdvDiffSemiImplicitHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -381,7 +381,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffSemiImplicitHierarchyIntegrator& operator=(const AdvDiffSemiImplicitHierarchyIntegrator& that);
+    AdvDiffSemiImplicitHierarchyIntegrator& operator=(const AdvDiffSemiImplicitHierarchyIntegrator& that) = delete;
 
     /*!
      * Read input values from a given database.

--- a/include/ibamr/AdvDiffStochasticForcing.h
+++ b/include/ibamr/AdvDiffStochasticForcing.h
@@ -142,7 +142,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvDiffStochasticForcing();
+    AdvDiffStochasticForcing() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -151,7 +151,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffStochasticForcing(const AdvDiffStochasticForcing& from);
+    AdvDiffStochasticForcing(const AdvDiffStochasticForcing& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -162,7 +162,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffStochasticForcing& operator=(const AdvDiffStochasticForcing& that);
+    AdvDiffStochasticForcing& operator=(const AdvDiffStochasticForcing& that) = delete;
 
     /*!
      * Pointer to the concentration variable associated with this source term

--- a/include/ibamr/AdvDiffWavePropConvectiveOperator.h
+++ b/include/ibamr/AdvDiffWavePropConvectiveOperator.h
@@ -198,7 +198,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvDiffWavePropConvectiveOperator();
+    AdvDiffWavePropConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -207,7 +207,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvDiffWavePropConvectiveOperator(const AdvDiffWavePropConvectiveOperator& from);
+    AdvDiffWavePropConvectiveOperator(const AdvDiffWavePropConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -218,7 +218,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvDiffWavePropConvectiveOperator& operator=(const AdvDiffWavePropConvectiveOperator& that);
+    AdvDiffWavePropConvectiveOperator& operator=(const AdvDiffWavePropConvectiveOperator& that) = delete;
 
     // Data communication algorithms, operators, and schedules.
     SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenAlgorithm<NDIM> > d_coarsen_alg_Q;

--- a/include/ibamr/AdvectorExplicitPredictorPatchOps.h
+++ b/include/ibamr/AdvectorExplicitPredictorPatchOps.h
@@ -330,7 +330,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvectorExplicitPredictorPatchOps();
+    AdvectorExplicitPredictorPatchOps() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -339,7 +339,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvectorExplicitPredictorPatchOps(const AdvectorExplicitPredictorPatchOps& from);
+    AdvectorExplicitPredictorPatchOps(const AdvectorExplicitPredictorPatchOps& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -350,7 +350,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvectorExplicitPredictorPatchOps& operator=(const AdvectorExplicitPredictorPatchOps& that);
+    AdvectorExplicitPredictorPatchOps& operator=(const AdvectorExplicitPredictorPatchOps& that) = delete;
 
     /*
      * Private functions used to compute the predicted values/fluxes.

--- a/include/ibamr/AdvectorPredictorCorrectorHyperbolicPatchOps.h
+++ b/include/ibamr/AdvectorPredictorCorrectorHyperbolicPatchOps.h
@@ -471,7 +471,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    AdvectorPredictorCorrectorHyperbolicPatchOps();
+    AdvectorPredictorCorrectorHyperbolicPatchOps() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -480,7 +480,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    AdvectorPredictorCorrectorHyperbolicPatchOps(const AdvectorPredictorCorrectorHyperbolicPatchOps& from);
+    AdvectorPredictorCorrectorHyperbolicPatchOps(const AdvectorPredictorCorrectorHyperbolicPatchOps& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -491,7 +491,7 @@ private:
      *
      * \return A reference to this object.
      */
-    AdvectorPredictorCorrectorHyperbolicPatchOps& operator=(const AdvectorPredictorCorrectorHyperbolicPatchOps& that);
+    AdvectorPredictorCorrectorHyperbolicPatchOps& operator=(const AdvectorPredictorCorrectorHyperbolicPatchOps& that) = delete;
 
     /*
      * Set physical boundary conditions at inflow boundaries for predicted

--- a/include/ibamr/CIBSaddlePointSolver.h
+++ b/include/ibamr/CIBSaddlePointSolver.h
@@ -281,7 +281,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CIBSaddlePointSolver(const CIBSaddlePointSolver& from);
+    CIBSaddlePointSolver(const CIBSaddlePointSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -292,7 +292,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CIBSaddlePointSolver& operator=(const CIBSaddlePointSolver& that);
+    CIBSaddlePointSolver& operator=(const CIBSaddlePointSolver& that) = delete;
 
     /*!
      * \brief Report the KSPConvergedReason.

--- a/include/ibamr/CIBStaggeredStokesOperator.h
+++ b/include/ibamr/CIBStaggeredStokesOperator.h
@@ -151,7 +151,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CIBStaggeredStokesOperator(const CIBStaggeredStokesOperator& from);
+    CIBStaggeredStokesOperator(const CIBStaggeredStokesOperator& from)= delete;
 
     /*!
      * \brief Assignment operator.
@@ -162,7 +162,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CIBStaggeredStokesOperator& operator=(const CIBStaggeredStokesOperator& that);
+    CIBStaggeredStokesOperator& operator=(const CIBStaggeredStokesOperator& that) = delete;
 };
 
 } // namespace IBAMR

--- a/include/ibamr/CIBStaggeredStokesSolver.h
+++ b/include/ibamr/CIBStaggeredStokesSolver.h
@@ -164,7 +164,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CIBStaggeredStokesSolver(const CIBStaggeredStokesSolver& from);
+    CIBStaggeredStokesSolver(const CIBStaggeredStokesSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -175,7 +175,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CIBStaggeredStokesSolver& operator=(const CIBStaggeredStokesSolver& that);
+    CIBStaggeredStokesSolver& operator=(const CIBStaggeredStokesSolver& that) = delete;
 
     // Pointer to the constraint IB strategy.
     SAMRAI::tbox::Pointer<CIBStrategy> d_cib_strategy;

--- a/include/ibamr/CIBStrategy.h
+++ b/include/ibamr/CIBStrategy.h
@@ -625,7 +625,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    CIBStrategy(const CIBStrategy& from);
+    CIBStrategy(const CIBStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -636,7 +636,7 @@ private:
      *
      * \return A reference to this object.
      */
-    CIBStrategy& operator=(const CIBStrategy& that);
+    CIBStrategy& operator=(const CIBStrategy& that) = delete;
 
 }; // CIBStrategy
 

--- a/include/ibamr/ConstraintIBKinematics.h
+++ b/include/ibamr/ConstraintIBKinematics.h
@@ -239,17 +239,17 @@ private:
     /*!
      * \brief Deleted default ctor.
      */
-    ConstraintIBKinematics();
+    ConstraintIBKinematics() = delete;
 
     /*!
      * \brief Deleted default copy ctor.
      */
-    ConstraintIBKinematics(const ConstraintIBKinematics& from);
+    ConstraintIBKinematics(const ConstraintIBKinematics& from) = delete;
 
     /*!
      * \brief Deleted default assignment.
      */
-    ConstraintIBKinematics& operator=(const ConstraintIBKinematics& that);
+    ConstraintIBKinematics& operator=(const ConstraintIBKinematics& that) = delete;
 
     /*!
      * \brief Object enclosing all the parameters of the structure.

--- a/include/ibamr/ConstraintIBMethod.h
+++ b/include/ibamr/ConstraintIBMethod.h
@@ -258,21 +258,21 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    ConstraintIBMethod();
+    ConstraintIBMethod() = delete;
 
     /*!
      * \brief Default copy constructor.
      *
      * \note This copy constructor is not implemented and should not be used.
      */
-    ConstraintIBMethod(const ConstraintIBMethod& from);
+    ConstraintIBMethod(const ConstraintIBMethod& from) = delete;
 
     /*!
      * \brief Default assignment operator.
      *
      * \note This assignment operator is not implemented and should not be used.
      */
-    ConstraintIBMethod& operator=(const ConstraintIBMethod& that);
+    ConstraintIBMethod& operator=(const ConstraintIBMethod& that) = delete;
 
     /*!
      * \brief Get values from input file.

--- a/include/ibamr/ConvectiveOperator.h
+++ b/include/ibamr/ConvectiveOperator.h
@@ -144,7 +144,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    ConvectiveOperator();
+    ConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -153,7 +153,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    ConvectiveOperator(const ConvectiveOperator& from);
+    ConvectiveOperator(const ConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -164,7 +164,7 @@ private:
      *
      * \return A reference to this object.
      */
-    ConvectiveOperator& operator=(const ConvectiveOperator& that);
+    ConvectiveOperator& operator=(const ConvectiveOperator& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/FastSweepingLSMethod.h
+++ b/include/ibamr/FastSweepingLSMethod.h
@@ -137,7 +137,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    FastSweepingLSMethod(const FastSweepingLSMethod& from);
+    FastSweepingLSMethod(const FastSweepingLSMethod& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -148,7 +148,7 @@ private:
      *
      * \return A reference to this object.
      */
-    FastSweepingLSMethod& operator=(const FastSweepingLSMethod& that);
+    FastSweepingLSMethod& operator=(const FastSweepingLSMethod& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/GeneralizedIBMethod.h
+++ b/include/ibamr/GeneralizedIBMethod.h
@@ -244,7 +244,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    GeneralizedIBMethod();
+    GeneralizedIBMethod() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -253,7 +253,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    GeneralizedIBMethod(const GeneralizedIBMethod& from);
+    GeneralizedIBMethod(const GeneralizedIBMethod& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -264,7 +264,7 @@ private:
      *
      * \return A reference to this object.
      */
-    GeneralizedIBMethod& operator=(const GeneralizedIBMethod& that);
+    GeneralizedIBMethod& operator=(const GeneralizedIBMethod& that) = delete;
 
     /*!
      * Reset the Lagrangian force function object.

--- a/include/ibamr/IBAnchorPointSpec.h
+++ b/include/ibamr/IBAnchorPointSpec.h
@@ -136,7 +136,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBAnchorPointSpec(const IBAnchorPointSpec& from);
+    IBAnchorPointSpec(const IBAnchorPointSpec& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -147,7 +147,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBAnchorPointSpec& operator=(const IBAnchorPointSpec& that);
+    IBAnchorPointSpec& operator=(const IBAnchorPointSpec& that) = delete;
 
     /*!
      * The Lagrangian index of the anchored curvilinear mesh node.
@@ -200,7 +200,7 @@ private:
          *
          * \param from The value to copy to this object.
          */
-        Factory(const Factory& from);
+        Factory(const Factory& from) = delete;
 
         /*!
          * \brief Assignment operator.
@@ -211,7 +211,7 @@ private:
          *
          * \return A reference to this object.
          */
-        Factory& operator=(const Factory& that);
+        Factory& operator=(const Factory& that) = delete;
 
         friend class IBAnchorPointSpec;
     };

--- a/include/ibamr/IBBeamForceSpec.h
+++ b/include/ibamr/IBBeamForceSpec.h
@@ -196,7 +196,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBBeamForceSpec(const IBBeamForceSpec& from);
+    IBBeamForceSpec(const IBBeamForceSpec& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -207,7 +207,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBBeamForceSpec& operator=(const IBBeamForceSpec& that);
+    IBBeamForceSpec& operator=(const IBBeamForceSpec& that) = delete;
 
     /*!
      * Data required to compute the beam forces.
@@ -263,7 +263,7 @@ private:
          *
          * \param from The value to copy to this object.
          */
-        Factory(const Factory& from);
+        Factory(const Factory& from) = delete;
 
         /*!
          * \brief Assignment operator.
@@ -274,7 +274,7 @@ private:
          *
          * \return A reference to this object.
          */
-        Factory& operator=(const Factory& that);
+        Factory& operator=(const Factory& that) = delete;
 
         friend class IBBeamForceSpec;
     };

--- a/include/ibamr/IBExplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBExplicitHierarchyIntegrator.h
@@ -136,7 +136,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IBExplicitHierarchyIntegrator();
+    IBExplicitHierarchyIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -145,7 +145,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBExplicitHierarchyIntegrator(const IBExplicitHierarchyIntegrator& from);
+    IBExplicitHierarchyIntegrator(const IBExplicitHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -156,7 +156,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBExplicitHierarchyIntegrator& operator=(const IBExplicitHierarchyIntegrator& that);
+    IBExplicitHierarchyIntegrator& operator=(const IBExplicitHierarchyIntegrator& that) = delete;
 
     /*!
      * Read object state from the restart file and initialize class data

--- a/include/ibamr/IBFECentroidPostProcessor.h
+++ b/include/ibamr/IBFECentroidPostProcessor.h
@@ -109,7 +109,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IBFECentroidPostProcessor();
+    IBFECentroidPostProcessor() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -118,7 +118,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBFECentroidPostProcessor(const IBFECentroidPostProcessor& from);
+    IBFECentroidPostProcessor(const IBFECentroidPostProcessor& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -129,7 +129,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBFECentroidPostProcessor& operator=(const IBFECentroidPostProcessor& that);
+    IBFECentroidPostProcessor& operator=(const IBFECentroidPostProcessor& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBFEDirectForcingKinematics.h
+++ b/include/ibamr/IBFEDirectForcingKinematics.h
@@ -270,7 +270,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IBFEDirectForcingKinematics();
+    IBFEDirectForcingKinematics() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -279,7 +279,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBFEDirectForcingKinematics(const IBFEDirectForcingKinematics& from);
+    IBFEDirectForcingKinematics(const IBFEDirectForcingKinematics& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -290,7 +290,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBFEDirectForcingKinematics& operator=(const IBFEDirectForcingKinematics& that);
+    IBFEDirectForcingKinematics& operator=(const IBFEDirectForcingKinematics& that) = delete;
 
     /*!
      * Read input values from a given database.

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -897,7 +897,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBFEMethod(const IBFEMethod& from);
+    IBFEMethod(const IBFEMethod& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -908,7 +908,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBFEMethod& operator=(const IBFEMethod& that);
+    IBFEMethod& operator=(const IBFEMethod& that) = delete;
 
     /*!
      * Implementation of class constructor.

--- a/include/ibamr/IBFEPostProcessor.h
+++ b/include/ibamr/IBFEPostProcessor.h
@@ -345,7 +345,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IBFEPostProcessor();
+    IBFEPostProcessor() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -354,7 +354,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBFEPostProcessor(const IBFEPostProcessor& from);
+    IBFEPostProcessor(const IBFEPostProcessor& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -365,7 +365,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBFEPostProcessor& operator=(const IBFEPostProcessor& that);
+    IBFEPostProcessor& operator=(const IBFEPostProcessor& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBFESurfaceMethod.h
+++ b/include/ibamr/IBFESurfaceMethod.h
@@ -598,7 +598,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IBFESurfaceMethod();
+    IBFESurfaceMethod() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -607,7 +607,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBFESurfaceMethod(const IBFESurfaceMethod& from);
+    IBFESurfaceMethod(const IBFESurfaceMethod& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -618,7 +618,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBFESurfaceMethod& operator=(const IBFESurfaceMethod& that);
+    IBFESurfaceMethod& operator=(const IBFESurfaceMethod& that) = delete;
 
     /*!
      * Implementation of class constructor.

--- a/include/ibamr/IBHierarchyIntegrator.h
+++ b/include/ibamr/IBHierarchyIntegrator.h
@@ -400,7 +400,7 @@ protected:
          *
          * \note This constructor is not implemented and should not be used.
          */
-        IBEulerianForceFunction();
+        IBEulerianForceFunction() = delete;
 
         /*!
          * \brief Copy constructor.
@@ -409,7 +409,7 @@ protected:
          *
          * \param from The value to copy to this object.
          */
-        IBEulerianForceFunction(const IBEulerianForceFunction& from);
+        IBEulerianForceFunction(const IBEulerianForceFunction& from) = delete;
 
         /*!
          * \brief Assignment operator.
@@ -420,7 +420,7 @@ protected:
          *
          * \return A reference to this object.
          */
-        IBEulerianForceFunction& operator=(const IBEulerianForceFunction& that);
+        IBEulerianForceFunction& operator=(const IBEulerianForceFunction& that) = delete;
 
         const IBHierarchyIntegrator* const d_ib_solver;
     };
@@ -474,7 +474,7 @@ protected:
          *
          * \note This constructor is not implemented and should not be used.
          */
-        IBEulerianSourceFunction();
+        IBEulerianSourceFunction() = delete;
 
         /*!
          * \brief Copy constructor.
@@ -483,7 +483,7 @@ protected:
          *
          * \param from The value to copy to this object.
          */
-        IBEulerianSourceFunction(const IBEulerianSourceFunction& from);
+        IBEulerianSourceFunction(const IBEulerianSourceFunction& from) = delete;
 
         /*!
          * \brief Assignment operator.
@@ -494,7 +494,7 @@ protected:
          *
          * \return A reference to this object.
          */
-        IBEulerianSourceFunction& operator=(const IBEulerianSourceFunction& that);
+        IBEulerianSourceFunction& operator=(const IBEulerianSourceFunction& that) = delete;
 
         const IBHierarchyIntegrator* const d_ib_solver;
     };
@@ -507,7 +507,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IBHierarchyIntegrator();
+    IBHierarchyIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -516,7 +516,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBHierarchyIntegrator(const IBHierarchyIntegrator& from);
+    IBHierarchyIntegrator(const IBHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -527,7 +527,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBHierarchyIntegrator& operator=(const IBHierarchyIntegrator& that);
+    IBHierarchyIntegrator& operator=(const IBHierarchyIntegrator& that) = delete;
 
     /*!
      * Read input values from a given database.

--- a/include/ibamr/IBHydrodynamicForceEvaluator.h
+++ b/include/ibamr/IBHydrodynamicForceEvaluator.h
@@ -301,7 +301,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBHydrodynamicForceEvaluator(const IBHydrodynamicForceEvaluator& from);
+    IBHydrodynamicForceEvaluator(const IBHydrodynamicForceEvaluator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -312,7 +312,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBHydrodynamicForceEvaluator& operator=(const IBHydrodynamicForceEvaluator& that);
+    IBHydrodynamicForceEvaluator& operator=(const IBHydrodynamicForceEvaluator& that) = delete;
 
     /*!
      * \brief Reset weight of the cell face to face area.

--- a/include/ibamr/IBHydrodynamicSurfaceForceEvaluator.h
+++ b/include/ibamr/IBHydrodynamicSurfaceForceEvaluator.h
@@ -115,7 +115,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBHydrodynamicSurfaceForceEvaluator(const IBHydrodynamicSurfaceForceEvaluator& from);
+    IBHydrodynamicSurfaceForceEvaluator(const IBHydrodynamicSurfaceForceEvaluator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -126,7 +126,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBHydrodynamicSurfaceForceEvaluator& operator=(const IBHydrodynamicSurfaceForceEvaluator& that);
+    IBHydrodynamicSurfaceForceEvaluator& operator=(const IBHydrodynamicSurfaceForceEvaluator& that) = delete;
 
     /*!
      * Read input values from a given database.

--- a/include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h
@@ -246,9 +246,9 @@ private:
         }
 
     private:
-        IBImplicitStaggeredStokesSolver();
-        IBImplicitStaggeredStokesSolver(const IBImplicitStaggeredStokesSolver& from);
-        IBImplicitStaggeredStokesSolver& operator=(const IBImplicitStaggeredStokesSolver& that);
+        IBImplicitStaggeredStokesSolver() = delete;
+        IBImplicitStaggeredStokesSolver(const IBImplicitStaggeredStokesSolver& from) = delete;
+        IBImplicitStaggeredStokesSolver& operator=(const IBImplicitStaggeredStokesSolver& that) = delete;
 
         // Operators and solvers maintained by this class.
         SAMRAI::tbox::Pointer<StaggeredStokesOperator> d_stokes_op;
@@ -262,7 +262,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBImplicitStaggeredHierarchyIntegrator(const IBImplicitStaggeredHierarchyIntegrator& from);
+    IBImplicitStaggeredHierarchyIntegrator(const IBImplicitStaggeredHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -273,7 +273,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBImplicitStaggeredHierarchyIntegrator& operator=(const IBImplicitStaggeredHierarchyIntegrator& that);
+    IBImplicitStaggeredHierarchyIntegrator& operator=(const IBImplicitStaggeredHierarchyIntegrator& that) = delete;
 
     /*!
      * Read object state from the restart file and initialize class data

--- a/include/ibamr/IBImplicitStrategy.h
+++ b/include/ibamr/IBImplicitStrategy.h
@@ -165,7 +165,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBImplicitStrategy(const IBImplicitStrategy& from);
+    IBImplicitStrategy(const IBImplicitStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -176,7 +176,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBImplicitStrategy& operator=(const IBImplicitStrategy& that);
+    IBImplicitStrategy& operator=(const IBImplicitStrategy& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBInstrumentPanel.h
+++ b/include/ibamr/IBInstrumentPanel.h
@@ -183,7 +183,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IBInstrumentPanel();
+    IBInstrumentPanel() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -192,7 +192,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBInstrumentPanel(const IBInstrumentPanel& from);
+    IBInstrumentPanel(const IBInstrumentPanel& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -203,7 +203,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBInstrumentPanel& operator=(const IBInstrumentPanel& that);
+    IBInstrumentPanel& operator=(const IBInstrumentPanel& that) = delete;
 
     /*!
      * Read input values, indicated above, from given database.

--- a/include/ibamr/IBInstrumentationSpec.h
+++ b/include/ibamr/IBInstrumentationSpec.h
@@ -170,7 +170,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBInstrumentationSpec(const IBInstrumentationSpec& from);
+    IBInstrumentationSpec(const IBInstrumentationSpec& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -181,7 +181,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBInstrumentationSpec& operator=(const IBInstrumentationSpec& that);
+    IBInstrumentationSpec& operator=(const IBInstrumentationSpec& that) = delete;
 
     /*!
      * The names of the instrument names.
@@ -239,7 +239,7 @@ private:
          *
          * \param from The value to copy to this object.
          */
-        Factory(const Factory& from);
+        Factory(const Factory& from) = delete;
 
         /*!
          * \brief Assignment operator.
@@ -250,7 +250,7 @@ private:
          *
          * \return A reference to this object.
          */
-        Factory& operator=(const Factory& that);
+        Factory& operator=(const Factory& that) = delete;
 
         friend class IBInstrumentationSpec;
     };

--- a/include/ibamr/IBKirchhoffRodForceGen.h
+++ b/include/ibamr/IBKirchhoffRodForceGen.h
@@ -117,7 +117,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBKirchhoffRodForceGen(const IBKirchhoffRodForceGen& from);
+    IBKirchhoffRodForceGen(const IBKirchhoffRodForceGen& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -128,7 +128,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBKirchhoffRodForceGen& operator=(const IBKirchhoffRodForceGen& that);
+    IBKirchhoffRodForceGen& operator=(const IBKirchhoffRodForceGen& that) = delete;
 
     /*!
      * \brief Read input values, indicated above, from given database.

--- a/include/ibamr/IBLagrangianForceStrategy.h
+++ b/include/ibamr/IBLagrangianForceStrategy.h
@@ -182,7 +182,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBLagrangianForceStrategy(const IBLagrangianForceStrategy& from);
+    IBLagrangianForceStrategy(const IBLagrangianForceStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -193,7 +193,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBLagrangianForceStrategy& operator=(const IBLagrangianForceStrategy& that);
+    IBLagrangianForceStrategy& operator=(const IBLagrangianForceStrategy& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBLagrangianForceStrategySet.h
+++ b/include/ibamr/IBLagrangianForceStrategySet.h
@@ -160,7 +160,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IBLagrangianForceStrategySet();
+    IBLagrangianForceStrategySet() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -169,7 +169,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBLagrangianForceStrategySet(const IBLagrangianForceStrategySet& from);
+    IBLagrangianForceStrategySet(const IBLagrangianForceStrategySet& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -180,7 +180,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBLagrangianForceStrategySet& operator=(const IBLagrangianForceStrategySet& that);
+    IBLagrangianForceStrategySet& operator=(const IBLagrangianForceStrategySet& that) = delete;
 
     /*!
      * \brief The set of IBLagrangianForceStrategy objects.

--- a/include/ibamr/IBLagrangianSourceStrategy.h
+++ b/include/ibamr/IBLagrangianSourceStrategy.h
@@ -155,7 +155,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBLagrangianSourceStrategy(const IBLagrangianSourceStrategy& from);
+    IBLagrangianSourceStrategy(const IBLagrangianSourceStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -166,7 +166,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBLagrangianSourceStrategy& operator=(const IBLagrangianSourceStrategy& that);
+    IBLagrangianSourceStrategy& operator=(const IBLagrangianSourceStrategy& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBMethod.h
+++ b/include/ibamr/IBMethod.h
@@ -609,7 +609,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IBMethod();
+    IBMethod() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -618,7 +618,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBMethod(const IBMethod& from);
+    IBMethod(const IBMethod& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -629,7 +629,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBMethod& operator=(const IBMethod& that);
+    IBMethod& operator=(const IBMethod& that) = delete;
 
     /*!
      * Reset the Lagrangian force function object.

--- a/include/ibamr/IBMethodPostProcessStrategy.h
+++ b/include/ibamr/IBMethodPostProcessStrategy.h
@@ -105,7 +105,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBMethodPostProcessStrategy(const IBMethodPostProcessStrategy& from);
+    IBMethodPostProcessStrategy(const IBMethodPostProcessStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -116,7 +116,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBMethodPostProcessStrategy& operator=(const IBMethodPostProcessStrategy& that);
+    IBMethodPostProcessStrategy& operator=(const IBMethodPostProcessStrategy& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBRedundantInitializer.h
+++ b/include/ibamr/IBRedundantInitializer.h
@@ -505,7 +505,7 @@ protected:
      *
      * \param from The value to copy to this object.
      */
-    IBRedundantInitializer(const IBRedundantInitializer& from);
+    IBRedundantInitializer(const IBRedundantInitializer& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -516,7 +516,7 @@ protected:
      *
      * \return A reference to this object.
      */
-    IBRedundantInitializer& operator=(const IBRedundantInitializer& that);
+    IBRedundantInitializer& operator=(const IBRedundantInitializer& that) = delete;
 
     /*!
      * \brief Configure the Lagrangian Silo data writer to plot the data

--- a/include/ibamr/IBRodForceSpec.h
+++ b/include/ibamr/IBRodForceSpec.h
@@ -174,7 +174,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBRodForceSpec(const IBRodForceSpec& from);
+    IBRodForceSpec(const IBRodForceSpec& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -185,7 +185,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBRodForceSpec& operator=(const IBRodForceSpec& that);
+    IBRodForceSpec& operator=(const IBRodForceSpec& that) = delete;
 
     /*!
      * Data required to define the spring forces.
@@ -240,7 +240,7 @@ private:
          *
          * \param from The value to copy to this object.
          */
-        Factory(const Factory& from);
+        Factory(const Factory& from) = delete;
 
         /*!
          * \brief Assignment operator.
@@ -251,7 +251,7 @@ private:
          *
          * \return A reference to this object.
          */
-        Factory& operator=(const Factory& that);
+        Factory& operator=(const Factory& that) = delete;
 
         friend class IBRodForceSpec;
     };

--- a/include/ibamr/IBSourceSpec.h
+++ b/include/ibamr/IBSourceSpec.h
@@ -145,7 +145,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBSourceSpec(const IBSourceSpec& from);
+    IBSourceSpec(const IBSourceSpec& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -156,7 +156,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBSourceSpec& operator=(const IBSourceSpec& that);
+    IBSourceSpec& operator=(const IBSourceSpec& that) = delete;
 
     /*!
      * Data required to define the source.
@@ -209,7 +209,7 @@ private:
          *
          * \param from The value to copy to this object.
          */
-        Factory(const Factory& from);
+        Factory(const Factory& from) = delete;
 
         /*!
          * \brief Assignment operator.
@@ -220,7 +220,7 @@ private:
          *
          * \return A reference to this object.
          */
-        Factory& operator=(const Factory& that);
+        Factory& operator=(const Factory& that) = delete;
 
         friend class IBSourceSpec;
     };

--- a/include/ibamr/IBSpringForceSpec.h
+++ b/include/ibamr/IBSpringForceSpec.h
@@ -204,7 +204,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBSpringForceSpec(const IBSpringForceSpec& from);
+    IBSpringForceSpec(const IBSpringForceSpec& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -215,7 +215,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBSpringForceSpec& operator=(const IBSpringForceSpec& that);
+    IBSpringForceSpec& operator=(const IBSpringForceSpec& that) = delete;
 
     /*!
      * Data required to define the spring forces.
@@ -270,7 +270,7 @@ private:
          *
          * \param from The value to copy to this object.
          */
-        Factory(const Factory& from);
+        Factory(const Factory& from) = delete;
 
         /*!
          * \brief Assignment operator.
@@ -281,7 +281,7 @@ private:
          *
          * \return A reference to this object.
          */
-        Factory& operator=(const Factory& that);
+        Factory& operator=(const Factory& that) = delete;
 
         friend class IBSpringForceSpec;
     };

--- a/include/ibamr/IBStandardForceGen.h
+++ b/include/ibamr/IBStandardForceGen.h
@@ -177,7 +177,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBStandardForceGen(const IBStandardForceGen& from);
+    IBStandardForceGen(const IBStandardForceGen& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -188,7 +188,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBStandardForceGen& operator=(const IBStandardForceGen& that);
+    IBStandardForceGen& operator=(const IBStandardForceGen& that) = delete;
 
     /*!
      * \name Data maintained separately for each level of the patch hierarchy.

--- a/include/ibamr/IBStandardInitializer.h
+++ b/include/ibamr/IBStandardInitializer.h
@@ -448,7 +448,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IBStandardInitializer();
+    IBStandardInitializer() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -457,7 +457,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBStandardInitializer(const IBStandardInitializer& from);
+    IBStandardInitializer(const IBStandardInitializer& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -468,7 +468,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBStandardInitializer& operator=(const IBStandardInitializer& that);
+    IBStandardInitializer& operator=(const IBStandardInitializer& that) = delete;
 
     /*!
      * \brief Read the vertex data from one or more input files.

--- a/include/ibamr/IBStandardSourceGen.h
+++ b/include/ibamr/IBStandardSourceGen.h
@@ -219,7 +219,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBStandardSourceGen(const IBStandardSourceGen& from);
+    IBStandardSourceGen(const IBStandardSourceGen& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -230,7 +230,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBStandardSourceGen& operator=(const IBStandardSourceGen& that);
+    IBStandardSourceGen& operator=(const IBStandardSourceGen& that) = delete;
 
     /*!
      * Read object state from the restart file and initialize class data

--- a/include/ibamr/IBStrategy.h
+++ b/include/ibamr/IBStrategy.h
@@ -550,7 +550,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBStrategy(const IBStrategy& from);
+    IBStrategy(const IBStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -561,7 +561,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBStrategy& operator=(const IBStrategy& that);
+    IBStrategy& operator=(const IBStrategy& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBStrategySet.h
+++ b/include/ibamr/IBStrategySet.h
@@ -340,7 +340,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBStrategySet(const IBStrategySet& from);
+    IBStrategySet(const IBStrategySet& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -351,7 +351,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBStrategySet& operator=(const IBStrategySet& that);
+    IBStrategySet& operator=(const IBStrategySet& that) = delete;
 
     /*!
      * \brief The set of IBStrategy objects.

--- a/include/ibamr/IBTargetPointForceSpec.h
+++ b/include/ibamr/IBTargetPointForceSpec.h
@@ -170,7 +170,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IBTargetPointForceSpec(const IBTargetPointForceSpec& from);
+    IBTargetPointForceSpec(const IBTargetPointForceSpec& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -181,7 +181,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IBTargetPointForceSpec& operator=(const IBTargetPointForceSpec& that);
+    IBTargetPointForceSpec& operator=(const IBTargetPointForceSpec& that) = delete;
 
     /*!
      * Data required to define the target point penalty forces.
@@ -236,7 +236,7 @@ private:
          *
          * \param from The value to copy to this object.
          */
-        Factory(const Factory& from);
+        Factory(const Factory& from) = delete;
 
         /*!
          * \brief Assignment operator.
@@ -247,7 +247,7 @@ private:
          *
          * \return A reference to this object.
          */
-        Factory& operator=(const Factory& that);
+        Factory& operator=(const Factory& that) = delete;
 
         friend class IBTargetPointForceSpec;
     };

--- a/include/ibamr/IMPInitializer.h
+++ b/include/ibamr/IMPInitializer.h
@@ -202,7 +202,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IMPInitializer();
+    IMPInitializer() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -211,7 +211,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IMPInitializer(const IMPInitializer& from);
+    IMPInitializer(const IMPInitializer& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -222,7 +222,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IMPInitializer& operator=(const IMPInitializer& that);
+    IMPInitializer& operator=(const IMPInitializer& that) = delete;
 
     /*!
      * \brief Configure the Lagrangian Silo data writer to plot the data

--- a/include/ibamr/IMPMethod.h
+++ b/include/ibamr/IMPMethod.h
@@ -415,7 +415,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    IMPMethod();
+    IMPMethod() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -424,7 +424,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    IMPMethod(const IMPMethod& from);
+    IMPMethod(const IMPMethod& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -435,7 +435,7 @@ private:
      *
      * \return A reference to this object.
      */
-    IMPMethod& operator=(const IMPMethod& that);
+    IMPMethod& operator=(const IMPMethod& that) = delete;
 
     /*!
      * Read input values from a given database.

--- a/include/ibamr/INSCollocatedCenteredConvectiveOperator.h
+++ b/include/ibamr/INSCollocatedCenteredConvectiveOperator.h
@@ -170,7 +170,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSCollocatedCenteredConvectiveOperator();
+    INSCollocatedCenteredConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -179,7 +179,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSCollocatedCenteredConvectiveOperator(const INSCollocatedCenteredConvectiveOperator& from);
+    INSCollocatedCenteredConvectiveOperator(const INSCollocatedCenteredConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -190,7 +190,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSCollocatedCenteredConvectiveOperator& operator=(const INSCollocatedCenteredConvectiveOperator& that);
+    INSCollocatedCenteredConvectiveOperator& operator=(const INSCollocatedCenteredConvectiveOperator& that) = delete;
 
     // Data communication algorithms, operators, and schedules.
     SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenAlgorithm<NDIM> > d_coarsen_alg;

--- a/include/ibamr/INSCollocatedConvectiveOperatorManager.h
+++ b/include/ibamr/INSCollocatedConvectiveOperatorManager.h
@@ -134,7 +134,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSCollocatedConvectiveOperatorManager(const INSCollocatedConvectiveOperatorManager& from);
+    INSCollocatedConvectiveOperatorManager(const INSCollocatedConvectiveOperatorManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -145,7 +145,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSCollocatedConvectiveOperatorManager& operator=(const INSCollocatedConvectiveOperatorManager& that);
+    INSCollocatedConvectiveOperatorManager& operator=(const INSCollocatedConvectiveOperatorManager& that) = delete;
 
     /*!
      * Static data members used to control access to and destruction of

--- a/include/ibamr/INSCollocatedHierarchyIntegrator.h
+++ b/include/ibamr/INSCollocatedHierarchyIntegrator.h
@@ -236,7 +236,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSCollocatedHierarchyIntegrator();
+    INSCollocatedHierarchyIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -245,7 +245,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSCollocatedHierarchyIntegrator(const INSCollocatedHierarchyIntegrator& from);
+    INSCollocatedHierarchyIntegrator(const INSCollocatedHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -256,7 +256,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSCollocatedHierarchyIntegrator& operator=(const INSCollocatedHierarchyIntegrator& that);
+    INSCollocatedHierarchyIntegrator& operator=(const INSCollocatedHierarchyIntegrator& that) = delete;
 
     /*!
      * Compute the appropriate source term that must be added to the momentum

--- a/include/ibamr/INSCollocatedPPMConvectiveOperator.h
+++ b/include/ibamr/INSCollocatedPPMConvectiveOperator.h
@@ -174,7 +174,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSCollocatedPPMConvectiveOperator();
+    INSCollocatedPPMConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -183,7 +183,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSCollocatedPPMConvectiveOperator(const INSCollocatedPPMConvectiveOperator& from);
+    INSCollocatedPPMConvectiveOperator(const INSCollocatedPPMConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -194,7 +194,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSCollocatedPPMConvectiveOperator& operator=(const INSCollocatedPPMConvectiveOperator& that);
+    INSCollocatedPPMConvectiveOperator& operator=(const INSCollocatedPPMConvectiveOperator& that) = delete;
 
     // Data communication algorithms, operators, and schedules.
     SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenAlgorithm<NDIM> > d_coarsen_alg;

--- a/include/ibamr/INSCollocatedVelocityBcCoef.h
+++ b/include/ibamr/INSCollocatedVelocityBcCoef.h
@@ -255,7 +255,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSCollocatedVelocityBcCoef();
+    INSCollocatedVelocityBcCoef() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -264,7 +264,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSCollocatedVelocityBcCoef(const INSCollocatedVelocityBcCoef& from);
+    INSCollocatedVelocityBcCoef(const INSCollocatedVelocityBcCoef& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -275,7 +275,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSCollocatedVelocityBcCoef& operator=(const INSCollocatedVelocityBcCoef& that);
+    INSCollocatedVelocityBcCoef& operator=(const INSCollocatedVelocityBcCoef& that) = delete;
 
     /*
      * Component of the velocity which this boundary condition specification is

--- a/include/ibamr/INSCollocatedWavePropConvectiveOperator.h
+++ b/include/ibamr/INSCollocatedWavePropConvectiveOperator.h
@@ -167,7 +167,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSCollocatedWavePropConvectiveOperator();
+    INSCollocatedWavePropConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -176,7 +176,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSCollocatedWavePropConvectiveOperator(const INSCollocatedWavePropConvectiveOperator& from);
+    INSCollocatedWavePropConvectiveOperator(const INSCollocatedWavePropConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -187,7 +187,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSCollocatedWavePropConvectiveOperator& operator=(const INSCollocatedWavePropConvectiveOperator& that);
+    INSCollocatedWavePropConvectiveOperator& operator=(const INSCollocatedWavePropConvectiveOperator& that) = delete;
 
     // Cached communications operators.
     std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*> d_bc_coefs;

--- a/include/ibamr/INSHierarchyIntegrator.h
+++ b/include/ibamr/INSHierarchyIntegrator.h
@@ -538,7 +538,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSHierarchyIntegrator(const INSHierarchyIntegrator& from);
+    INSHierarchyIntegrator(const INSHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -549,7 +549,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSHierarchyIntegrator& operator=(const INSHierarchyIntegrator& that);
+    INSHierarchyIntegrator& operator=(const INSHierarchyIntegrator& that) = delete;
 
     /*!
      * Read input values from a given database.

--- a/include/ibamr/INSIntermediateVelocityBcCoef.h
+++ b/include/ibamr/INSIntermediateVelocityBcCoef.h
@@ -221,7 +221,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSIntermediateVelocityBcCoef();
+    INSIntermediateVelocityBcCoef() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -230,7 +230,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSIntermediateVelocityBcCoef(const INSIntermediateVelocityBcCoef& from);
+    INSIntermediateVelocityBcCoef(const INSIntermediateVelocityBcCoef& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -241,7 +241,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSIntermediateVelocityBcCoef& operator=(const INSIntermediateVelocityBcCoef& that);
+    INSIntermediateVelocityBcCoef& operator=(const INSIntermediateVelocityBcCoef& that) = delete;
 
     /*
      * Component of the velocity which this boundary condition specification is

--- a/include/ibamr/INSProjectionBcCoef.h
+++ b/include/ibamr/INSProjectionBcCoef.h
@@ -217,7 +217,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSProjectionBcCoef();
+    INSProjectionBcCoef() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -226,7 +226,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSProjectionBcCoef(const INSProjectionBcCoef& from);
+    INSProjectionBcCoef(const INSProjectionBcCoef& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -237,7 +237,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSProjectionBcCoef& operator=(const INSProjectionBcCoef& that);
+    INSProjectionBcCoef& operator=(const INSProjectionBcCoef& that) = delete;
 
     /*
      * The boundary condition specification objects for the updated velocity.

--- a/include/ibamr/INSStaggeredCUIConvectiveOperator.h
+++ b/include/ibamr/INSStaggeredCUIConvectiveOperator.h
@@ -172,7 +172,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSStaggeredCUIConvectiveOperator();
+    INSStaggeredCUIConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -181,7 +181,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredCUIConvectiveOperator(const INSStaggeredCUIConvectiveOperator& from);
+    INSStaggeredCUIConvectiveOperator(const INSStaggeredCUIConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -192,7 +192,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredCUIConvectiveOperator& operator=(const INSStaggeredCUIConvectiveOperator& that);
+    INSStaggeredCUIConvectiveOperator& operator=(const INSStaggeredCUIConvectiveOperator& that) = delete;
 
     // Boundary condition helper object.
     SAMRAI::tbox::Pointer<StaggeredStokesPhysicalBoundaryHelper> d_bc_helper;

--- a/include/ibamr/INSStaggeredCenteredConvectiveOperator.h
+++ b/include/ibamr/INSStaggeredCenteredConvectiveOperator.h
@@ -161,7 +161,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSStaggeredCenteredConvectiveOperator();
+    INSStaggeredCenteredConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -170,7 +170,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredCenteredConvectiveOperator(const INSStaggeredCenteredConvectiveOperator& from);
+    INSStaggeredCenteredConvectiveOperator(const INSStaggeredCenteredConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -181,7 +181,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredCenteredConvectiveOperator& operator=(const INSStaggeredCenteredConvectiveOperator& that);
+    INSStaggeredCenteredConvectiveOperator& operator=(const INSStaggeredCenteredConvectiveOperator& that) = delete;
 
     // Boundary condition helper object.
     SAMRAI::tbox::Pointer<StaggeredStokesPhysicalBoundaryHelper> d_bc_helper;

--- a/include/ibamr/INSStaggeredConvectiveOperatorManager.h
+++ b/include/ibamr/INSStaggeredConvectiveOperatorManager.h
@@ -137,7 +137,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredConvectiveOperatorManager(const INSStaggeredConvectiveOperatorManager& from);
+    INSStaggeredConvectiveOperatorManager(const INSStaggeredConvectiveOperatorManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -148,7 +148,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredConvectiveOperatorManager& operator=(const INSStaggeredConvectiveOperatorManager& that);
+    INSStaggeredConvectiveOperatorManager& operator=(const INSStaggeredConvectiveOperatorManager& that) = delete;
 
     /*!
      * Static data members used to control access to and destruction of

--- a/include/ibamr/INSStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSStaggeredHierarchyIntegrator.h
@@ -278,7 +278,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSStaggeredHierarchyIntegrator();
+    INSStaggeredHierarchyIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -287,7 +287,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredHierarchyIntegrator(const INSStaggeredHierarchyIntegrator& from);
+    INSStaggeredHierarchyIntegrator(const INSStaggeredHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -298,7 +298,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredHierarchyIntegrator& operator=(const INSStaggeredHierarchyIntegrator& that);
+    INSStaggeredHierarchyIntegrator& operator=(const INSStaggeredHierarchyIntegrator& that) = delete;
 
     /*!
      * Compute the appropriate source term that must be added to the momentum

--- a/include/ibamr/INSStaggeredPPMConvectiveOperator.h
+++ b/include/ibamr/INSStaggeredPPMConvectiveOperator.h
@@ -164,7 +164,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSStaggeredPPMConvectiveOperator();
+    INSStaggeredPPMConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -173,7 +173,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredPPMConvectiveOperator(const INSStaggeredPPMConvectiveOperator& from);
+    INSStaggeredPPMConvectiveOperator(const INSStaggeredPPMConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -184,7 +184,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredPPMConvectiveOperator& operator=(const INSStaggeredPPMConvectiveOperator& that);
+    INSStaggeredPPMConvectiveOperator& operator=(const INSStaggeredPPMConvectiveOperator& that) = delete;
 
     // Boundary condition helper object.
     SAMRAI::tbox::Pointer<StaggeredStokesPhysicalBoundaryHelper> d_bc_helper;

--- a/include/ibamr/INSStaggeredPressureBcCoef.h
+++ b/include/ibamr/INSStaggeredPressureBcCoef.h
@@ -251,7 +251,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSStaggeredPressureBcCoef();
+    INSStaggeredPressureBcCoef() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -260,7 +260,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredPressureBcCoef(const INSStaggeredPressureBcCoef& from);
+    INSStaggeredPressureBcCoef(const INSStaggeredPressureBcCoef& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -271,7 +271,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredPressureBcCoef& operator=(const INSStaggeredPressureBcCoef& that);
+    INSStaggeredPressureBcCoef& operator=(const INSStaggeredPressureBcCoef& that) = delete;
 
     /*
      * The fluid solver.

--- a/include/ibamr/INSStaggeredStabilizedPPMConvectiveOperator.h
+++ b/include/ibamr/INSStaggeredStabilizedPPMConvectiveOperator.h
@@ -168,7 +168,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSStaggeredStabilizedPPMConvectiveOperator();
+    INSStaggeredStabilizedPPMConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -177,7 +177,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredStabilizedPPMConvectiveOperator(const INSStaggeredStabilizedPPMConvectiveOperator& from);
+    INSStaggeredStabilizedPPMConvectiveOperator(const INSStaggeredStabilizedPPMConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -188,7 +188,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredStabilizedPPMConvectiveOperator& operator=(const INSStaggeredStabilizedPPMConvectiveOperator& that);
+    INSStaggeredStabilizedPPMConvectiveOperator& operator=(const INSStaggeredStabilizedPPMConvectiveOperator& that) = delete;
 
     // Operator configuration.
     std::string d_stabilization_type;

--- a/include/ibamr/INSStaggeredStochasticForcing.h
+++ b/include/ibamr/INSStaggeredStochasticForcing.h
@@ -143,7 +143,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSStaggeredStochasticForcing();
+    INSStaggeredStochasticForcing() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -152,7 +152,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredStochasticForcing(const INSStaggeredStochasticForcing& from);
+    INSStaggeredStochasticForcing(const INSStaggeredStochasticForcing& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -163,7 +163,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredStochasticForcing& operator=(const INSStaggeredStochasticForcing& that);
+    INSStaggeredStochasticForcing& operator=(const INSStaggeredStochasticForcing& that) = delete;
 
     /*!
      * Pointer to the fluid solver object that is using this stochastic force

--- a/include/ibamr/INSStaggeredUpwindConvectiveOperator.h
+++ b/include/ibamr/INSStaggeredUpwindConvectiveOperator.h
@@ -160,7 +160,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSStaggeredUpwindConvectiveOperator();
+    INSStaggeredUpwindConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -169,7 +169,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredUpwindConvectiveOperator(const INSStaggeredUpwindConvectiveOperator& from);
+    INSStaggeredUpwindConvectiveOperator(const INSStaggeredUpwindConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -180,7 +180,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredUpwindConvectiveOperator& operator=(const INSStaggeredUpwindConvectiveOperator& that);
+    INSStaggeredUpwindConvectiveOperator& operator=(const INSStaggeredUpwindConvectiveOperator& that) = delete;
 
     // Boundary condition helper object.
     SAMRAI::tbox::Pointer<StaggeredStokesPhysicalBoundaryHelper> d_bc_helper;

--- a/include/ibamr/INSStaggeredVelocityBcCoef.h
+++ b/include/ibamr/INSStaggeredVelocityBcCoef.h
@@ -255,7 +255,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSStaggeredVelocityBcCoef();
+    INSStaggeredVelocityBcCoef() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -264,7 +264,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredVelocityBcCoef(const INSStaggeredVelocityBcCoef& from);
+    INSStaggeredVelocityBcCoef(const INSStaggeredVelocityBcCoef& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -275,7 +275,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredVelocityBcCoef& operator=(const INSStaggeredVelocityBcCoef& that);
+    INSStaggeredVelocityBcCoef& operator=(const INSStaggeredVelocityBcCoef& that) = delete;
 
     /*
      * Component of the velocity which this boundary condition specification is

--- a/include/ibamr/INSStaggeredWavePropConvectiveOperator.h
+++ b/include/ibamr/INSStaggeredWavePropConvectiveOperator.h
@@ -170,7 +170,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSStaggeredWavePropConvectiveOperator();
+    INSStaggeredWavePropConvectiveOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -179,7 +179,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSStaggeredWavePropConvectiveOperator(const INSStaggeredWavePropConvectiveOperator& from);
+    INSStaggeredWavePropConvectiveOperator(const INSStaggeredWavePropConvectiveOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -190,7 +190,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSStaggeredWavePropConvectiveOperator& operator=(const INSStaggeredWavePropConvectiveOperator& that);
+    INSStaggeredWavePropConvectiveOperator& operator=(const INSStaggeredWavePropConvectiveOperator& that) = delete;
 
     // Boundary condition helper object.
     SAMRAI::tbox::Pointer<StaggeredStokesPhysicalBoundaryHelper> d_bc_helper;

--- a/include/ibamr/INSVCStaggeredConservativeHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredConservativeHierarchyIntegrator.h
@@ -234,7 +234,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSVCStaggeredConservativeHierarchyIntegrator();
+    INSVCStaggeredConservativeHierarchyIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -243,7 +243,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSVCStaggeredConservativeHierarchyIntegrator(const INSVCStaggeredConservativeHierarchyIntegrator& from);
+    INSVCStaggeredConservativeHierarchyIntegrator(const INSVCStaggeredConservativeHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -254,7 +254,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSVCStaggeredConservativeHierarchyIntegrator& operator=(const INSVCStaggeredConservativeHierarchyIntegrator& that);
+    INSVCStaggeredConservativeHierarchyIntegrator& operator=(const INSVCStaggeredConservativeHierarchyIntegrator& that) = delete;
 
     /*!
      * Update the operators and solvers to account for changes due to time-dependent coefficients

--- a/include/ibamr/INSVCStaggeredConservativeMassMomentumIntegrator.h
+++ b/include/ibamr/INSVCStaggeredConservativeMassMomentumIntegrator.h
@@ -238,7 +238,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSVCStaggeredConservativeMassMomentumIntegrator();
+    INSVCStaggeredConservativeMassMomentumIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -247,7 +247,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSVCStaggeredConservativeMassMomentumIntegrator(const INSVCStaggeredConservativeMassMomentumIntegrator& from);
+    INSVCStaggeredConservativeMassMomentumIntegrator(const INSVCStaggeredConservativeMassMomentumIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -259,7 +259,7 @@ private:
      * \return A reference to this object.
      */
     INSVCStaggeredConservativeMassMomentumIntegrator&
-    operator=(const INSVCStaggeredConservativeMassMomentumIntegrator& that);
+    operator=(const INSVCStaggeredConservativeMassMomentumIntegrator& that) = delete;
 
     /*!
      * \brief Compute the advection velocity using simple averages

--- a/include/ibamr/INSVCStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredHierarchyIntegrator.h
@@ -642,7 +642,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSVCStaggeredHierarchyIntegrator();
+    INSVCStaggeredHierarchyIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -651,7 +651,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSVCStaggeredHierarchyIntegrator(const INSVCStaggeredHierarchyIntegrator& from);
+    INSVCStaggeredHierarchyIntegrator(const INSVCStaggeredHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -662,7 +662,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSVCStaggeredHierarchyIntegrator& operator=(const INSVCStaggeredHierarchyIntegrator& that);
+    INSVCStaggeredHierarchyIntegrator& operator=(const INSVCStaggeredHierarchyIntegrator& that) = delete;
 
     /*!
      * Preprocess the operators and solvers used by the hierarchy integrator.

--- a/include/ibamr/INSVCStaggeredNonConservativeHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredNonConservativeHierarchyIntegrator.h
@@ -214,7 +214,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSVCStaggeredNonConservativeHierarchyIntegrator();
+    INSVCStaggeredNonConservativeHierarchyIntegrator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -223,7 +223,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSVCStaggeredNonConservativeHierarchyIntegrator(const INSVCStaggeredNonConservativeHierarchyIntegrator& from);
+    INSVCStaggeredNonConservativeHierarchyIntegrator(const INSVCStaggeredNonConservativeHierarchyIntegrator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -235,7 +235,7 @@ private:
      * \return A reference to this object.
      */
     INSVCStaggeredNonConservativeHierarchyIntegrator&
-    operator=(const INSVCStaggeredNonConservativeHierarchyIntegrator& that);
+    operator=(const INSVCStaggeredNonConservativeHierarchyIntegrator& that) = delete;
 
     /*!
      * Determine the convective time stepping type for the current time step and

--- a/include/ibamr/INSVCStaggeredPressureBcCoef.h
+++ b/include/ibamr/INSVCStaggeredPressureBcCoef.h
@@ -258,7 +258,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSVCStaggeredPressureBcCoef();
+    INSVCStaggeredPressureBcCoef() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -267,7 +267,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSVCStaggeredPressureBcCoef(const INSVCStaggeredPressureBcCoef& from);
+    INSVCStaggeredPressureBcCoef(const INSVCStaggeredPressureBcCoef& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -278,7 +278,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSVCStaggeredPressureBcCoef& operator=(const INSVCStaggeredPressureBcCoef& that);
+    INSVCStaggeredPressureBcCoef& operator=(const INSVCStaggeredPressureBcCoef& that) = delete;
 
     /*
      * The fluid solver.

--- a/include/ibamr/INSVCStaggeredVelocityBcCoef.h
+++ b/include/ibamr/INSVCStaggeredVelocityBcCoef.h
@@ -255,7 +255,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    INSVCStaggeredVelocityBcCoef();
+    INSVCStaggeredVelocityBcCoef() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -264,7 +264,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    INSVCStaggeredVelocityBcCoef(const INSVCStaggeredVelocityBcCoef& from);
+    INSVCStaggeredVelocityBcCoef(const INSVCStaggeredVelocityBcCoef& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -275,7 +275,7 @@ private:
      *
      * \return A reference to this object.
      */
-    INSVCStaggeredVelocityBcCoef& operator=(const INSVCStaggeredVelocityBcCoef& that);
+    INSVCStaggeredVelocityBcCoef& operator=(const INSVCStaggeredVelocityBcCoef& that) = delete;
 
     /*
      * Component of the velocity which this boundary condition specification is

--- a/include/ibamr/KrylovFreeBodyMobilitySolver.h
+++ b/include/ibamr/KrylovFreeBodyMobilitySolver.h
@@ -175,7 +175,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    KrylovFreeBodyMobilitySolver(const KrylovFreeBodyMobilitySolver& from);
+    KrylovFreeBodyMobilitySolver(const KrylovFreeBodyMobilitySolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -186,7 +186,7 @@ private:
      *
      * \return A reference to this object.
      */
-    KrylovFreeBodyMobilitySolver& operator=(const KrylovFreeBodyMobilitySolver& that);
+    KrylovFreeBodyMobilitySolver& operator=(const KrylovFreeBodyMobilitySolver& that) = delete;
 
     /*!
      * \brief Report the KSPConvergedReason.

--- a/include/ibamr/KrylovLinearSolverStaggeredStokesSolverInterface.h
+++ b/include/ibamr/KrylovLinearSolverStaggeredStokesSolverInterface.h
@@ -126,7 +126,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    KrylovLinearSolverStaggeredStokesSolverInterface(const KrylovLinearSolverStaggeredStokesSolverInterface& from);
+    KrylovLinearSolverStaggeredStokesSolverInterface(const KrylovLinearSolverStaggeredStokesSolverInterface& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -138,7 +138,7 @@ private:
      * \return A reference to this object.
      */
     KrylovLinearSolverStaggeredStokesSolverInterface&
-    operator=(const KrylovLinearSolverStaggeredStokesSolverInterface& that);
+    operator=(const KrylovLinearSolverStaggeredStokesSolverInterface& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/KrylovMobilitySolver.h
+++ b/include/ibamr/KrylovMobilitySolver.h
@@ -217,7 +217,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    KrylovMobilitySolver(const KrylovMobilitySolver& from);
+    KrylovMobilitySolver(const KrylovMobilitySolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -228,7 +228,7 @@ private:
      *
      * \return A reference to this object.
      */
-    KrylovMobilitySolver& operator=(const KrylovMobilitySolver& that);
+    KrylovMobilitySolver& operator=(const KrylovMobilitySolver& that) = delete;
 
     /*!
      * \brief Get solver settings from the input file.

--- a/include/ibamr/LSInitStrategy.h
+++ b/include/ibamr/LSInitStrategy.h
@@ -161,7 +161,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    LSInitStrategy(const LSInitStrategy& from);
+    LSInitStrategy(const LSInitStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -172,7 +172,7 @@ private:
      *
      * \return A reference to this object.
      */
-    LSInitStrategy& operator=(const LSInitStrategy& that);
+    LSInitStrategy& operator=(const LSInitStrategy& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/MaterialPointSpec.h
+++ b/include/ibamr/MaterialPointSpec.h
@@ -174,7 +174,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    MaterialPointSpec(const MaterialPointSpec& from);
+    MaterialPointSpec(const MaterialPointSpec& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -185,7 +185,7 @@ private:
      *
      * \return A reference to this object.
      */
-    MaterialPointSpec& operator=(const MaterialPointSpec& that);
+    MaterialPointSpec& operator=(const MaterialPointSpec& that) = delete;
 
     /*!
      * Material point data.
@@ -241,7 +241,7 @@ private:
          *
          * \param from The value to copy to this object.
          */
-        Factory(const Factory& from);
+        Factory(const Factory& from) = delete;
 
         /*!
          * \brief Assignment operator.
@@ -252,7 +252,7 @@ private:
          *
          * \return A reference to this object.
          */
-        Factory& operator=(const Factory& that);
+        Factory& operator=(const Factory& that) = delete;
 
         friend class MaterialPointSpec;
     };

--- a/include/ibamr/NonbondedForceEvaluator.h
+++ b/include/ibamr/NonbondedForceEvaluator.h
@@ -82,13 +82,13 @@ public:
 
 private:
     // Default constructor, not implemented.
-    NonbondedForceEvaluator();
+    NonbondedForceEvaluator() = delete;
 
     // Copy constructor, not implemented.
-    NonbondedForceEvaluator(const NonbondedForceEvaluator& from);
+    NonbondedForceEvaluator(const NonbondedForceEvaluator& from) = delete;
 
     // Assignment operator, not implemented.
-    NonbondedForceEvaluator& operator=(const NonbondedForceEvaluator& that);
+    NonbondedForceEvaluator& operator=(const NonbondedForceEvaluator& that) = delete;
 
     // type of force to use:
     int d_force_type;

--- a/include/ibamr/PETScKrylovStaggeredStokesSolver.h
+++ b/include/ibamr/PETScKrylovStaggeredStokesSolver.h
@@ -81,7 +81,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PETScKrylovStaggeredStokesSolver();
+    PETScKrylovStaggeredStokesSolver() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -90,7 +90,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PETScKrylovStaggeredStokesSolver(const PETScKrylovStaggeredStokesSolver& from);
+    PETScKrylovStaggeredStokesSolver(const PETScKrylovStaggeredStokesSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -101,7 +101,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PETScKrylovStaggeredStokesSolver& operator=(const PETScKrylovStaggeredStokesSolver& that);
+    PETScKrylovStaggeredStokesSolver& operator=(const PETScKrylovStaggeredStokesSolver& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/PenaltyIBMethod.h
+++ b/include/ibamr/PenaltyIBMethod.h
@@ -186,7 +186,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    PenaltyIBMethod();
+    PenaltyIBMethod() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -195,7 +195,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    PenaltyIBMethod(const PenaltyIBMethod& from);
+    PenaltyIBMethod(const PenaltyIBMethod& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -206,7 +206,7 @@ private:
      *
      * \return A reference to this object.
      */
-    PenaltyIBMethod& operator=(const PenaltyIBMethod& that);
+    PenaltyIBMethod& operator=(const PenaltyIBMethod& that) = delete;
 
     /*!
      * Read input values from a given database.

--- a/include/ibamr/RNG.h
+++ b/include/ibamr/RNG.h
@@ -19,10 +19,10 @@ public:
     static void parallel_seed(int global_seed);
 
 private:
-    RNG();
-    RNG(RNG&);
-    ~RNG();
-    RNG& operator=(RNG&);
+    RNG() = delete;
+    RNG(RNG&) = delete;
+    ~RNG() = delete;
+    RNG& operator=(RNG&) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/RelaxationLSBcCoefs.h
+++ b/include/ibamr/RelaxationLSBcCoefs.h
@@ -164,7 +164,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    RelaxationLSBcCoefs(const RelaxationLSBcCoefs& from);
+    RelaxationLSBcCoefs(const RelaxationLSBcCoefs& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -175,7 +175,7 @@ private:
      *
      * \return A reference to this object.
      */
-    RelaxationLSBcCoefs& operator=(const RelaxationLSBcCoefs& that);
+    RelaxationLSBcCoefs& operator=(const RelaxationLSBcCoefs& that) = delete;
 
     const std::string d_object_name;
     int d_phi_idx;

--- a/include/ibamr/RelaxationLSMethod.h
+++ b/include/ibamr/RelaxationLSMethod.h
@@ -251,7 +251,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    RelaxationLSMethod(const RelaxationLSMethod& from);
+    RelaxationLSMethod(const RelaxationLSMethod& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -262,7 +262,7 @@ private:
      *
      * \return A reference to this object.
      */
-    RelaxationLSMethod& operator=(const RelaxationLSMethod& that);
+    RelaxationLSMethod& operator=(const RelaxationLSMethod& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/SpongeLayerForceFunction.h
+++ b/include/ibamr/SpongeLayerForceFunction.h
@@ -124,7 +124,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    SpongeLayerForceFunction();
+    SpongeLayerForceFunction() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -133,7 +133,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    SpongeLayerForceFunction(const SpongeLayerForceFunction& from);
+    SpongeLayerForceFunction(const SpongeLayerForceFunction& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -144,7 +144,7 @@ private:
      *
      * \return A reference to this object.
      */
-    SpongeLayerForceFunction& operator=(const SpongeLayerForceFunction& that);
+    SpongeLayerForceFunction& operator=(const SpongeLayerForceFunction& that) = delete;
 
     /*!
      * Set the data on the patch interior.

--- a/include/ibamr/StaggeredStokesBlockFactorizationPreconditioner.h
+++ b/include/ibamr/StaggeredStokesBlockFactorizationPreconditioner.h
@@ -174,7 +174,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesBlockFactorizationPreconditioner();
+    StaggeredStokesBlockFactorizationPreconditioner() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -183,7 +183,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesBlockFactorizationPreconditioner(const StaggeredStokesBlockFactorizationPreconditioner& from);
+    StaggeredStokesBlockFactorizationPreconditioner(const StaggeredStokesBlockFactorizationPreconditioner& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -195,7 +195,7 @@ private:
      * \return A reference to this object.
      */
     StaggeredStokesBlockFactorizationPreconditioner&
-    operator=(const StaggeredStokesBlockFactorizationPreconditioner& that);
+    operator=(const StaggeredStokesBlockFactorizationPreconditioner& that) = delete;
 
     /*!
      * \brief Solve the pressure subsystem.

--- a/include/ibamr/StaggeredStokesBlockPreconditioner.h
+++ b/include/ibamr/StaggeredStokesBlockPreconditioner.h
@@ -192,7 +192,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesBlockPreconditioner();
+    StaggeredStokesBlockPreconditioner() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -201,7 +201,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesBlockPreconditioner(const StaggeredStokesBlockPreconditioner& from);
+    StaggeredStokesBlockPreconditioner(const StaggeredStokesBlockPreconditioner& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -212,7 +212,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesBlockPreconditioner& operator=(const StaggeredStokesBlockPreconditioner& that);
+    StaggeredStokesBlockPreconditioner& operator=(const StaggeredStokesBlockPreconditioner& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/StaggeredStokesBoxRelaxationFACOperator.h
+++ b/include/ibamr/StaggeredStokesBoxRelaxationFACOperator.h
@@ -150,7 +150,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesBoxRelaxationFACOperator(const StaggeredStokesBoxRelaxationFACOperator& from);
+    StaggeredStokesBoxRelaxationFACOperator(const StaggeredStokesBoxRelaxationFACOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -161,7 +161,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesBoxRelaxationFACOperator& operator=(const StaggeredStokesBoxRelaxationFACOperator& that);
+    StaggeredStokesBoxRelaxationFACOperator& operator=(const StaggeredStokesBoxRelaxationFACOperator& that) = delete;
 
     /*
      * Box operator data.

--- a/include/ibamr/StaggeredStokesFACPreconditioner.h
+++ b/include/ibamr/StaggeredStokesFACPreconditioner.h
@@ -130,7 +130,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesFACPreconditioner();
+    StaggeredStokesFACPreconditioner() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -139,7 +139,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesFACPreconditioner(const StaggeredStokesFACPreconditioner& from);
+    StaggeredStokesFACPreconditioner(const StaggeredStokesFACPreconditioner& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -150,7 +150,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesFACPreconditioner& operator=(const StaggeredStokesFACPreconditioner& that);
+    StaggeredStokesFACPreconditioner& operator=(const StaggeredStokesFACPreconditioner& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/StaggeredStokesFACPreconditionerStrategy.h
+++ b/include/ibamr/StaggeredStokesFACPreconditionerStrategy.h
@@ -522,7 +522,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesFACPreconditionerStrategy();
+    StaggeredStokesFACPreconditionerStrategy() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -531,7 +531,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesFACPreconditionerStrategy(const StaggeredStokesFACPreconditionerStrategy& from);
+    StaggeredStokesFACPreconditionerStrategy(const StaggeredStokesFACPreconditionerStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -542,7 +542,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesFACPreconditionerStrategy& operator=(const StaggeredStokesFACPreconditionerStrategy& that);
+    StaggeredStokesFACPreconditionerStrategy& operator=(const StaggeredStokesFACPreconditionerStrategy& that) = delete;
 
     /*
      * Combined U & P physical boundary operator.

--- a/include/ibamr/StaggeredStokesIBLevelRelaxationFACOperator.h
+++ b/include/ibamr/StaggeredStokesIBLevelRelaxationFACOperator.h
@@ -269,7 +269,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesIBLevelRelaxationFACOperator();
+    StaggeredStokesIBLevelRelaxationFACOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -278,7 +278,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesIBLevelRelaxationFACOperator(const StaggeredStokesIBLevelRelaxationFACOperator& from);
+    StaggeredStokesIBLevelRelaxationFACOperator(const StaggeredStokesIBLevelRelaxationFACOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -289,7 +289,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesIBLevelRelaxationFACOperator& operator=(const StaggeredStokesIBLevelRelaxationFACOperator& that);
+    StaggeredStokesIBLevelRelaxationFACOperator& operator=(const StaggeredStokesIBLevelRelaxationFACOperator& that) = delete;
 
     /*
      * Whether we re-discretize the Stokes operator on coarser level or are

--- a/include/ibamr/StaggeredStokesLevelRelaxationFACOperator.h
+++ b/include/ibamr/StaggeredStokesLevelRelaxationFACOperator.h
@@ -161,7 +161,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesLevelRelaxationFACOperator();
+    StaggeredStokesLevelRelaxationFACOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -170,7 +170,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesLevelRelaxationFACOperator(const StaggeredStokesLevelRelaxationFACOperator& from);
+    StaggeredStokesLevelRelaxationFACOperator(const StaggeredStokesLevelRelaxationFACOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -181,7 +181,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesLevelRelaxationFACOperator& operator=(const StaggeredStokesLevelRelaxationFACOperator& that);
+    StaggeredStokesLevelRelaxationFACOperator& operator=(const StaggeredStokesLevelRelaxationFACOperator& that) = delete;
 
     /*
      * Level solvers and solver parameters.

--- a/include/ibamr/StaggeredStokesOpenBoundaryStabilizer.h
+++ b/include/ibamr/StaggeredStokesOpenBoundaryStabilizer.h
@@ -117,7 +117,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesOpenBoundaryStabilizer();
+    StaggeredStokesOpenBoundaryStabilizer() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -126,7 +126,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesOpenBoundaryStabilizer(const StaggeredStokesOpenBoundaryStabilizer& from);
+    StaggeredStokesOpenBoundaryStabilizer(const StaggeredStokesOpenBoundaryStabilizer& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -137,7 +137,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesOpenBoundaryStabilizer& operator=(const StaggeredStokesOpenBoundaryStabilizer& that);
+    StaggeredStokesOpenBoundaryStabilizer& operator=(const StaggeredStokesOpenBoundaryStabilizer& that) = delete;
 
     std::array<bool, 2 * NDIM> d_open_bdry, d_inflow_bdry, d_outflow_bdry;
     std::array<double, 2 * NDIM> d_width;

--- a/include/ibamr/StaggeredStokesOperator.h
+++ b/include/ibamr/StaggeredStokesOperator.h
@@ -235,7 +235,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesOperator();
+    StaggeredStokesOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -244,7 +244,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesOperator(const StaggeredStokesOperator& from);
+    StaggeredStokesOperator(const StaggeredStokesOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -255,7 +255,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesOperator& operator=(const StaggeredStokesOperator& that);
+    StaggeredStokesOperator& operator=(const StaggeredStokesOperator& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/StaggeredStokesPETScLevelSolver.h
+++ b/include/ibamr/StaggeredStokesPETScLevelSolver.h
@@ -149,7 +149,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesPETScLevelSolver();
+    StaggeredStokesPETScLevelSolver() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -158,7 +158,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesPETScLevelSolver(const StaggeredStokesPETScLevelSolver& from);
+    StaggeredStokesPETScLevelSolver(const StaggeredStokesPETScLevelSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -169,7 +169,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesPETScLevelSolver& operator=(const StaggeredStokesPETScLevelSolver& that);
+    StaggeredStokesPETScLevelSolver& operator=(const StaggeredStokesPETScLevelSolver& that) = delete;
 
     /*!
      * \name PETSc objects.

--- a/include/ibamr/StaggeredStokesPETScMatUtilities.h
+++ b/include/ibamr/StaggeredStokesPETScMatUtilities.h
@@ -141,7 +141,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesPETScMatUtilities();
+    StaggeredStokesPETScMatUtilities() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -150,7 +150,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesPETScMatUtilities(const StaggeredStokesPETScMatUtilities& from);
+    StaggeredStokesPETScMatUtilities(const StaggeredStokesPETScMatUtilities& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -161,7 +161,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesPETScMatUtilities& operator=(const StaggeredStokesPETScMatUtilities& that);
+    StaggeredStokesPETScMatUtilities& operator=(const StaggeredStokesPETScMatUtilities& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/StaggeredStokesPETScVecUtilities.h
+++ b/include/ibamr/StaggeredStokesPETScVecUtilities.h
@@ -161,7 +161,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesPETScVecUtilities();
+    StaggeredStokesPETScVecUtilities() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -170,7 +170,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesPETScVecUtilities(const StaggeredStokesPETScVecUtilities& from);
+    StaggeredStokesPETScVecUtilities(const StaggeredStokesPETScVecUtilities& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -181,7 +181,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesPETScVecUtilities& operator=(const StaggeredStokesPETScVecUtilities& that);
+    StaggeredStokesPETScVecUtilities& operator=(const StaggeredStokesPETScVecUtilities& that) = delete;
 
     /*!
      * \brief Implementation of copyToPatchLevelVec() for a standard MAC

--- a/include/ibamr/StaggeredStokesPhysicalBoundaryHelper.h
+++ b/include/ibamr/StaggeredStokesPhysicalBoundaryHelper.h
@@ -144,7 +144,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesPhysicalBoundaryHelper(const StaggeredStokesPhysicalBoundaryHelper& from);
+    StaggeredStokesPhysicalBoundaryHelper(const StaggeredStokesPhysicalBoundaryHelper& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -155,7 +155,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesPhysicalBoundaryHelper& operator=(const StaggeredStokesPhysicalBoundaryHelper& that);
+    StaggeredStokesPhysicalBoundaryHelper& operator=(const StaggeredStokesPhysicalBoundaryHelper& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/StaggeredStokesProjectionPreconditioner.h
+++ b/include/ibamr/StaggeredStokesProjectionPreconditioner.h
@@ -159,7 +159,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    StaggeredStokesProjectionPreconditioner();
+    StaggeredStokesProjectionPreconditioner() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -168,7 +168,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesProjectionPreconditioner(const StaggeredStokesProjectionPreconditioner& from);
+    StaggeredStokesProjectionPreconditioner(const StaggeredStokesProjectionPreconditioner& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -179,7 +179,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesProjectionPreconditioner& operator=(const StaggeredStokesProjectionPreconditioner& that);
+    StaggeredStokesProjectionPreconditioner& operator=(const StaggeredStokesProjectionPreconditioner& that) = delete;
 
     // Boundary condition objects.
     SAMRAI::tbox::Pointer<IBTK::HierarchyGhostCellInterpolation> d_Phi_bdry_fill_op, d_no_fill_op;

--- a/include/ibamr/StaggeredStokesSolver.h
+++ b/include/ibamr/StaggeredStokesSolver.h
@@ -130,7 +130,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesSolver(const StaggeredStokesSolver& from);
+    StaggeredStokesSolver(const StaggeredStokesSolver& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -141,7 +141,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesSolver& operator=(const StaggeredStokesSolver& that);
+    StaggeredStokesSolver& operator=(const StaggeredStokesSolver& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/StaggeredStokesSolverManager.h
+++ b/include/ibamr/StaggeredStokesSolverManager.h
@@ -166,7 +166,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StaggeredStokesSolverManager(const StaggeredStokesSolverManager& from);
+    StaggeredStokesSolverManager(const StaggeredStokesSolverManager& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -177,7 +177,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StaggeredStokesSolverManager& operator=(const StaggeredStokesSolverManager& that);
+    StaggeredStokesSolverManager& operator=(const StaggeredStokesSolverManager& that) = delete;
 
     /*!
      * Static data members used to control access to and destruction of

--- a/include/ibamr/StokesBcCoefStrategy.h
+++ b/include/ibamr/StokesBcCoefStrategy.h
@@ -136,7 +136,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    StokesBcCoefStrategy(const StokesBcCoefStrategy& from);
+    StokesBcCoefStrategy(const StokesBcCoefStrategy& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -147,7 +147,7 @@ private:
      *
      * \return A reference to this object.
      */
-    StokesBcCoefStrategy& operator=(const StokesBcCoefStrategy& that);
+    StokesBcCoefStrategy& operator=(const StokesBcCoefStrategy& that) = delete;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/SurfaceTensionForceFunction.h
+++ b/include/ibamr/SurfaceTensionForceFunction.h
@@ -189,7 +189,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    SurfaceTensionForceFunction();
+    SurfaceTensionForceFunction() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -198,7 +198,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    SurfaceTensionForceFunction(const SurfaceTensionForceFunction& from);
+    SurfaceTensionForceFunction(const SurfaceTensionForceFunction& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -209,7 +209,7 @@ private:
      *
      * \return A reference to this object.
      */
-    SurfaceTensionForceFunction& operator=(const SurfaceTensionForceFunction& that);
+    SurfaceTensionForceFunction& operator=(const SurfaceTensionForceFunction& that) = delete;
 
     /*!
      * Convert the level set variable to a smoothed heaviside function.

--- a/include/ibamr/VCStaggeredStokesOperator.h
+++ b/include/ibamr/VCStaggeredStokesOperator.h
@@ -130,7 +130,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    VCStaggeredStokesOperator();
+    VCStaggeredStokesOperator() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -139,7 +139,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    VCStaggeredStokesOperator(const VCStaggeredStokesOperator& from);
+    VCStaggeredStokesOperator(const VCStaggeredStokesOperator& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -150,7 +150,7 @@ private:
      *
      * \return A reference to this object.
      */
-    VCStaggeredStokesOperator& operator=(const VCStaggeredStokesOperator& that);
+    VCStaggeredStokesOperator& operator=(const VCStaggeredStokesOperator& that) = delete;
 
     /*
      * The interpolation type to be used in computing the variable coefficient viscous Laplacian.

--- a/include/ibamr/VCStaggeredStokesProjectionPreconditioner.h
+++ b/include/ibamr/VCStaggeredStokesProjectionPreconditioner.h
@@ -172,7 +172,7 @@ private:
      *
      * \note This constructor is not implemented and should not be used.
      */
-    VCStaggeredStokesProjectionPreconditioner();
+    VCStaggeredStokesProjectionPreconditioner() = delete;
 
     /*!
      * \brief Copy constructor.
@@ -181,7 +181,7 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    VCStaggeredStokesProjectionPreconditioner(const VCStaggeredStokesProjectionPreconditioner& from);
+    VCStaggeredStokesProjectionPreconditioner(const VCStaggeredStokesProjectionPreconditioner& from) = delete;
 
     /*!
      * \brief Assignment operator.
@@ -192,7 +192,7 @@ private:
      *
      * \return A reference to this object.
      */
-    VCStaggeredStokesProjectionPreconditioner& operator=(const VCStaggeredStokesProjectionPreconditioner& that);
+    VCStaggeredStokesProjectionPreconditioner& operator=(const VCStaggeredStokesProjectionPreconditioner& that) = delete;
 
     // Boundary condition objects.
     SAMRAI::tbox::Pointer<IBTK::HierarchyGhostCellInterpolation> d_Phi_bdry_fill_op, d_no_fill_op;

--- a/include/ibamr/WallForceEvaluator.h
+++ b/include/ibamr/WallForceEvaluator.h
@@ -69,13 +69,13 @@ public:
 
 private:
     // Default constructor, not implemented.
-    WallForceEvaluator();
+    WallForceEvaluator() = delete;
 
     // Copy constructor, not implemented.
-    WallForceEvaluator(const WallForceEvaluator& from);
+    WallForceEvaluator(const WallForceEvaluator& from) = delete;
 
     // Assignment operator, not implemented.
-    WallForceEvaluator& operator=(const WallForceEvaluator& that);
+    WallForceEvaluator& operator=(const WallForceEvaluator& that) = delete;
 
     // collection of walls:
     std::vector<Wall> d_walls_vec;


### PR DESCRIPTION
This is a run of clang-tidy with modernize-use-equals-delete