### PR TITLE
fixing initialization of LDataManager::d_needs_synch

### DIFF
--- a/ibtk/include/ibtk/LDataManager.h
+++ b/ibtk/include/ibtk/LDataManager.h
@@ -1165,7 +1165,7 @@ private:
     /*!
      * Indicates whether the LData is in synch with the LNodeData.
      */
-    std::vector<bool> d_needs_synch = { true };
+    std::vector<bool> d_needs_synch;
 
     /*!
      * PETSc AO objects provide mappings between the fixed global Lagrangian


### PR DESCRIPTION
Prior to #380, `std::vector<bool> LDataManager::d_needs_synch` had been initialized via an initialization list in `LDataManager.cpp` via
```
    ...
    d_needs_synch(true),
    ...
```
I think that what was happening here is that `true` was being silently converted to the integer value `1`, and then the constructor was populating `d_needs_synch` with `false`.

This member actually does not need to be initialized to anything, because its values will be set correctly in `LDataManager::setPatchLevels()` when setting up the Lagrangian data structures.