### PR TITLE
Add lib mesh partitioning visualization

### DIFF
--- a/doc/news/changes/minor/20181214DavidWells
+++ b/doc/news/changes/minor/20181214DavidWells
@@ -1,0 +1,5 @@
+New: IBTK gained two new functions, IBTK::write_elem_partitioning() and
+IBTK::write_node_partitioning(), that save the subdomain ids of a libMesh system
+to a file for visualization.
+<br>
+(David Wells, 2018/12/14)

--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -873,6 +873,35 @@ get_nodal_dof_indices(const libMesh::DofMap &dof_map,
 #endif
 }
 
+/*!
+ * Save, in a plain text file, the libMesh partitioning, with the format
+ *
+ *     x,y,z,rank
+ *
+ * where x, y, and z are the center of an Elem and rank is the current MPI
+ * rank.
+ *
+ * @note this function collates the output from all MPI processors in the
+ * communicator assigned to @p position_system, so it is an inherently serial
+ * function.
+ */
+inline void
+write_elem_partitioning(const std::string& file_name, const libMesh::System& position_system);
+
+/*!
+ * Save, in a plain text file, the libMesh Node partitioning, with the format
+ *
+ *     x,y,z,rank
+ *
+ * where x, y, and z are the coordinates of a Node and rank is the current MPI
+ * rank.
+ *
+ * @note this function collates the output from all MPI processors in the
+ * communicator assigned to @p position_system, so it is an inherently serial
+ * function.
+ */
+inline void
+write_node_partitioning(const std::string& file_name, const libMesh::System& position_system);
 } // namespace IBTK
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ibtk/lib/Makefile.am
+++ b/ibtk/lib/Makefile.am
@@ -155,7 +155,8 @@ DIM_INDEPENDENT_SOURCES = \
 if LIBMESH_ENABLED
 DIM_INDEPENDENT_SOURCES += \
 ../src/lagrangian/FEDataInterpolation.cpp \
-../src/lagrangian/FEDataManager.cpp
+../src/lagrangian/FEDataManager.cpp \
+../src/utilities/libmesh_utilities.cpp
 endif
 
 pkg_include_HEADERS += \

--- a/ibtk/lib/Makefile.in
+++ b/ibtk/lib/Makefile.in
@@ -93,6 +93,7 @@ host_triplet = @host@
 @SAMRAI3D_ENABLED_TRUE@am__append_2 = libIBTK3d.a
 @LIBMESH_ENABLED_TRUE@am__append_3 = ../src/lagrangian/FEDataInterpolation.cpp \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/FEDataManager.cpp \
+@LIBMESH_ENABLED_TRUE@	../src/utilities/libmesh_utilities.cpp \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/FEDataInterpolation.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/FEDataManager.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/libmesh_utilities.h
@@ -286,6 +287,7 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 	../src/utilities/muParserCartGridFunction.cpp \
 	../src/lagrangian/FEDataInterpolation.cpp \
 	../src/lagrangian/FEDataManager.cpp \
+	../src/utilities/libmesh_utilities.cpp \
 	../include/ibtk/FEDataInterpolation.h \
 	../include/ibtk/FEDataManager.h \
 	../include/ibtk/libmesh_utilities.h \
@@ -310,7 +312,8 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 	$(top_builddir)/src/refine_ops/fortran/divpreservingrefine2d.f \
 	$(top_builddir)/src/solvers/impls/fortran/patchsmoothers2d.f
 @LIBMESH_ENABLED_TRUE@am__objects_1 = ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.$(OBJEXT) \
-@LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK2d_a-FEDataManager.$(OBJEXT)
+@LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK2d_a-FEDataManager.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK2d_a-libmesh_utilities.$(OBJEXT)
 am__objects_2 = ../src/boundary/libIBTK2d_a-HierarchyGhostCellInterpolation.$(OBJEXT) \
 	../src/boundary/cf_interface/libIBTK2d_a-CartCellDoubleLinearCFInterpolation.$(OBJEXT) \
 	../src/boundary/cf_interface/libIBTK2d_a-CartCellDoubleQuadraticCFInterpolation.$(OBJEXT) \
@@ -570,6 +573,7 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 	../src/utilities/muParserCartGridFunction.cpp \
 	../src/lagrangian/FEDataInterpolation.cpp \
 	../src/lagrangian/FEDataManager.cpp \
+	../src/utilities/libmesh_utilities.cpp \
 	../include/ibtk/FEDataInterpolation.h \
 	../include/ibtk/FEDataManager.h \
 	../include/ibtk/libmesh_utilities.h \
@@ -594,7 +598,8 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 	$(top_builddir)/src/refine_ops/fortran/divpreservingrefine3d.f \
 	$(top_builddir)/src/solvers/impls/fortran/patchsmoothers3d.f
 @LIBMESH_ENABLED_TRUE@am__objects_3 = ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.$(OBJEXT) \
-@LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK3d_a-FEDataManager.$(OBJEXT)
+@LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK3d_a-FEDataManager.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK3d_a-libmesh_utilities.$(OBJEXT)
 am__objects_4 = ../src/boundary/libIBTK3d_a-HierarchyGhostCellInterpolation.$(OBJEXT) \
 	../src/boundary/cf_interface/libIBTK3d_a-CartCellDoubleLinearCFInterpolation.$(OBJEXT) \
 	../src/boundary/cf_interface/libIBTK3d_a-CartCellDoubleQuadraticCFInterpolation.$(OBJEXT) \
@@ -960,6 +965,7 @@ am__depfiles_remade = ../src/boundary/$(DEPDIR)/libIBTK2d_a-HierarchyGhostCellIn
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-StandardTagAndInitStrategySet.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-Streamable.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-StreamableManager.Po \
+	../src/utilities/$(DEPDIR)/libIBTK2d_a-libmesh_utilities.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-muParserCartGridFunction.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-AppInitializer.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunction.Po \
@@ -990,6 +996,7 @@ am__depfiles_remade = ../src/boundary/$(DEPDIR)/libIBTK2d_a-HierarchyGhostCellIn
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-StandardTagAndInitStrategySet.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-Streamable.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-StreamableManager.Po \
+	../src/utilities/$(DEPDIR)/libIBTK3d_a-libmesh_utilities.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-muParserCartGridFunction.Po
 am__mv = mv -f
 AM_V_lt = $(am__v_lt_@AM_V@)
@@ -2197,6 +2204,9 @@ libIBTK.a: $(libIBTK_a_OBJECTS) $(libIBTK_a_DEPENDENCIES) $(EXTRA_libIBTK_a_DEPE
 ../src/lagrangian/libIBTK2d_a-FEDataManager.$(OBJEXT):  \
 	../src/lagrangian/$(am__dirstamp) \
 	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/libIBTK2d_a-libmesh_utilities.$(OBJEXT):  \
+	../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 $(top_builddir)/src/boundary/cf_interface/fortran/$(am__dirstamp):
 	@$(MKDIR_P) $(top_builddir)/src/boundary/cf_interface/fortran
 	@: > $(top_builddir)/src/boundary/cf_interface/fortran/$(am__dirstamp)
@@ -2655,6 +2665,9 @@ libIBTK2d.a: $(libIBTK2d_a_OBJECTS) $(libIBTK2d_a_DEPENDENCIES) $(EXTRA_libIBTK2
 ../src/lagrangian/libIBTK3d_a-FEDataManager.$(OBJEXT):  \
 	../src/lagrangian/$(am__dirstamp) \
 	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/libIBTK3d_a-libmesh_utilities.$(OBJEXT):  \
+	../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 $(top_builddir)/src/boundary/cf_interface/fortran/linearcfinterpolation3d.$(OBJEXT): $(top_builddir)/src/boundary/cf_interface/fortran/$(am__dirstamp) \
 	$(top_builddir)/src/boundary/cf_interface/fortran/$(DEPDIR)/$(am__dirstamp)
 $(top_builddir)/src/boundary/cf_interface/fortran/quadcfinterpolation3d.$(OBJEXT): $(top_builddir)/src/boundary/cf_interface/fortran/$(am__dirstamp) \
@@ -2951,6 +2964,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-StandardTagAndInitStrategySet.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-Streamable.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-StreamableManager.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-libmesh_utilities.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-muParserCartGridFunction.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-AppInitializer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunction.Po@am__quote@ # am--include-marker
@@ -2981,6 +2995,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-StandardTagAndInitStrategySet.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-Streamable.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-StreamableManager.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-libmesh_utilities.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-muParserCartGridFunction.Po@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
@@ -4693,6 +4708,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK2d_a-FEDataManager.obj `if test -f '../src/lagrangian/FEDataManager.cpp'; then $(CYGPATH_W) '../src/lagrangian/FEDataManager.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/FEDataManager.cpp'; fi`
 
+../src/utilities/libIBTK2d_a-libmesh_utilities.o: ../src/utilities/libmesh_utilities.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-libmesh_utilities.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-libmesh_utilities.Tpo -c -o ../src/utilities/libIBTK2d_a-libmesh_utilities.o `test -f '../src/utilities/libmesh_utilities.cpp' || echo '$(srcdir)/'`../src/utilities/libmesh_utilities.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-libmesh_utilities.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-libmesh_utilities.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/libmesh_utilities.cpp' object='../src/utilities/libIBTK2d_a-libmesh_utilities.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-libmesh_utilities.o `test -f '../src/utilities/libmesh_utilities.cpp' || echo '$(srcdir)/'`../src/utilities/libmesh_utilities.cpp
+
+../src/utilities/libIBTK2d_a-libmesh_utilities.obj: ../src/utilities/libmesh_utilities.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-libmesh_utilities.obj -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-libmesh_utilities.Tpo -c -o ../src/utilities/libIBTK2d_a-libmesh_utilities.obj `if test -f '../src/utilities/libmesh_utilities.cpp'; then $(CYGPATH_W) '../src/utilities/libmesh_utilities.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/libmesh_utilities.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-libmesh_utilities.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-libmesh_utilities.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/libmesh_utilities.cpp' object='../src/utilities/libIBTK2d_a-libmesh_utilities.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-libmesh_utilities.obj `if test -f '../src/utilities/libmesh_utilities.cpp'; then $(CYGPATH_W) '../src/utilities/libmesh_utilities.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/libmesh_utilities.cpp'; fi`
+
 ../src/boundary/libIBTK3d_a-HierarchyGhostCellInterpolation.o: ../src/boundary/HierarchyGhostCellInterpolation.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/boundary/libIBTK3d_a-HierarchyGhostCellInterpolation.o -MD -MP -MF ../src/boundary/$(DEPDIR)/libIBTK3d_a-HierarchyGhostCellInterpolation.Tpo -c -o ../src/boundary/libIBTK3d_a-HierarchyGhostCellInterpolation.o `test -f '../src/boundary/HierarchyGhostCellInterpolation.cpp' || echo '$(srcdir)/'`../src/boundary/HierarchyGhostCellInterpolation.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/boundary/$(DEPDIR)/libIBTK3d_a-HierarchyGhostCellInterpolation.Tpo ../src/boundary/$(DEPDIR)/libIBTK3d_a-HierarchyGhostCellInterpolation.Po
@@ -6373,6 +6402,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK3d_a-FEDataManager.obj `if test -f '../src/lagrangian/FEDataManager.cpp'; then $(CYGPATH_W) '../src/lagrangian/FEDataManager.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/FEDataManager.cpp'; fi`
 
+../src/utilities/libIBTK3d_a-libmesh_utilities.o: ../src/utilities/libmesh_utilities.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-libmesh_utilities.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-libmesh_utilities.Tpo -c -o ../src/utilities/libIBTK3d_a-libmesh_utilities.o `test -f '../src/utilities/libmesh_utilities.cpp' || echo '$(srcdir)/'`../src/utilities/libmesh_utilities.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-libmesh_utilities.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-libmesh_utilities.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/libmesh_utilities.cpp' object='../src/utilities/libIBTK3d_a-libmesh_utilities.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-libmesh_utilities.o `test -f '../src/utilities/libmesh_utilities.cpp' || echo '$(srcdir)/'`../src/utilities/libmesh_utilities.cpp
+
+../src/utilities/libIBTK3d_a-libmesh_utilities.obj: ../src/utilities/libmesh_utilities.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-libmesh_utilities.obj -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-libmesh_utilities.Tpo -c -o ../src/utilities/libIBTK3d_a-libmesh_utilities.obj `if test -f '../src/utilities/libmesh_utilities.cpp'; then $(CYGPATH_W) '../src/utilities/libmesh_utilities.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/libmesh_utilities.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-libmesh_utilities.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-libmesh_utilities.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/libmesh_utilities.cpp' object='../src/utilities/libIBTK3d_a-libmesh_utilities.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-libmesh_utilities.obj `if test -f '../src/utilities/libmesh_utilities.cpp'; then $(CYGPATH_W) '../src/utilities/libmesh_utilities.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/libmesh_utilities.cpp'; fi`
+
 .f.o:
 	$(AM_V_F77)$(F77COMPILE) -c -o $@ $<
 
@@ -6783,6 +6826,7 @@ distclean: distclean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-StandardTagAndInitStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-Streamable.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-StreamableManager.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-libmesh_utilities.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-muParserCartGridFunction.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-AppInitializer.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunction.Po
@@ -6813,6 +6857,7 @@ distclean: distclean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-StandardTagAndInitStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-Streamable.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-StreamableManager.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-libmesh_utilities.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-muParserCartGridFunction.Po
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
@@ -7068,6 +7113,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-StandardTagAndInitStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-Streamable.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-StreamableManager.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-libmesh_utilities.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-muParserCartGridFunction.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-AppInitializer.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunction.Po
@@ -7098,6 +7144,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-StandardTagAndInitStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-Streamable.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-StreamableManager.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-libmesh_utilities.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-muParserCartGridFunction.Po
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic

--- a/ibtk/src/utilities/libmesh_utilities.cpp
+++ b/ibtk/src/utilities/libmesh_utilities.cpp
@@ -1,0 +1,187 @@
+// Filename: libmesh_utilities.cpp
+// Created on 14 Dec 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include "ibtk/libmesh_utilities.h"
+
+#include "libmesh/parallel.h"
+#include "libmesh/point.h"
+#include "libmesh/mesh_base.h"
+#include "libmesh/numeric_vector.h"
+#include "libmesh/system.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace IBTK
+{
+/////////////////////////////// STATIC ///////////////////////////////////////
+
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+
+inline void
+write_elem_partitioning(const std::string& file_name, const libMesh::System& position_system)
+{
+    const int current_rank = position_system.comm().rank();
+    const unsigned int position_system_n = position_system.number();
+    const libMesh::NumericVector<double>& local_position = *position_system.solution.get();
+    const libMesh::MeshBase &mesh = position_system.get_mesh();
+    const unsigned int spacedim = mesh.spatial_dimension();
+    // TODO: there is something wrong with the way we set up the ghost data in
+    // the position vectors: not all locally owned nodes are, in fact, locally
+    // available. Get around this by localizing first. Since all processes
+    // write to the same file this isn't the worst bottleneck in this
+    // function, anyway.
+    std::vector<double> position(local_position.size());
+    local_position.localize(position);
+    std::stringstream current_processor_output;
+
+    const auto end_elem = mesh.local_elements_end();
+    for (auto elem = mesh.local_elements_begin(); elem != end_elem; ++elem)
+    {
+        const unsigned int n_nodes = (*elem)->n_nodes();
+        libMesh::Point center;
+        // TODO: this is a bit crude: if we use isoparametric elements (e.g.,
+        // Tri6) then this is not a very accurate representation of the center
+        // of the element. We should replace this with something more accurate.
+        for (unsigned int node_n = 0; node_n < n_nodes; ++node_n)
+        {
+            const libMesh::Node &node = (*elem)->node_ref(node_n);
+            TBOX_ASSERT(node.n_vars(position_system_n) == spacedim);
+            for (unsigned int d = 0; d < spacedim; ++d)
+            {
+                center(d) += position[node.dof_number(position_system_n, d, 0)];
+            }
+        }
+        center *= 1.0/n_nodes;
+
+        for (unsigned int d = 0; d < spacedim; ++d)
+        {
+            current_processor_output << center(d) << ',';
+        }
+        if (spacedim == 2)
+        {
+            current_processor_output << 0.0 << ',';
+        }
+        current_processor_output << current_rank << '\n';
+    }
+
+    // clear the file before we append to it
+    if (current_rank == 0)
+    {
+        std::remove(file_name.c_str());
+    }
+    const int n_processes = position_system.comm().size();
+    for (int rank = 0; rank < n_processes; ++rank)
+    {
+        if (rank == current_rank)
+        {
+            std::ofstream out(file_name, std::ios_base::app);
+            if (rank == 0)
+            {
+                out << "x,y,z,r\n";
+            }
+            out << current_processor_output.rdbuf();
+        }
+        position_system.comm().barrier();
+    }
+}
+
+inline void
+write_node_partitioning(const std::string& file_name, const libMesh::System& position_system)
+{
+    const int current_rank = position_system.comm().rank();
+    const unsigned int position_system_n = position_system.number();
+    const libMesh::NumericVector<double>& local_position = *position_system.solution.get();
+    const libMesh::MeshBase &mesh = position_system.get_mesh();
+    const unsigned int spacedim = mesh.spatial_dimension();
+
+    // TODO: there is something wrong with the way we set up the ghost data in
+    // the position vectors: not all locally owned nodes are, in fact,
+    // locally available. Get around this by localizing first. Since all
+    // processes write to the same file this isn't the worst bottleneck in
+    // this function, anyway.
+    std::vector<double> position(local_position.size());
+    local_position.localize(position);
+    std::stringstream current_processor_output;
+
+    const auto end_node = mesh.local_nodes_end();
+    for (auto node_it = mesh.local_nodes_begin(); node_it != end_node; ++node_it)
+    {
+        const libMesh::Node* const node = *node_it;
+        if (node->n_vars(position_system_n))
+        {
+            TBOX_ASSERT(node->n_vars(position_system_n) == spacedim);
+            for (unsigned int d = 0; d < spacedim; ++d)
+            {
+                current_processor_output << position[node->dof_number(position_system_n, d, 0)]
+                                         << ',';
+            }
+            if (spacedim == 2)
+            {
+                current_processor_output << 0.0 << ',';
+            }
+            current_processor_output << current_rank << '\n';
+        }
+    }
+
+    // clear the file before we append to it
+    if (current_rank == 0)
+    {
+        std::remove(file_name.c_str());
+    }
+    const int n_processes = position_system.comm().size();
+    for (int rank = 0; rank < n_processes; ++rank)
+    {
+        if (rank == current_rank)
+        {
+            std::ofstream out(file_name, std::ios_base::app);
+            if (rank == 0)
+            {
+                out << "x,y,z,r\n";
+            }
+            out << current_processor_output.rdbuf();
+        }
+        position_system.comm().barrier();
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+} // namespace IBTK
+
+//////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Another spinoff from #396: this PR adds two new functions to visualize the libMesh partitioning (both `Elem`-wise and `Node`-wise).