### PR TITLE
Replaced UniquePtr with unique_ptr

### DIFF
--- a/examples/CIBFE/ex0/example.cpp
+++ b/examples/CIBFE/ex0/example.cpp
@@ -353,7 +353,7 @@ run_example(int argc, char* argv[])
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();
@@ -469,8 +469,8 @@ run_example(int argc, char* argv[])
             X_vec->localize(*X_ghost_vec);
             DofMap& X_dof_map = X_system.get_dof_map();
             std::vector<std::vector<unsigned int> > X_dof_indices(NDIM);
-            libMesh::UniquePtr<FEBase> fe(FEBase::build(1, X_dof_map.variable_type(0)));
-            libMesh::UniquePtr<QBase> qrule = QBase::build(QGAUSS, 1, THIRD);
+            std::unique_ptr<FEBase> fe(FEBase::build(1, X_dof_map.variable_type(0)));
+            std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, 1, THIRD);
             fe->attach_quadrature_rule(qrule.get());
             const std::vector<double>& JxW = fe->get_JxW();
             const std::vector<std::vector<VectorValue<double> > >& dphi = fe->get_dphi();

--- a/examples/CIBFE/ex1/example.cpp
+++ b/examples/CIBFE/ex1/example.cpp
@@ -477,7 +477,7 @@ run_example(int argc, char* argv[])
 
         // Set up visualization plot file writers.
         Pointer<VisItDataWriter<NDIM> > visit_writer = app_initializer->getVisItDataWriter();
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
         if (dump_viz_data && uses_visit)
         {
             visit_writer->registerPlotQuantity("U", "VECTOR", u_plot_idx, 0);

--- a/examples/IBFE/explicit/ex0/example.cpp
+++ b/examples/IBFE/explicit/ex0/example.cpp
@@ -339,7 +339,7 @@ bool run_example(int argc, char** argv, std::vector<double>& u_err, std::vector<
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         EquationSystems* equation_systems = fe_data_manager->getEquationSystems();
@@ -553,8 +553,8 @@ bool run_example(int argc, char** argv, std::vector<double>& u_err, std::vector<
             X_vec->localize(*X_ghost_vec);
             DofMap& X_dof_map = X_system.get_dof_map();
             std::vector<std::vector<unsigned int> > X_dof_indices(NDIM);
-            libMesh::UniquePtr<FEBase> fe(FEBase::build(NDIM, X_dof_map.variable_type(0)));
-            libMesh::UniquePtr<QBase> qrule = QBase::build(QGAUSS, NDIM, FIFTH);
+            std::unique_ptr<FEBase> fe(FEBase::build(NDIM, X_dof_map.variable_type(0)));
+            std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, NDIM, FIFTH);
             fe->attach_quadrature_rule(qrule.get());
             const std::vector<double>& JxW = fe->get_JxW();
             const std::vector<std::vector<VectorValue<double> > >& dphi = fe->get_dphi();

--- a/examples/IBFE/explicit/ex1/example.cpp
+++ b/examples/IBFE/explicit/ex1/example.cpp
@@ -344,7 +344,7 @@ run_example(int argc, char* argv[])
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         EquationSystems* equation_systems = ib_method_ops->getFEDataManager()->getEquationSystems();
@@ -464,8 +464,8 @@ run_example(int argc, char* argv[])
             X_vec->localize(*X_ghost_vec);
             DofMap& X_dof_map = X_system.get_dof_map();
             std::vector<std::vector<unsigned int> > X_dof_indices(NDIM);
-            libMesh::UniquePtr<FEBase> fe(FEBase::build(NDIM, X_dof_map.variable_type(0)));
-            libMesh::UniquePtr<QBase> qrule = QBase::build(QGAUSS, NDIM, FIFTH);
+            std::unique_ptr<FEBase> fe(FEBase::build(NDIM, X_dof_map.variable_type(0)));
+            std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, NDIM, FIFTH);
             fe->attach_quadrature_rule(qrule.get());
             const std::vector<double>& JxW = fe->get_JxW();
             const std::vector<std::vector<VectorValue<double> > >& dphi = fe->get_dphi();

--- a/examples/IBFE/explicit/ex10/example.cpp
+++ b/examples/IBFE/explicit/ex10/example.cpp
@@ -321,7 +321,7 @@ run_example(int argc, char** argv)
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();

--- a/examples/IBFE/explicit/ex11/example.cpp
+++ b/examples/IBFE/explicit/ex11/example.cpp
@@ -356,7 +356,7 @@ run_example(int argc, char** argv)
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();
@@ -497,8 +497,8 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
     F_vec->localize(*F_ghost_vec);
     const DofMap& dof_map = F_system.get_dof_map();
     FEType fe_type = dof_map.variable_type(0);
-    libMesh::UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
-    libMesh::UniquePtr<QBase> qrule = fe_type.default_quadrature_rule(dim);
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
+    std::unique_ptr<QBase> qrule = fe_type.default_quadrature_rule(dim);
     fe->attach_quadrature_rule(qrule.get());
     const vector<double>& JxW = fe->get_JxW();
     const vector<vector<double> >& phi = fe->get_phi();

--- a/examples/IBFE/explicit/ex2/example.cpp
+++ b/examples/IBFE/explicit/ex2/example.cpp
@@ -353,8 +353,8 @@ run_example(int argc, char* argv[])
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
-        libMesh::UniquePtr<GMVIO> gmv_io(uses_gmv ? new GMVIO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<GMVIO> gmv_io(uses_gmv ? new GMVIO(mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();

--- a/examples/IBFE/explicit/ex3/example.cpp
+++ b/examples/IBFE/explicit/ex3/example.cpp
@@ -357,7 +357,7 @@ bool run_example(int argc, char** argv)
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();

--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -403,7 +403,7 @@ bool run_example(int argc, char** argv)
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();
@@ -515,8 +515,8 @@ bool run_example(int argc, char** argv)
             X_vec->localize(*X_ghost_vec);
             DofMap& X_dof_map = X_system.get_dof_map();
             vector<vector<unsigned int> > X_dof_indices(NDIM);
-            libMesh::UniquePtr<FEBase> fe(FEBase::build(NDIM, X_dof_map.variable_type(0)));
-            libMesh::UniquePtr<QBase> qrule = QBase::build(QGAUSS, NDIM, FIFTH);
+            std::unique_ptr<FEBase> fe(FEBase::build(NDIM, X_dof_map.variable_type(0)));
+            std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, NDIM, FIFTH);
             fe->attach_quadrature_rule(qrule.get());
             const vector<double>& JxW = fe->get_JxW();
             const vector<vector<VectorValue<double> > >& dphi = fe->get_dphi();

--- a/examples/IBFE/explicit/ex5/example.cpp
+++ b/examples/IBFE/explicit/ex5/example.cpp
@@ -493,7 +493,7 @@ run_example(int argc, char** argv)
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         if (use_boundary_mesh)
@@ -663,16 +663,16 @@ postprocess_data(Pointer<Database> input_db,
     const DofMap& dof_map = x_system.get_dof_map();
     std::vector<std::vector<unsigned int> > dof_indices(NDIM);
 
-    libMesh::UniquePtr<FEBase> fe(FEBase::build(dim, dof_map.variable_type(0)));
-    libMesh::UniquePtr<QBase> qrule = QBase::build(QGAUSS, dim, SEVENTH);
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, dof_map.variable_type(0)));
+    std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, dim, SEVENTH);
     fe->attach_quadrature_rule(qrule.get());
     const vector<double>& JxW = fe->get_JxW();
     const vector<libMesh::Point>& q_point = fe->get_xyz();
     const vector<vector<double> >& phi = fe->get_phi();
     const vector<vector<VectorValue<double> > >& dphi = fe->get_dphi();
 
-    libMesh::UniquePtr<FEBase> fe_face(FEBase::build(dim, dof_map.variable_type(0)));
-    libMesh::UniquePtr<QBase> qrule_face = QBase::build(QGAUSS, dim - 1, SEVENTH);
+    std::unique_ptr<FEBase> fe_face(FEBase::build(dim, dof_map.variable_type(0)));
+    std::unique_ptr<QBase> qrule_face = QBase::build(QGAUSS, dim - 1, SEVENTH);
     fe_face->attach_quadrature_rule(qrule_face.get());
     const vector<double>& JxW_face = fe_face->get_JxW();
     const vector<libMesh::Point>& q_point_face = fe_face->get_xyz();

--- a/examples/IBFE/explicit/ex6/example.cpp
+++ b/examples/IBFE/explicit/ex6/example.cpp
@@ -449,8 +449,8 @@ run_example(int argc, char* argv[])
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> block_exodus_io(uses_exodus ? new ExodusII_IO(block_mesh) : NULL);
-        libMesh::UniquePtr<ExodusII_IO> beam_exodus_io(uses_exodus ? new ExodusII_IO(beam_mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> block_exodus_io(uses_exodus ? new ExodusII_IO(block_mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> beam_exodus_io(uses_exodus ? new ExodusII_IO(beam_mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();
@@ -605,8 +605,8 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
         F_vec->localize(*F_ghost_vec);
         DofMap& F_dof_map = F_system.get_dof_map();
         std::vector<std::vector<unsigned int> > F_dof_indices(NDIM);
-        libMesh::UniquePtr<FEBase> fe(FEBase::build(NDIM, F_dof_map.variable_type(0)));
-        libMesh::UniquePtr<QBase> qrule = QBase::build(QGAUSS, NDIM, FIFTH);
+        std::unique_ptr<FEBase> fe(FEBase::build(NDIM, F_dof_map.variable_type(0)));
+        std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, NDIM, FIFTH);
         fe->attach_quadrature_rule(qrule.get());
         const std::vector<std::vector<double> >& phi = fe->get_phi();
         const std::vector<double>& JxW = fe->get_JxW();
@@ -649,7 +649,7 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
 
     System& X_system = beam_equation_systems->get_system<System>(IBFEMethod::COORDS_SYSTEM_NAME);
     NumericVector<double>* X_vec = X_system.solution.get();
-    libMesh::UniquePtr<NumericVector<Number> > X_serial_vec = NumericVector<Number>::build(X_vec->comm());
+    std::unique_ptr<NumericVector<Number> > X_serial_vec = NumericVector<Number>::build(X_vec->comm());
     X_serial_vec->init(X_vec->size(), true, SERIAL);
     X_vec->localize(*X_serial_vec);
     DofMap& X_dof_map = X_system.get_dof_map();

--- a/examples/IBFE/explicit/ex7/example.cpp
+++ b/examples/IBFE/explicit/ex7/example.cpp
@@ -352,8 +352,8 @@ bool run_example(int argc, char* argv[])
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> lower_exodus_io(uses_exodus ? new ExodusII_IO(lower_mesh) : NULL);
-        libMesh::UniquePtr<ExodusII_IO> upper_exodus_io(uses_exodus ? new ExodusII_IO(upper_mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> lower_exodus_io(uses_exodus ? new ExodusII_IO(lower_mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> upper_exodus_io(uses_exodus ? new ExodusII_IO(upper_mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();

--- a/examples/IBFE/explicit/ex8/example.cpp
+++ b/examples/IBFE/explicit/ex8/example.cpp
@@ -166,7 +166,7 @@ compute_deformed_length(node_set& nodes, EquationSystems* equation_systems)
     System& X_system = equation_systems->get_system<System>(IBFEMethod::COORDS_SYSTEM_NAME);
     const unsigned int X_sys_num = X_system.number();
     NumericVector<double>* X_vec = X_system.solution.get();
-    libMesh::UniquePtr<NumericVector<Number> > X_serial_vec = NumericVector<Number>::build(X_vec->comm());
+    std::unique_ptr<NumericVector<Number> > X_serial_vec = NumericVector<Number>::build(X_vec->comm());
     X_serial_vec->init(X_vec->size(), true, SERIAL);
     X_vec->localize(*X_serial_vec);
 
@@ -211,7 +211,7 @@ compute_displaced_area(node_set& nodes, EquationSystems* equation_systems)
     System& X_system = equation_systems->get_system<System>(IBFEMethod::COORDS_SYSTEM_NAME);
     const unsigned int X_sys_num = X_system.number();
     NumericVector<double>* X_vec = X_system.solution.get();
-    libMesh::UniquePtr<NumericVector<Number> > X_serial_vec = NumericVector<Number>::build(X_vec->comm());
+    std::unique_ptr<NumericVector<Number> > X_serial_vec = NumericVector<Number>::build(X_vec->comm());
     X_serial_vec->init(X_vec->size(), true, SERIAL);
     X_vec->localize(*X_serial_vec);
 
@@ -579,9 +579,9 @@ bool run_example(int argc, char** argv)
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> block1_exodus_io(uses_exodus ? new ExodusII_IO(block1_mesh) : NULL);
-        libMesh::UniquePtr<ExodusII_IO> block2_exodus_io(uses_exodus ? new ExodusII_IO(block2_mesh) : NULL);
-        libMesh::UniquePtr<ExodusII_IO> beam_exodus_io(uses_exodus ? new ExodusII_IO(beam_mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> block1_exodus_io(uses_exodus ? new ExodusII_IO(block1_mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> block2_exodus_io(uses_exodus ? new ExodusII_IO(block2_mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> beam_exodus_io(uses_exodus ? new ExodusII_IO(beam_mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();

--- a/examples/IBFE/explicit/ex9/example.cpp
+++ b/examples/IBFE/explicit/ex9/example.cpp
@@ -292,7 +292,7 @@ bool run_example(int argc, char** argv)
         EquationSystems* bndry_equation_systems = ib_method_ops->getFEDataManager()->getEquationSystems();
 
         // Setup solid systems.
-        libMesh::UniquePtr<EquationSystems> solid_equation_systems(new EquationSystems(solid_mesh));
+        std::unique_ptr<EquationSystems> solid_equation_systems(new EquationSystems(solid_mesh));
         x_solid_system = &solid_equation_systems->add_system<ExplicitSystem>("position");
         u_solid_system = &solid_equation_systems->add_system<ExplicitSystem>("velocity");
         Order order = SECOND;
@@ -402,8 +402,8 @@ bool run_example(int argc, char** argv)
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_solid_io(uses_exodus ? new ExodusII_IO(solid_mesh) : NULL);
-        libMesh::UniquePtr<ExodusII_IO> exodus_bndry_io(uses_exodus ? new ExodusII_IO(bndry_mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_solid_io(uses_exodus ? new ExodusII_IO(solid_mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_bndry_io(uses_exodus ? new ExodusII_IO(bndry_mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();

--- a/examples/multiphase_flow/ex2/example.cpp
+++ b/examples/multiphase_flow/ex2/example.cpp
@@ -542,7 +542,7 @@ run_example(int argc, char* argv[])
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
+        std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
 
         // Initialize hierarchy configuration and data on all patches.
         ib_method_ops->initializeFEData();

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -522,7 +522,7 @@ public:
      * reinitialization (e.g. because the element type or p_level changed);
      * false otherwise.
      */
-    static bool updateQuadratureRule(libMesh::UniquePtr<libMesh::QBase>& qrule,
+    static bool updateQuadratureRule(std::unique_ptr<libMesh::QBase>& qrule,
                                      libMesh::QuadratureType quad_type,
                                      libMesh::Order quad_order,
                                      bool use_adaptive_quadrature,
@@ -540,7 +540,7 @@ public:
      * reinitialization (e.g. because the element type or p_level changed);
      * false otherwise.
      */
-    static bool updateInterpQuadratureRule(libMesh::UniquePtr<libMesh::QBase>& qrule,
+    static bool updateInterpQuadratureRule(std::unique_ptr<libMesh::QBase>& qrule,
                                            const InterpSpec& spec,
                                            const libMesh::Elem* elem,
                                            const boost::multi_array<double, 2>& X_node,
@@ -555,7 +555,7 @@ public:
      * reinitialization (e.g. because the element type or p_level changed);
      * false otherwise.
      */
-    static bool updateSpreadQuadratureRule(libMesh::UniquePtr<libMesh::QBase>& qrule,
+    static bool updateSpreadQuadratureRule(std::unique_ptr<libMesh::QBase>& qrule,
                                            const SpreadSpec& spec,
                                            const libMesh::Elem* elem,
                                            const boost::multi_array<double, 2>& X_node,

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -32,12 +32,13 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
-#include <array>
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <functional>
 #include <limits>
 #include <map>
+#include <memory>
 #include <ostream>
 #include <set>
 #include <string>
@@ -86,7 +87,6 @@
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/libmesh_utilities.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
-#include "libmesh/auto_ptr.h"
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/dof_map.h"
@@ -543,7 +543,7 @@ FEDataManager::spread(const int f_data_idx,
     // Extract the mesh.
     const MeshBase& mesh = d_es->get_mesh();
     const unsigned int dim = mesh.mesh_dimension();
-    UniquePtr<QBase> qrule;
+    std::unique_ptr<QBase> qrule;
 
     // Extract the FE systems and DOF maps, and setup the FE object.
     System& F_system = d_es->get_system(system_name);
@@ -569,10 +569,10 @@ FEDataManager::spread(const int f_data_idx,
         TBOX_ASSERT(X_dof_map.variable_type(d) == X_fe_type);
         TBOX_ASSERT(X_dof_map.variable_order(d) == X_order);
     }
-    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
+    std::unique_ptr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
     if (F_fe_type != X_fe_type)
     {
-        X_fe_autoptr = UniquePtr<FEBase>(FEBase::build(dim, X_fe_type));
+        X_fe_autoptr = std::unique_ptr<FEBase>(FEBase::build(dim, X_fe_type));
     }
     FEBase* F_fe = F_fe_autoptr.get();
     FEBase* X_fe = X_fe_autoptr.get() ? X_fe_autoptr.get() : F_fe_autoptr.get();
@@ -592,8 +592,8 @@ FEDataManager::spread(const int f_data_idx,
     {
         // Multiply by the nodal volume fractions (to convert densities into
         // values).
-        UniquePtr<NumericVector<double> > F_dX_vec = F_vec.clone();
-        UniquePtr<NumericVector<double> > dX_vec = F_vec.clone();
+        std::unique_ptr<NumericVector<double> > F_dX_vec = F_vec.clone();
+        std::unique_ptr<NumericVector<double> > dX_vec = F_vec.clone();
         copy_and_synch(*buildDiagonalL2MassMatrix(system_name), *dX_vec, /*close_v_in*/ false);
         F_dX_vec->pointwise_mult(F_vec, *dX_vec);
         F_dX_vec->close();
@@ -899,10 +899,10 @@ FEDataManager::prolongData(const int f_data_idx,
     {
         TBOX_ASSERT(X_dof_map.variable_type(d) == X_fe_type);
     }
-    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
+    std::unique_ptr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
     if (F_fe_type != X_fe_type)
     {
-        X_fe_autoptr = UniquePtr<FEBase>(FEBase::build(dim, X_fe_type));
+        X_fe_autoptr = std::unique_ptr<FEBase>(FEBase::build(dim, X_fe_type));
     }
     FEBase* F_fe = F_fe_autoptr.get();
     FEBase* X_fe = X_fe_autoptr.get() ? X_fe_autoptr.get() : F_fe_autoptr.get();
@@ -1120,7 +1120,7 @@ FEDataManager::interpWeighted(const int f_data_idx,
     // Extract the mesh.
     const MeshBase& mesh = d_es->get_mesh();
     const unsigned int dim = mesh.mesh_dimension();
-    UniquePtr<QBase> qrule;
+    std::unique_ptr<QBase> qrule;
 
     // Extract the FE systems and DOF maps, and setup the FE object.
     System& F_system = d_es->get_system(system_name);
@@ -1146,10 +1146,10 @@ FEDataManager::interpWeighted(const int f_data_idx,
         TBOX_ASSERT(X_dof_map.variable_type(d) == X_fe_type);
         TBOX_ASSERT(X_dof_map.variable_order(d) == X_order);
     }
-    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
+    std::unique_ptr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
     if (F_fe_type != X_fe_type)
     {
-        X_fe_autoptr = UniquePtr<FEBase>(FEBase::build(dim, X_fe_type));
+        X_fe_autoptr = std::unique_ptr<FEBase>(FEBase::build(dim, X_fe_type));
     }
     FEBase* F_fe = F_fe_autoptr.get();
     FEBase* X_fe = X_fe_autoptr.get() ? X_fe_autoptr.get() : F_fe_autoptr.get();
@@ -1263,7 +1263,7 @@ FEDataManager::interpWeighted(const int f_data_idx,
 
         // Scale by the diagonal mass matrix.
         F_vec.close();
-        UniquePtr<NumericVector<double> > dX_vec = F_vec.clone();
+        std::unique_ptr<NumericVector<double> > dX_vec = F_vec.clone();
         copy_and_synch(*buildDiagonalL2MassMatrix(system_name), *dX_vec, /*close_v_in*/ false);
         F_vec.pointwise_mult(F_vec, *dX_vec);
         if (close_F) F_vec.close();
@@ -1470,7 +1470,7 @@ FEDataManager::interp(const int f_data_idx,
     IBTK_TIMER_START(t_interp);
 
     // Interpolate quantity at quadrature points and filter it to nodal points.
-    UniquePtr<NumericVector<double> > F_rhs_vec = F_vec.zero_clone();
+    std::unique_ptr<NumericVector<double> > F_rhs_vec = F_vec.zero_clone();
     interpWeighted(f_data_idx, *F_rhs_vec, X_vec, system_name, interp_spec, f_refine_scheds, fill_data_time, /*close_F*/ true, close_X);
 
     // Solve for the nodal values.
@@ -1528,10 +1528,10 @@ FEDataManager::restrictData(const int f_data_idx,
     {
         TBOX_ASSERT(X_dof_map.variable_type(d) == X_fe_type);
     }
-    UniquePtr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
+    std::unique_ptr<FEBase> F_fe_autoptr(FEBase::build(dim, F_fe_type)), X_fe_autoptr;
     if (F_fe_type != X_fe_type)
     {
-        X_fe_autoptr = UniquePtr<FEBase>(FEBase::build(dim, X_fe_type));
+        X_fe_autoptr = std::unique_ptr<FEBase>(FEBase::build(dim, X_fe_type));
     }
     FEBase* F_fe = F_fe_autoptr.get();
     FEBase* X_fe = X_fe_autoptr.get() ? X_fe_autoptr.get() : F_fe_autoptr.get();
@@ -1550,7 +1550,7 @@ FEDataManager::restrictData(const int f_data_idx,
 
     // Loop over the patches to assemble the right-hand-side vector used to
     // solve for F.
-    UniquePtr<NumericVector<double> > F_rhs_vec = F_vec.zero_clone();
+    std::unique_ptr<NumericVector<double> > F_rhs_vec = F_vec.zero_clone();
     std::vector<DenseVector<double> > F_rhs_e(n_vars);
     TensorValue<double> dX_ds;
     boost::multi_array<double, 2> X_node;
@@ -1730,8 +1730,8 @@ FEDataManager::buildL2ProjectionSolver(const std::string& system_name)
         dof_map.compute_sparsity(mesh);
         std::vector<unsigned int> dof_indices;
         FEType fe_type = dof_map.variable_type(0);
-        UniquePtr<QBase> qrule = fe_type.default_quadrature_rule(dim);
-        UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+        std::unique_ptr<QBase> qrule = fe_type.default_quadrature_rule(dim);
+        std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
         fe->attach_quadrature_rule(qrule.get());
         const std::vector<double>& JxW = fe->get_JxW();
         const std::vector<std::vector<double> >& phi = fe->get_phi();
@@ -1856,8 +1856,8 @@ FEDataManager::buildDiagonalL2MassMatrix(const std::string& system_name)
         dof_map.compute_sparsity(mesh);
         std::vector<unsigned int> dof_indices;
         FEType fe_type = dof_map.variable_type(0);
-        UniquePtr<QBase> qrule = fe_type.default_quadrature_rule(dim);
-        UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+        std::unique_ptr<QBase> qrule = fe_type.default_quadrature_rule(dim);
+        std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
         fe->attach_quadrature_rule(qrule.get());
         const std::vector<double>& JxW = fe->get_JxW();
         const std::vector<std::vector<double> >& phi = fe->get_phi();
@@ -2015,7 +2015,7 @@ FEDataManager::computeL2Projection(NumericVector<double>& U_vec,
 } // computeL2Projection
 
 bool
-FEDataManager::updateQuadratureRule(UniquePtr<QBase>& qrule,
+FEDataManager::updateQuadratureRule(std::unique_ptr<QBase>& qrule,
                                     QuadratureType type,
                                     Order order,
                                     bool use_adaptive_quadrature,
@@ -2050,7 +2050,8 @@ FEDataManager::updateQuadratureRule(UniquePtr<QBase>& qrule,
     if (!qrule || qrule->type() != type || qrule->get_dim() != elem_dim || qrule->get_order() != order ||
         qrule->get_elem_type() != elem_type || qrule->get_p_level() != elem_p_level)
     {
-        qrule = (type == QGRID ? UniquePtr<QBase>(new QGrid(elem_dim, order)) : QBase::build(type, elem_dim, order));
+        qrule =
+            (type == QGRID ? std::unique_ptr<QBase>(new QGrid(elem_dim, order)) : QBase::build(type, elem_dim, order));
         // qrule->allow_rules_with_negative_weights = false;
         qrule->init(elem_type, elem_p_level);
         qrule_updated = true;
@@ -2059,7 +2060,7 @@ FEDataManager::updateQuadratureRule(UniquePtr<QBase>& qrule,
 }
 
 bool
-FEDataManager::updateInterpQuadratureRule(UniquePtr<QBase>& qrule,
+FEDataManager::updateInterpQuadratureRule(std::unique_ptr<QBase>& qrule,
                                           const FEDataManager::InterpSpec& spec,
                                           const Elem* const elem,
                                           const boost::multi_array<double, 2>& X_node,
@@ -2070,7 +2071,7 @@ FEDataManager::updateInterpQuadratureRule(UniquePtr<QBase>& qrule,
 }
 
 bool
-FEDataManager::updateSpreadQuadratureRule(UniquePtr<QBase>& qrule,
+FEDataManager::updateSpreadQuadratureRule(std::unique_ptr<QBase>& qrule,
                                           const FEDataManager::SpreadSpec& spec,
                                           const Elem* const elem,
                                           const boost::multi_array<double, 2>& X_node,
@@ -2183,7 +2184,7 @@ FEDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> > hi
         const MeshBase& mesh = d_es->get_mesh();
         const Parallel::Communicator& comm = mesh.comm();
         const unsigned int dim = mesh.mesh_dimension();
-        UniquePtr<QBase> qrule;
+        std::unique_ptr<QBase> qrule;
 
         // Extract the FE system and DOF map, and setup the FE object.
         System& X_system = d_es->get_system(COORDINATES_SYSTEM_NAME);
@@ -2195,12 +2196,12 @@ FEDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> > hi
         {
             TBOX_ASSERT(X_dof_map.variable_type(d) == fe_type);
         }
-        UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+        std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
         const std::vector<std::vector<double> >& phi = fe->get_phi();
 
         // Setup and extract the underlying solution data.
         NumericVector<double>* X_vec = getCoordsVector();
-        UniquePtr<NumericVector<double> > X_ghost_vec = NumericVector<double>::build(comm);
+        std::unique_ptr<NumericVector<double> > X_ghost_vec = NumericVector<double>::build(comm);
         X_ghost_vec->init(X_vec->size(), X_vec->local_size(), X_ghost_dofs, true, GHOSTED);
         copy_and_synch(*X_vec, *X_ghost_vec, /*close_v_in*/ false);
         auto X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec.get());
@@ -2395,7 +2396,7 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
         // Extract the mesh.
         const MeshBase& mesh = d_es->get_mesh();
         const unsigned int dim = mesh.mesh_dimension();
-        UniquePtr<QBase> qrule;
+        std::unique_ptr<QBase> qrule;
 
         // Extract the FE system and DOF map, and setup the FE object.
         System& X_system = d_es->get_system(COORDINATES_SYSTEM_NAME);
@@ -2407,7 +2408,7 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
         {
             TBOX_ASSERT(X_dof_map.variable_type(d) == fe_type);
         }
-        UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+        std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
         const std::vector<std::vector<double> >& phi = fe->get_phi();
 
         // Extract the underlying solution data.
@@ -2558,7 +2559,7 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
     const MeshBase& mesh = d_es->get_mesh();
     const Parallel::Communicator& comm = mesh.comm();
     const unsigned int dim = mesh.mesh_dimension();
-    UniquePtr<QBase> qrule;
+    std::unique_ptr<QBase> qrule;
     System& X_system = d_es->get_system(COORDINATES_SYSTEM_NAME);
     const DofMap& X_dof_map = X_system.get_dof_map();
     SystemDofMapCache& X_dof_map_cache = *getDofMapCache(COORDINATES_SYSTEM_NAME);
@@ -2568,10 +2569,10 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
     {
         TBOX_ASSERT(X_dof_map.variable_type(d) == fe_type);
     }
-    UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
     const std::vector<std::vector<double> >& phi = fe->get_phi();
     NumericVector<double>* X_vec = getCoordsVector();
-    UniquePtr<NumericVector<double> > X_ghost_vec = NumericVector<double>::build(comm);
+    std::unique_ptr<NumericVector<double> > X_ghost_vec = NumericVector<double>::build(comm);
 
     // Setup data structures used to assign elements to patches.
     Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(level_number);

--- a/scripts/replaceLibmeshPointers.pl
+++ b/scripts/replaceLibmeshPointers.pl
@@ -1,0 +1,62 @@
+#! /usr/bin/perl
+# This script replaces UniquePtr and AutoPtr with std::unique_ptr.
+# To use this file, use the command
+# perl replaceUnique.pl <directory>
+# where <directory> is the base path to be changed.
+use strict;
+
+use File::Basename;
+use File::Find;
+use File::Compare;
+use Cwd;
+
+my $replaceDir = $ARGV[0];
+
+my $debug = 0;
+
+my $end_of_line = $/;
+
+my $filePattern = q/(.*\.[ChI]$)|(.*\.CPP$)|(.*\.cpp$)|(.*\.cxx$)|(.*\.CXX$)|(.*\.H$)|(.*\.hxx$)|(.*\.Hxx$)|(.*\.HXX$)|(.*\.txx$)|(.*\.ixx$)/;
+my @filesToProcess = ();
+sub selectAllSourceFiles {
+    if ( $File::Find::name =~ m!/(build|\.git|CVS|contrib|scripts|config|configure|\{arch\})$!o ) {
+        $File::Find::prune = 1;
+    }
+    elsif ( -f && m/$filePattern/ ) {
+        push @filesToProcess, $File::Find::name;
+        $filesToProcess[$#filesToProcess] =~ s|^\./||o;
+   }
+}
+
+find( \&selectAllSourceFiles, $replaceDir );
+
+print "@filesToProcess\n";
+
+for my $file (@filesToProcess) {
+    print "Replacing UniquePtr<> and AutoPtr<> for source file $file\n";
+    my $directory = dirname $file;
+    my $filebasename = basename $file;
+    my $tempFile = $filebasename . ".tmp";
+    open FILE, "< $file" || die "Cannot open file $file";
+    open TEMPFILE, "> $tempFile" || die "Cannot open temporary work file $tempFile";
+    while ( my $str = <FILE> ) {
+        # Delete libMesh auto_ptr header include and replace with memory
+        $str =~ s/\#include\ \"libmesh\/auto_ptr\.h\"/\#include\ <memory>/g;
+
+        # Replace Pointer<STUFF> with unique_ptr<STUFF>
+        $str =~ s/(libMesh::)?(UniquePtr|AutoPtr)\</std::unique_ptr\</g;
+
+        print TEMPFILE $str;
+    }
+
+    close FILE || die "Cannot close file $file\n";
+    close TEMPFILE || die "Cannot close file $tempFile\n";
+    if (compare($file,$tempFile) == 0) {
+        unlink($tempFile);
+    } else {
+        unlink($file);
+        rename($tempFile, $file);
+    }
+
+}
+

--- a/src/IB/CIBFEMethod.cpp
+++ b/src/IB/CIBFEMethod.cpp
@@ -630,14 +630,14 @@ CIBFEMethod::subtractMeanConstraintForce(Vec L, int f_data_idx, const double sca
         EquationSystems& equation_systems = *d_equation_systems[part];
         MeshBase& mesh = equation_systems.get_mesh();
         const unsigned int dim = mesh.mesh_dimension();
-        UniquePtr<QBase> qrule = QBase::build(d_default_quad_type[part], dim, d_default_quad_order[part]);
+        std::unique_ptr<QBase> qrule = QBase::build(d_default_quad_type[part], dim, d_default_quad_order[part]);
 
         // Extract the FE system and DOF map, and setup the FE object.
         System& L_system = *d_F_systems[part];
         DofMap& L_dof_map = L_system.get_dof_map();
         std::vector<std::vector<unsigned int> > L_dof_indices(NDIM);
         FEType L_fe_type = L_dof_map.variable_type(0);
-        UniquePtr<FEBase> L_fe_autoptr(FEBase::build(dim, L_fe_type));
+        std::unique_ptr<FEBase> L_fe_autoptr(FEBase::build(dim, L_fe_type));
         FEBase* L_fe = L_fe_autoptr.get();
         L_fe->attach_quadrature_rule(qrule.get());
         const std::vector<double>& JxW = L_fe->get_JxW();
@@ -765,7 +765,7 @@ CIBFEMethod::computeNetRigidGeneralizedForce(const unsigned int part, Vec L, Rig
     EquationSystems& equation_systems = *d_equation_systems[part];
     MeshBase& mesh = equation_systems.get_mesh();
     const unsigned int dim = mesh.mesh_dimension();
-    UniquePtr<QBase> qrule = QBase::build(d_default_quad_type[part], dim, d_default_quad_order[part]);
+    std::unique_ptr<QBase> qrule = QBase::build(d_default_quad_type[part], dim, d_default_quad_order[part]);
 
     // Extract the FE system and DOF map, and setup the FE object.
     System& L_system = *d_F_systems[part];
@@ -776,10 +776,10 @@ CIBFEMethod::computeNetRigidGeneralizedForce(const unsigned int part, Vec L, Rig
     std::vector<std::vector<unsigned int> > X_dof_indices(NDIM);
     FEType L_fe_type = L_dof_map.variable_type(0);
     FEType X_fe_type = X_dof_map.variable_type(0);
-    UniquePtr<FEBase> L_fe_autoptr(FEBase::build(dim, L_fe_type)), X_fe_autoptr;
+    std::unique_ptr<FEBase> L_fe_autoptr(FEBase::build(dim, L_fe_type)), X_fe_autoptr;
     if (L_fe_type != X_fe_type)
     {
-        X_fe_autoptr = UniquePtr<FEBase>(FEBase::build(dim, X_fe_type));
+        X_fe_autoptr = std::unique_ptr<FEBase>(FEBase::build(dim, X_fe_type));
     }
     FEBase* L_fe = L_fe_autoptr.get();
     FEBase* X_fe = X_fe_autoptr.get() ? X_fe_autoptr.get() : L_fe_autoptr.get();
@@ -1330,7 +1330,7 @@ CIBFEMethod::computeCOMOfStructure(Eigen::Vector3d& center_of_mass, EquationSyst
     const int part = 0; // XXXX
     MeshBase& mesh = equation_systems->get_mesh();
     const unsigned int dim = mesh.mesh_dimension();
-    UniquePtr<QBase> qrule = QBase::build(d_default_quad_type[part], dim, d_default_quad_order[part]);
+    std::unique_ptr<QBase> qrule = QBase::build(d_default_quad_type[part], dim, d_default_quad_order[part]);
 
     // Extract the FE system and DOF map, and setup the FE object.
     System& X_system = equation_systems->get_system(COORDS_SYSTEM_NAME);
@@ -1339,7 +1339,7 @@ CIBFEMethod::computeCOMOfStructure(Eigen::Vector3d& center_of_mass, EquationSyst
     std::vector<std::vector<unsigned int> > X_dof_indices(NDIM);
     FEType fe_type = X_dof_map.variable_type(0);
 
-    UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
     fe->attach_quadrature_rule(qrule.get());
     const std::vector<double>& JxW = fe->get_JxW();
     const std::vector<std::vector<double> >& phi = fe->get_phi();

--- a/src/IB/IBFECentroidPostProcessor.cpp
+++ b/src/IB/IBFECentroidPostProcessor.cpp
@@ -32,6 +32,7 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include <memory>
 #include <ostream>
 #include <set>
 #include <string>
@@ -45,7 +46,6 @@
 #include "ibtk/FEDataInterpolation.h"
 #include "ibtk/FEDataManager.h"
 #include "ibtk/libmesh_utilities.h"
-#include "libmesh/auto_ptr.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/enum_fe_family.h"
 #include "libmesh/enum_order.h"
@@ -166,7 +166,7 @@ IBFECentroidPostProcessor::reconstructVariables(double data_time)
     EquationSystems* equation_systems = d_fe_data_manager->getEquationSystems();
     const MeshBase& mesh = equation_systems->get_mesh();
     const int dim = mesh.mesh_dimension();
-    UniquePtr<QBase> qrule = QBase::build(QGAUSS, NDIM, CONSTANT);
+    std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, NDIM, CONSTANT);
 
     // Set up all system data required to evaluate the mesh functions.
     FEDataInterpolation fe(dim, d_fe_data_manager);

--- a/src/IB/IBFEDirectForcingKinematics.cpp
+++ b/src/IB/IBFEDirectForcingKinematics.cpp
@@ -544,9 +544,9 @@ IBFEDirectForcingKinematics::computeCOMOfStructure(Eigen::Vector3d& X0)
     DofMap& X_dof_map = X_system.get_dof_map();
     std::vector<std::vector<unsigned int> > X_dof_indices(NDIM);
     FEType fe_type = X_dof_map.variable_type(0);
-    UniquePtr<QBase> qrule = fe_type.default_quadrature_rule(dim);
+    std::unique_ptr<QBase> qrule = fe_type.default_quadrature_rule(dim);
 
-    UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
     fe->attach_quadrature_rule(qrule.get());
     const std::vector<double>& JxW = fe->get_JxW();
     const std::vector<std::vector<double> >& phi = fe->get_phi();
@@ -612,9 +612,9 @@ IBFEDirectForcingKinematics::computeMOIOfStructure(Eigen::Matrix3d& I, const Eig
     DofMap& X_dof_map = X_system.get_dof_map();
     std::vector<std::vector<unsigned int> > X_dof_indices(NDIM);
     FEType fe_type = X_dof_map.variable_type(0);
-    UniquePtr<QBase> qrule = fe_type.default_quadrature_rule(dim);
+    std::unique_ptr<QBase> qrule = fe_type.default_quadrature_rule(dim);
 
-    UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
     fe->attach_quadrature_rule(qrule.get());
     const std::vector<double>& JxW = fe->get_JxW();
     const std::vector<std::vector<double> >& phi = fe->get_phi();
@@ -790,8 +790,8 @@ IBFEDirectForcingKinematics::computeMixedLagrangianForceDensity(PetscVector<doub
     std::vector<std::vector<unsigned int> > U_dof_indices(NDIM);
     std::vector<std::vector<unsigned int> > X_dof_indices(NDIM);
     FEType fe_type = U_dof_map.variable_type(0);
-    UniquePtr<QBase> qrule = fe_type.default_quadrature_rule(dim);
-    UniquePtr<FEBase> fe_autoptr(FEBase::build(dim, fe_type));
+    std::unique_ptr<QBase> qrule = fe_type.default_quadrature_rule(dim);
+    std::unique_ptr<FEBase> fe_autoptr(FEBase::build(dim, fe_type));
     FEBase* fe = fe_autoptr.get();
     fe->attach_quadrature_rule(qrule.get());
     const std::vector<double>& JxW = fe->get_JxW();

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -616,8 +616,8 @@ IBFEInstrumentPanel::initializeHierarchyDependentData(IBFEMethod* ib_method_ops,
             FEType fe_type = displacement_sys.variable_type(0);
 
             // set up FE objects
-            UniquePtr<FEBase> fe_elem(FEBase::build(NDIM - 1, fe_type));
-            UniquePtr<QBase> qrule(QBase::build(d_quad_type, NDIM - 1, d_quad_order[jj]));
+            std::unique_ptr<FEBase> fe_elem(FEBase::build(NDIM - 1, fe_type));
+            std::unique_ptr<QBase> qrule(QBase::build(d_quad_type, NDIM - 1, d_quad_order[jj]));
             fe_elem->attach_quadrature_rule(qrule.get());
             //  for evaluating the displacement system
             const std::vector<Real>& JxW = fe_elem->get_JxW();
@@ -836,7 +836,7 @@ IBFEInstrumentPanel::readInstrumentData(const int U_data_idx,
         FEType fe_type = velocity_sys.variable_type(0);
 
         // set up FE objects
-        UniquePtr<FEBase> fe_elem(FEBase::build(NDIM - 1, fe_type));
+        std::unique_ptr<FEBase> fe_elem(FEBase::build(NDIM - 1, fe_type));
         QGauss qrule(NDIM - 1, fe_type.default_quadrature_order());
         fe_elem->attach_quadrature_rule(&qrule);
 

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -36,6 +36,7 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <ostream>
 #include <set>
 #include <string>
@@ -75,7 +76,6 @@
 #include "ibtk/RobinPhysBdryPatchStrategy.h"
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/libmesh_utilities.h"
-#include "libmesh/auto_ptr.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/compare_types.h"
 #include "libmesh/dense_vector.h"
@@ -236,10 +236,10 @@ assemble_poisson(EquationSystems& es, const std::string& /*system_name*/)
     const DofMap& dof_map = system.get_dof_map();
     FEType fe_type = dof_map.variable_type(0);
 
-    UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
     QGauss qrule(dim, FIFTH);
     fe->attach_quadrature_rule(&qrule);
-    UniquePtr<FEBase> fe_face(FEBase::build(dim, fe_type));
+    std::unique_ptr<FEBase> fe_face(FEBase::build(dim, fe_type));
     QGauss qface(dim - 1, FIFTH);
     fe_face->attach_quadrature_rule(&qface);
 
@@ -532,7 +532,7 @@ IBFEMethod::registerOverlappingVelocityReset(const unsigned int part1, const uns
     std::array<EquationSystems*, 2> es;
     std::array<MeshBase*, 2> mesh;
     std::array<const DofMap*, 2> U_dof_map, X_dof_map;
-    std::array<UniquePtr<PointLocatorBase>, 2> ploc;
+    std::array<std::unique_ptr<PointLocatorBase>, 2> ploc;
     std::array<numeric_index_type, 2> first_local_idx, last_local_idx;
     for (int k = 0; k < 2; ++k)
     {
@@ -635,8 +635,8 @@ IBFEMethod::registerOverlappingForceConstraint(const unsigned int part1,
     std::array<EquationSystems*, 2> es;
     std::array<MeshBase*, 2> mesh;
     std::array<const DofMap*, 2> F_dof_map, X_dof_map;
-    std::array<UniquePtr<FEBase>, 2> fe;
-    std::array<UniquePtr<PointLocatorBase>, 2> ploc;
+    std::array<std::unique_ptr<FEBase>, 2> fe;
+    std::array<std::unique_ptr<PointLocatorBase>, 2> ploc;
     std::array<numeric_index_type, 2> first_local_idx, last_local_idx;
     for (int k = 0; k < 2; ++k)
     {
@@ -1233,7 +1233,7 @@ IBFEMethod::computeLagrangianFluidSource(double data_time)
         for (unsigned int d = 0; d < NDIM; ++d) vars[d] = d;
 
         FEDataInterpolation fe(dim, d_fe_data_managers[part]);
-        UniquePtr<QBase> qrule = QBase::build(QGAUSS, dim, FIFTH);
+        std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, dim, FIFTH);
         fe.attachQuadratureRule(qrule.get());
         fe.evalQuadraturePoints();
         fe.evalQuadratureWeights();
@@ -1745,7 +1745,7 @@ IBFEMethod::computeStressNormalization(PetscVector<double>& Phi_vec,
     for (unsigned int d = 0; d < NDIM; ++d) X_vars[d] = d;
 
     FEDataInterpolation fe(dim, d_fe_data_managers[part]);
-    UniquePtr<QBase> qrule_face = QBase::build(QGAUSS, dim - 1, FIFTH);
+    std::unique_ptr<QBase> qrule_face = QBase::build(QGAUSS, dim - 1, FIFTH);
     fe.attachQuadratureRuleFace(qrule_face.get());
     fe.evalNormalsFace();
     fe.evalQuadraturePointsFace();
@@ -1944,7 +1944,7 @@ IBFEMethod::computeInteriorForceDensity(PetscVector<double>& G_vec,
     const unsigned int dim = mesh.mesh_dimension();
 
     // Setup global and elemental right-hand-side vectors.
-    UniquePtr<NumericVector<double> > G_rhs_vec = G_vec.zero_clone();
+    std::unique_ptr<NumericVector<double> > G_rhs_vec = G_vec.zero_clone();
     DenseVector<double> G_rhs_e[NDIM];
 
     // First handle the stress contributions.  These are handled separately because
@@ -1970,9 +1970,9 @@ IBFEMethod::computeInteriorForceDensity(PetscVector<double>& G_vec,
         for (unsigned int d = 0; d < NDIM; ++d) vars[d] = d;
 
         FEDataInterpolation fe(dim, d_fe_data_managers[part]);
-        UniquePtr<QBase> qrule =
+        std::unique_ptr<QBase> qrule =
             QBase::build(d_PK1_stress_fcn_data[part][k].quad_type, dim, d_PK1_stress_fcn_data[part][k].quad_order);
-        UniquePtr<QBase> qrule_face =
+        std::unique_ptr<QBase> qrule_face =
             QBase::build(d_PK1_stress_fcn_data[part][k].quad_type, dim - 1, d_PK1_stress_fcn_data[part][k].quad_order);
         fe.attachQuadratureRule(qrule.get());
         fe.attachQuadratureRuleFace(qrule_face.get());
@@ -2152,8 +2152,8 @@ IBFEMethod::computeInteriorForceDensity(PetscVector<double>& G_vec,
     std::vector<int> no_vars;
 
     FEDataInterpolation fe(dim, d_fe_data_managers[part]);
-    UniquePtr<QBase> qrule = QBase::build(d_default_quad_type[part], dim, d_default_quad_order[part]);
-    UniquePtr<QBase> qrule_face = QBase::build(d_default_quad_type[part], dim - 1, d_default_quad_order[part]);
+    std::unique_ptr<QBase> qrule = QBase::build(d_default_quad_type[part], dim, d_default_quad_order[part]);
+    std::unique_ptr<QBase> qrule_face = QBase::build(d_default_quad_type[part], dim - 1, d_default_quad_order[part]);
     fe.attachQuadratureRule(qrule.get());
     fe.attachQuadratureRuleFace(qrule_face.get());
     fe.evalNormalsFace();
@@ -2528,7 +2528,7 @@ IBFEMethod::computeOverlapConstraintForceDensity(std::vector<PetscVector<double>
         std::array<const DofMap*, 2> F_dof_map, X_dof_map;
         std::array<FEDataManager::SystemDofMapCache*, 2> F_dof_map_cache, X_dof_map_cache;
         FEType fe_type;
-        std::array<UniquePtr<FEBase>, 2> fe;
+        std::array<std::unique_ptr<FEBase>, 2> fe;
         for (int k = 0; k < 2; ++k)
         {
             es[k] = d_fe_data_managers[part_idx[k]]->getEquationSystems();
@@ -2642,7 +2642,7 @@ IBFEMethod::computeOverlapConstraintForceDensity(std::vector<PetscVector<double>
     {
         if (d_is_overlap_force_part[k])
         {
-            UniquePtr<NumericVector<double> > F_tmp_vec = F_vec[k]->zero_clone();
+            std::unique_ptr<NumericVector<double> > F_tmp_vec = F_vec[k]->zero_clone();
             d_fe_data_managers[k]->computeL2Projection(
                 *F_tmp_vec, *F_rhs_vec[k], FORCE_SYSTEM_NAME, d_use_consistent_mass_matrix);
             F_vec[k]->add(*F_tmp_vec);
@@ -2713,8 +2713,9 @@ IBFEMethod::spreadTransmissionForceDensity(const int f_data_idx,
     for (unsigned int d = 0; d < NDIM; ++d) vars[d] = d;
 
     FEDataInterpolation fe(dim, d_fe_data_managers[part]);
-    UniquePtr<QBase> default_qrule_face = QBase::build(d_default_quad_type[part], dim - 1, d_default_quad_order[part]);
-    UniquePtr<QBase> qrule_face;
+    std::unique_ptr<QBase> default_qrule_face =
+        QBase::build(d_default_quad_type[part], dim - 1, d_default_quad_order[part]);
+    std::unique_ptr<QBase> qrule_face;
     fe.attachQuadratureRuleFace(default_qrule_face.get());
     fe.evalNormalsFace();
     fe.evalQuadraturePointsFace();
@@ -2796,7 +2797,7 @@ IBFEMethod::spreadTransmissionForceDensity(const int f_data_idx,
                 if (is_dirichlet_bdry(elem, side, boundary_info, G_dof_map)) continue;
 
                 // Construct a side element.
-                UniquePtr<Elem> side_elem = elem->build_side(side, /*proxy*/ false);
+                std::unique_ptr<Elem> side_elem = elem->build_side(side, /*proxy*/ false);
                 const bool qrule_changed = d_fe_data_managers[part]->updateSpreadQuadratureRule(
                     qrule_face, d_spread_spec[part], side_elem.get(), X_node, patch_dx_min);
                 if (qrule_changed)
@@ -2974,7 +2975,7 @@ IBFEMethod::imposeJumpConditions(const int f_data_idx,
     std::vector<int> no_vars;
 
     FEDataInterpolation fe(dim, d_fe_data_managers[part]);
-    UniquePtr<QBase> qrule_face = QBase::build(d_default_quad_type[part], dim - 1, d_default_quad_order[part]);
+    std::unique_ptr<QBase> qrule_face = QBase::build(d_default_quad_type[part], dim - 1, d_default_quad_order[part]);
     fe.attachQuadratureRuleFace(qrule_face.get());
     fe.evalQuadraturePointsFace();
     fe.evalNormalsFace();
@@ -3063,7 +3064,7 @@ IBFEMethod::imposeJumpConditions(const int f_data_idx,
                 if (is_dirichlet_bdry(elem, side, boundary_info, G_dof_map)) continue;
 
                 // Construct a side element.
-                UniquePtr<Elem> side_elem = elem->build_side(side, /*proxy*/ false);
+                std::unique_ptr<Elem> side_elem = elem->build_side(side, /*proxy*/ false);
                 const unsigned int n_node_side = side_elem->n_nodes();
                 for (int d = 0; d < NDIM; ++d)
                 {

--- a/src/IB/IBFEPatchRecoveryPostProcessor.cpp
+++ b/src/IB/IBFEPatchRecoveryPostProcessor.cpp
@@ -218,7 +218,7 @@ IBFEPatchRecoveryPostProcessor::initializeFEData(const PeriodicBoundaries* const
     //
     // Unlike the standard Z-Z patch recovery algorithm, we use "tight" element
     // patches for non-vertex nodes.
-    UniquePtr<PointLocatorBase> point_locator = PointLocatorBase::build(TREE, *d_mesh);
+    std::unique_ptr<PointLocatorBase> point_locator = PointLocatorBase::build(TREE, *d_mesh);
     for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
     {
         const Elem* const elem = *el_it;
@@ -323,7 +323,7 @@ IBFEPatchRecoveryPostProcessor::initializeFEData(const PeriodicBoundaries* const
     d_elem_n_qp.resize(n_elem, 0);
     d_elem_qp_global_offset.resize(n_elem, 0);
     d_elem_qp_local_offset.resize(n_elem, 0);
-    UniquePtr<QBase> qrule;
+    std::unique_ptr<QBase> qrule;
     for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
     {
         const Elem* const elem = *el_it;
@@ -366,7 +366,7 @@ IBFEPatchRecoveryPostProcessor::initializeFEData(const PeriodicBoundaries* const
     const unsigned int num_basis_fcns = num_polynomial_basis_fcns(dim, d_interp_order);
     Eigen::MatrixXd M(num_basis_fcns, num_basis_fcns);
     Eigen::VectorXd P(num_basis_fcns);
-    UniquePtr<FEBase> fe(FEBase::build(dim, FEType(d_interp_order, LAGRANGE)));
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, FEType(d_interp_order, LAGRANGE)));
     const std::vector<libMesh::Point>& q_point = fe->get_xyz();
     qrule = QBase::build(QGAUSS, dim, d_quad_order);
     fe->attach_quadrature_rule(qrule.get());
@@ -508,9 +508,9 @@ IBFEPatchRecoveryPostProcessor::reconstructCauchyStress(System& sigma_system)
     const unsigned int dim = d_mesh->mesh_dimension();
     const unsigned int num_basis_fcns = num_polynomial_basis_fcns(dim, d_interp_order);
     Eigen::VectorXd P(num_basis_fcns), a(num_basis_fcns), f(num_basis_fcns);
-    UniquePtr<FEBase> fe(FEBase::build(dim, FEType(d_interp_order, LAGRANGE)));
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, FEType(d_interp_order, LAGRANGE)));
     const std::vector<libMesh::Point>& q_point = fe->get_xyz();
-    UniquePtr<QBase> qrule = QBase::build(QGAUSS, dim, d_quad_order);
+    std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, dim, d_quad_order);
     fe->attach_quadrature_rule(qrule.get());
     unsigned int k = 0;
     for (std::map<dof_id_type, ElemPatch>::const_iterator it = d_local_elem_patches.begin();
@@ -576,9 +576,9 @@ IBFEPatchRecoveryPostProcessor::reconstructPressure(System& p_system)
     const unsigned int dim = d_mesh->mesh_dimension();
     const unsigned int num_basis_fcns = num_polynomial_basis_fcns(dim, d_interp_order);
     Eigen::VectorXd P(num_basis_fcns), a(num_basis_fcns), f(num_basis_fcns);
-    UniquePtr<FEBase> fe(FEBase::build(dim, FEType(d_interp_order, LAGRANGE)));
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, FEType(d_interp_order, LAGRANGE)));
     const std::vector<libMesh::Point>& q_point = fe->get_xyz();
-    UniquePtr<QBase> qrule = QBase::build(QGAUSS, dim, d_quad_order);
+    std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, dim, d_quad_order);
     fe->attach_quadrature_rule(qrule.get());
     unsigned int k = 0;
     for (std::map<dof_id_type, ElemPatch>::const_iterator it = d_local_elem_patches.begin();

--- a/src/IB/IBFEPostProcessor.cpp
+++ b/src/IB/IBFEPostProcessor.cpp
@@ -32,6 +32,7 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include <memory>
 #include <ostream>
 #include <set>
 #include <string>
@@ -52,7 +53,6 @@
 #include "ibtk/FEDataManager.h"
 #include "ibtk/LEInteractor.h"
 #include "ibtk/libmesh_utilities.h"
-#include "libmesh/auto_ptr.h"
 #include "libmesh/enum_fe_family.h"
 #include "libmesh/enum_order.h"
 #include "libmesh/equation_systems.h"

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -36,6 +36,7 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <ostream>
 #include <set>
 #include <string>
@@ -76,7 +77,6 @@
 #include "ibtk/RobinPhysBdryPatchStrategy.h"
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/libmesh_utilities.h"
-#include "libmesh/auto_ptr.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/compare_types.h"
 #include "libmesh/dense_vector.h"
@@ -86,6 +86,7 @@
 #include "libmesh/enum_fe_family.h"
 #include "libmesh/enum_order.h"
 #include "libmesh/enum_quadrature_type.h"
+#include "libmesh/enum_xdr_mode.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/fem_context.h"
@@ -105,7 +106,6 @@
 #include "libmesh/type_vector.h"
 #include "libmesh/variant_filter_iterator.h"
 #include "libmesh/vector_value.h"
-#include "libmesh/enum_xdr_mode.h"
 #include "petscvec.h"
 #include "tbox/Array.h"
 #include "tbox/Database.h"
@@ -538,7 +538,7 @@ IBFESurfaceMethod::interpolateVelocity(const int u_data_idx,
         EquationSystems* equation_systems = d_fe_data_managers[part]->getEquationSystems();
         const MeshBase& mesh = equation_systems->get_mesh();
         const unsigned int dim = mesh.mesh_dimension();
-        UniquePtr<QBase> qrule;
+        std::unique_ptr<QBase> qrule;
 
         // Extract the FE systems and DOF maps, and setup the FE object.
         System& U_system = *d_U_systems[part];
@@ -557,7 +557,7 @@ IBFESurfaceMethod::interpolateVelocity(const int u_data_idx,
         for (unsigned d = 0; d < NDIM; ++d) TBOX_ASSERT(X_dof_map.variable_type(d) == X_fe_type);
         TBOX_ASSERT(U_fe_type == X_fe_type);
         FEType fe_type = U_fe_type;
-        UniquePtr<FEBase> fe = FEBase::build(dim, fe_type);
+        std::unique_ptr<FEBase> fe = FEBase::build(dim, fe_type);
         const std::vector<double>& JxW = fe->get_JxW();
         const std::vector<std::vector<double> >& phi = fe->get_phi();
         std::array<const std::vector<std::vector<double> >*, NDIM - 1> dphi_dxi;
@@ -578,18 +578,18 @@ IBFESurfaceMethod::interpolateVelocity(const int u_data_idx,
         VecGhostGetLocalForm(X_global_vec, &X_local_vec);
         double* X_local_soln;
         VecGetArray(X_local_vec, &X_local_soln);
-        UniquePtr<NumericVector<double> > X0_vec = X_petsc_vec->clone();
+        std::unique_ptr<NumericVector<double> > X0_vec = X_petsc_vec->clone();
         X_system.get_vector("INITIAL_COORDINATES").localize(*X0_vec);
         X0_vec->close();
 
         // Loop over the patches to interpolate values to the element quadrature
         // points from the grid, then use these values to compute the projection
         // of the interpolated velocity field onto the FE basis functions.
-        UniquePtr<NumericVector<double> > U_rhs_vec = U_vec->zero_clone();
+        std::unique_ptr<NumericVector<double> > U_rhs_vec = U_vec->zero_clone();
         std::vector<DenseVector<double> > U_rhs_e(NDIM);
-        UniquePtr<NumericVector<double> > U_n_rhs_vec = U_n_vec->zero_clone();
+        std::unique_ptr<NumericVector<double> > U_n_rhs_vec = U_n_vec->zero_clone();
         std::vector<DenseVector<double> > U_n_rhs_e(NDIM);
-        UniquePtr<NumericVector<double> > U_t_rhs_vec = U_t_vec->zero_clone();
+        std::unique_ptr<NumericVector<double> > U_t_rhs_vec = U_t_vec->zero_clone();
         std::vector<DenseVector<double> > U_t_rhs_e(NDIM);
         boost::multi_array<double, 2> X_node, x_node;
         std::vector<double> U_qp, x_qp;
@@ -861,11 +861,11 @@ IBFESurfaceMethod::computeLagrangianForce(const double data_time)
 
         // Setup global and elemental right-hand-side vectors.
         NumericVector<double>* F_vec = d_F_half_vecs[part];
-        UniquePtr<NumericVector<double> > F_rhs_vec = F_vec->zero_clone();
+        std::unique_ptr<NumericVector<double> > F_rhs_vec = F_vec->zero_clone();
         DenseVector<double> F_rhs_e[NDIM];
         NumericVector<double>* DP_vec = d_DP_half_vecs[part];
-        UniquePtr<NumericVector<double> > DP_rhs_vec =
-            (d_use_jump_conditions ? DP_vec->zero_clone() : UniquePtr<NumericVector<double> >());
+        std::unique_ptr<NumericVector<double> > DP_rhs_vec =
+            (d_use_jump_conditions ? DP_vec->zero_clone() : std::unique_ptr<NumericVector<double> >());
         DenseVector<double> DP_rhs_e;
         VectorValue<double>& F_integral = d_lag_surface_force_integral[part];
         F_integral.zero();
@@ -914,9 +914,9 @@ IBFESurfaceMethod::computeLagrangianForce(const double data_time)
 
         FEType fe_type = F_fe_type;
 
-        UniquePtr<QBase> qrule = QBase::build(d_default_quad_type[part], dim, d_default_quad_order[part]);
+        std::unique_ptr<QBase> qrule = QBase::build(d_default_quad_type[part], dim, d_default_quad_order[part]);
 
-        UniquePtr<FEBase> fe = FEBase::build(dim, fe_type);
+        std::unique_ptr<FEBase> fe = FEBase::build(dim, fe_type);
         fe->attach_quadrature_rule(qrule.get());
         const std::vector<double>& JxW = fe->get_JxW();
         const std::vector<std::vector<double> >& phi = fe->get_phi();
@@ -1522,7 +1522,7 @@ IBFESurfaceMethod::imposeJumpConditions(const int f_data_idx,
     TBOX_ASSERT(DP_fe_type == X_fe_type);
     FEType fe_type = DP_fe_type;
 
-    UniquePtr<FEBase> fe = FEBase::build(dim, fe_type);
+    std::unique_ptr<FEBase> fe = FEBase::build(dim, fe_type);
     const std::vector<std::vector<double> >& phi = fe->get_phi();
     std::array<const std::vector<std::vector<double> >*, NDIM - 1> dphi_dxi;
     dphi_dxi[0] = &fe->get_dphidxi();

--- a/src/IB/IMPInitializer.cpp
+++ b/src/IB/IMPInitializer.cpp
@@ -32,9 +32,10 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 #include <map>
+#include <memory>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -63,7 +64,6 @@
 #include "ibtk/LSiloDataWriter.h"
 #include "ibtk/Streamable.h"
 #include "ibtk/ibtk_utilities.h"
-#include "libmesh/auto_ptr.h"
 #include "libmesh/elem.h"
 #include "libmesh/enum_fe_family.h"
 #include "libmesh/enum_order.h"
@@ -163,8 +163,8 @@ IMPInitializer::registerMesh(MeshBase* mesh, int level_number)
     // and weighting factors.
     const int dim = mesh->mesh_dimension();
     FEType fe_type(FIRST, LAGRANGE);
-    UniquePtr<QBase> qrule = QBase::build(QGAUSS, dim, FIRST);
-    UniquePtr<FEBase> fe(FEBase::build(dim, fe_type));
+    std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, dim, FIRST);
+    std::unique_ptr<FEBase> fe(FEBase::build(dim, fe_type));
     fe->attach_quadrature_rule(qrule.get());
     const std::vector<libMesh::Point>& q_point = fe->get_xyz();
     const std::vector<double>& JxW = fe->get_JxW();


### PR DESCRIPTION
Follow up to #403. Replace all instances of `LibMesh::UniquePtr` with `std::unique_ptr`. A perl script is provided in the scripts directory.

If we want to keep using the Libmesh alias we can close this. I won't be offended :)