### PR TITLE
Require libMesh 1.1.0 or newer.

### DIFF
--- a/configure
+++ b/configure
@@ -24075,19 +24075,17 @@ else
 fi
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libMesh version 1.0.0 or newer" >&5
-$as_echo_n "checking for libMesh version 1.0.0 or newer... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libMesh version 1.1.0 or newer" >&5
+$as_echo_n "checking for libMesh version 1.1.0 or newer... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <libmesh/libmesh_config.h>
 
-#if !defined LIBMESH_SUBMINOR_VERSION
-#define LIBMESH_SUBMINOR_VERSION LIBMESH_MICRO_VERSION
-#endif
-#if LIBMESH_MAJOR_VERSION >= 1
+#if LIBMESH_MAJOR_VERSION >= 1 && LIBMESH_MINOR_VERSION >= 2
+// OK
 #else
-asdf
+#error
 #endif
 
 #ifdef FC_DUMMY_MAIN

--- a/doc/news/changes/incompatibilities/20181220DavidWells
+++ b/doc/news/changes/incompatibilities/20181220DavidWells
@@ -1,0 +1,3 @@
+Changed: IBAMR now requires libMesh version 1.1.0 or newer since parts of IBFE
+now require the new, as of 1.1.0, class <code>ReplicatedMesh</code>.
+(David Wells, 2018/12/20)

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -24195,19 +24195,17 @@ else
 fi
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libMesh version 1.0.0 or newer" >&5
-$as_echo_n "checking for libMesh version 1.0.0 or newer... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libMesh version 1.1.0 or newer" >&5
+$as_echo_n "checking for libMesh version 1.1.0 or newer... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <libmesh/libmesh_config.h>
 
-#if !defined LIBMESH_SUBMINOR_VERSION
-#define LIBMESH_SUBMINOR_VERSION LIBMESH_MICRO_VERSION
-#endif
-#if LIBMESH_MAJOR_VERSION >= 1
+#if LIBMESH_MAJOR_VERSION >= 1 && LIBMESH_MINOR_VERSION >= 2
+// OK
 #else
-asdf
+#error
 #endif
 
 #ifdef FC_DUMMY_MAIN

--- a/ibtk/m4/configure_libmesh.m4
+++ b/ibtk/m4/configure_libmesh.m4
@@ -52,16 +52,14 @@ if test "$LIBMESH_ENABLED" = yes; then
   CPPFLAGS_PREPEND($LIBMESH_CPPFLAGS)
   AC_CHECK_HEADER([libmesh/libmesh.h],,AC_MSG_ERROR([libMesh enabled but could not find working libmesh.h]))
   AC_CHECK_HEADER([libmesh/libmesh_config.h],,AC_MSG_ERROR([libMesh enabled but could not find working libmesh_config.h]))
-  AC_MSG_CHECKING([for libMesh version 1.0.0 or newer])
+  AC_MSG_CHECKING([for libMesh version 1.1.0 or newer])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <libmesh/libmesh_config.h>
 
-#if !defined LIBMESH_SUBMINOR_VERSION
-#define LIBMESH_SUBMINOR_VERSION LIBMESH_MICRO_VERSION
-#endif
-#if LIBMESH_MAJOR_VERSION >= 1
+#if LIBMESH_MAJOR_VERSION >= 1 && LIBMESH_MINOR_VERSION >= 2
+// OK
 #else
-asdf
+#error
 #endif
   ]])],[LIBMESH_VERSION_VALID=yes],[LIBMESH_VERSION_VALID=no])
   AC_MSG_RESULT([${LIBMESH_VERSION_VALID}])

--- a/m4/configure_libmesh.m4
+++ b/m4/configure_libmesh.m4
@@ -52,16 +52,14 @@ if test "$LIBMESH_ENABLED" = yes; then
   CPPFLAGS_PREPEND($LIBMESH_CPPFLAGS)
   AC_CHECK_HEADER([libmesh/libmesh.h],,AC_MSG_ERROR([libMesh enabled but could not find working libmesh.h]))
   AC_CHECK_HEADER([libmesh/libmesh_config.h],,AC_MSG_ERROR([libMesh enabled but could not find working libmesh_config.h]))
-  AC_MSG_CHECKING([for libMesh version 1.0.0 or newer])
+  AC_MSG_CHECKING([for libMesh version 1.1.0 or newer])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <libmesh/libmesh_config.h>
 
-#if !defined LIBMESH_SUBMINOR_VERSION
-#define LIBMESH_SUBMINOR_VERSION LIBMESH_MICRO_VERSION
-#endif
-#if LIBMESH_MAJOR_VERSION >= 1
+#if LIBMESH_MAJOR_VERSION >= 1 && LIBMESH_MINOR_VERSION >= 2
+// OK
 #else
-asdf
+#error
 #endif
   ]])],[LIBMESH_VERSION_VALID=yes],[LIBMESH_VERSION_VALID=no])
   AC_MSG_RESULT([${LIBMESH_VERSION_VALID}])


### PR DESCRIPTION
We use ReplicatedMesh now, which was new with libMesh 1.1.0.