### PR TITLE
Update a few default initialization values.

### DIFF
--- a/include/ibamr/StaggeredStokesFACPreconditionerStrategy.h
+++ b/include/ibamr/StaggeredStokesFACPreconditionerStrategy.h
@@ -450,7 +450,7 @@ protected:
      * The names of the refinement operators used to prolong the coarse grid
      * correction.
      */
-    std::string d_U_prolongation_method = "CONSTANT_REFINE", d_P_prolongation_method = "LIENAR_REFINE";
+    std::string d_U_prolongation_method = "CONSTANT_REFINE", d_P_prolongation_method = "LINEAR_REFINE";
 
     /*
      * The names of the coarsening operators used to restrict the fine grid

--- a/src/adv_diff/AdvDiffPredictorCorrectorHyperbolicPatchOps.cpp
+++ b/src/adv_diff/AdvDiffPredictorCorrectorHyperbolicPatchOps.cpp
@@ -187,7 +187,7 @@ AdvDiffPredictorCorrectorHyperbolicPatchOps::AdvDiffPredictorCorrectorHyperbolic
                                                    grid_geom,
                                                    register_for_restart)
 {
-    // intentionally blank
+    d_overwrite_tags = false;
     return;
 } // AdvDiffPredictorCorrectorHyperbolicPatchOps
 


### PR DESCRIPTION
Follow up to #380. This fixes a spelling error and an incorrect deletion.