### PR TITLE
Add quadrature cache

### DIFF
--- a/ibtk/include/ibtk/FECache.h
+++ b/ibtk/include/ibtk/FECache.h
@@ -30,6 +30,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#ifndef included_IBTK_FECache
+#define included_IBTK_FECache
+
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include <libmesh/enum_elem_type.h>
@@ -186,3 +189,5 @@ FECache::operator[](const FECache::key_type &quad_key)
 } // namespace IBTK
 
 //////////////////////////////////////////////////////////////////////////////
+
+#endif //#ifndef included_IBTK_FECache

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -53,6 +53,7 @@
 #include "VariableContext.h"
 #include "boost/multi_array.hpp"
 #include "ibtk/ibtk_utilities.h"
+#include "ibtk/QuadratureCache.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/elem.h"
 #include "libmesh/enum_order.h"
@@ -842,6 +843,12 @@ private:
     std::vector<std::vector<libMesh::Node*> > d_active_patch_node_map;
     std::map<std::string, std::vector<unsigned int> > d_active_patch_ghost_dofs;
     std::vector<std::pair<Point, Point> > d_active_elem_bboxes;
+
+    /*
+     * Cache of libMesh quadrature objects. Defaults to being an NDIM cache
+     * but is overwritten once a libMesh::EquationSystems object is attached.
+     */
+    QuadratureCache d_quadrature_cache;
 
     /*
      * Ghost vectors for the various equation systems.

--- a/ibtk/include/ibtk/FEMapCache.h
+++ b/ibtk/include/ibtk/FEMapCache.h
@@ -30,6 +30,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#ifndef included_IBTK_FEMapCache
+#define included_IBTK_FEMapCache
+
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include <libmesh/elem.h>
@@ -196,3 +199,5 @@ FEMapCache::operator[](const FEMapCache::key_type &quad_key)
 } // namespace IBTK
 
 //////////////////////////////////////////////////////////////////////////////
+
+#endif //#ifndef included_IBTK_FEMapCache

--- a/ibtk/include/ibtk/FEMapCache.h
+++ b/ibtk/include/ibtk/FEMapCache.h
@@ -46,6 +46,8 @@
 #include <memory>
 #include <tuple>
 
+#include <ibtk/QuadratureCache.h>
+
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
 namespace IBTK
@@ -117,10 +119,10 @@ protected:
     const unsigned int dim;
 
     /**
-     * Managed libMesh::Quadrature objects. These are attached to the FE
-     * objects.
+     * Managed libMesh::Quadrature objects. These are used to partially
+     * initialize (i.e., points but not weights are stored) the FEMap objects.
      */
-    std::map<key_type, std::unique_ptr<libMesh::QBase>> quadratures;
+    QuadratureCache quadrature_cache;
 
     /**
      * Managed libMesh::FEMap objects of specified dimension and family.
@@ -131,29 +133,17 @@ protected:
 inline
 FEMapCache::FEMapCache(const unsigned int dim)
     : dim(dim)
+    , quadrature_cache(dim)
 {}
 
 inline
 libMesh::FEMap &
 FEMapCache::operator[](const FEMapCache::key_type &quad_key)
 {
-    const libMesh::ElemType elem_type = std::get<0>(quad_key);
-    const libMesh::QuadratureType quad_type = std::get<1>(quad_key);
-    const libMesh::Order order = std::get<2>(quad_key);
-
     auto it = fe_maps.find(quad_key);
     if (it == fe_maps.end())
     {
-        // we should also need a new Quadrature object unless something has
-        // gone wrong
-#ifndef NDBEBUG
-        TBOX_ASSERT(quadratures.find(quad_key) == quadratures.end());
-#endif // ifndef NDEBUG
-        std::unique_ptr<libMesh::QBase> &new_quad = (
-            *quadratures.emplace(
-                quad_key, libMesh::QBase::build(quad_type, dim, order)).first).second;
-        new_quad->init(elem_type);
-
+        libMesh::QBase &quad = quadrature_cache[quad_key];
         libMesh::FEMap &fe_map = fe_maps[quad_key];
         // Calling this function enables JxW calculations
         fe_map.get_JxW();
@@ -164,6 +154,7 @@ FEMapCache::operator[](const FEMapCache::key_type &quad_key)
         // but libMesh developers) and *happens* to not read any geometric or
         // topological information from the Elem argument (just the default
         // order and type).
+        const libMesh::ElemType elem_type = std::get<0>(quad_key);
         std::unique_ptr<libMesh::Elem> exemplar_elem(libMesh::Elem::build(elem_type));
 
         // This is one of very few functions in libMesh that is templated on
@@ -171,13 +162,13 @@ FEMapCache::operator[](const FEMapCache::key_type &quad_key)
         switch (dim)
         {
         case 1:
-            fe_map.init_reference_to_physical_map<1>(new_quad->get_points(), exemplar_elem.get());
+            fe_map.init_reference_to_physical_map<1>(quad.get_points(), exemplar_elem.get());
             break;
         case 2:
-            fe_map.init_reference_to_physical_map<2>(new_quad->get_points(), exemplar_elem.get());
+            fe_map.init_reference_to_physical_map<2>(quad.get_points(), exemplar_elem.get());
             break;
         case 3:
-            fe_map.init_reference_to_physical_map<3>(new_quad->get_points(), exemplar_elem.get());
+            fe_map.init_reference_to_physical_map<3>(quad.get_points(), exemplar_elem.get());
             break;
         default:
             TBOX_ASSERT(false);

--- a/ibtk/include/ibtk/QuadratureCache.h
+++ b/ibtk/include/ibtk/QuadratureCache.h
@@ -98,7 +98,7 @@ protected:
     /**
      * Dimension of the FE mesh.
      */
-    const unsigned int dim;
+    unsigned int dim;
 
     /**
      * Managed libMesh::Quadrature objects.

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -802,6 +802,10 @@ FEDataManager::spread(const int f_data_idx,
             const double* const patch_dx = patch_geom->getDx();
             const double patch_dx_min = *std::min_element(patch_dx, patch_dx + NDIM);
 
+            // Determining which quadrature rule should be used on which
+            // processor is surprisingly expensive, so cache the keys:
+            std::vector<quad_key_type> quad_keys(num_active_patch_elems);
+
             // Setup vectors to store the values of F_JxW and X at the
             // quadrature points.
             unsigned int n_qp_patch = 0;
@@ -820,6 +824,7 @@ FEDataManager::spread(const int f_data_idx,
                                                            elem,
                                                            X_node,
                                                            patch_dx_min);
+                quad_keys[e_idx] = key;
                 QBase &qrule = quad_cache[key];
                 n_qp_patch += qrule.n_points();
             }
@@ -844,13 +849,7 @@ FEDataManager::spread(const int f_data_idx,
                     X_dof_map_cache.dof_indices(elem, X_dof_indices[d], d);
                 }
                 get_values_for_interpolation(X_node, *X_petsc_vec, X_local_soln, X_dof_indices);
-                const quad_key_type key = getQuadratureKey(spread_spec.quad_type,
-                                                           spread_spec.quad_order,
-                                                           spread_spec.use_adaptive_quadrature,
-                                                           spread_spec.point_density,
-                                                           elem,
-                                                           X_node,
-                                                           patch_dx_min);
+                const quad_key_type &key = quad_keys[e_idx];
                 FEBase &X_fe = X_fe_cache[key];
                 FEBase &F_fe = F_fe_cache[key];
                 FEMap &fe_map = fe_map_cache[key];
@@ -1436,6 +1435,10 @@ FEDataManager::interpWeighted(const int f_data_idx,
             const double* const patch_dx = patch_geom->getDx();
             const double patch_dx_min = *std::min_element(patch_dx, patch_dx + NDIM);
 
+            // Determining which quadrature rule should be used on which
+            // processor is surprisingly expensive, so cache the keys:
+            std::vector<quad_key_type> quad_keys(num_active_patch_elems);
+
             // Setup vectors to store the values of F and X at the quadrature
             // points.
             unsigned int n_qp_patch = 0;
@@ -1456,6 +1459,7 @@ FEDataManager::interpWeighted(const int f_data_idx,
                                                            patch_dx_min);
                 QBase &qrule = quad_cache[key];
                 n_qp_patch += qrule.n_points();
+                quad_keys[e_idx] = key;
             }
             if (!n_qp_patch) continue;
             F_qp.resize(n_vars * n_qp_patch);
@@ -1474,13 +1478,7 @@ FEDataManager::interpWeighted(const int f_data_idx,
                     X_dof_map_cache.dof_indices(elem, X_dof_indices[d], d);
                 }
                 get_values_for_interpolation(X_node, *X_petsc_vec, X_local_soln, X_dof_indices);
-                const quad_key_type key = getQuadratureKey(interp_spec.quad_type,
-                                                           interp_spec.quad_order,
-                                                           interp_spec.use_adaptive_quadrature,
-                                                           interp_spec.point_density,
-                                                           elem,
-                                                           X_node,
-                                                           patch_dx_min);
+                const quad_key_type &key = quad_keys[e_idx];
                 QBase &qrule = quad_cache[key];
                 FEBase &X_fe = X_fe_cache[key];
 
@@ -1558,13 +1556,7 @@ FEDataManager::interpWeighted(const int f_data_idx,
                     X_dof_map_cache.dof_indices(elem, X_dof_indices[d], d);
                 }
                 get_values_for_interpolation(X_node, *X_petsc_vec, X_local_soln, X_dof_indices);
-                const quad_key_type key = getQuadratureKey(interp_spec.quad_type,
-                                                           interp_spec.quad_order,
-                                                           interp_spec.use_adaptive_quadrature,
-                                                           interp_spec.point_density,
-                                                           elem,
-                                                           X_node,
-                                                           patch_dx_min);
+                const quad_key_type &key = quad_keys[e_idx];
                 FEBase &F_fe = F_fe_cache[key];
                 FEMap &fe_map = fe_map_cache[key];
                 QBase &qrule = quad_cache[key];


### PR DESCRIPTION
This is the last caching object that we can use. I am still running callgrind to see how much this saves us.

I want to add one more optimization: store a `quad_key_type` for each `Elem` during the first loop over elements in `interpWeighted` and `spread`. Since `quad_key_type` is just three integers this is not a lot of memory but it will save us a lot of repeated calculations. I'll try to add that later tonight or tomorrow (I have to be somewhere at 7).
