### PR TITLE
eliminate some calls to NumericVector<T>::close()

### DIFF
--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -169,6 +169,118 @@ copy_and_synch(libMesh::NumericVector<double>& v_in,
     if (close_v_out) v_out.close();
 }
 
+inline void
+batch_vec_copy(const std::vector<libMesh::PetscVector<double>*>& x_vecs,
+               const std::vector<libMesh::PetscVector<double>*>& y_vecs)
+{
+#if defined(NDEBUG)
+    TBOX_ASSERT(x_vecs.size() == y_vecs.size());
+#endif
+    for (unsigned int k = 0; k < x_vecs.size(); ++k)
+    {
+        if (!x_vecs[k] || !y_vecs[k]) continue;
+        int ierr = VecCopy(x_vecs[k]->vec(), y_vecs[k]->vec());
+        IBTK_CHKERRQ(ierr);
+    }
+}
+
+inline void
+batch_vec_copy(const std::vector<std::vector<libMesh::PetscVector<double>*> >& x_vecs,
+               const std::vector<std::vector<libMesh::PetscVector<double>*> >& y_vecs)
+{
+#if defined(NDEBUG)
+    TBOX_ASSERT(x_vecs.size() == y_vecs.size());
+#endif
+    for (unsigned int n = 0; n < x_vecs.size(); ++n)
+    {
+        batch_vec_copy(x_vecs[n], y_vecs[n]);
+    }
+}
+
+inline void
+batch_vec_assembly(const std::vector<libMesh::PetscVector<double>*>& vecs)
+{
+    for (const auto& v : vecs)
+    {
+        if (!v) continue;
+        int ierr = VecAssemblyBegin(v->vec());
+        IBTK_CHKERRQ(ierr);
+    }
+    for (const auto& v : vecs)
+    {
+        if (!v) continue;
+        int ierr = VecAssemblyEnd(v->vec());
+        IBTK_CHKERRQ(ierr);
+    }
+}
+
+inline void
+batch_vec_assembly(const std::vector<std::vector<libMesh::PetscVector<double>*> >& vecs)
+{
+    for (unsigned int n = 0; n < vecs.size(); ++n)
+    {
+        for (const auto& v : vecs[n])
+        {
+            if (!v) continue;
+            int ierr = VecAssemblyBegin(v->vec());
+            IBTK_CHKERRQ(ierr);
+        }
+    }
+    for (unsigned int n = 0; n < vecs.size(); ++n)
+    {
+        for (const auto& v : vecs[n])
+        {
+            if (!v) continue;
+            int ierr = VecAssemblyEnd(v->vec());
+            IBTK_CHKERRQ(ierr);
+        }
+    }
+}
+
+inline void
+batch_vec_ghost_update(const std::vector<libMesh::PetscVector<double>*>& vecs,
+                       const InsertMode insert_mode,
+                       const ScatterMode scatter_mode)
+{
+    for (const auto& v : vecs)
+    {
+        if (!v) continue;
+        int ierr = VecGhostUpdateBegin(v->vec(), insert_mode, scatter_mode);
+        IBTK_CHKERRQ(ierr);
+    }
+    for (const auto& v : vecs)
+    {
+        if (!v) continue;
+        int ierr = VecGhostUpdateEnd(v->vec(), insert_mode, scatter_mode);
+        IBTK_CHKERRQ(ierr);
+    }
+}
+
+inline void
+batch_vec_ghost_update(const std::vector<std::vector<libMesh::PetscVector<double>*> >& vecs,
+                       const InsertMode insert_mode,
+                       const ScatterMode scatter_mode)
+{
+    for (unsigned int n = 0; n < vecs.size(); ++n)
+    {
+        for (const auto& v : vecs[n])
+        {
+            if (!v) continue;
+            int ierr = VecGhostUpdateBegin(v->vec(), insert_mode, scatter_mode);
+            IBTK_CHKERRQ(ierr);
+        }
+    }
+    for (unsigned int n = 0; n < vecs.size(); ++n)
+    {
+        for (const auto& v : vecs[n])
+        {
+            if (!v) continue;
+            int ierr = VecGhostUpdateEnd(v->vec(), insert_mode, scatter_mode);
+            IBTK_CHKERRQ(ierr);
+        }
+    }
+}
+
 template <class MultiArray, class Array>
 inline void
 get_values_for_interpolation(MultiArray& U_node,

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -604,16 +604,21 @@ FEDataManager::spread(const int f_data_idx,
         auto F_dX_petsc_vec = static_cast<PetscVector<double>*>(&F_dX_vec);
         Vec F_dX_global_vec = F_dX_petsc_vec->vec();
         Vec F_dX_local_vec;
-        VecGhostGetLocalForm(F_dX_global_vec, &F_dX_local_vec);
+        int ierr;
+        ierr = VecGhostGetLocalForm(F_dX_global_vec, &F_dX_local_vec);
+        IBTK_CHKERRQ(ierr);
         double* F_dX_local_soln;
-        VecGetArray(F_dX_local_vec, &F_dX_local_soln);
+        ierr = VecGetArray(F_dX_local_vec, &F_dX_local_soln);
+        IBTK_CHKERRQ(ierr);
 
         auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
-        VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        ierr = VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
         double* X_local_soln;
-        VecGetArray(X_local_vec, &X_local_soln);
+        ierr = VecGetArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
 
         // Spread from the nodes.
         int local_patch_num = 0;
@@ -684,11 +689,15 @@ FEDataManager::spread(const int f_data_idx,
         }
 
         // Restore local form vectors.
-        VecRestoreArray(F_dX_local_vec, &F_dX_local_soln);
-        VecGhostRestoreLocalForm(F_dX_global_vec, &F_dX_local_vec);
+        ierr = VecRestoreArray(F_dX_local_vec, &F_dX_local_soln);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecGhostRestoreLocalForm(F_dX_global_vec, &F_dX_local_vec);
+        IBTK_CHKERRQ(ierr);
 
-        VecRestoreArray(X_local_vec, &X_local_soln);
-        VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        ierr = VecRestoreArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
 
         // Restore the value of the F vector.
         F_vec = *F_vec_bak;
@@ -699,16 +708,21 @@ FEDataManager::spread(const int f_data_idx,
         auto F_petsc_vec = static_cast<PetscVector<double>*>(&F_vec);
         Vec F_global_vec = F_petsc_vec->vec();
         Vec F_local_vec;
-        VecGhostGetLocalForm(F_global_vec, &F_local_vec);
+        int ierr;
+        ierr = VecGhostGetLocalForm(F_global_vec, &F_local_vec);
+        IBTK_CHKERRQ(ierr);
         double* F_local_soln;
-        VecGetArray(F_local_vec, &F_local_soln);
+        ierr = VecGetArray(F_local_vec, &F_local_soln);
+        IBTK_CHKERRQ(ierr);
 
         auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
-        VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        ierr = VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
         double* X_local_soln;
-        VecGetArray(X_local_vec, &X_local_soln);
+        ierr = VecGetArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
 
         // Loop over the patches to interpolate nodal values on the FE mesh to
         // the element quadrature points, then spread those values onto the
@@ -832,11 +846,15 @@ FEDataManager::spread(const int f_data_idx,
         }
 
         // Restore local form vectors.
-        VecRestoreArray(F_local_vec, &F_local_soln);
-        VecGhostRestoreLocalForm(F_global_vec, &F_local_vec);
+        ierr = VecRestoreArray(F_local_vec, &F_local_soln);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecGhostRestoreLocalForm(F_global_vec, &F_local_vec);
+        IBTK_CHKERRQ(ierr);
 
-        VecRestoreArray(X_local_vec, &X_local_soln);
-        VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        ierr = VecRestoreArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
     }
 
     // Accumulate data.
@@ -920,17 +938,22 @@ FEDataManager::prolongData(const int f_data_idx,
     auto F_petsc_vec = static_cast<PetscVector<double>*>(&F_vec);
     Vec F_global_vec = F_petsc_vec->vec();
     Vec F_local_vec;
-    VecGhostGetLocalForm(F_global_vec, &F_local_vec);
+    int ierr;
+    ierr = VecGhostGetLocalForm(F_global_vec, &F_local_vec);
+    IBTK_CHKERRQ(ierr);
     double* F_local_soln;
-    VecGetArray(F_local_vec, &F_local_soln);
+    ierr = VecGetArray(F_local_vec, &F_local_soln);
+    IBTK_CHKERRQ(ierr);
 
     if (close_X) X_vec.close();
     auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
     Vec X_global_vec = X_petsc_vec->vec();
     Vec X_local_vec;
-    VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+    ierr = VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+    IBTK_CHKERRQ(ierr);
     double* X_local_soln;
-    VecGetArray(X_local_vec, &X_local_soln);
+    ierr = VecGetArray(X_local_vec, &X_local_soln);
+    IBTK_CHKERRQ(ierr);
 
     // Loop over the patches to interpolate nodal values on the FE mesh to the
     // points of the Eulerian grid.
@@ -1071,11 +1094,15 @@ FEDataManager::prolongData(const int f_data_idx,
         }
     }
 
-    VecRestoreArray(F_local_vec, &F_local_soln);
-    VecGhostRestoreLocalForm(F_global_vec, &F_local_vec);
+    ierr = VecRestoreArray(F_local_vec, &F_local_soln);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecGhostRestoreLocalForm(F_global_vec, &F_local_vec);
+    IBTK_CHKERRQ(ierr);
 
-    VecRestoreArray(X_local_vec, &X_local_soln);
-    VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+    ierr = VecRestoreArray(X_local_vec, &X_local_soln);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+    IBTK_CHKERRQ(ierr);
 
     IBTK_TIMER_STOP(t_prolong_data);
     return;
@@ -1180,9 +1207,12 @@ FEDataManager::interpWeighted(const int f_data_idx,
         auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
-        VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        int ierr;
+        ierr = VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
         double* X_local_soln;
-        VecGetArray(X_local_vec, &X_local_soln);
+        ierr = VecGetArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
 
         // Interpolate to the nodes.
         int local_patch_num = 0;
@@ -1263,8 +1293,10 @@ FEDataManager::interpWeighted(const int f_data_idx,
         }
 
         // Restore local form vectors.
-        VecRestoreArray(X_local_vec, &X_local_soln);
-        VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        ierr = VecRestoreArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
 
         // Scale by the diagonal mass matrix.
         F_vec.close();
@@ -1278,9 +1310,12 @@ FEDataManager::interpWeighted(const int f_data_idx,
         auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
-        VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        int ierr;
+        ierr = VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
         double* X_local_soln;
-        VecGetArray(X_local_vec, &X_local_soln);
+        ierr = VecGetArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
 
         // Loop over the patches to interpolate values to the element quadrature
         // points from the grid, then use these values to compute the projection
@@ -1437,8 +1472,10 @@ FEDataManager::interpWeighted(const int f_data_idx,
         }
 
         // Restore local form vectors.
-        VecRestoreArray(X_local_vec, &X_local_soln);
-        VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        ierr = VecRestoreArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
     }
 
     // Accumulate data.
@@ -1548,9 +1585,12 @@ FEDataManager::restrictData(const int f_data_idx,
     auto X_petsc_vec = static_cast<PetscVector<double>*>(&X_vec);
     Vec X_global_vec = X_petsc_vec->vec();
     Vec X_local_vec;
-    VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+    int ierr;
+    ierr = VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+    IBTK_CHKERRQ(ierr);
     double* X_local_soln;
-    VecGetArray(X_local_vec, &X_local_soln);
+    ierr = VecGetArray(X_local_vec, &X_local_soln);
+    IBTK_CHKERRQ(ierr);
 
     // Loop over the patches to assemble the right-hand-side vector used to
     // solve for F.
@@ -1699,8 +1739,10 @@ FEDataManager::restrictData(const int f_data_idx,
         }
     }
 
-    VecRestoreArray(X_local_vec, &X_local_soln);
-    VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+    ierr = VecRestoreArray(X_local_vec, &X_local_soln);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+    IBTK_CHKERRQ(ierr);
 
     // Solve for the nodal values.
     F_rhs_vec->close();
@@ -2211,9 +2253,12 @@ FEDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> > hi
         auto X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec.get());
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
-        VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        int ierr;
+        ierr = VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
         double* X_local_soln;
-        VecGetArray(X_local_vec, &X_local_soln);
+        ierr = VecGetArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
 
         // Tag cells for refinement whenever they contain active element
         // quadrature points.
@@ -2267,8 +2312,10 @@ FEDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> > hi
             }
         }
 
-        VecRestoreArray(X_local_vec, &X_local_soln);
-        VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        ierr = VecRestoreArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
     }
     else if (level_number + 1 == d_level_number && level_number < d_hierarchy->getFinestLevelNumber())
     {
@@ -2420,9 +2467,12 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
         auto X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec);
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
-        VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        int ierr;
+        ierr = VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
         double* X_local_soln;
-        VecGetArray(X_local_vec, &X_local_soln);
+        ierr = VecGetArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
 
         // Determine the number of element quadrature points associated with
         // each Cartesian grid cell.
@@ -2472,8 +2522,10 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
             }
         }
 
-        VecRestoreArray(X_local_vec, &X_local_soln);
-        VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        ierr = VecRestoreArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
     }
     return;
 } // updateQuadPointCountData
@@ -2647,9 +2699,12 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
         auto X_petsc_vec = static_cast<PetscVector<double>*>(X_ghost_vec.get());
         Vec X_global_vec = X_petsc_vec->vec();
         Vec X_local_vec;
-        VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        int ierr;
+        ierr = VecGhostGetLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
         double* X_local_soln;
-        VecGetArray(X_local_vec, &X_local_soln);
+        ierr = VecGetArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
 
         // Keep only those elements that have a quadrature point on the local
         // patch.
@@ -2707,8 +2762,10 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
             }
         }
 
-        VecRestoreArray(X_local_vec, &X_local_soln);
-        VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        ierr = VecRestoreArray(X_local_vec, &X_local_soln);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecGhostRestoreLocalForm(X_global_vec, &X_local_vec);
+        IBTK_CHKERRQ(ierr);
 
         // Rebuild the set of frontier elements, which are any neighbors of a
         // local element that has not already been determined to be either a

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -662,15 +662,15 @@ protected:
                                     unsigned int part);
 
     /*!
-     * \brief Compute the interior elastic density, possibly splitting off the
-     * normal component of the transmission force along the physical boundary of
-     * the Lagrangian structure.
+     * \brief Assemble the RHS for the interior elastic density, possibly
+     * splitting off the normal component of the transmission force along the
+     * physical boundary of the Lagrangian structure.
      */
-    void computeInteriorForceDensity(libMesh::PetscVector<double>& G_vec,
-                                     libMesh::PetscVector<double>& X_vec,
-                                     libMesh::PetscVector<double>* Phi_vec,
-                                     double data_time,
-                                     unsigned int part);
+    void assembleInteriorForceDensityRHS(libMesh::PetscVector<double>& G_rhs_vec,
+                                         libMesh::PetscVector<double>& X_vec,
+                                         libMesh::PetscVector<double>* Phi_vec,
+                                         double data_time,
+                                         unsigned int part);
 
     /*!
      * \brief Reset positions in overlap regions.


### PR DESCRIPTION
This PR supersedes #430, which had a couple of bugs that changed the computed solution in parallel.