### PR TITLE
Remove usage of std::binary_function.

### DIFF
--- a/ibtk/include/ibtk/IndexUtilities.h
+++ b/ibtk/include/ibtk/IndexUtilities.h
@@ -50,7 +50,7 @@
 namespace IBTK
 {
 template <typename T>
-struct IndexOrder : std::binary_function<T, T, bool>
+struct IndexOrder
 {
     inline bool operator()(const T& lhs, const T& rhs) const
     {

--- a/ibtk/include/ibtk/LNodeIndex.h
+++ b/ibtk/include/ibtk/LNodeIndex.h
@@ -207,8 +207,7 @@ private:
  * \brief Comparison functor to order on the physical location of the Lagrangian
  * node.
  */
-class LNodeIndexPosnComp : std::binary_function<const LNodeIndex&, const LNodeIndex&, bool>,
-                           std::binary_function<const LNodeIndex*, const LNodeIndex*, bool>
+class LNodeIndexPosnComp
 {
 public:
     LNodeIndexPosnComp(const boost::multi_array_ref<double, 2>& X_ghosted_local_form_array)
@@ -263,8 +262,7 @@ private:
  * \brief Comparison functor to order on the Lagrangian index of the Lagrangian
  * node.
  */
-struct LNodeIndexLagrangianIndexComp : std::binary_function<const LNodeIndex&, const LNodeIndex&, bool>,
-                                       std::binary_function<const LNodeIndex*, const LNodeIndex*, bool>
+struct LNodeIndexLagrangianIndexComp
 {
     inline bool operator()(const LNodeIndex& lhs, const LNodeIndex& rhs)
     {
@@ -285,8 +283,7 @@ struct LNodeIndexLagrangianIndexComp : std::binary_function<const LNodeIndex&, c
  * \brief Comparison functor to order on the global PETSc index of the
  * Lagrangian node.
  */
-struct LNodeIndexGlobalPETScIndexComp : std::binary_function<const LNodeIndex&, const LNodeIndex&, bool>,
-                                        std::binary_function<const LNodeIndex*, const LNodeIndex*, bool>
+struct LNodeIndexGlobalPETScIndexComp
 {
     inline bool operator()(const LNodeIndex& lhs, const LNodeIndex& rhs)
     {
@@ -307,8 +304,7 @@ struct LNodeIndexGlobalPETScIndexComp : std::binary_function<const LNodeIndex&, 
  * \brief Comparison functor to order on the local PETSc index of the
  * Lagrangian node.
  */
-struct LNodeIndexLocalPETScIndexComp : std::binary_function<const LNodeIndex&, const LNodeIndex&, bool>,
-                                       std::binary_function<const LNodeIndex*, const LNodeIndex*, bool>
+struct LNodeIndexLocalPETScIndexComp
 {
     inline bool operator()(const LNodeIndex& lhs, const LNodeIndex& rhs)
     {
@@ -329,8 +325,7 @@ struct LNodeIndexLocalPETScIndexComp : std::binary_function<const LNodeIndex&, c
  * \brief Comparison functor to check for equality between LNodeIndex objects
  * based on their positions.
  */
-class LNodeIndexPosnEqual : std::binary_function<const LNodeIndex&, const LNodeIndex&, bool>,
-                            std::binary_function<const LNodeIndex*, const LNodeIndex*, bool>
+class LNodeIndexPosnEqual
 {
 public:
     LNodeIndexPosnEqual(const boost::multi_array_ref<double, 2>& X_ghosted_local_form_array)
@@ -370,8 +365,7 @@ private:
  * \brief Comparison functor to check for equality between LNodeIndex objects
  * based on their Lagrangian indices.
  */
-struct LNodeIndexLagrangianIndexEqual : std::binary_function<const LNodeIndex&, const LNodeIndex&, bool>,
-                                        std::binary_function<const LNodeIndex*, const LNodeIndex*, bool>
+struct LNodeIndexLagrangianIndexEqual
 {
     inline bool operator()(const LNodeIndex& lhs, const LNodeIndex& rhs)
     {
@@ -392,8 +386,7 @@ struct LNodeIndexLagrangianIndexEqual : std::binary_function<const LNodeIndex&, 
  * \brief Comparison functor to check for equality between between LNodeIndex
  * objects based on their global PETSc indices.
  */
-struct LNodeIndexGlobalPETScIndexEqual : std::binary_function<const LNodeIndex&, const LNodeIndex&, bool>,
-                                         std::binary_function<const LNodeIndex*, const LNodeIndex*, bool>
+struct LNodeIndexGlobalPETScIndexEqual
 {
     inline bool operator()(const LNodeIndex& lhs, const LNodeIndex& rhs)
     {
@@ -414,8 +407,7 @@ struct LNodeIndexGlobalPETScIndexEqual : std::binary_function<const LNodeIndex&,
  * \brief Comparison functor to check for equality between LNodeIndex objects
  * based on their local PETSc indices.
  */
-struct LNodeIndexLocalPETScIndexEqual : std::binary_function<const LNodeIndex&, const LNodeIndex&, bool>,
-                                        std::binary_function<const LNodeIndex*, const LNodeIndex*, bool>
+struct LNodeIndexLocalPETScIndexEqual
 {
     inline bool operator()(const LNodeIndex& lhs, const LNodeIndex& rhs)
     {

--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -821,7 +821,7 @@ intersect_line_with_face(std::vector<std::pair<double, libMesh::Point> >& t_vals
     return is_interior_intersection;
 } // intersect_line_with_face
 
-struct DofObjectComp : std::binary_function<const libMesh::DofObject* const, const libMesh::DofObject* const, bool>
+struct DofObjectComp
 {
     inline bool operator()(const libMesh::DofObject* const lhs, const libMesh::DofObject* const rhs)
     {

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -172,7 +172,7 @@ static Timer* t_put_to_database;
 static const int FE_DATA_MANAGER_VERSION = 1;
 
 // Local helper functions.
-struct ElemComp : std::binary_function<Elem*, Elem*, bool>
+struct ElemComp
 {
     inline bool operator()(const Elem* const x, const Elem* const y) const
     {

--- a/ibtk/src/solvers/impls/CCPoissonBoxRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonBoxRelaxationFACOperator.cpp
@@ -130,7 +130,7 @@ static const std::string BDRY_EXTRAP_TYPE = "LINEAR";
 // interface ghost cells; used only to evaluate composite grid residuals.
 static const bool CONSISTENT_TYPE_2_BDRY = false;
 
-struct IndexComp : std::binary_function<Index<NDIM>, Index<NDIM>, bool>
+struct IndexComp
 {
     inline bool operator()(const Index<NDIM>& lhs, const Index<NDIM>& rhs) const
     {

--- a/ibtk/src/solvers/impls/CCPoissonHypreLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonHypreLevelSolver.cpp
@@ -105,7 +105,7 @@ enum HypreStructRelaxType
     RELAX_TYPE_RB_GAUSS_SEIDEL_NONSYMMETRIC = 3
 };
 
-struct IndexComp : std::binary_function<Index<NDIM>, Index<NDIM>, bool>
+struct IndexComp
 {
     bool operator()(const Index<NDIM>& lhs, const Index<NDIM>& rhs) const
     {

--- a/ibtk/src/solvers/impls/CCPoissonPointRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonPointRelaxationFACOperator.cpp
@@ -221,7 +221,7 @@ static const std::string BDRY_EXTRAP_TYPE = "LINEAR";
 // interface ghost cells; used only to evaluate composite grid residuals.
 static const bool CONSISTENT_TYPE_2_BDRY = false;
 
-struct IndexComp : std::binary_function<Index<NDIM>, Index<NDIM>, bool>
+struct IndexComp
 {
     inline bool operator()(const Index<NDIM>& lhs, const Index<NDIM>& rhs) const
     {

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -259,7 +259,7 @@ private:
     /*!
      * \brief for ordering objects in a multimap.
      */
-    struct IndexFortranOrder : public std::binary_function<SAMRAI::hier::Index<NDIM>, SAMRAI::hier::Index<NDIM>, bool>
+    struct IndexFortranOrder
     {
         inline bool operator()(const SAMRAI::hier::Index<NDIM>& lhs, const SAMRAI::hier::Index<NDIM>& rhs) const
         {

--- a/include/ibamr/IBInstrumentPanel.h
+++ b/include/ibamr/IBInstrumentPanel.h
@@ -243,7 +243,7 @@ private:
      * and web patch data (i.e., patch centroids and area-weighted normals) and
      * meter centroid data.
      */
-    struct IndexFortranOrder : public std::binary_function<SAMRAI::hier::Index<NDIM>, SAMRAI::hier::Index<NDIM>, bool>
+    struct IndexFortranOrder
     {
         inline bool operator()(const SAMRAI::hier::Index<NDIM>& lhs, const SAMRAI::hier::Index<NDIM>& rhs) const
         {

--- a/include/ibamr/IBRedundantInitializer.h
+++ b/include/ibamr/IBRedundantInitializer.h
@@ -154,7 +154,7 @@ public:
      * Edge data structures.
      */
     using Edge = std::pair<int, int>;
-    struct EdgeComp : public std::binary_function<Edge, Edge, bool>
+    struct EdgeComp
     {
         inline bool operator()(const Edge& e1, const Edge& e2) const
         {

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -1476,7 +1476,7 @@ IBFESurfaceMethod::writeFEDataToRestartFile(const std::string& restart_dump_dirn
 
 namespace
 {
-struct IndexOrder : std::binary_function<SAMRAI::hier::Index<NDIM>, SAMRAI::hier::Index<NDIM>, bool>
+struct IndexOrder
 {
     inline bool operator()(const SAMRAI::hier::Index<NDIM>& lhs, const SAMRAI::hier::Index<NDIM>& rhs) const
     {


### PR DESCRIPTION
`std::binary_function` is only necessary for defining two member typedefs when using `std::not2`, which we do not ever use. `std::binary_function `was also deprecated in C++11.