### PR TITLE
Fix ibfe restart

### DIFF
--- a/examples/IBFE/explicit/ex0/example.cpp
+++ b/examples/IBFE/explicit/ex0/example.cpp
@@ -230,7 +230,10 @@ bool run_example(int argc, char** argv, std::vector<double>& u_err, std::vector<
             new IBFEMethod("IBFEMethod",
                            app_initializer->getComponentDatabase("IBFEMethod"),
                            &mesh,
-                           app_initializer->getComponentDatabase("GriddingAlgorithm")->getInteger("max_levels"));
+                           app_initializer->getComponentDatabase("GriddingAlgorithm")->getInteger("max_levels"),
+                           /*register_for_restart*/ true,
+                           app_initializer->getRestartDumpDirectory(),
+                           app_initializer->getRestartRestoreNumber());
         Pointer<IBHierarchyIntegrator> time_integrator =
             new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
                                               app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
@@ -455,6 +458,7 @@ bool run_example(int argc, char** argv, std::vector<double>& u_err, std::vector<
             {
                 pout << "\nWriting restart files...\n\n";
                 RestartManager::getManager()->writeRestartFile(restart_dump_dirname, iteration_num);
+                ib_method_ops->writeFEDataToRestartFile(restart_dump_dirname, iteration_num);
             }
             if (dump_timer_data && (iteration_num % timer_dump_interval == 0 || last_step))
             {


### PR DESCRIPTION
Supercedes #454: since we avoid localization this should always set up ghost data. I am pretty sure that `VecScatterCreate`, when called with complete index sets, will set up the current vector with a global set of ghost data: not what we want.

@xxjaehoxx would it be possible for you to give this a try?

The same ex0 test program passes for me in debug mode, so this should be okay.