### PR TITLE
Add some checks for valid structure ids.

### DIFF
--- a/ibtk/include/ibtk/private/IndexUtilities-inl.h
+++ b/ibtk/include/ibtk/private/IndexUtilities-inl.h
@@ -156,6 +156,7 @@ IndexUtilities::mapIndexToInteger(const SAMRAI::hier::Index<NDIM>& i,
             offset);
 
 #else
+    TBOX_ASSERT(false);
     return -1;
 #endif
 

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -690,6 +690,7 @@ CIBMethod::forwardEulerStep(double current_time, double new_time)
 
             int struct_handle = 0;
             if (structs_on_this_ln > 1) struct_handle = getStructureHandle(lag_idx);
+            TBOX_ASSERT(struct_handle != -1);
 
             for (unsigned int d = 0; d < NDIM; ++d)
             {
@@ -810,6 +811,7 @@ CIBMethod::midpointStep(double current_time, double new_time)
 
             int struct_handle = 0;
             if (structs_on_this_ln > 1) struct_handle = getStructureHandle(lag_idx);
+            TBOX_ASSERT(struct_handle != -1);
 
             for (unsigned int d = 0; d < NDIM; ++d)
             {
@@ -1776,6 +1778,7 @@ CIBMethod::computeCOMOfStructures(std::vector<Eigen::Vector3d>& center_of_mass, 
 
             int struct_handle = 0;
             if (structs_on_this_ln > 1) struct_handle = getStructureHandle(lag_idx);
+            TBOX_ASSERT(struct_handle != -1);
 
             for (unsigned int d = 0; d < NDIM; ++d) center_of_mass[struct_handle][d] += X[d];
         }

--- a/src/IB/ConstraintIBMethod.cpp
+++ b/src/IB/ConstraintIBMethod.cpp
@@ -139,6 +139,8 @@ find_struct_handle_position(itr begin, itr end, const T& value)
         else
             ++position;
     }
+
+    TBOX_ASSERT(false);
     return -1;
 }
 

--- a/src/IB/MobilityFunctions.cpp
+++ b/src/IB/MobilityFunctions.cpp
@@ -40,6 +40,8 @@
 
 #include "ibamr/MobilityFunctions.h"
 
+#include "tbox/Utilities.h"
+
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
 namespace IBAMR
@@ -113,6 +115,7 @@ get_sqnorm(const double* a_vec)
     return a_vec[0] * a_vec[0] + a_vec[1] * a_vec[1];
 #endif
 
+    TBOX_ASSERT(false);
     return -1.0;
 } // get_sqnorm
 


### PR DESCRIPTION
Caught while debugging something in #380.

I opted to add the check at the call site instead of the function itself since, conceivably, someone else already has such a check (and an invalid structure id may not mean the program cannot continue).