### PR TITLE
Clear the system dof cache on partitioning.

### DIFF
--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -107,6 +107,11 @@ class FEDataManager : public SAMRAI::tbox::Serializable, public SAMRAI::mesh::St
 public:
     /*!
      * Class which enables fast lookup of dofs on a given libMesh <code>elem</code>.
+     *
+     * @note The contents of this cache are invalidated when we regrid and the
+     * caches should be reset at that point. Copies of this class should
+     * always be retrieved via FEDataManager::getDofCache() to avoid this
+     * problem.
      */
     class SystemDofMapCache
     {

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -471,6 +471,10 @@ FEDataManager::reinitElementMappings()
 {
     IBTK_TIMER_START(t_reinit_element_mappings);
 
+    // We reinitialize mappings after repartitioning, so clear the cache since
+    // its content is no longer relevant:
+    d_system_dof_map_cache.clear();
+
     // Delete cached hierarchy-dependent data.
     d_active_patch_elem_map.clear();
     d_active_patch_node_map.clear();


### PR DESCRIPTION
Another spinoff of #396.

libMesh guarantees that each processor owns a contiguous range of dofs. Hence, when we repartition, the new dof numbering on each elem and node is unrelated to the old numbering, so all of this information is out of date.