### PR TITLE
Fedatamanager unique ptrs

### DIFF
--- a/configure
+++ b/configure
@@ -24225,15 +24225,9 @@ fi
   LIBMESH_FCFLAGS="`$LIBMESH_CONFIG --fflags`"
   LIBMESH_LIBS="`$LIBMESH_CONFIG --libs`"
 
-  # libMesh implements UniquePtr by including parts of boost in
-  # libmesh/unique_ptr.hpp (or in contrib/unique_ptr/unique_ptr.hpp). This
-  # causes compilation errors when one #includes both that file and the original
-  # file from boost, since the preprocessor guards on the libMesh-provided
-  # unique_ptr.hpp do not match the preprocessor guards on the boost headers (so
-  # we get multiple definition errors). To ensure that this does not happen,
-  # check that libMesh will not include unique_ptr.hpp in its own auto_ptr.hpp
-  # file (which we use). libMesh uses the preprocessor guard symbol
-  # UNIQUE_PTR_HPP in 1.0, 1.1, 1.2, and 1.3, so we check for that.
+  # libMesh (for pre-C++11 compatibility) can implement libMesh::UniquePtr in
+  # several different ways. We are only compatible when libMesh::UniquePtr
+  # really is std::unique_ptr:
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for a usable libMesh UniquePtr/unique_ptr configuration" >&5
 $as_echo_n "checking for a usable libMesh UniquePtr/unique_ptr configuration... " >&6; }
@@ -24242,10 +24236,10 @@ $as_echo_n "checking for a usable libMesh UniquePtr/unique_ptr configuration... 
 
 #include <libmesh/auto_ptr.h>
 
-#ifdef UNIQUE_PTR_HPP
-#error
-#endif
+#include <type_traits>
 
+static_assert(std::is_same<libMesh::UniquePtr<int>, std::unique_ptr<int>>::value,
+              "libMesh should use std::unique_ptr");
 
 #ifdef FC_DUMMY_MAIN
 #ifndef FC_DUMMY_MAIN_EQ_F77
@@ -24272,7 +24266,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${LIBMESH_UNIQUE_PTR_OK}" >&5
 $as_echo "${LIBMESH_UNIQUE_PTR_OK}" >&6; }
   if test "$LIBMESH_UNIQUE_PTR_OK" = no; then
-    as_fn_error $? "If libMesh is compiled without C++11 support then it must be compiled with --disable-unique-ptr or (in version 1.1 or later) compiled with a copy of boost including boost.move." "$LINENO" 5
+    as_fn_error $? "libMesh must be compiled with C++11 support and without --disable-unique-ptr." "$LINENO" 5
   fi
 
 

--- a/doc/news/changes/incompatibilities/20181129DavidWells
+++ b/doc/news/changes/incompatibilities/20181129DavidWells
@@ -1,0 +1,4 @@
+Changed: IBAMR now requires that libMesh be built in such a way that
+<code>libMesh::UniquePtr</code> is the same class as
+<code>std::unique_ptr</code>.
+(David Wells, 2018/11/29)

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -24345,15 +24345,9 @@ fi
   LIBMESH_FCFLAGS="`$LIBMESH_CONFIG --fflags`"
   LIBMESH_LIBS="`$LIBMESH_CONFIG --libs`"
 
-  # libMesh implements UniquePtr by including parts of boost in
-  # libmesh/unique_ptr.hpp (or in contrib/unique_ptr/unique_ptr.hpp). This
-  # causes compilation errors when one #includes both that file and the original
-  # file from boost, since the preprocessor guards on the libMesh-provided
-  # unique_ptr.hpp do not match the preprocessor guards on the boost headers (so
-  # we get multiple definition errors). To ensure that this does not happen,
-  # check that libMesh will not include unique_ptr.hpp in its own auto_ptr.hpp
-  # file (which we use). libMesh uses the preprocessor guard symbol
-  # UNIQUE_PTR_HPP in 1.0, 1.1, 1.2, and 1.3, so we check for that.
+  # libMesh (for pre-C++11 compatibility) can implement libMesh::UniquePtr in
+  # several different ways. We are only compatible when libMesh::UniquePtr
+  # really is std::unique_ptr:
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for a usable libMesh UniquePtr/unique_ptr configuration" >&5
 $as_echo_n "checking for a usable libMesh UniquePtr/unique_ptr configuration... " >&6; }
@@ -24362,10 +24356,10 @@ $as_echo_n "checking for a usable libMesh UniquePtr/unique_ptr configuration... 
 
 #include <libmesh/auto_ptr.h>
 
-#ifdef UNIQUE_PTR_HPP
-#error
-#endif
+#include <type_traits>
 
+static_assert(std::is_same<libMesh::UniquePtr<int>, std::unique_ptr<int>>::value,
+              "libMesh should use std::unique_ptr");
 
 #ifdef FC_DUMMY_MAIN
 #ifndef FC_DUMMY_MAIN_EQ_F77
@@ -24392,7 +24386,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${LIBMESH_UNIQUE_PTR_OK}" >&5
 $as_echo "${LIBMESH_UNIQUE_PTR_OK}" >&6; }
   if test "$LIBMESH_UNIQUE_PTR_OK" = no; then
-    as_fn_error $? "If libMesh is compiled without C++11 support then it must be compiled with --disable-unique-ptr or (in version 1.1 or later) compiled with a copy of boost including boost.move." "$LINENO" 5
+    as_fn_error $? "libMesh must be compiled with C++11 support and without --disable-unique-ptr." "$LINENO" 5
   fi
 
 

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -664,7 +664,7 @@ protected:
     /*!
      * \brief The FEDataManager destructor cleans up any allocated data objects.
      */
-    ~FEDataManager();
+    ~FEDataManager() = default;
 
 private:
     /*!
@@ -834,15 +834,15 @@ private:
     /*
      * Ghost vectors for the various equation systems.
      */
-    std::map<std::string, libMesh::NumericVector<double>*> d_system_ghost_vec;
+    std::map<std::string, std::unique_ptr<libMesh::NumericVector<double>>> d_system_ghost_vec;
 
     /*
      * Linear solvers and related data for performing interpolation in the IB-FE
      * framework.
      */
-    std::map<std::string, libMesh::LinearSolver<double>*> d_L2_proj_solver;
-    std::map<std::string, libMesh::SparseMatrix<double>*> d_L2_proj_matrix;
-    std::map<std::string, libMesh::NumericVector<double>*> d_L2_proj_matrix_diag;
+    std::map<std::string, std::unique_ptr<libMesh::LinearSolver<double>>> d_L2_proj_solver;
+    std::map<std::string, std::unique_ptr<libMesh::SparseMatrix<double>>> d_L2_proj_matrix;
+    std::map<std::string, std::unique_ptr<libMesh::NumericVector<double>>> d_L2_proj_matrix_diag;
 };
 } // namespace IBTK
 


### PR DESCRIPTION
Related to #396: we need to recalculate all members of `FEDataManager` after we repartition the mesh. Its getting a bit complicated to call `delete` in a dozen places, so I replaced all owning raw pointers with `std::unique_ptr`s.

This is a lot easier if we make the (minor) change of really requiring that `libMesh::UniquePtr` is `std::unique_ptr`. I updated the configuration scripts to check this.