### PR TITLE
Add partitioning 1

### DIFF
--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -478,6 +478,12 @@ bool run_example(int argc, char** argv)
                 {
                     time_integrator->setupPlotData();
                     visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+
+                    // Write partitioning data from libMesh.
+                    IBTK::write_elem_partitioning("elem-part-" + std::to_string(iteration_num) + ".txt",
+                                                  equation_systems->get_system(IBFEMethod::COORDS_SYSTEM_NAME));
+                    IBTK::write_node_partitioning("node-part-" + std::to_string(iteration_num) + ".txt",
+                                                  equation_systems->get_system(IBFEMethod::COORDS_SYSTEM_NAME));
                 }
                 if (uses_exodus)
                 {
@@ -605,5 +611,6 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     sprintf(temp_buf, "%05d", iteration_num);
     file_name += temp_buf;
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
+
     return;
 } // output_data

--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -190,7 +190,7 @@ bool run_example(int argc, char** argv)
         const double ds = input_db->getDouble("MFAC") * dx;
         string elem_type = input_db->getString("ELEM_TYPE");
         const double R = 0.2;
-        if (NDIM == 2 && (elem_type == "TRI3" || elem_type == "TRI6"))
+        if (NDIM == 2)
         {
 #ifdef LIBMESH_HAVE_TRIANGLE
             const int num_circum_nodes = ceil(2.0 * M_PI * R / ds);
@@ -202,7 +202,8 @@ bool run_example(int argc, char** argv)
             TriangleInterface triangle(mesh);
             triangle.triangulation_type() = TriangleInterface::GENERATE_CONVEX_HULL;
             triangle.elem_type() = Utility::string_to_enum<ElemType>(elem_type);
-            triangle.desired_area() = 1.5 * sqrt(3.0) / 4.0 * ds * ds;
+            triangle.desired_area() = sqrt(3.0) / 4.0 * ds * ds;
+            triangle.minimum_angle() = 30.0;
             triangle.insert_extra_points() = true;
             triangle.smooth_after_generating() = true;
             triangle.triangulate();

--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -468,6 +468,8 @@ bool run_example(int argc, char** argv)
             time_integrator->advanceHierarchy(dt);
             loop_time += dt;
 
+            // ib_method_ops->getFEDataManager()->updateWorkloadEstimates(2, 2);
+
             pout << "\n";
             pout << "At end       of timestep # " << iteration_num << "\n";
             pout << "Simulation time is " << loop_time << "\n";

--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -57,6 +57,7 @@
 #include <ibamr/INSCollocatedHierarchyIntegrator.h>
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 #include <ibtk/AppInitializer.h>
+#include <ibtk/BoxPartitioner.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -483,14 +484,24 @@ bool run_example(int argc, char** argv)
                 pout << "\nWriting visualization files...\n\n";
                 if (uses_visit)
                 {
+                    const System& position_system = equation_systems->get_system(
+                        IBFEMethod::COORDS_SYSTEM_NAME);
                     time_integrator->setupPlotData();
                     visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
 
+                    {
+                        // TODO: I haven't yet been able to convince SAMRAI to
+                        // save this data, so do it here instead
+                        IBTK::BoxPartitioner partitioner(*patch_hierarchy,
+                                                         position_system);
+                        partitioner.writePartitioning("patch-part-" + std::to_string(iteration_num) + ".txt");
+                    }
+
                     // Write partitioning data from libMesh.
                     IBTK::write_elem_partitioning("elem-part-" + std::to_string(iteration_num) + ".txt",
-                                                  equation_systems->get_system(IBFEMethod::COORDS_SYSTEM_NAME));
+                                                  position_system);
                     IBTK::write_node_partitioning("node-part-" + std::to_string(iteration_num) + ".txt",
-                                                  equation_systems->get_system(IBFEMethod::COORDS_SYSTEM_NAME));
+                                                  position_system);
                 }
                 if (uses_exodus)
                 {

--- a/examples/IBFE/explicit/ex4/input2d
+++ b/examples/IBFE/explicit/ex4/input2d
@@ -4,14 +4,14 @@ RHO = 1.0
 L   = 1.0
 
 // grid spacing parameters
-MAX_LEVELS = 3                                      // maximum number of levels in locally refined grid
-REF_RATIO  = 4                                      // refinement ratio between levels
-N = 32                                              // actual    number of grid cells on coarsest grid level
-NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N            // effective number of grid cells on finest   grid level
-DX0 = L/N                                           // mesh width on coarsest grid level
-DX  = L/NFINEST                                     // mesh width on finest   grid level
-MFAC = 2.0                                          // ratio of Lagrangian mesh width to Cartesian mesh width
-ELEM_TYPE = "TRI6"                                  // type of element to use for structure discretization
+MAX_LEVELS = 3                                     // maximum number of levels in locally refined grid
+REF_RATIO  = 4                                     // refinement ratio between levels
+N = 32                                             // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N           // effective number of grid cells on finest   grid level
+DX0 = L/N                                          // mesh width on coarsest grid level
+DX  = L/NFINEST                                    // mesh width on finest   grid level
+MFAC = 1.0                                         // ratio of Lagrangian mesh width to Cartesian mesh width
+ELEM_TYPE = "TRI6"                                 // type of element to use for structure discretization
 PK1_DEV_QUAD_ORDER = "FIFTH"
 PK1_DIL_QUAD_ORDER = "THIRD"
 
@@ -31,7 +31,7 @@ SOLVER_TYPE                = "STAGGERED"            // the fluid solver to use (
 CFL_MAX                    = 0.25                   // maximum CFL number
 DT                         = 0.25*CFL_MAX*DX/U_MAX  // maximum timestep size
 START_TIME                 = 0.0e0                  // initial simulation time
-END_TIME                   = 10000*DT               // final simulation time
+END_TIME                   = 1000*DT               // final simulation time
 GROW_DT                    = 2.0e0                  // growth factor for timesteps
 NUM_CYCLES                 = 1                      // number of cycles of fixed-point iteration
 CONVECTIVE_TS_TYPE         = "ADAMS_BASHFORTH"      // convective time stepping type

--- a/examples/IBFE/explicit/ex4/input2d
+++ b/examples/IBFE/explicit/ex4/input2d
@@ -4,9 +4,9 @@ RHO = 1.0
 L   = 1.0
 
 // grid spacing parameters
-MAX_LEVELS = 1                                      // maximum number of levels in locally refined grid
-REF_RATIO  = 2                                      // refinement ratio between levels
-N = 64                                              // actual    number of grid cells on coarsest grid level
+MAX_LEVELS = 3                                      // maximum number of levels in locally refined grid
+REF_RATIO  = 4                                      // refinement ratio between levels
+N = 32                                              // actual    number of grid cells on coarsest grid level
 NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N            // effective number of grid cells on finest   grid level
 DX0 = L/N                                           // mesh width on coarsest grid level
 DX  = L/NFINEST                                     // mesh width on finest   grid level
@@ -31,7 +31,7 @@ SOLVER_TYPE                = "STAGGERED"            // the fluid solver to use (
 CFL_MAX                    = 0.25                   // maximum CFL number
 DT                         = 0.25*CFL_MAX*DX/U_MAX  // maximum timestep size
 START_TIME                 = 0.0e0                  // initial simulation time
-END_TIME                   = 100*DT                   // final simulation time
+END_TIME                   = 10000*DT               // final simulation time
 GROW_DT                    = 2.0e0                  // growth factor for timesteps
 NUM_CYCLES                 = 1                      // number of cycles of fixed-point iteration
 CONVECTIVE_TS_TYPE         = "ADAMS_BASHFORTH"      // convective time stepping type
@@ -163,7 +163,7 @@ Main {
 
 // visualization dump parameters
    viz_writer                  = "VisIt","ExodusII"
-   viz_dump_interval           = int(0.125/DT)
+   viz_dump_interval           = 10
    viz_dump_dirname            = "viz_IB2d"
    visit_number_procs_per_file = 1
 
@@ -211,7 +211,7 @@ StandardTagAndInitialize {
 
 LoadBalancer {
    bin_pack_method     = "SPATIAL"
-   max_workload_factor = 1
+   max_workload_factor = 0.25
 }
 
 TimerManager{

--- a/ibtk/include/ibtk/BoxPartitioner.h
+++ b/ibtk/include/ibtk/BoxPartitioner.h
@@ -1,0 +1,93 @@
+// Filename: BoxPartitioner.h
+// Created on 6 Nov 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith, David Wells
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef included_IBTK_ibtk_boxpartitioner
+#define included_IBTK_ibtk_boxpartitioner
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibtk/PartitioningBox.h>
+
+#include <libmesh/partitioner.h>
+#include <libmesh/mesh_base.h>
+#include <libmesh/system.h>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+namespace IBTK
+{
+/*!
+ * @brief A libMesh partitioner that partitions a mesh based on
+ * PartitioningBox objects owned by each processor.
+ *
+ * IBAMR assumes that all Lagrangian structures exist on the finest level of
+ * the fluid mesh. This partitioner uses the data stored by the SAMRAI
+ * PatchHierarchy object (which is used, under most circumstances, to create
+ * the PartitioningBoxes object) to compute partitioning boxes corresponding
+ * to the locally owned fluid patches on the finest level: since these
+ * partition the part of the domain over which the structure exists, they can
+ * be used to partition the libMesh Mesh object across the MPI network. Put
+ * another way: this Partitioner uses Eulerian grid data to partition the
+ * structural meshes.
+ */
+class BoxPartitioner : public libMesh::Partitioner
+{
+public:
+    /// Constructor from a PartitioningBoxes instance.
+    BoxPartitioner(const PartitioningBoxes& partitioning_boxes);
+
+    /*!
+     * Constructor. This is like the other constructor that takes a
+     * PartitioningBoxes object, but it permits the use of a background mesh
+     * that is displaced by a vector finite element field.
+     *
+     * @param partitioning_boxes the boxes comprising the partition.
+     *
+     * @param position_system the libMesh::System object whose current
+     * solution is the position of the Mesh which will subsequently be
+     * partitioned.
+     */
+    BoxPartitioner(const PartitioningBoxes& partitioning_boxes,
+                   const libMesh::System &position_system);
+
+    virtual std::unique_ptr<libMesh::Partitioner> clone() const override;
+
+    virtual void _do_partition(libMesh::MeshBase& mesh, const unsigned int n) override;
+
+protected:
+    /// The PartitioningBoxes object used to establish whether or not an Elem
+    /// (via its centroid) or Node is owned by the current processor.
+    PartitioningBoxes d_partitioning_boxes;
+
+    /// Pointer, if relevant, to the libMesh mesh position system.
+    const libMesh::System* const d_position_system = nullptr;
+};
+} // namespace IBTK
+//////////////////////////////////////////////////////////////////////////////
+#endif //#ifndef included_IBTK_ibtk_boxpartitioner

--- a/ibtk/include/ibtk/BoxPartitioner.h
+++ b/ibtk/include/ibtk/BoxPartitioner.h
@@ -76,6 +76,17 @@ public:
     BoxPartitioner(const PartitioningBoxes& partitioning_boxes,
                    const libMesh::System &position_system);
 
+    /*!
+     * Write the partitioning to a file in a simple point-based format: for
+     * each patch several points are printed to the specified file in the
+     * format
+     *
+     * x,y,z,r
+     *
+     * format.
+     */
+    void writePartitioning(const std::string &file_name) const;
+
     virtual std::unique_ptr<libMesh::Partitioner> clone() const override;
 
     virtual void _do_partition(libMesh::MeshBase& mesh, const unsigned int n) override;

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -117,6 +117,17 @@ public:
         {
         }
 
+        inline ~SystemDofMapCache() = default;
+
+        /*!
+         * Clear the contents of the cache.
+         */
+        inline void
+        clear()
+        {
+            d_dof_cache.clear();
+        }
+
         /*!
          * Populate the vector @p dof_indices with the dofs corresponding to
          * variable @var on element @elem. The dof indices on each cell are

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -275,6 +275,10 @@ public:
 
     /*!
      * \brief Register a load balancer for non-uniform load balancing.
+     *
+     * @note This function is not intended for use in user codes and is
+     * usually called by an object, like IBFEMethod, that sets up
+     * FEDataManager objects.
      */
     void registerLoadBalancer(SAMRAI::tbox::Pointer<SAMRAI::mesh::LoadBalancer<NDIM> > load_balancer,
                               int workload_data_idx);

--- a/ibtk/include/ibtk/PartitioningBox.h
+++ b/ibtk/include/ibtk/PartitioningBox.h
@@ -123,6 +123,13 @@ public:
     /// otherwise.
     bool contains(const Point &point) const;
 
+    /// Return a pointer to the first partitioning box.
+    const PartitioningBox * begin() const;
+
+    /// Return a pointer to one past the end of the end of the partitioning
+    /// box array.
+    const PartitioningBox * end() const;
+
 protected:
     /// The partitioning box that bounds all other partitioning boxes.
     PartitioningBox d_bounding_partitioning_box;

--- a/ibtk/include/ibtk/PartitioningBox.h
+++ b/ibtk/include/ibtk/PartitioningBox.h
@@ -1,0 +1,141 @@
+// Filename: PartitioningBox.h
+// Created on 30 Oct 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith, David Wells
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef included_IBTK_ibtk_partitioningbox
+#define included_IBTK_ibtk_partitioningbox
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibtk/ibtk_utilities.h>
+
+#include <CartesianPatchGeometry.h>
+#include <PatchHierarchy.h>
+
+#include <utility>
+#include <vector>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+namespace IBTK
+{
+// TODO: move all code to a proper source file
+
+/*!
+ * \brief Class PartitioningBox implements an NDIM-dimensional bounding box
+ * defined by two points. Unlike a standard bounding box, a PartitioningBox is
+ * an <code>NDIM</code>-dimensional tensor product of half-open intervals:
+ * i.e., it is a half-open box. This property allows one to partition a domain
+ * into a set of boxes.
+ *
+ * It is possible for a partitioning box to be 'empty': in that case the
+ * bounds are [oo, oo) in each dimension.
+ */
+class PartitioningBox
+{
+public:
+    /// Default Constructor: an 'empty' partitioning box.
+    PartitioningBox();
+
+    /// Constructor.
+    PartitioningBox(const Point &bottom_point,
+                    const Point &top_point);
+
+    /// Constructor, starting from a SAMRAI data type.
+    PartitioningBox(const SAMRAI::geom::CartesianPatchGeometry<NDIM> &patch);
+
+    /// Get the bottom left corner of the box.
+    const Point &bottom() const;
+
+    /// Get the top right corner of the box. Note that this point is not in
+    /// the box.
+    const Point &top() const;
+
+    /// Return true if the point is inside the box and false otherwise.
+    bool contains(const Point &point) const;
+
+    /// Return the volume of the box. If the box is empty then this is zero.
+    double volume() const;
+
+protected:
+    /// bottom left and top right corners of the bounding box.
+    std::pair<Point, Point> d_bounding_points;
+};
+
+/*!
+ * \brief Class PartitioningBoxes stores a set of bounding boxes and can check
+ * if a point is in the set of partitioning boxes or not in a more optimized
+ * way than just looping over a std::vector<PartitioningBox>.
+ *
+ * It is possible for the set of bounding boxes to be empty: in that case the
+ * bounds are [oo, oo) in each dimension.
+ */
+class PartitioningBoxes
+{
+public:
+    /// Default constructor: an empty collection of partitioning boxes with
+    /// bounds at oo.
+    PartitioningBoxes() = default;
+
+    /// Constructor. Creates an object from a sequence of partitioning boxes.
+    template <typename ForwardIterator>
+    PartitioningBoxes(const ForwardIterator begin, const ForwardIterator end);
+
+    /// Constructor. Uses the finest level boxes on the provided
+    /// PatchHierarchy to create a set of bounding boxes.
+    PartitioningBoxes(const SAMRAI::hier::PatchHierarchy<NDIM> &hierarchy);
+
+    /// Get the bottom left corner of the partitioning box bounding all other
+    /// partitioning boxes.
+    const Point &bottom() const;
+
+    /// Get the top right corner of the partitioning box bounding all other
+    /// partitioning boxes. Note that this point is not in the collection of
+    /// boxes.
+    const Point &top() const;
+
+    /// Return true if the point is inside the set of boxes and false
+    /// otherwise.
+    bool contains(const Point &point) const;
+
+protected:
+    /// The partitioning box that bounds all other partitioning boxes.
+    PartitioningBox d_bounding_partitioning_box;
+
+    /// The set of bounding boxes.
+    std::vector<PartitioningBox> d_boxes;
+};
+} // namespace IBTK
+
+/////////////////////////////// INLINE ///////////////////////////////////////
+
+#include "ibtk/private/PartitioningBox-inl.h" // IWYU pragma: keep
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif //#ifndef included_IBTK_ibtk_partitioningbox

--- a/ibtk/include/ibtk/private/PartitioningBox-inl.h
+++ b/ibtk/include/ibtk/private/PartitioningBox-inl.h
@@ -106,6 +106,18 @@ inline const Point& PartitioningBoxes::top() const
     return d_bounding_partitioning_box.top();
 } // top
 
+inline
+const PartitioningBox* PartitioningBoxes::begin() const
+{
+    return d_boxes.data();
+}
+
+inline
+const PartitioningBox* PartitioningBoxes::end() const
+{
+    return d_boxes.data() + d_boxes.size();
+}
+
 inline bool PartitioningBoxes::contains(const Point &point) const
 {
     if (d_bounding_partitioning_box.contains(point))

--- a/ibtk/include/ibtk/private/PartitioningBox-inl.h
+++ b/ibtk/include/ibtk/private/PartitioningBox-inl.h
@@ -1,0 +1,133 @@
+// Filename: PartitioningBox-inl.h
+// Created on 06 Dec 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef included_IBTK_PartitioningBox_inl_h
+#define included_IBTK_PartitioningBox_inl_h
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include "ibtk/PartitioningBox.h"
+
+#include <algorithm>
+#include <limits>
+#include <type_traits>
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace IBTK
+{
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+inline const Point& PartitioningBox::bottom() const
+{
+    return d_bounding_points.first;
+} // bottom
+
+inline const Point& PartitioningBox::top() const
+{
+    return d_bounding_points.second;
+} // top
+
+inline bool PartitioningBox::contains(const Point &point) const
+{
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+        if (!(bottom()[dim_n] <= point[dim_n] && point[dim_n] < top()[dim_n]))
+            return false;
+    return true;
+} // contains
+
+template <typename ForwardIterator>
+inline PartitioningBoxes::PartitioningBoxes(const ForwardIterator begin, const ForwardIterator end)
+    : d_boxes(begin, end)
+{
+    static_assert(std::is_same<decltype(*begin), PartitioningBox &>::value ||
+                  std::is_same<decltype(*begin), const PartitioningBox &>::value,
+                  "The iterators should point to PartitioningBoxes");
+    if (begin != end)
+    {
+        IBTK::Point bottom;
+        IBTK::Point top;
+        for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+        {
+            bottom[dim_n] = std::min_element(
+                begin, end,
+                [=](const PartitioningBox &a,
+                    const PartitioningBox &b) -> bool
+                {
+                    return a.bottom()[dim_n] < b.bottom()[dim_n];
+                })->bottom()[dim_n];
+            top[dim_n] = std::max_element(
+                begin, end,
+                [=](const PartitioningBox &a,
+                    const PartitioningBox &b) -> bool
+                {
+                    return a.top()[dim_n] < b.top()[dim_n];
+                })->top()[dim_n];
+        }
+        d_bounding_partitioning_box = PartitioningBox(bottom, top);
+    }
+} // PartitioningBoxes
+
+inline const Point& PartitioningBoxes::bottom() const
+{
+    return d_bounding_partitioning_box.bottom();
+} // bottom
+
+inline const Point& PartitioningBoxes::top() const
+{
+    return d_bounding_partitioning_box.top();
+} // top
+
+inline bool PartitioningBoxes::contains(const Point &point) const
+{
+    if (d_bounding_partitioning_box.contains(point))
+    {
+        // TODO it would be vastly more efficient to store the collection of
+        // boxes in a tree structure so that we can search in logarithmic time
+        // instead of linear time.
+        for (const PartitioningBox& box : d_boxes)
+        {
+            if (box.contains(point))
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+} // contains
+
+//////////////////////////////////////////////////////////////////////////////
+
+} // namespace IBTK
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif //#ifndef included_IBTK_PartitioningBox_inl_h

--- a/ibtk/lib/Makefile.am
+++ b/ibtk/lib/Makefile.am
@@ -143,6 +143,7 @@ DIM_INDEPENDENT_SOURCES = \
 ../src/utilities/ParallelEdgeMap.cpp \
 ../src/utilities/ParallelMap.cpp \
 ../src/utilities/ParallelSet.cpp \
+../src/utilities/PartitioningBox.cpp \
 ../src/utilities/RefinePatchStrategySet.cpp \
 ../src/utilities/SideDataSynchronization.cpp \
 ../src/utilities/SideNoCornersFillPattern.cpp \
@@ -154,6 +155,7 @@ DIM_INDEPENDENT_SOURCES = \
 
 if LIBMESH_ENABLED
 DIM_INDEPENDENT_SOURCES += \
+../src/lagrangian/BoxPartitioner.cpp \
 ../src/lagrangian/FEDataInterpolation.cpp \
 ../src/lagrangian/FEDataManager.cpp \
 ../src/utilities/libmesh_utilities.cpp
@@ -272,6 +274,7 @@ pkg_include_HEADERS += \
 ../include/ibtk/ParallelEdgeMap.h \
 ../include/ibtk/ParallelMap.h \
 ../include/ibtk/ParallelSet.h \
+../include/ibtk/PartitioningBox.h \
 ../include/ibtk/PatchMathOps.h \
 ../include/ibtk/PhysicalBoundaryUtilities.h \
 ../include/ibtk/PoissonFACPreconditioner.h \
@@ -315,6 +318,7 @@ pkg_include_HEADERS += \
 
 if LIBMESH_ENABLED
 DIM_INDEPENDENT_SOURCES += \
+../include/lagrangian/BoxPartitioner.h \
 ../include/ibtk/FEDataInterpolation.h \
 ../include/ibtk/FEDataManager.h \
 ../include/ibtk/libmesh_utilities.h

--- a/ibtk/lib/Makefile.in
+++ b/ibtk/lib/Makefile.in
@@ -91,9 +91,12 @@ build_triplet = @build@
 host_triplet = @host@
 @SAMRAI2D_ENABLED_TRUE@am__append_1 = libIBTK2d.a
 @SAMRAI3D_ENABLED_TRUE@am__append_2 = libIBTK3d.a
-@LIBMESH_ENABLED_TRUE@am__append_3 = ../src/lagrangian/FEDataInterpolation.cpp \
+@LIBMESH_ENABLED_TRUE@am__append_3 =  \
+@LIBMESH_ENABLED_TRUE@	../src/lagrangian/BoxPartitioner.cpp \
+@LIBMESH_ENABLED_TRUE@	../src/lagrangian/FEDataInterpolation.cpp \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/FEDataManager.cpp \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libmesh_utilities.cpp \
+@LIBMESH_ENABLED_TRUE@	../include/lagrangian/BoxPartitioner.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/FEDataInterpolation.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/FEDataManager.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/libmesh_utilities.h
@@ -277,6 +280,7 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 	../src/utilities/ParallelEdgeMap.cpp \
 	../src/utilities/ParallelMap.cpp \
 	../src/utilities/ParallelSet.cpp \
+	../src/utilities/PartitioningBox.cpp \
 	../src/utilities/RefinePatchStrategySet.cpp \
 	../src/utilities/SideDataSynchronization.cpp \
 	../src/utilities/SideNoCornersFillPattern.cpp \
@@ -285,9 +289,11 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 	../src/utilities/Streamable.cpp \
 	../src/utilities/StreamableManager.cpp \
 	../src/utilities/muParserCartGridFunction.cpp \
+	../src/lagrangian/BoxPartitioner.cpp \
 	../src/lagrangian/FEDataInterpolation.cpp \
 	../src/lagrangian/FEDataManager.cpp \
 	../src/utilities/libmesh_utilities.cpp \
+	../include/lagrangian/BoxPartitioner.h \
 	../include/ibtk/FEDataInterpolation.h \
 	../include/ibtk/FEDataManager.h \
 	../include/ibtk/libmesh_utilities.h \
@@ -311,7 +317,8 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 	$(top_builddir)/src/refine_ops/fortran/cart_side_refine2d.f \
 	$(top_builddir)/src/refine_ops/fortran/divpreservingrefine2d.f \
 	$(top_builddir)/src/solvers/impls/fortran/patchsmoothers2d.f
-@LIBMESH_ENABLED_TRUE@am__objects_1 = ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@am__objects_1 = ../src/lagrangian/libIBTK2d_a-BoxPartitioner.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK2d_a-FEDataInterpolation.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK2d_a-FEDataManager.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK2d_a-libmesh_utilities.$(OBJEXT)
 am__objects_2 = ../src/boundary/libIBTK2d_a-HierarchyGhostCellInterpolation.$(OBJEXT) \
@@ -424,6 +431,7 @@ am__objects_2 = ../src/boundary/libIBTK2d_a-HierarchyGhostCellInterpolation.$(OB
 	../src/utilities/libIBTK2d_a-ParallelEdgeMap.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-ParallelMap.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-ParallelSet.$(OBJEXT) \
+	../src/utilities/libIBTK2d_a-PartitioningBox.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-RefinePatchStrategySet.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-SideDataSynchronization.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-SideNoCornersFillPattern.$(OBJEXT) \
@@ -563,6 +571,7 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 	../src/utilities/ParallelEdgeMap.cpp \
 	../src/utilities/ParallelMap.cpp \
 	../src/utilities/ParallelSet.cpp \
+	../src/utilities/PartitioningBox.cpp \
 	../src/utilities/RefinePatchStrategySet.cpp \
 	../src/utilities/SideDataSynchronization.cpp \
 	../src/utilities/SideNoCornersFillPattern.cpp \
@@ -571,9 +580,11 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 	../src/utilities/Streamable.cpp \
 	../src/utilities/StreamableManager.cpp \
 	../src/utilities/muParserCartGridFunction.cpp \
+	../src/lagrangian/BoxPartitioner.cpp \
 	../src/lagrangian/FEDataInterpolation.cpp \
 	../src/lagrangian/FEDataManager.cpp \
 	../src/utilities/libmesh_utilities.cpp \
+	../include/lagrangian/BoxPartitioner.h \
 	../include/ibtk/FEDataInterpolation.h \
 	../include/ibtk/FEDataManager.h \
 	../include/ibtk/libmesh_utilities.h \
@@ -597,7 +608,8 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 	$(top_builddir)/src/refine_ops/fortran/cart_side_refine3d.f \
 	$(top_builddir)/src/refine_ops/fortran/divpreservingrefine3d.f \
 	$(top_builddir)/src/solvers/impls/fortran/patchsmoothers3d.f
-@LIBMESH_ENABLED_TRUE@am__objects_3 = ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@am__objects_3 = ../src/lagrangian/libIBTK3d_a-BoxPartitioner.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK3d_a-FEDataInterpolation.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK3d_a-FEDataManager.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK3d_a-libmesh_utilities.$(OBJEXT)
 am__objects_4 = ../src/boundary/libIBTK3d_a-HierarchyGhostCellInterpolation.$(OBJEXT) \
@@ -710,6 +722,7 @@ am__objects_4 = ../src/boundary/libIBTK3d_a-HierarchyGhostCellInterpolation.$(OB
 	../src/utilities/libIBTK3d_a-ParallelEdgeMap.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-ParallelMap.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-ParallelSet.$(OBJEXT) \
+	../src/utilities/libIBTK3d_a-PartitioningBox.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-RefinePatchStrategySet.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-SideDataSynchronization.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-SideNoCornersFillPattern.$(OBJEXT) \
@@ -788,6 +801,7 @@ am__depfiles_remade = ../src/boundary/$(DEPDIR)/libIBTK2d_a-HierarchyGhostCellIn
 	../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleCubicCoarsen.Po \
 	../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleRT0Coarsen.Po \
 	../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-LMarkerCoarsen.Po \
+	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataInterpolation.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataManager.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LData.Po \
@@ -808,6 +822,7 @@ am__depfiles_remade = ../src/boundary/$(DEPDIR)/libIBTK2d_a-HierarchyGhostCellIn
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSetVariable.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSiloDataWriter.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LTransaction.Po \
+	../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataInterpolation.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataManager.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK3d_a-LData.Po \
@@ -958,6 +973,7 @@ am__depfiles_remade = ../src/boundary/$(DEPDIR)/libIBTK2d_a-HierarchyGhostCellIn
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelEdgeMap.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelMap.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelSet.Po \
+	../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-SideDataSynchronization.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-SideNoCornersFillPattern.Po \
@@ -989,6 +1005,7 @@ am__depfiles_remade = ../src/boundary/$(DEPDIR)/libIBTK2d_a-HierarchyGhostCellIn
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelEdgeMap.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelMap.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelSet.Po \
+	../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-SideDataSynchronization.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-SideNoCornersFillPattern.Po \
@@ -1499,6 +1516,7 @@ pkg_include_HEADERS = ../include/ibtk/IBTK_CHKERRQ.h \
 	../include/ibtk/PETScVecUtilities.h \
 	../include/ibtk/ParallelEdgeMap.h \
 	../include/ibtk/ParallelMap.h ../include/ibtk/ParallelSet.h \
+	../include/ibtk/PartitioningBox.h \
 	../include/ibtk/PatchMathOps.h \
 	../include/ibtk/PhysicalBoundaryUtilities.h \
 	../include/ibtk/PoissonFACPreconditioner.h \
@@ -1645,6 +1663,7 @@ DIM_INDEPENDENT_SOURCES =  \
 	../src/utilities/ParallelEdgeMap.cpp \
 	../src/utilities/ParallelMap.cpp \
 	../src/utilities/ParallelSet.cpp \
+	../src/utilities/PartitioningBox.cpp \
 	../src/utilities/RefinePatchStrategySet.cpp \
 	../src/utilities/SideDataSynchronization.cpp \
 	../src/utilities/SideNoCornersFillPattern.cpp \
@@ -2174,6 +2193,9 @@ libIBTK.a: $(libIBTK_a_OBJECTS) $(libIBTK_a_DEPENDENCIES) $(EXTRA_libIBTK_a_DEPE
 ../src/utilities/libIBTK2d_a-ParallelSet.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/libIBTK2d_a-PartitioningBox.$(OBJEXT):  \
+	../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 ../src/utilities/libIBTK2d_a-RefinePatchStrategySet.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
@@ -2198,6 +2220,9 @@ libIBTK.a: $(libIBTK_a_OBJECTS) $(libIBTK_a_DEPENDENCIES) $(EXTRA_libIBTK_a_DEPE
 ../src/utilities/libIBTK2d_a-muParserCartGridFunction.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/lagrangian/libIBTK2d_a-BoxPartitioner.$(OBJEXT):  \
+	../src/lagrangian/$(am__dirstamp) \
+	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
 ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.$(OBJEXT):  \
 	../src/lagrangian/$(am__dirstamp) \
 	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
@@ -2635,6 +2660,9 @@ libIBTK2d.a: $(libIBTK2d_a_OBJECTS) $(libIBTK2d_a_DEPENDENCIES) $(EXTRA_libIBTK2
 ../src/utilities/libIBTK3d_a-ParallelSet.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/libIBTK3d_a-PartitioningBox.$(OBJEXT):  \
+	../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 ../src/utilities/libIBTK3d_a-RefinePatchStrategySet.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
@@ -2659,6 +2687,9 @@ libIBTK2d.a: $(libIBTK2d_a_OBJECTS) $(libIBTK2d_a_DEPENDENCIES) $(EXTRA_libIBTK2
 ../src/utilities/libIBTK3d_a-muParserCartGridFunction.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/lagrangian/libIBTK3d_a-BoxPartitioner.$(OBJEXT):  \
+	../src/lagrangian/$(am__dirstamp) \
+	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
 ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.$(OBJEXT):  \
 	../src/lagrangian/$(am__dirstamp) \
 	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
@@ -2787,6 +2818,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleCubicCoarsen.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleRT0Coarsen.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-LMarkerCoarsen.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataInterpolation.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataManager.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LData.Po@am__quote@ # am--include-marker
@@ -2807,6 +2839,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSetVariable.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSiloDataWriter.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LTransaction.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataInterpolation.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataManager.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK3d_a-LData.Po@am__quote@ # am--include-marker
@@ -2957,6 +2990,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelEdgeMap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelMap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelSet.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-SideDataSynchronization.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-SideNoCornersFillPattern.Po@am__quote@ # am--include-marker
@@ -2988,6 +3022,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelEdgeMap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelMap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelSet.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-SideDataSynchronization.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-SideNoCornersFillPattern.Po@am__quote@ # am--include-marker
@@ -4568,6 +4603,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-ParallelSet.obj `if test -f '../src/utilities/ParallelSet.cpp'; then $(CYGPATH_W) '../src/utilities/ParallelSet.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/ParallelSet.cpp'; fi`
 
+../src/utilities/libIBTK2d_a-PartitioningBox.o: ../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-PartitioningBox.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Tpo -c -o ../src/utilities/libIBTK2d_a-PartitioningBox.o `test -f '../src/utilities/PartitioningBox.cpp' || echo '$(srcdir)/'`../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/PartitioningBox.cpp' object='../src/utilities/libIBTK2d_a-PartitioningBox.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-PartitioningBox.o `test -f '../src/utilities/PartitioningBox.cpp' || echo '$(srcdir)/'`../src/utilities/PartitioningBox.cpp
+
+../src/utilities/libIBTK2d_a-PartitioningBox.obj: ../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-PartitioningBox.obj -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Tpo -c -o ../src/utilities/libIBTK2d_a-PartitioningBox.obj `if test -f '../src/utilities/PartitioningBox.cpp'; then $(CYGPATH_W) '../src/utilities/PartitioningBox.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/PartitioningBox.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/PartitioningBox.cpp' object='../src/utilities/libIBTK2d_a-PartitioningBox.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-PartitioningBox.obj `if test -f '../src/utilities/PartitioningBox.cpp'; then $(CYGPATH_W) '../src/utilities/PartitioningBox.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/PartitioningBox.cpp'; fi`
+
 ../src/utilities/libIBTK2d_a-RefinePatchStrategySet.o: ../src/utilities/RefinePatchStrategySet.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-RefinePatchStrategySet.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Tpo -c -o ../src/utilities/libIBTK2d_a-RefinePatchStrategySet.o `test -f '../src/utilities/RefinePatchStrategySet.cpp' || echo '$(srcdir)/'`../src/utilities/RefinePatchStrategySet.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Po
@@ -4679,6 +4728,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/muParserCartGridFunction.cpp' object='../src/utilities/libIBTK2d_a-muParserCartGridFunction.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-muParserCartGridFunction.obj `if test -f '../src/utilities/muParserCartGridFunction.cpp'; then $(CYGPATH_W) '../src/utilities/muParserCartGridFunction.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/muParserCartGridFunction.cpp'; fi`
+
+../src/lagrangian/libIBTK2d_a-BoxPartitioner.o: ../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK2d_a-BoxPartitioner.o -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Tpo -c -o ../src/lagrangian/libIBTK2d_a-BoxPartitioner.o `test -f '../src/lagrangian/BoxPartitioner.cpp' || echo '$(srcdir)/'`../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Tpo ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/lagrangian/BoxPartitioner.cpp' object='../src/lagrangian/libIBTK2d_a-BoxPartitioner.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK2d_a-BoxPartitioner.o `test -f '../src/lagrangian/BoxPartitioner.cpp' || echo '$(srcdir)/'`../src/lagrangian/BoxPartitioner.cpp
+
+../src/lagrangian/libIBTK2d_a-BoxPartitioner.obj: ../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK2d_a-BoxPartitioner.obj -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Tpo -c -o ../src/lagrangian/libIBTK2d_a-BoxPartitioner.obj `if test -f '../src/lagrangian/BoxPartitioner.cpp'; then $(CYGPATH_W) '../src/lagrangian/BoxPartitioner.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/BoxPartitioner.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Tpo ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/lagrangian/BoxPartitioner.cpp' object='../src/lagrangian/libIBTK2d_a-BoxPartitioner.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK2d_a-BoxPartitioner.obj `if test -f '../src/lagrangian/BoxPartitioner.cpp'; then $(CYGPATH_W) '../src/lagrangian/BoxPartitioner.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/BoxPartitioner.cpp'; fi`
 
 ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.o: ../src/lagrangian/FEDataInterpolation.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.o -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataInterpolation.Tpo -c -o ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.o `test -f '../src/lagrangian/FEDataInterpolation.cpp' || echo '$(srcdir)/'`../src/lagrangian/FEDataInterpolation.cpp
@@ -6262,6 +6325,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-ParallelSet.obj `if test -f '../src/utilities/ParallelSet.cpp'; then $(CYGPATH_W) '../src/utilities/ParallelSet.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/ParallelSet.cpp'; fi`
 
+../src/utilities/libIBTK3d_a-PartitioningBox.o: ../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-PartitioningBox.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Tpo -c -o ../src/utilities/libIBTK3d_a-PartitioningBox.o `test -f '../src/utilities/PartitioningBox.cpp' || echo '$(srcdir)/'`../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/PartitioningBox.cpp' object='../src/utilities/libIBTK3d_a-PartitioningBox.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-PartitioningBox.o `test -f '../src/utilities/PartitioningBox.cpp' || echo '$(srcdir)/'`../src/utilities/PartitioningBox.cpp
+
+../src/utilities/libIBTK3d_a-PartitioningBox.obj: ../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-PartitioningBox.obj -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Tpo -c -o ../src/utilities/libIBTK3d_a-PartitioningBox.obj `if test -f '../src/utilities/PartitioningBox.cpp'; then $(CYGPATH_W) '../src/utilities/PartitioningBox.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/PartitioningBox.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/PartitioningBox.cpp' object='../src/utilities/libIBTK3d_a-PartitioningBox.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-PartitioningBox.obj `if test -f '../src/utilities/PartitioningBox.cpp'; then $(CYGPATH_W) '../src/utilities/PartitioningBox.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/PartitioningBox.cpp'; fi`
+
 ../src/utilities/libIBTK3d_a-RefinePatchStrategySet.o: ../src/utilities/RefinePatchStrategySet.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-RefinePatchStrategySet.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Tpo -c -o ../src/utilities/libIBTK3d_a-RefinePatchStrategySet.o `test -f '../src/utilities/RefinePatchStrategySet.cpp' || echo '$(srcdir)/'`../src/utilities/RefinePatchStrategySet.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Po
@@ -6373,6 +6450,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/muParserCartGridFunction.cpp' object='../src/utilities/libIBTK3d_a-muParserCartGridFunction.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-muParserCartGridFunction.obj `if test -f '../src/utilities/muParserCartGridFunction.cpp'; then $(CYGPATH_W) '../src/utilities/muParserCartGridFunction.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/muParserCartGridFunction.cpp'; fi`
+
+../src/lagrangian/libIBTK3d_a-BoxPartitioner.o: ../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK3d_a-BoxPartitioner.o -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Tpo -c -o ../src/lagrangian/libIBTK3d_a-BoxPartitioner.o `test -f '../src/lagrangian/BoxPartitioner.cpp' || echo '$(srcdir)/'`../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Tpo ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/lagrangian/BoxPartitioner.cpp' object='../src/lagrangian/libIBTK3d_a-BoxPartitioner.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK3d_a-BoxPartitioner.o `test -f '../src/lagrangian/BoxPartitioner.cpp' || echo '$(srcdir)/'`../src/lagrangian/BoxPartitioner.cpp
+
+../src/lagrangian/libIBTK3d_a-BoxPartitioner.obj: ../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK3d_a-BoxPartitioner.obj -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Tpo -c -o ../src/lagrangian/libIBTK3d_a-BoxPartitioner.obj `if test -f '../src/lagrangian/BoxPartitioner.cpp'; then $(CYGPATH_W) '../src/lagrangian/BoxPartitioner.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/BoxPartitioner.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Tpo ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/lagrangian/BoxPartitioner.cpp' object='../src/lagrangian/libIBTK3d_a-BoxPartitioner.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK3d_a-BoxPartitioner.obj `if test -f '../src/lagrangian/BoxPartitioner.cpp'; then $(CYGPATH_W) '../src/lagrangian/BoxPartitioner.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/BoxPartitioner.cpp'; fi`
 
 ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.o: ../src/lagrangian/FEDataInterpolation.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.o -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataInterpolation.Tpo -c -o ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.o `test -f '../src/lagrangian/FEDataInterpolation.cpp' || echo '$(srcdir)/'`../src/lagrangian/FEDataInterpolation.cpp
@@ -6649,6 +6740,7 @@ distclean: distclean-am
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleCubicCoarsen.Po
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleRT0Coarsen.Po
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-LMarkerCoarsen.Po
+	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataInterpolation.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataManager.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LData.Po
@@ -6669,6 +6761,7 @@ distclean: distclean-am
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSetVariable.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSiloDataWriter.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LTransaction.Po
+	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataInterpolation.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataManager.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-LData.Po
@@ -6819,6 +6912,7 @@ distclean: distclean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelEdgeMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-SideDataSynchronization.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-SideNoCornersFillPattern.Po
@@ -6850,6 +6944,7 @@ distclean: distclean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelEdgeMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-SideDataSynchronization.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-SideNoCornersFillPattern.Po
@@ -6936,6 +7031,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleCubicCoarsen.Po
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleRT0Coarsen.Po
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-LMarkerCoarsen.Po
+	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataInterpolation.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataManager.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LData.Po
@@ -6956,6 +7052,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSetVariable.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSiloDataWriter.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LTransaction.Po
+	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataInterpolation.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataManager.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-LData.Po
@@ -7106,6 +7203,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelEdgeMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-SideDataSynchronization.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-SideNoCornersFillPattern.Po
@@ -7137,6 +7235,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelEdgeMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-SideDataSynchronization.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-SideNoCornersFillPattern.Po

--- a/ibtk/src/lagrangian/BoxPartitioner.cpp
+++ b/ibtk/src/lagrangian/BoxPartitioner.cpp
@@ -1,0 +1,250 @@
+// Filename: BoxPartitioner.cpp
+// Created on 6 Dec 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibtk/BoxPartitioner.h>
+#include <ibtk/PartitioningBox.h>
+
+#include <libmesh/elem.h>
+#include <libmesh/mesh_base.h>
+#include <libmesh/node.h>
+#include <libmesh/numeric_vector.h>
+#include <libmesh/point.h>
+
+#include <tbox/SAMRAI_MPI.h>
+
+#include <algorithm>
+#include <vector>
+
+#include <mpi.h>
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace IBTK
+{
+/////////////////////////////// STATIC ///////////////////////////////////////
+
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+
+BoxPartitioner::BoxPartitioner(const PartitioningBoxes& bounding_boxes)
+    : d_partitioning_boxes(bounding_boxes)
+{
+} // BoxPartitioner
+
+BoxPartitioner::BoxPartitioner(const PartitioningBoxes& bounding_boxes,
+                               const libMesh::System &position_system)
+    : d_partitioning_boxes(bounding_boxes),
+      d_position_system(&position_system)
+{
+} // BoxPartitioner
+
+std::unique_ptr<libMesh::Partitioner> BoxPartitioner::clone() const
+{
+    return std::unique_ptr<libMesh::Partitioner>(new BoxPartitioner(d_partitioning_boxes,
+                                                                    *d_position_system));
+} // clone
+
+void BoxPartitioner::_do_partition(libMesh::MeshBase& mesh, const unsigned int n)
+{
+    // We assume every cell is on every processor
+    TBOX_ASSERT(mesh.is_replicated());
+    // only implemented when we use SAMRAI's partitioning
+    TBOX_ASSERT(n == static_cast<unsigned int>(SAMRAI::tbox::SAMRAI_MPI::getNodes()));
+
+    // convert the libMesh type to an MPI type
+    MPI_Datatype pid_integral_type = 0;
+    switch (sizeof(libMesh::processor_id_type))
+    {
+    case 1:
+        pid_integral_type = MPI_UNSIGNED_CHAR;
+        break;
+    case 2:
+        pid_integral_type = MPI_UNSIGNED_SHORT;
+        break;
+    case 4:
+        pid_integral_type = MPI_UNSIGNED;
+        break;
+    case 8:
+        pid_integral_type = MPI_UNSIGNED_LONG;
+        break;
+    }
+
+    const int current_rank = SAMRAI::tbox::SAMRAI_MPI::getRank();
+    auto to_ibtk_point = [](const libMesh::Point& p) -> IBTK::Point
+    {
+        IBTK::Point point;
+        for (unsigned int d = 0; d < NDIM; ++d)
+            point[d] = p(d);
+        return point;
+    };
+
+    // TODO this partitioning algorithm is not scalable since every processor
+    // looks at every cell. This will ultimately be replaced by an approach
+    // driven by SAMRAI, where SAMRAI propagates nodes and cells in a
+    // particle-like fashion.
+    //
+    // Step 0: determine the current location of the Mesh nodes.
+    const bool use_position_vector = d_position_system != nullptr;
+    const unsigned int position_system_n = use_position_vector
+        ? d_position_system->number() : 0;
+    std::vector<double> position;
+    if (use_position_vector)
+    {
+        TBOX_ASSERT(&d_position_system->get_mesh() == &mesh);
+        libMesh::NumericVector<double> *position_solution
+            = d_position_system->solution.get();
+        position.resize(position_solution->size());
+        position_solution->localize(position);
+    }
+    std::vector<libMesh::Point> node_positions(mesh.parallel_n_nodes());
+    std::size_t node_n = 0;
+    for (auto node_it = mesh.nodes_begin(); node_it != mesh.nodes_end(); ++node_it)
+    {
+        const libMesh::Node* const node = *node_it;
+        TBOX_ASSERT(node->id() == node_n);
+        libMesh::Point node_position;
+        if (use_position_vector)
+        {
+            if (node->n_vars(position_system_n))
+            {
+                TBOX_ASSERT(node->n_vars(position_system_n) == NDIM);
+                for (unsigned int d = 0; d < NDIM; ++d)
+                {
+                    node_position(d)
+                        = position[node->dof_number(position_system_n, d, 0)];
+                }
+            }
+        }
+        else
+        {
+            node_position = *node;
+        }
+        node_positions[node_n] = node_position;
+        ++node_n;
+    }
+    TBOX_ASSERT(node_n == node_positions.size());
+
+    // Step 1: determine which elements belong to which processor and
+    // communicate the partitioning information across the network.
+    //
+    // We offset the processor ids by 1 so that we can check, by summation,
+    // that each Elem and Node is given exactly one processor id.
+    std::vector<libMesh::processor_id_type> elem_ids(mesh.parallel_n_elem());
+    std::vector<libMesh::dof_id_type> local_elem_ids;
+    std::size_t elem_n = 0;
+    const auto end_elem = mesh.active_elements_end();
+    for (auto elem = mesh.active_elements_begin(); elem != end_elem; ++elem)
+    {
+        libMesh::Point centroid;
+        const unsigned int n_nodes = (*elem)->n_nodes();
+        for (unsigned int node_n = 0; node_n < n_nodes; ++node_n)
+        {
+            centroid += node_positions[(*elem)->node_id(node_n)];
+        }
+        centroid *= 1.0/n_nodes;
+
+        if (d_partitioning_boxes.contains(to_ibtk_point(centroid)))
+        {
+            local_elem_ids.push_back(elem_n);
+            TBOX_ASSERT(elem_n < elem_ids.size());
+            elem_ids[elem_n] = current_rank + 1;
+        }
+        ++elem_n;
+    }
+
+    std::vector<libMesh::processor_id_type> node_ids(mesh.parallel_n_nodes());
+    std::vector<libMesh::dof_id_type> local_node_ids;
+    node_n = 0;
+    const auto end_node = mesh.active_nodes_end();
+    for (auto node = mesh.active_nodes_begin(); node != end_node; ++node)
+    {
+        if (d_partitioning_boxes.contains(to_ibtk_point(node_positions[node_n])))
+        {
+            local_node_ids.push_back(node_n);
+            TBOX_ASSERT(node_n < node_ids.size());
+            node_ids[node_n] = current_rank + 1;
+        }
+        ++node_n;
+    }
+
+    // step 2: communicate the partitioning across all processors:
+    int ierr = MPI_Allreduce(
+        MPI_IN_PLACE, elem_ids.data(), elem_ids.size(), pid_integral_type,
+        MPI_SUM, SAMRAI::tbox::SAMRAI_MPI::commWorld);
+    TBOX_ASSERT(ierr == 0);
+    ierr = MPI_Allreduce(
+        MPI_IN_PLACE, node_ids.data(), node_ids.size(), pid_integral_type,
+        MPI_SUM, SAMRAI::tbox::SAMRAI_MPI::commWorld);
+    TBOX_ASSERT(ierr == 0);
+
+    // step 3: verify that we partitioned each elem and node exactly once:
+    for (const libMesh::dof_id_type id : local_elem_ids)
+    {
+        TBOX_ASSERT(id < elem_ids.size());
+        TBOX_ASSERT(elem_ids[id] == current_rank + 1);
+    }
+    for (const libMesh::dof_id_type id : local_node_ids)
+    {
+        TBOX_ASSERT(id < node_ids.size());
+        TBOX_ASSERT(node_ids[id] == current_rank + 1);
+    }
+
+    TBOX_ASSERT(std::find(elem_ids.begin(), elem_ids.end(), 0) == elem_ids.end());
+    TBOX_ASSERT(std::find(node_ids.begin(), node_ids.end(), 0) == node_ids.end());
+
+    // Step 4: label all elements and nodes with the correct processor id.
+    elem_n = 0;
+    for (auto elem = mesh.active_elements_begin(); elem != end_elem; ++elem)
+    {
+        TBOX_ASSERT(elem_n < elem_ids.size());
+        (*elem)->processor_id() = elem_ids[elem_n] - 1;
+        ++elem_n;
+    }
+
+    node_n = 0;
+    for (auto node = mesh.active_nodes_begin(); node != end_node; ++node)
+    {
+        TBOX_ASSERT(node_n < node_ids.size());
+        (*node)->processor_id() = node_ids[node_n] - 1;
+        ++node_n;
+    }
+} // _do_partition
+
+/////////////////////////////// PROTECTED ////////////////////////////////////
+
+/////////////////////////////// PRIVATE //////////////////////////////////////
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+} // namespace IBTK
+
+/////////////////////////////////////////////////////////////////////////////

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -2110,6 +2110,10 @@ FEDataManager::updateWorkloadEstimates(const int coarsest_ln_in, const int fines
 
     IBTK_TIMER_START(t_update_workload_estimates);
 
+    // Set a default value of 1 for all cells. We will add into this below.
+    HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(d_hierarchy);
+    hier_cc_data_ops.setToScalar(d_workload_idx, 1.0, /*interior_only*/ false);
+
     const int coarsest_ln = (coarsest_ln_in == -1) ? d_coarsest_ln : coarsest_ln_in;
     const int finest_ln = (finest_ln_in == -1) ? d_finest_ln : finest_ln_in;
     TBOX_ASSERT(coarsest_ln >= d_coarsest_ln && coarsest_ln <= d_finest_ln);
@@ -2412,7 +2416,7 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
         const Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
         if (!level->checkAllocated(d_qp_count_idx)) level->allocatePatchData(d_qp_count_idx);
         HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(d_hierarchy, ln, ln);
-        hier_cc_data_ops.setToScalar(d_qp_count_idx, 0.0);
+        hier_cc_data_ops.setToScalar(d_qp_count_idx, 0.0, /*interior_only*/ false);
         if (ln != d_level_number) continue;
 
         // Extract the mesh.

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -421,11 +421,20 @@ FEDataManager::reinitElementMappings()
 {
     IBTK_TIMER_START(t_reinit_element_mappings);
 
+    // We reinitialize mappings after repartitioning, so clear the cache since
+    // most of its content is no longer relevant:
+    for (std::pair<const unsigned int, std::unique_ptr<SystemDofMapCache> > &pair
+             : d_system_dof_map_cache)
+    {
+        pair.second->clear();
+    }
+
     // Delete cached hierarchy-dependent data.
     d_active_patch_elem_map.clear();
     d_active_patch_node_map.clear();
     d_active_patch_ghost_dofs.clear();
     d_system_ghost_vec.clear();
+
 
     // Reset the mappings between grid patches and active mesh elements.
     collectActivePatchElements(d_active_patch_elem_map, d_level_number, d_ghost_width);

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -2485,7 +2485,7 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
                 {
                     interpolate(&X_qp[0], qp, X_node, phi);
                     const Index<NDIM> i = IndexUtilities::getCellIndex(X_qp, grid_geom, ratio);
-                    if (patch_box.contains(i)) (*qp_count_data)(i) += 1.0;
+                    if (patch_box.contains(i)) (*qp_count_data)(i) += 10.0;
                 }
             }
         }

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -416,6 +416,13 @@ FEDataManager::getActivePatchNodeMap() const
     return d_active_patch_node_map;
 } // getActivePatchNodeMap
 
+// TODO: reinitElementMappings is now doing two related, but separate, things:
+// it figures out which libMesh elems are locally relevant (after solving for
+// new system coordinates) and also resets all data related to
+// partitioning. It should be possible to improve performance by splitting
+// what is done here into something that does what the original version did
+// (i.e., assume no repartitioning) and a second function that clears data
+// that is stale after repartitioning.
 void
 FEDataManager::reinitElementMappings()
 {
@@ -433,8 +440,13 @@ FEDataManager::reinitElementMappings()
     d_active_patch_elem_map.clear();
     d_active_patch_node_map.clear();
     d_active_patch_ghost_dofs.clear();
+    d_active_elem_bboxes.clear();
     d_system_ghost_vec.clear();
 
+    // also clear any stored matrices:
+    d_L2_proj_solver.clear();
+    d_L2_proj_matrix.clear();
+    d_L2_proj_matrix_diag.clear();
 
     // Reset the mappings between grid patches and active mesh elements.
     collectActivePatchElements(d_active_patch_elem_map, d_level_number, d_ghost_width);

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -2167,7 +2167,7 @@ FEDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> > hi
     TBOX_ASSERT((level_number >= 0) && (level_number <= hierarchy->getFinestLevelNumber()));
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
 
-    if (initial_time)
+    if (true) // TODO when may we reuse cached data?
     {
         // Determine the active elements associated with the prescribed patch
         // level.
@@ -2590,8 +2590,17 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
     // processor will have access to all of the element bounding boxes.  This is
     // not a scalable approach, but we won't worry about this until it becomes
     // an actual issue.
+    //
+    // TODO: rewrite this function to use the new bounding box class instead
+    // of the present ad-hoc std::pair<Point, Point> implementation.
     computeActiveElementBoundingBoxes();
-    int local_patch_num = 0;
+
+    // Find all libMesh elements whose bounding boxes are within the patch.
+    //
+    // TODO: it should be possible to remove this once we partition libMesh
+    // cells based on SAMRAI data. Put another way: frontier_elems will, by
+    // construction, contain all locally owned cells.
+    unsigned int local_patch_num = 0;
     for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++local_patch_num)
     {
         std::set<Elem*>& frontier_elems = frontier_patch_elems[local_patch_num];

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -2104,7 +2104,9 @@ FEDataManager::updateSpreadQuadratureRule(std::unique_ptr<QBase>& qrule,
 void
 FEDataManager::updateWorkloadEstimates(const int coarsest_ln_in, const int finest_ln_in)
 {
-    if (!d_load_balancer) return;
+    if (d_workload_idx == IBTK::invalid_index) return;
+
+    reinitElementMappings();
 
     IBTK_TIMER_START(t_update_workload_estimates);
 

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -532,6 +532,7 @@ HierarchyIntegrator::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_bala
         d_workload_var = new CellVariable<NDIM, double>(d_object_name + "::workload");
         registerVariable(d_workload_idx, d_workload_var, 0, getCurrentContext());
     }
+    d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx);
     return;
 } // registerLoadBalancer
 

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -539,6 +539,11 @@ void
 HierarchyIntegrator::registerVisItDataWriter(Pointer<VisItDataWriter<NDIM> > visit_writer)
 {
     d_visit_writer = visit_writer;
+    if (d_workload_idx != IBTK::invalid_index)
+    {
+        d_visit_writer->registerPlotQuantity(d_object_name + "::workload", "SCALAR", d_workload_idx);
+    }
+
     for (const auto& child_integrator : d_child_integrators)
     {
         child_integrator->registerVisItDataWriter(visit_writer);

--- a/ibtk/src/utilities/PartitioningBox.cpp
+++ b/ibtk/src/utilities/PartitioningBox.cpp
@@ -1,0 +1,124 @@
+// Filename: PartitioningBox.cpp
+// Created on 06 Dec 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith, David Wells
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibtk/ibtk_utilities.h>
+#include <ibtk/PartitioningBox.h>
+
+#include <CartesianPatchGeometry.h>
+
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+namespace IBTK
+{
+PartitioningBox::PartitioningBox()
+{
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+    {
+        d_bounding_points.first[dim_n] = std::numeric_limits<double>::infinity();
+        d_bounding_points.second[dim_n] = std::numeric_limits<double>::infinity();
+    }
+} // PartitioningBox
+
+PartitioningBox::PartitioningBox(const Point &bottom_point,
+                                 const Point &top_point)
+    : d_bounding_points(bottom_point, top_point)
+{
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+    {
+        // Do not permit negative volume boxes
+        TBOX_ASSERT(bottom()[dim_n] <= top()[dim_n]);
+    }
+} // PartitioningBox
+
+PartitioningBox::PartitioningBox(const SAMRAI::geom::CartesianPatchGeometry<NDIM> &patch)
+{
+    std::copy(patch.getXLower(), patch.getXLower() + NDIM,
+              d_bounding_points.first.data());
+    std::copy(patch.getXUpper(), patch.getXUpper() + NDIM,
+              d_bounding_points.second.data());
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+    {
+        // Do not permit negative volume boxes
+        TBOX_ASSERT(bottom()[dim_n] <= top()[dim_n]);
+    }
+} // PartitioningBox
+
+double PartitioningBox::volume() const
+{
+    // The bounds may be infinite: check for point equality first to avoid
+    // evaluating oo - oo
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+    {
+        if (d_bounding_points.first[dim_n] == d_bounding_points.second[dim_n])
+            return 0.0;
+    }
+    double vol = 1.0;
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+    {
+        vol *= d_bounding_points.second[dim_n] - d_bounding_points.first[dim_n];
+    }
+    return vol;
+} // volume
+
+namespace
+{
+    std::vector<IBTK::PartitioningBox>
+    get_partitioning_boxes(const SAMRAI::hier::PatchHierarchy<NDIM> &patch_hierarchy)
+    {
+        std::vector<IBTK::PartitioningBox> boxes;
+        const int finest_level = patch_hierarchy.getFinestLevelNumber();
+        SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM> > level
+            = patch_hierarchy.getPatchLevel(finest_level);
+        for (SAMRAI::hier::PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            const SAMRAI::hier::Patch<NDIM>& patch = *level->getPatch(p());
+            SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianPatchGeometry<NDIM> > patch_geometry
+                = patch.getPatchGeometry();
+            boxes.emplace_back(*patch_geometry);
+        }
+        return boxes;
+    }
+}
+
+PartitioningBoxes::PartitioningBoxes(const SAMRAI::hier::PatchHierarchy<NDIM> &hierarchy)
+{
+    const auto boxes = get_partitioning_boxes(hierarchy);
+    *this = PartitioningBoxes(boxes.begin(), boxes.end());
+}
+
+}
+//////////////////////////////////////////////////////////////////////////////

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -590,6 +590,8 @@ public:
     /*!
      * Register a load balancer and work load patch data index with the IB
      * strategy object.
+     *
+     * This function should be called before IBFEMethod::initializeFEData().
      */
     void registerLoadBalancer(SAMRAI::tbox::Pointer<SAMRAI::mesh::LoadBalancer<NDIM> > load_balancer,
                               int workload_data_idx) override;

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -555,6 +555,15 @@ public:
     void initializeFEData();
 
     /*!
+     * Reinitialize FE data by calling `reinit` on each part's EquationSystem,
+     * reassembling the system matrices, and setting boundary conditions.
+     *
+     * TODO when may we call this function? We should only call this after we
+     * repartition, which places it at a precise point in the AMR process.
+     */
+    void reinitializeFEData();
+
+    /*!
      * \brief Register Eulerian variables with the parent IBHierarchyIntegrator.
      */
     void registerEulerianVariables() override;
@@ -933,6 +942,15 @@ private:
      * members.
      */
     void getFromRestart();
+
+    /*!
+     * Do the actual work in reinitializeFEData and initializeFEData. if @p
+     * use_present_data is `true` then the current content of the solution
+     * vectors is used: more exactly, the coordinates and velocities (computed
+     * by initializeCoordinates and initializeVelocity) are considered as
+     * being up to date, as is the direct forcing kinematic data.
+     */
+    void doInitializeFEData(const bool use_present_data);
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBHierarchyIntegrator.h
+++ b/include/ibamr/IBHierarchyIntegrator.h
@@ -121,7 +121,8 @@ public:
     void registerBodyForceFunction(SAMRAI::tbox::Pointer<IBTK::CartGridFunction> F_fcn);
 
     /*!
-     * Register a load balancer for non-uniform load balancing.
+     * Register a load balancer. The same load balancer is used with all
+     * member objects such as the integrator.
      */
     virtual void registerLoadBalancer(SAMRAI::tbox::Pointer<SAMRAI::mesh::LoadBalancer<NDIM> > load_balancer) override;
 

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1691,7 +1691,6 @@ IBFEMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
             hierarchy, level_number, init_data_time, can_be_refined, initial_time, old_level, allocate_data);
         if (d_load_balancer && level_number == d_fe_data_managers[part]->getLevelNumber())
         {
-            d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number);
             d_fe_data_managers[part]->updateWorkloadEstimates(level_number, level_number);
         }
     }

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -76,6 +76,7 @@
 #include "ibtk/RobinPhysBdryPatchStrategy.h"
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/libmesh_utilities.h"
+#include "ibtk/BoxPartitioner.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/compare_types.h"
 #include "libmesh/dense_vector.h"
@@ -1637,13 +1638,25 @@ void IBFEMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierar
     return;
 } // beginDataRedistribution
 
-void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > hierarchy,
                                        Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     // if we are not initialized then there is nothing to do
     if (d_is_initialized)
     {
-        // This is where we will repartition in a future commit
+        // At this point in the code SAMRAI has already redistributed the
+        // patches (usually by taking into account the number of IB points on
+        // each patch). Here is the other half: we inform libMesh of the
+        // updated partitioning so that libMesh Elems and Nodes are on the
+        // same processor as the relevant SAMRAI patch.
+        for (unsigned int part = 0; part < d_num_parts; ++part)
+        {
+            EquationSystems& equation_systems = *d_fe_data_managers[part]->getEquationSystems();
+            MeshBase& mesh = equation_systems.get_mesh();
+            BoxPartitioner partitioner(*hierarchy,
+                                       equation_systems.get_system(COORDS_SYSTEM_NAME));
+            partitioner.repartition(mesh);
+        }
 
         reinitializeFEData();
         for (unsigned int part = 0; part < d_num_parts; ++part)

--- a/src/IB/IBFEPostProcessor.cpp
+++ b/src/IB/IBFEPostProcessor.cpp
@@ -288,6 +288,7 @@ IBFEPostProcessor::interpolateVariables(const double data_time)
     for (unsigned int k = 0; k < num_eulerian_vars; ++k)
     {
         System* system = d_scalar_interp_var_systems[k];
+        TBOX_ASSERT(system->is_initialized());
         const std::string& system_name = system->name();
         const int scratch_idx = d_scalar_interp_scratch_idxs[k];
         d_fe_data_manager->interp(scratch_idx, *system->solution, *X_ghost_vec, system_name, d_scalar_interp_specs[k]);

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -1404,7 +1404,7 @@ IBFESurfaceMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierar
             hierarchy, level_number, init_data_time, can_be_refined, initial_time, old_level, allocate_data);
         if (d_load_balancer && level_number == d_fe_data_managers[part]->getLevelNumber())
         {
-            d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number);
+            // d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number); // ???
             d_fe_data_managers[part]->updateWorkloadEstimates(level_number, level_number);
         }
     }

--- a/src/IB/IBHierarchyIntegrator.cpp
+++ b/src/IB/IBHierarchyIntegrator.cpp
@@ -445,7 +445,7 @@ IBHierarchyIntegrator::regridHierarchy()
     if (d_load_balancer)
     {
         if (d_enable_logging) plog << d_object_name << "::regridHierarchy(): updating workload estimates\n";
-        d_hier_cc_data_ops->setToScalar(d_workload_idx, 1.0);
+        // d_hier_cc_data_ops->setToScalar(d_workload_idx, 1.0);
         d_ib_method_ops->updateWorkloadEstimates(d_hierarchy, d_workload_idx);
     }
 
@@ -569,14 +569,6 @@ IBHierarchyIntegrator::initializeLevelDataSpecialized(const Pointer<BasePatchHie
     }
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
 #endif
-
-    // Initialize workload data.
-    if (d_workload_idx != IBTK::invalid_index)
-    {
-        HierarchyCellDataOpsReal<NDIM, double> level_cc_data_ops(hierarchy, level_number, level_number);
-        level_cc_data_ops.setToScalar(d_workload_idx, 1.0);
-        d_load_balancer->setUniformWorkload(level_number);
-    }
 
     // Initialize marker data
     if (d_mark_var)

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -1571,7 +1571,7 @@ IBMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
     }
     if (d_load_balancer && d_l_data_manager->levelContainsLagrangianData(level_number))
     {
-        d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number);
+        // d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number); ???
         d_l_data_manager->updateWorkloadEstimates(level_number, level_number);
     }
     return;

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -1051,7 +1051,7 @@ IMPMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
     }
     if (d_load_balancer && d_l_data_manager->levelContainsLagrangianData(level_number))
     {
-        d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number);
+        // d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number); ???
         d_l_data_manager->updateWorkloadEstimates(level_number, level_number);
     }
     return;


### PR DESCRIPTION
Successor to #386. This is a good chunk of the code (the partitioner currently lives elsewhere; I alternate between two libMesh partitioners for now instead) that we need to automatically repartition the finite element data.

The initialization check in the preprocessor currently fails. I'm investigating.