### PR TITLE
Use unique_ptr and references in IBFEMethod.

### DIFF
--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -763,7 +763,7 @@ protected:
      */
     std::vector<libMesh::MeshBase*> d_meshes;
     int d_max_level_number;
-    std::vector<libMesh::EquationSystems*> d_equation_systems;
+    std::vector<std::unique_ptr<libMesh::EquationSystems>> d_equation_systems;
 
     const unsigned int d_num_parts = 1;
     std::vector<IBTK::FEDataManager*> d_fe_data_managers;


### PR DESCRIPTION
Some of the IBFE examples (i.e., IBFE/explicit/ex10) leak memory at the end of the calculation: in particular, libMesh claims that we do not delete all `EquationSystem` objects. This PR gets rid of manual memory management of these objects: it doesn't completely fix the problem but it does allow us to get rid of a few tricky `delete` statements.