### PR TITLE
Unroll some loops to avoid zeroing data.

### DIFF
--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -280,8 +280,17 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_trimmed_lower(1),ic_trimmed_upper(1)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic1 = ic_trimmed_lower(1),ic_trimmed_lower(1)
+               do ic0 = ic_trimmed_lower(0),ic_trimmed_upper(0)
+                  V(d,s) = w(0,ic0-ic_lower(0))
+     &                 *w(1,ic1-ic_lower(1))
+     &                 *u(ic0,ic1,d)
+               enddo
+            enddo
+            do ic1 = ic_trimmed_lower(1)+1,ic_trimmed_upper(1)
                do ic0 = ic_trimmed_lower(0),ic_trimmed_upper(0)
                   V(d,s) = V(d,s)
      &                 +w(0,ic0-ic_lower(0))
@@ -521,8 +530,17 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_trimmed_lower(1),ic_trimmed_upper(1)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic1 = ic_trimmed_lower(1),ic_trimmed_lower(1)
+               do ic0 = ic_trimmed_lower(0),ic_trimmed_upper(0)
+                  V(d,s) = w(0,ic0-ic_lower(0))
+     &                 *w(1,ic1-ic_lower(1))
+     &                 *u(ic0,ic1,d)
+               enddo
+            enddo
+            do ic1 = ic_trimmed_lower(1)+1,ic_trimmed_upper(1)
                do ic0 = ic_trimmed_lower(0),ic_trimmed_upper(0)
                   V(d,s) = V(d,s)
      &                 +w(0,ic0-ic_lower(0))
@@ -765,8 +783,17 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic1 = ic_lower(1),ic_lower(1)
+               do ic0 = ic_lower(0),ic_upper(0)
+                  V(d,s) = w0(ic0-ic_lower(0))
+     &                 *w1(ic1-ic_lower(1))
+     &                 *u(ic0,ic1,d)
+               enddo
+            enddo
+            do ic1 = ic_lower(1)+1,ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
      &                 +w0(ic0-ic_lower(0))
@@ -1014,8 +1041,17 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic1 = ic_lower(1),ic_lower(1)
+               do ic0 = ic_lower(0),ic_upper(0)
+                  V(d,s) = w0(ic0-ic_lower(0))
+     &                 *w1(ic1-ic_lower(1))
+     &                 *u(ic0,ic1,d)
+               enddo
+            enddo
+            do ic1 = ic_lower(1)+1,ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
      &                 +w0(ic0-ic_lower(0))
@@ -1257,8 +1293,17 @@ c
          istart1 =   max(ig_lower(1)-ic_lower(1),0)
          istop1  = 3-max(ic_upper(1)-ig_upper(1),0)
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do i1 = istart1,istop1
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do i1 = istart1,istart1
+               ic1 = ic_lower(1)+i1
+               do i0 = istart0,istop0
+                  ic0 = ic_lower(0)+i0
+                  V(d,s) = w(i0,i1)*u(ic0,ic1,d)
+               enddo
+            enddo
+            do i1 = istart1+1,istop1
                ic1 = ic_lower(1)+i1
                do i0 = istart0,istop0
                   ic0 = ic_lower(0)+i0
@@ -1511,8 +1556,17 @@ c
          istart1 =   max(ig_lower(1)-ic_lower(1),0)
          istop1  = 7-max(ic_upper(1)-ig_upper(1),0)
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do i1 = istart1,istop1
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do i1 = istart1,istart1
+               ic1 = ic_lower(1)+i1
+               do i0 = istart0,istop0
+                  ic0 = ic_lower(0)+i0
+                  V(d,s) = w(i0,i1)*u(ic0,ic1,d)
+               enddo
+            enddo
+            do i1 = istart1+1,istop1
                ic1 = ic_lower(1)+i1
                do i0 = istart0,istop0
                   ic0 = ic_lower(0)+i0
@@ -1797,8 +1851,17 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic1 = ic_lower(1),ic_lower(1)
+               do ic0 = ic_lower(0),ic_upper(0)
+                  V(d,s) = w0(ic0-ic_lower(0))
+     &                 *w1(ic1-ic_lower(1))
+     &                 *u(ic0,ic1,d)
+               enddo
+            enddo
+            do ic1 = ic_lower(1)+1,ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
      &                 +w0(ic0-ic_lower(0))
@@ -2118,8 +2181,17 @@ c
          istart1 =   max(ig_lower(1)-ic_lower(1),0)
          istop1  = 5-max(ic_upper(1)-ig_upper(1),0)
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do i1 = istart1,istop1
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do i1 = istart1,istart1
+               ic1 = ic_lower(1)+i1
+               do i0 = istart0,istop0
+                  ic0 = ic_lower(0)+i0
+                  V(d,s) = w(i0,i1)*u(ic0,ic1,d)
+               enddo
+            enddo
+            do i1 = istart1+1,istop1
                ic1 = ic_lower(1)+i1
                do i0 = istart0,istop0
                   ic0 = ic_lower(0)+i0
@@ -2403,8 +2475,17 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic1 = ic_lower(1),ic_lower(1)
+               do ic0 = ic_lower(0),ic_upper(0)
+                  V(d,s) = w0(ic0-ic_lower(0))
+     &                 *w1(ic1-ic_lower(1))
+     &                 *u(ic0,ic1,d)
+               enddo
+            enddo
+            do ic1 = ic_lower(1)+1,ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
      &                 +w0(ic0-ic_lower(0))
@@ -2652,8 +2733,17 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic1 = ic_lower(1),ic_lower(1)
+               do ic0 = ic_lower(0),ic_upper(0)
+                  V(d,s) = w0(ic0-ic_lower(0))
+     &                 *w1(ic1-ic_lower(1))
+     &                 *u(ic0,ic1,d)
+               enddo
+            enddo
+            do ic1 = ic_lower(1)+1,ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
      &                 +w0(ic0-ic_lower(0))
@@ -2901,8 +2991,17 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic1 = ic_lower(1),ic_lower(1)
+               do ic0 = ic_lower(0),ic_upper(0)
+                  V(d,s) = w0(ic0-ic_lower(0))
+     &                 *w1(ic1-ic_lower(1))
+     &                 *u(ic0,ic1,d)
+               enddo
+            enddo
+            do ic1 = ic_lower(1)+1,ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
      &                 +w0(ic0-ic_lower(0))
@@ -3150,8 +3249,17 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic1 = ic_lower(1),ic_lower(1)
+               do ic0 = ic_lower(0),ic_upper(0)
+                  V(d,s) = w0(ic0-ic_lower(0))
+     &                 *w1(ic1-ic_lower(1))
+     &                 *u(ic0,ic1,d)
+               enddo
+            enddo
+            do ic1 = ic_lower(1)+1,ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
      &                 +w0(ic0-ic_lower(0))

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
@@ -286,8 +286,20 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_trimmed_lower(2),ic_trimmed_upper(2)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic2 = ic_trimmed_lower(2),ic_trimmed_lower(2)
+               do ic1 = ic_trimmed_lower(1),ic_trimmed_upper(1)
+                  do ic0 = ic_trimmed_lower(0),ic_trimmed_upper(0)
+                     V(d,s) = w(0,ic0-ic_lower(0))
+     &                    *w(1,ic1-ic_lower(1))
+     &                    *w(2,ic2-ic_lower(2))
+     &                    *u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do ic2 = ic_trimmed_lower(2)+1,ic_trimmed_upper(2)
                do ic1 = ic_trimmed_lower(1),ic_trimmed_upper(1)
                   do ic0 = ic_trimmed_lower(0),ic_trimmed_upper(0)
                      V(d,s) = V(d,s)
@@ -538,8 +550,20 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_trimmed_lower(2),ic_trimmed_upper(2)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic2 = ic_trimmed_lower(2),ic_trimmed_lower(2)
+               do ic1 = ic_trimmed_lower(1),ic_trimmed_upper(1)
+                  do ic0 = ic_trimmed_lower(0),ic_trimmed_upper(0)
+                     V(d,s) = w(0,ic0-ic_lower(0))
+     &                    *w(1,ic1-ic_lower(1))
+     &                    *w(2,ic2-ic_lower(2))
+     &                    *u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do ic2 = ic_trimmed_lower(2)+1,ic_trimmed_upper(2)
                do ic1 = ic_trimmed_lower(1),ic_trimmed_upper(1)
                   do ic0 = ic_trimmed_lower(0),ic_trimmed_upper(0)
                      V(d,s) = V(d,s)
@@ -805,8 +829,20 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic2 = ic_lower(2),ic_lower(2)
+               do ic1 = ic_lower(1),ic_upper(1)
+                  do ic0 = ic_lower(0),ic_upper(0)
+                     V(d,s) = w0(ic0-ic_lower(0))
+     &                    *w1(ic1-ic_lower(1))
+     &                    *w2(ic2-ic_lower(2))
+     &                    *u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do ic2 = ic_lower(2)+1,ic_upper(2)
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
@@ -1088,8 +1124,20 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic2 = ic_lower(2),ic_lower(2)
+               do ic1 = ic_lower(1),ic_upper(1)
+                  do ic0 = ic_lower(0),ic_upper(0)
+                     V(d,s) = w0(ic0-ic_lower(0))
+     &                    *w1(ic1-ic_lower(1))
+     &                    *w2(ic2-ic_lower(2))
+     &                    *u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do ic2 = ic_lower(2)+1,ic_upper(2)
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
@@ -1368,8 +1416,20 @@ c
          istart2 =   max(ig_lower(2)-ic_lower(2),0)
          istop2  = 3-max(ic_upper(2)-ig_upper(2),0)
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do i2 = istart2,istop2
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do i2 = istart2,istart2
+               ic2 = ic_lower(2)+i2
+               do i1 = istart1,istop1
+                  ic1 = ic_lower(1)+i1
+                  do i0 = istart0,istop0
+                     ic0 = ic_lower(0)+i0
+                     V(d,s) = w(i0,i1,i2)*u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do i2 = istart2+1,istop2
                ic2 = ic_lower(2)+i2
                do i1 = istart1,istop1
                   ic1 = ic_lower(1)+i1
@@ -1669,8 +1729,20 @@ c
          istart2 =   max(ig_lower(2)-ic_lower(2),0)
          istop2  = 7-max(ic_upper(2)-ig_upper(2),0)
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do i2 = istart2,istop2
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do i2 = istart2,istart2
+               ic2 = ic_lower(2)+i2
+               do i1 = istart1,istop1
+                  ic1 = ic_lower(1)+i1
+                  do i0 = istart0,istop0
+                     ic0 = ic_lower(0)+i0
+                     V(d,s) = w(i0,i1,i2)*u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do i2 = istart2+1,istop2
                ic2 = ic_lower(2)+i2
                do i1 = istart1,istop1
                   ic1 = ic_lower(1)+i1
@@ -2012,8 +2084,20 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic2 = ic_lower(2),ic_lower(2)
+               do ic1 = ic_lower(1),ic_upper(1)
+                  do ic0 = ic_lower(0),ic_upper(0)
+                     V(d,s) = w0(ic0-ic_lower(0))
+     &                    *w1(ic1-ic_lower(1))
+     &                    *w2(ic2-ic_lower(2))
+     &                    *u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do ic2 = ic_lower(2)+1,ic_upper(2)
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
@@ -2403,8 +2487,20 @@ c
          istart2 =   max(ig_lower(2)-ic_lower(2),0)
          istop2  = 5-max(ic_upper(2)-ig_upper(2),0)
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do i2 = istart2,istop2
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do i2 = istart2,istart2
+               ic2 = ic_lower(2)+i2
+               do i1 = istart1,istop1
+                  ic1 = ic_lower(1)+i1
+                  do i0 = istart0,istop0
+                     ic0 = ic_lower(0)+i0
+                     V(d,s) = w(i0,i1,i2)*u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do i2 = istart2+1,istop2
                ic2 = ic_lower(2)+i2
                do i1 = istart1,istop1
                   ic1 = ic_lower(1)+i1
@@ -2748,8 +2844,20 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic2 = ic_lower(2),ic_lower(2)
+               do ic1 = ic_lower(1),ic_upper(1)
+                  do ic0 = ic_lower(0),ic_upper(0)
+                     V(d,s) = w0(ic0-ic_lower(0))
+     &                    *w1(ic1-ic_lower(1))
+     &                    *w2(ic2-ic_lower(2))
+     &                    *u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do ic2 = ic_lower(2)+1,ic_upper(2)
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
@@ -3031,8 +3139,20 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic2 = ic_lower(2),ic_lower(2)
+               do ic1 = ic_lower(1),ic_upper(1)
+                  do ic0 = ic_lower(0),ic_upper(0)
+                     V(d,s) = w0(ic0-ic_lower(0))
+     &                    *w1(ic1-ic_lower(1))
+     &                    *w2(ic2-ic_lower(2))
+     &                    *u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do ic2 = ic_lower(2)+1,ic_upper(2)
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
@@ -3314,8 +3434,20 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic2 = ic_lower(2),ic_lower(2)
+               do ic1 = ic_lower(1),ic_upper(1)
+                  do ic0 = ic_lower(0),ic_upper(0)
+                     V(d,s) = w0(ic0-ic_lower(0))
+     &                    *w1(ic1-ic_lower(1))
+     &                    *w2(ic2-ic_lower(2))
+     &                    *u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do ic2 = ic_lower(2)+1,ic_upper(2)
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
@@ -3597,8 +3729,20 @@ c
 c     Interpolate u onto V.
 c
          do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
+c
+c     Avoid explicitly zeroing the data by doing one outer iteration:
+c
+            do ic2 = ic_lower(2),ic_lower(2)
+               do ic1 = ic_lower(1),ic_upper(1)
+                  do ic0 = ic_lower(0),ic_upper(0)
+                     V(d,s) = w0(ic0-ic_lower(0))
+     &                    *w1(ic1-ic_lower(1))
+     &                    *w2(ic2-ic_lower(2))
+     &                    *u(ic0,ic1,ic2,d)
+                  enddo
+               enddo
+            enddo
+            do ic2 = ic_lower(2)+1,ic_upper(2)
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)


### PR DESCRIPTION
According to callgrind this saves us about 4% of the total cycles used in lagrangian_ib_4_interp3d, and about 0.6% of overall runtime.

This doesn't save us as much as the other optimizations but it was easy to implement.