### PR TITLE
Fix alignment of Eigen objects.

### DIFF
--- a/ibtk/include/ibtk/ibtk_utilities.h
+++ b/ibtk/include/ibtk/ibtk_utilities.h
@@ -39,6 +39,7 @@
 #include <algorithm>
 
 #include "Eigen/Core" // IWYU pragma: export
+#include "Eigen/StdVector"
 #include "tbox/PIO.h"
 #include "tbox/Utilities.h"
 
@@ -166,6 +167,14 @@ level_can_be_refined(int level_number, int max_levels)
     const int finest_level_number = max_levels - 1;
     return level_number < finest_level_number;
 }
+
+/*!
+ * Eigen types have special alignment requirements and require a specific
+ * memory allocator. This is a convenience type alias for a
+ * <code>std::vector</code> with the correct allocator.
+ */
+template <typename T>
+using EigenAlignedVector = std::vector<T, Eigen::aligned_allocator<T>>;
 
 using Matrix2d = Eigen::Matrix<double, 2, 2>;
 using Vector2d = Eigen::Matrix<double, 2, 1>;

--- a/include/ibamr/CIBMethod.h
+++ b/include/ibamr/CIBMethod.h
@@ -512,7 +512,7 @@ private:
     /*!
      * \brief Compute center of mass of structures.
      */
-    void computeCOMOfStructures(std::vector<Eigen::Vector3d>& center_of_mass,
+    void computeCOMOfStructures(IBTK::EigenAlignedVector<Eigen::Vector3d>& center_of_mass,
                                 std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >& X_data);
 
     /*!

--- a/include/ibamr/CIBStrategy.h
+++ b/include/ibamr/CIBStrategy.h
@@ -580,24 +580,27 @@ protected:
      * \param rot_mat Matrix to set.
      * \param dt Time interval of rotation.
      */
-    void setRotationMatrix(const std::vector<Eigen::Vector3d>& rot_vel,
-                           const std::vector<Eigen::Quaterniond>& q_old,
-                           std::vector<Eigen::Quaterniond>& q_new,
-                           std::vector<Eigen::Matrix3d>& rot_mat,
+    void setRotationMatrix(const IBTK::EigenAlignedVector<Eigen::Vector3d>& rot_vel,
+                           const IBTK::EigenAlignedVector<Eigen::Quaterniond>& q_old,
+                           IBTK::EigenAlignedVector<Eigen::Quaterniond>& q_new,
+                           IBTK::EigenAlignedVector<Eigen::Matrix3d>& rot_mat,
                            const double dt);
 
     // Number of rigid parts.
     unsigned int d_num_rigid_parts;
 
-    // Center of mass.
-    std::vector<Eigen::Vector3d> d_center_of_mass_initial, d_center_of_mass_current, d_center_of_mass_half,
+    /*!
+     * Center of mass.
+     */
+    IBTK::EigenAlignedVector<Eigen::Vector3d> d_center_of_mass_initial, d_center_of_mass_current, d_center_of_mass_half,
         d_center_of_mass_new;
 
     // User-defined (initial) center of mass.
     std::vector<bool> d_compute_center_of_mass_initial;
 
-    // Quaternion of the body.
-    std::vector<Eigen::Quaterniond> d_quaternion_current, d_quaternion_half, d_quaternion_new;
+    /*! Quaternion of the body.
+     */
+    IBTK::EigenAlignedVector<Eigen::Quaterniond> d_quaternion_current, d_quaternion_half, d_quaternion_new;
 
     // Whether to solve for rigid body velocity.
     std::vector<IBTK::FRDV> d_solve_rigid_vel;
@@ -609,9 +612,11 @@ protected:
     std::vector<std::pair<int, int> > d_free_dofs_map;
     bool d_free_dofs_map_updated;
 
-    // Rigid body velocity of the structures.
-    std::vector<Eigen::Vector3d> d_trans_vel_current, d_trans_vel_half, d_trans_vel_new;
-    std::vector<Eigen::Vector3d> d_rot_vel_current, d_rot_vel_half, d_rot_vel_new;
+    /*!
+     * Rigid body velocity of the structures.
+     */
+    IBTK::EigenAlignedVector<Eigen::Vector3d> d_trans_vel_current, d_trans_vel_half, d_trans_vel_new;
+    IBTK::EigenAlignedVector<Eigen::Vector3d> d_rot_vel_current, d_rot_vel_half, d_rot_vel_new;
 
     // Net rigid generalized force.
     std::vector<IBTK::RigidDOFVector> d_net_rigid_generalized_force;

--- a/include/ibamr/ConstraintIBMethod.h
+++ b/include/ibamr/ConstraintIBMethod.h
@@ -501,7 +501,7 @@ private:
     /*!
      * Moment of inertia of the structures.
      */
-    std::vector<Eigen::Matrix3d> d_moment_of_inertia_current, d_moment_of_inertia_new;
+    IBTK::EigenAlignedVector<Eigen::Matrix3d> d_moment_of_inertia_current, d_moment_of_inertia_new;
 
     /*!
      * Tag a Lagrangian point (generally eye of the fish) of the immersed structures.

--- a/include/ibamr/IBFEDirectForcingKinematics.h
+++ b/include/ibamr/IBFEDirectForcingKinematics.h
@@ -75,6 +75,13 @@ class IBFEDirectForcingKinematics : public virtual SAMRAI::tbox::DescribedClass,
 {
 public:
     /*!
+     * Since this class has Eigen object members, which have special alignment
+     * requirements, we must explicitly override operator new to get the
+     * correct aligment for the object as a whole.
+     */
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    /*!
      * \brief Constructor.
      */
     IBFEDirectForcingKinematics(std::string object_name,

--- a/include/ibamr/IBHydrodynamicForceEvaluator.h
+++ b/include/ibamr/IBHydrodynamicForceEvaluator.h
@@ -114,8 +114,9 @@ public:
 
     struct IBHydrodynamicForceObject
     {
-        // Structure details.
-        int strct_id;
+        // Since this structure has Eigen members we must explicitly override
+        // its new and delete operators:
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
         // Force, torque, and momentum of the body.
         IBTK::Vector3d F_current, T_current, P_current, L_current;
@@ -140,6 +141,9 @@ public:
 
         // Indicator variable index of the control volume for plotting
         int inside_strct_idx;
+
+        // Structure details.
+        int strct_id;
 
         // File streams associated for the output.
         std::ofstream *drag_CV_stream, *torque_CV_stream;

--- a/src/IB/CIBFEMethod.cpp
+++ b/src/IB/CIBFEMethod.cpp
@@ -369,7 +369,7 @@ CIBFEMethod::eulerStep(const double current_time, const double new_time)
     const double dt = MathUtilities<double>::equalEps(d_rho, 0.0) ? 0.0 : (new_time - current_time);
 
     // Fill the rotation matrix of structures with rotation angle 0.5*(W^n)*dt.
-    std::vector<Eigen::Matrix3d> rotation_mat(d_num_rigid_parts, Eigen::Matrix3d::Identity(3, 3));
+    IBTK::EigenAlignedVector<Eigen::Matrix3d> rotation_mat(d_num_rigid_parts, Eigen::Matrix3d::Identity(3, 3));
     setRotationMatrix(d_rot_vel_current, d_quaternion_current, d_quaternion_half, rotation_mat, 0.5 * dt);
 
     // Rotate the body with current rotational velocity about center of mass
@@ -445,7 +445,7 @@ CIBFEMethod::midpointStep(const double current_time, const double new_time)
     const double dt = new_time - current_time;
 
     // Fill the rotation matrix of structures with rotation angle (W^n+1)*dt.
-    std::vector<Eigen::Matrix3d> rotation_mat(d_num_rigid_parts, Eigen::Matrix3d::Identity(3, 3));
+    IBTK::EigenAlignedVector<Eigen::Matrix3d> rotation_mat(d_num_rigid_parts, Eigen::Matrix3d::Identity(3, 3));
     setRotationMatrix(d_rot_vel_half, d_quaternion_current, d_quaternion_new, rotation_mat, dt);
 
     // Rotate the body with current rotational velocity about origin

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -37,6 +37,7 @@
 #include "ibamr/MobilityFunctions.h"
 #include "ibamr/StokesSpecifications.h"
 #include "ibamr/namespaces.h"
+#include "ibtk/ibtk_utilities.h"
 #include "ibtk/LSiloDataWriter.h"
 
 namespace IBAMR
@@ -561,7 +562,7 @@ CIBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy,
     }
 
     // Initialize initial center of mass of structures.
-    std::vector<Eigen::Vector3d> X0_com(d_num_rigid_parts, Eigen::Vector3d::Zero());
+    IBTK::EigenAlignedVector<Eigen::Vector3d> X0_com(d_num_rigid_parts, Eigen::Vector3d::Zero());
     std::vector<Pointer<LData> > X0_unshifted_data_vec(finest_ln + 1, Pointer<LData>(nullptr));
     X0_unshifted_data_vec[finest_ln] = d_l_data_manager->getLData("X0_unshifted", finest_ln);
     computeCOMOfStructures(X0_com, X0_unshifted_data_vec);
@@ -637,7 +638,7 @@ CIBMethod::forwardEulerStep(double current_time, double new_time)
     const double dt = MathUtilities<double>::equalEps(d_rho, 0.0) ? 0.0 : (new_time - current_time);
 
     // Fill the rotation matrix of structures with rotation angle 0.5*(W^n)*dt.
-    std::vector<Eigen::Matrix3d> rotation_mat(d_num_rigid_parts, Eigen::Matrix3d::Identity(3, 3));
+    IBTK::EigenAlignedVector<Eigen::Matrix3d> rotation_mat(d_num_rigid_parts, Eigen::Matrix3d::Identity(3, 3));
     setRotationMatrix(d_rot_vel_current, d_quaternion_current, d_quaternion_half, rotation_mat, 0.5 * dt);
 
     // Get the domain limits.
@@ -757,7 +758,7 @@ CIBMethod::midpointStep(double current_time, double new_time)
     const bool is_steady_stokes = MathUtilities<double>::equalEps(d_rho, 0.0);
 
     // Fill the rotation matrix of structures with rotation angle (W^n+1)*dt.
-    std::vector<Eigen::Matrix3d> rotation_mat(d_num_rigid_parts, Eigen::Matrix3d::Identity(3, 3));
+    IBTK::EigenAlignedVector<Eigen::Matrix3d> rotation_mat(d_num_rigid_parts, Eigen::Matrix3d::Identity(3, 3));
     setRotationMatrix(
         is_steady_stokes ? d_rot_vel_new : d_rot_vel_half, d_quaternion_current, d_quaternion_new, rotation_mat, dt);
 
@@ -1735,7 +1736,7 @@ CIBMethod::getFromRestart()
 } // getFromRestart
 
 void
-CIBMethod::computeCOMOfStructures(std::vector<Eigen::Vector3d>& center_of_mass, std::vector<Pointer<LData> >& X_data)
+CIBMethod::computeCOMOfStructures(IBTK::EigenAlignedVector<Eigen::Vector3d>& center_of_mass, std::vector<Pointer<LData> >& X_data)
 {
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();

--- a/src/IB/CIBStrategy.cpp
+++ b/src/IB/CIBStrategy.cpp
@@ -35,6 +35,7 @@
 #include "ibamr/CIBStrategy.h"
 #include "ibamr/ibamr_utilities.h"
 #include "ibamr/namespaces.h"
+#include "ibtk/ibtk_utilities.h"
 #include "tbox/MathUtilities.h"
 #include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
@@ -860,10 +861,10 @@ CIBStrategy::rotateArray(double* /*array*/,
 /////////////////////////////// PROTECTED ////////////////////////////////////
 
 void
-CIBStrategy::setRotationMatrix(const std::vector<Eigen::Vector3d>& rot_vel,
-                               const std::vector<Eigen::Quaterniond>& q_old,
-                               std::vector<Eigen::Quaterniond>& q_new,
-                               std::vector<Eigen::Matrix3d>& rot_mat,
+CIBStrategy::setRotationMatrix(const IBTK::EigenAlignedVector<Eigen::Vector3d>& rot_vel,
+                               const IBTK::EigenAlignedVector<Eigen::Quaterniond>& q_old,
+                               IBTK::EigenAlignedVector<Eigen::Quaterniond>& q_new,
+                               IBTK::EigenAlignedVector<Eigen::Matrix3d>& rot_mat,
                                const double dt)
 {
     for (unsigned struct_no = 0; struct_no < d_num_rigid_parts; ++struct_no)


### PR DESCRIPTION
Eigen will automatically use AVX512 and other vectorized instruction sets if they are available. This causes segmentation faults (on AMD64, at least) when objects are not aligned to 128-bit (or better) addresses. This commit gets around this by specifying alignment requirements (or, for std::vector [1], a custom allocator) for objects with Eigen members.

[1] http://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html