### PR TITLE
Partitioning 2c

### DIFF
--- a/ibtk/include/ibtk/BoxPartitioner.h
+++ b/ibtk/include/ibtk/BoxPartitioner.h
@@ -1,0 +1,117 @@
+// Filename: BoxPartitioner.h
+// Created on 6 Nov 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith, David Wells
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef included_IBTK_ibtk_boxpartitioner
+#define included_IBTK_ibtk_boxpartitioner
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibtk/PartitioningBox.h>
+
+#include <libmesh/mesh_base.h>
+#include <libmesh/partitioner.h>
+#include <libmesh/system.h>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+namespace IBTK
+{
+/*!
+ * @brief A libMesh partitioner that partitions a mesh based on
+ * PartitioningBox objects owned by each processor.
+ *
+ * IBAMR assumes that all Lagrangian structures exist on the finest level of
+ * the fluid mesh. This partitioner uses the data stored by the SAMRAI
+ * PatchHierarchy object (which is used, under most circumstances, to create
+ * the PartitioningBoxes object) to compute partitioning boxes corresponding
+ * to the locally owned fluid patches on the finest level: since these
+ * partition the part of the domain over which the structure exists, they can
+ * be used to partition the libMesh Mesh object across the MPI network. Put
+ * another way: this Partitioner uses Eulerian grid data to partition the
+ * structural meshes.
+ */
+class BoxPartitioner : public libMesh::Partitioner
+{
+public:
+    /// Constructor from a PartitioningBoxes instance.
+    BoxPartitioner(const PartitioningBoxes& partitioning_boxes);
+
+    /*!
+     * Constructor. This is like the other constructor that takes a
+     * PartitioningBoxes object, but it permits the use of a background mesh
+     * that is displaced by a vector finite element field.
+     *
+     * @param partitioning_boxes the boxes comprising the partition.
+     *
+     * @param position_system the libMesh::System object whose current
+     * solution is the position of the Mesh which will subsequently be
+     * partitioned.
+     */
+    BoxPartitioner(const PartitioningBoxes& partitioning_boxes, const libMesh::System& position_system);
+
+    /*!
+     * \brief Enable or disable logging.
+     */
+    void setLoggingEnabled(bool enable_logging = true);
+
+    /*!
+     * \brief Determine whether logging is enabled or disabled.
+     */
+    bool getLoggingEnabled() const;
+
+    /*!
+     * Write the partitioning to a file in a simple point-based format: for
+     * each patch several points are printed to the specified file in the
+     * format
+     *
+     * x,y,z,r
+     *
+     * format.
+     */
+    void writePartitioning(const std::string& file_name) const;
+
+    virtual std::unique_ptr<libMesh::Partitioner> clone() const override;
+
+protected:
+    /// The function used to actually do the partitioning.
+    virtual void _do_partition(libMesh::MeshBase& mesh, const unsigned int n) override;
+
+    /// Logging configuration.
+    bool d_enable_logging = false;
+
+    /// The PartitioningBoxes object used to establish whether or not an Elem
+    /// (via its centroid) or Node is owned by the current processor.
+    PartitioningBoxes d_partitioning_boxes;
+
+    /// Pointer, if relevant, to the libMesh mesh position system.
+    const libMesh::System* const d_position_system = nullptr;
+};
+} // namespace IBTK
+//////////////////////////////////////////////////////////////////////////////
+#endif //#ifndef included_IBTK_ibtk_boxpartitioner

--- a/ibtk/include/ibtk/PartitioningBox.h
+++ b/ibtk/include/ibtk/PartitioningBox.h
@@ -1,0 +1,145 @@
+// Filename: PartitioningBox.h
+// Created on 30 Oct 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith, David Wells
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef included_IBTK_ibtk_partitioningbox
+#define included_IBTK_ibtk_partitioningbox
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibtk/ibtk_utilities.h>
+
+#include <CartesianPatchGeometry.h>
+#include <PatchHierarchy.h>
+
+#include <utility>
+#include <vector>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+namespace IBTK
+{
+/*!
+ * \brief Class PartitioningBox implements an NDIM-dimensional bounding box
+ * defined by two points. Unlike a standard bounding box, a PartitioningBox is
+ * an <code>NDIM</code>-dimensional tensor product of half-open intervals:
+ * i.e., it is a half-open box. This property allows one to partition a domain
+ * into a set of boxes.
+ *
+ * It is possible for a partitioning box to be 'empty': in that case the
+ * bounds are [oo, oo) in each dimension.
+ */
+class PartitioningBox
+{
+public:
+    /// Default Constructor: an 'empty' partitioning box.
+    PartitioningBox();
+
+    /// Constructor.
+    PartitioningBox(const Point& bottom_point, const Point& top_point);
+
+    /// Constructor, starting from a SAMRAI data type.
+    PartitioningBox(const SAMRAI::geom::CartesianPatchGeometry<NDIM>& patch);
+
+    /// Get the bottom left corner of the box.
+    const Point& bottom() const;
+
+    /// Get the top right corner of the box. Note that this point is not in
+    /// the box.
+    const Point& top() const;
+
+    /// Return true if the point is inside the box and false otherwise.
+    bool contains(const Point& point) const;
+
+    /// Return the volume of the box. If the box is empty then this is zero.
+    double volume() const;
+
+protected:
+    /// bottom left and top right corners of the bounding box.
+    std::pair<Point, Point> d_bounding_points;
+};
+
+/*!
+ * \brief Class PartitioningBoxes stores a set of bounding boxes and can check
+ * if a point is in the set of partitioning boxes or not in a more optimized
+ * way than just looping over a std::vector<PartitioningBox>.
+ *
+ * It is possible for the set of bounding boxes to be empty: in that case the
+ * bounds are [oo, oo) in each dimension.
+ */
+class PartitioningBoxes
+{
+public:
+    /// Default constructor: an empty collection of partitioning boxes with
+    /// bounds at oo.
+    PartitioningBoxes() = default;
+
+    /// Constructor. Creates an object from a sequence of partitioning boxes.
+    template <typename ForwardIterator>
+    PartitioningBoxes(const ForwardIterator begin, const ForwardIterator end);
+
+    /// Constructor. Uses the finest level boxes on the provided
+    /// PatchHierarchy to create a set of bounding boxes.
+    PartitioningBoxes(const SAMRAI::hier::PatchHierarchy<NDIM>& hierarchy);
+
+    /// Get the bottom left corner of the partitioning box bounding all other
+    /// partitioning boxes.
+    const Point& bottom() const;
+
+    /// Get the top right corner of the partitioning box bounding all other
+    /// partitioning boxes. Note that this point is not in the collection of
+    /// boxes.
+    const Point& top() const;
+
+    /// Return true if the point is inside the set of boxes and false
+    /// otherwise.
+    bool contains(const Point& point) const;
+
+    /// Return a pointer to the first partitioning box.
+    const PartitioningBox* begin() const;
+
+    /// Return a pointer to one past the end of the end of the partitioning
+    /// box array.
+    const PartitioningBox* end() const;
+
+protected:
+    /// The partitioning box that bounds all other partitioning boxes.
+    PartitioningBox d_bounding_partitioning_box;
+
+    /// The set of bounding boxes.
+    std::vector<PartitioningBox> d_boxes;
+};
+} // namespace IBTK
+
+/////////////////////////////// INLINE ///////////////////////////////////////
+
+#include "ibtk/private/PartitioningBox-inl.h" // IWYU pragma: keep
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif //#ifndef included_IBTK_ibtk_partitioningbox

--- a/ibtk/include/ibtk/private/PartitioningBox-inl.h
+++ b/ibtk/include/ibtk/private/PartitioningBox-inl.h
@@ -1,0 +1,148 @@
+// Filename: PartitioningBox-inl.h
+// Created on 06 Dec 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef included_IBTK_PartitioningBox_inl_h
+#define included_IBTK_PartitioningBox_inl_h
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include "ibtk/PartitioningBox.h"
+
+#include <algorithm>
+#include <limits>
+#include <type_traits>
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace IBTK
+{
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+inline const Point&
+PartitioningBox::bottom() const
+{
+    return d_bounding_points.first;
+} // bottom
+
+inline const Point&
+PartitioningBox::top() const
+{
+    return d_bounding_points.second;
+} // top
+
+inline bool
+PartitioningBox::contains(const Point& point) const
+{
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+        if (!(bottom()[dim_n] <= point[dim_n] && point[dim_n] < top()[dim_n])) return false;
+    return true;
+} // contains
+
+template <typename ForwardIterator>
+inline PartitioningBoxes::PartitioningBoxes(const ForwardIterator begin, const ForwardIterator end)
+    : d_boxes(begin, end)
+{
+    static_assert(std::is_same<decltype(*begin), PartitioningBox&>::value ||
+                      std::is_same<decltype(*begin), const PartitioningBox&>::value,
+                  "The iterators should point to PartitioningBoxes");
+    if (begin != end)
+    {
+        IBTK::Point bottom;
+        IBTK::Point top;
+        for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+        {
+            bottom[dim_n] = std::min_element(begin,
+                                             end,
+                                             [=](const PartitioningBox& a, const PartitioningBox& b) -> bool {
+                                                 return a.bottom()[dim_n] < b.bottom()[dim_n];
+                                             })
+                                ->bottom()[dim_n];
+            top[dim_n] = std::max_element(begin,
+                                          end,
+                                          [=](const PartitioningBox& a, const PartitioningBox& b) -> bool {
+                                              return a.top()[dim_n] < b.top()[dim_n];
+                                          })
+                             ->top()[dim_n];
+        }
+        d_bounding_partitioning_box = PartitioningBox(bottom, top);
+    }
+} // PartitioningBoxes
+
+inline const Point&
+PartitioningBoxes::bottom() const
+{
+    return d_bounding_partitioning_box.bottom();
+} // bottom
+
+inline const Point&
+PartitioningBoxes::top() const
+{
+    return d_bounding_partitioning_box.top();
+} // top
+
+inline const PartitioningBox*
+PartitioningBoxes::begin() const
+{
+    return d_boxes.data();
+}
+
+inline const PartitioningBox*
+PartitioningBoxes::end() const
+{
+    return d_boxes.data() + d_boxes.size();
+}
+
+inline bool
+PartitioningBoxes::contains(const Point& point) const
+{
+    if (d_bounding_partitioning_box.contains(point))
+    {
+        // TODO it would be vastly more efficient to store the collection of
+        // boxes in a tree structure so that we can search in logarithmic time
+        // instead of linear time.
+        for (const PartitioningBox& box : d_boxes)
+        {
+            if (box.contains(point))
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+} // contains
+
+//////////////////////////////////////////////////////////////////////////////
+
+} // namespace IBTK
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif //#ifndef included_IBTK_PartitioningBox_inl_h

--- a/ibtk/lib/Makefile.am
+++ b/ibtk/lib/Makefile.am
@@ -143,6 +143,7 @@ DIM_INDEPENDENT_SOURCES = \
 ../src/utilities/ParallelEdgeMap.cpp \
 ../src/utilities/ParallelMap.cpp \
 ../src/utilities/ParallelSet.cpp \
+../src/utilities/PartitioningBox.cpp \
 ../src/utilities/RefinePatchStrategySet.cpp \
 ../src/utilities/SideDataSynchronization.cpp \
 ../src/utilities/SideNoCornersFillPattern.cpp \
@@ -154,6 +155,7 @@ DIM_INDEPENDENT_SOURCES = \
 
 if LIBMESH_ENABLED
 DIM_INDEPENDENT_SOURCES += \
+../src/lagrangian/BoxPartitioner.cpp \
 ../src/lagrangian/FEDataInterpolation.cpp \
 ../src/lagrangian/FEDataManager.cpp \
 ../src/utilities/libmesh_utilities.cpp
@@ -272,6 +274,7 @@ pkg_include_HEADERS += \
 ../include/ibtk/ParallelEdgeMap.h \
 ../include/ibtk/ParallelMap.h \
 ../include/ibtk/ParallelSet.h \
+../include/ibtk/PartitioningBox.h \
 ../include/ibtk/PatchMathOps.h \
 ../include/ibtk/PhysicalBoundaryUtilities.h \
 ../include/ibtk/PoissonFACPreconditioner.h \
@@ -315,6 +318,7 @@ pkg_include_HEADERS += \
 
 if LIBMESH_ENABLED
 DIM_INDEPENDENT_SOURCES += \
+../include/lagrangian/BoxPartitioner.h \
 ../include/ibtk/FEDataInterpolation.h \
 ../include/ibtk/FEDataManager.h \
 ../include/ibtk/libmesh_utilities.h

--- a/ibtk/lib/Makefile.in
+++ b/ibtk/lib/Makefile.in
@@ -91,9 +91,12 @@ build_triplet = @build@
 host_triplet = @host@
 @SAMRAI2D_ENABLED_TRUE@am__append_1 = libIBTK2d.a
 @SAMRAI3D_ENABLED_TRUE@am__append_2 = libIBTK3d.a
-@LIBMESH_ENABLED_TRUE@am__append_3 = ../src/lagrangian/FEDataInterpolation.cpp \
+@LIBMESH_ENABLED_TRUE@am__append_3 =  \
+@LIBMESH_ENABLED_TRUE@	../src/lagrangian/BoxPartitioner.cpp \
+@LIBMESH_ENABLED_TRUE@	../src/lagrangian/FEDataInterpolation.cpp \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/FEDataManager.cpp \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libmesh_utilities.cpp \
+@LIBMESH_ENABLED_TRUE@	../include/lagrangian/BoxPartitioner.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/FEDataInterpolation.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/FEDataManager.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/libmesh_utilities.h
@@ -277,6 +280,7 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 	../src/utilities/ParallelEdgeMap.cpp \
 	../src/utilities/ParallelMap.cpp \
 	../src/utilities/ParallelSet.cpp \
+	../src/utilities/PartitioningBox.cpp \
 	../src/utilities/RefinePatchStrategySet.cpp \
 	../src/utilities/SideDataSynchronization.cpp \
 	../src/utilities/SideNoCornersFillPattern.cpp \
@@ -285,9 +289,11 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 	../src/utilities/Streamable.cpp \
 	../src/utilities/StreamableManager.cpp \
 	../src/utilities/muParserCartGridFunction.cpp \
+	../src/lagrangian/BoxPartitioner.cpp \
 	../src/lagrangian/FEDataInterpolation.cpp \
 	../src/lagrangian/FEDataManager.cpp \
 	../src/utilities/libmesh_utilities.cpp \
+	../include/lagrangian/BoxPartitioner.h \
 	../include/ibtk/FEDataInterpolation.h \
 	../include/ibtk/FEDataManager.h \
 	../include/ibtk/libmesh_utilities.h \
@@ -311,7 +317,8 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 	$(top_builddir)/src/refine_ops/fortran/cart_side_refine2d.f \
 	$(top_builddir)/src/refine_ops/fortran/divpreservingrefine2d.f \
 	$(top_builddir)/src/solvers/impls/fortran/patchsmoothers2d.f
-@LIBMESH_ENABLED_TRUE@am__objects_1 = ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@am__objects_1 = ../src/lagrangian/libIBTK2d_a-BoxPartitioner.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK2d_a-FEDataInterpolation.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK2d_a-FEDataManager.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK2d_a-libmesh_utilities.$(OBJEXT)
 am__objects_2 = ../src/boundary/libIBTK2d_a-HierarchyGhostCellInterpolation.$(OBJEXT) \
@@ -424,6 +431,7 @@ am__objects_2 = ../src/boundary/libIBTK2d_a-HierarchyGhostCellInterpolation.$(OB
 	../src/utilities/libIBTK2d_a-ParallelEdgeMap.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-ParallelMap.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-ParallelSet.$(OBJEXT) \
+	../src/utilities/libIBTK2d_a-PartitioningBox.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-RefinePatchStrategySet.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-SideDataSynchronization.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-SideNoCornersFillPattern.$(OBJEXT) \
@@ -563,6 +571,7 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 	../src/utilities/ParallelEdgeMap.cpp \
 	../src/utilities/ParallelMap.cpp \
 	../src/utilities/ParallelSet.cpp \
+	../src/utilities/PartitioningBox.cpp \
 	../src/utilities/RefinePatchStrategySet.cpp \
 	../src/utilities/SideDataSynchronization.cpp \
 	../src/utilities/SideNoCornersFillPattern.cpp \
@@ -571,9 +580,11 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 	../src/utilities/Streamable.cpp \
 	../src/utilities/StreamableManager.cpp \
 	../src/utilities/muParserCartGridFunction.cpp \
+	../src/lagrangian/BoxPartitioner.cpp \
 	../src/lagrangian/FEDataInterpolation.cpp \
 	../src/lagrangian/FEDataManager.cpp \
 	../src/utilities/libmesh_utilities.cpp \
+	../include/lagrangian/BoxPartitioner.h \
 	../include/ibtk/FEDataInterpolation.h \
 	../include/ibtk/FEDataManager.h \
 	../include/ibtk/libmesh_utilities.h \
@@ -597,7 +608,8 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 	$(top_builddir)/src/refine_ops/fortran/cart_side_refine3d.f \
 	$(top_builddir)/src/refine_ops/fortran/divpreservingrefine3d.f \
 	$(top_builddir)/src/solvers/impls/fortran/patchsmoothers3d.f
-@LIBMESH_ENABLED_TRUE@am__objects_3 = ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@am__objects_3 = ../src/lagrangian/libIBTK3d_a-BoxPartitioner.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK3d_a-FEDataInterpolation.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK3d_a-FEDataManager.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK3d_a-libmesh_utilities.$(OBJEXT)
 am__objects_4 = ../src/boundary/libIBTK3d_a-HierarchyGhostCellInterpolation.$(OBJEXT) \
@@ -710,6 +722,7 @@ am__objects_4 = ../src/boundary/libIBTK3d_a-HierarchyGhostCellInterpolation.$(OB
 	../src/utilities/libIBTK3d_a-ParallelEdgeMap.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-ParallelMap.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-ParallelSet.$(OBJEXT) \
+	../src/utilities/libIBTK3d_a-PartitioningBox.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-RefinePatchStrategySet.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-SideDataSynchronization.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-SideNoCornersFillPattern.$(OBJEXT) \
@@ -788,6 +801,7 @@ am__depfiles_remade = ../src/boundary/$(DEPDIR)/libIBTK2d_a-HierarchyGhostCellIn
 	../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleCubicCoarsen.Po \
 	../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleRT0Coarsen.Po \
 	../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-LMarkerCoarsen.Po \
+	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataInterpolation.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataManager.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LData.Po \
@@ -808,6 +822,7 @@ am__depfiles_remade = ../src/boundary/$(DEPDIR)/libIBTK2d_a-HierarchyGhostCellIn
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSetVariable.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSiloDataWriter.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LTransaction.Po \
+	../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataInterpolation.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataManager.Po \
 	../src/lagrangian/$(DEPDIR)/libIBTK3d_a-LData.Po \
@@ -958,6 +973,7 @@ am__depfiles_remade = ../src/boundary/$(DEPDIR)/libIBTK2d_a-HierarchyGhostCellIn
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelEdgeMap.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelMap.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelSet.Po \
+	../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-SideDataSynchronization.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-SideNoCornersFillPattern.Po \
@@ -989,6 +1005,7 @@ am__depfiles_remade = ../src/boundary/$(DEPDIR)/libIBTK2d_a-HierarchyGhostCellIn
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelEdgeMap.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelMap.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelSet.Po \
+	../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-SideDataSynchronization.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-SideNoCornersFillPattern.Po \
@@ -1499,6 +1516,7 @@ pkg_include_HEADERS = ../include/ibtk/IBTK_CHKERRQ.h \
 	../include/ibtk/PETScVecUtilities.h \
 	../include/ibtk/ParallelEdgeMap.h \
 	../include/ibtk/ParallelMap.h ../include/ibtk/ParallelSet.h \
+	../include/ibtk/PartitioningBox.h \
 	../include/ibtk/PatchMathOps.h \
 	../include/ibtk/PhysicalBoundaryUtilities.h \
 	../include/ibtk/PoissonFACPreconditioner.h \
@@ -1645,6 +1663,7 @@ DIM_INDEPENDENT_SOURCES =  \
 	../src/utilities/ParallelEdgeMap.cpp \
 	../src/utilities/ParallelMap.cpp \
 	../src/utilities/ParallelSet.cpp \
+	../src/utilities/PartitioningBox.cpp \
 	../src/utilities/RefinePatchStrategySet.cpp \
 	../src/utilities/SideDataSynchronization.cpp \
 	../src/utilities/SideNoCornersFillPattern.cpp \
@@ -2174,6 +2193,9 @@ libIBTK.a: $(libIBTK_a_OBJECTS) $(libIBTK_a_DEPENDENCIES) $(EXTRA_libIBTK_a_DEPE
 ../src/utilities/libIBTK2d_a-ParallelSet.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/libIBTK2d_a-PartitioningBox.$(OBJEXT):  \
+	../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 ../src/utilities/libIBTK2d_a-RefinePatchStrategySet.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
@@ -2198,6 +2220,9 @@ libIBTK.a: $(libIBTK_a_OBJECTS) $(libIBTK_a_DEPENDENCIES) $(EXTRA_libIBTK_a_DEPE
 ../src/utilities/libIBTK2d_a-muParserCartGridFunction.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/lagrangian/libIBTK2d_a-BoxPartitioner.$(OBJEXT):  \
+	../src/lagrangian/$(am__dirstamp) \
+	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
 ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.$(OBJEXT):  \
 	../src/lagrangian/$(am__dirstamp) \
 	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
@@ -2635,6 +2660,9 @@ libIBTK2d.a: $(libIBTK2d_a_OBJECTS) $(libIBTK2d_a_DEPENDENCIES) $(EXTRA_libIBTK2
 ../src/utilities/libIBTK3d_a-ParallelSet.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/libIBTK3d_a-PartitioningBox.$(OBJEXT):  \
+	../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 ../src/utilities/libIBTK3d_a-RefinePatchStrategySet.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
@@ -2659,6 +2687,9 @@ libIBTK2d.a: $(libIBTK2d_a_OBJECTS) $(libIBTK2d_a_DEPENDENCIES) $(EXTRA_libIBTK2
 ../src/utilities/libIBTK3d_a-muParserCartGridFunction.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/lagrangian/libIBTK3d_a-BoxPartitioner.$(OBJEXT):  \
+	../src/lagrangian/$(am__dirstamp) \
+	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
 ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.$(OBJEXT):  \
 	../src/lagrangian/$(am__dirstamp) \
 	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
@@ -2787,6 +2818,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleCubicCoarsen.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleRT0Coarsen.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-LMarkerCoarsen.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataInterpolation.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataManager.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LData.Po@am__quote@ # am--include-marker
@@ -2807,6 +2839,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSetVariable.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSiloDataWriter.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LTransaction.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataInterpolation.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataManager.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/lagrangian/$(DEPDIR)/libIBTK3d_a-LData.Po@am__quote@ # am--include-marker
@@ -2957,6 +2990,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelEdgeMap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelMap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelSet.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-SideDataSynchronization.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-SideNoCornersFillPattern.Po@am__quote@ # am--include-marker
@@ -2988,6 +3022,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelEdgeMap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelMap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelSet.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-SideDataSynchronization.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-SideNoCornersFillPattern.Po@am__quote@ # am--include-marker
@@ -4568,6 +4603,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-ParallelSet.obj `if test -f '../src/utilities/ParallelSet.cpp'; then $(CYGPATH_W) '../src/utilities/ParallelSet.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/ParallelSet.cpp'; fi`
 
+../src/utilities/libIBTK2d_a-PartitioningBox.o: ../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-PartitioningBox.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Tpo -c -o ../src/utilities/libIBTK2d_a-PartitioningBox.o `test -f '../src/utilities/PartitioningBox.cpp' || echo '$(srcdir)/'`../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/PartitioningBox.cpp' object='../src/utilities/libIBTK2d_a-PartitioningBox.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-PartitioningBox.o `test -f '../src/utilities/PartitioningBox.cpp' || echo '$(srcdir)/'`../src/utilities/PartitioningBox.cpp
+
+../src/utilities/libIBTK2d_a-PartitioningBox.obj: ../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-PartitioningBox.obj -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Tpo -c -o ../src/utilities/libIBTK2d_a-PartitioningBox.obj `if test -f '../src/utilities/PartitioningBox.cpp'; then $(CYGPATH_W) '../src/utilities/PartitioningBox.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/PartitioningBox.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/PartitioningBox.cpp' object='../src/utilities/libIBTK2d_a-PartitioningBox.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-PartitioningBox.obj `if test -f '../src/utilities/PartitioningBox.cpp'; then $(CYGPATH_W) '../src/utilities/PartitioningBox.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/PartitioningBox.cpp'; fi`
+
 ../src/utilities/libIBTK2d_a-RefinePatchStrategySet.o: ../src/utilities/RefinePatchStrategySet.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-RefinePatchStrategySet.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Tpo -c -o ../src/utilities/libIBTK2d_a-RefinePatchStrategySet.o `test -f '../src/utilities/RefinePatchStrategySet.cpp' || echo '$(srcdir)/'`../src/utilities/RefinePatchStrategySet.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Po
@@ -4679,6 +4728,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/muParserCartGridFunction.cpp' object='../src/utilities/libIBTK2d_a-muParserCartGridFunction.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-muParserCartGridFunction.obj `if test -f '../src/utilities/muParserCartGridFunction.cpp'; then $(CYGPATH_W) '../src/utilities/muParserCartGridFunction.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/muParserCartGridFunction.cpp'; fi`
+
+../src/lagrangian/libIBTK2d_a-BoxPartitioner.o: ../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK2d_a-BoxPartitioner.o -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Tpo -c -o ../src/lagrangian/libIBTK2d_a-BoxPartitioner.o `test -f '../src/lagrangian/BoxPartitioner.cpp' || echo '$(srcdir)/'`../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Tpo ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/lagrangian/BoxPartitioner.cpp' object='../src/lagrangian/libIBTK2d_a-BoxPartitioner.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK2d_a-BoxPartitioner.o `test -f '../src/lagrangian/BoxPartitioner.cpp' || echo '$(srcdir)/'`../src/lagrangian/BoxPartitioner.cpp
+
+../src/lagrangian/libIBTK2d_a-BoxPartitioner.obj: ../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK2d_a-BoxPartitioner.obj -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Tpo -c -o ../src/lagrangian/libIBTK2d_a-BoxPartitioner.obj `if test -f '../src/lagrangian/BoxPartitioner.cpp'; then $(CYGPATH_W) '../src/lagrangian/BoxPartitioner.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/BoxPartitioner.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Tpo ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/lagrangian/BoxPartitioner.cpp' object='../src/lagrangian/libIBTK2d_a-BoxPartitioner.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK2d_a-BoxPartitioner.obj `if test -f '../src/lagrangian/BoxPartitioner.cpp'; then $(CYGPATH_W) '../src/lagrangian/BoxPartitioner.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/BoxPartitioner.cpp'; fi`
 
 ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.o: ../src/lagrangian/FEDataInterpolation.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.o -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataInterpolation.Tpo -c -o ../src/lagrangian/libIBTK2d_a-FEDataInterpolation.o `test -f '../src/lagrangian/FEDataInterpolation.cpp' || echo '$(srcdir)/'`../src/lagrangian/FEDataInterpolation.cpp
@@ -6262,6 +6325,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-ParallelSet.obj `if test -f '../src/utilities/ParallelSet.cpp'; then $(CYGPATH_W) '../src/utilities/ParallelSet.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/ParallelSet.cpp'; fi`
 
+../src/utilities/libIBTK3d_a-PartitioningBox.o: ../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-PartitioningBox.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Tpo -c -o ../src/utilities/libIBTK3d_a-PartitioningBox.o `test -f '../src/utilities/PartitioningBox.cpp' || echo '$(srcdir)/'`../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/PartitioningBox.cpp' object='../src/utilities/libIBTK3d_a-PartitioningBox.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-PartitioningBox.o `test -f '../src/utilities/PartitioningBox.cpp' || echo '$(srcdir)/'`../src/utilities/PartitioningBox.cpp
+
+../src/utilities/libIBTK3d_a-PartitioningBox.obj: ../src/utilities/PartitioningBox.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-PartitioningBox.obj -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Tpo -c -o ../src/utilities/libIBTK3d_a-PartitioningBox.obj `if test -f '../src/utilities/PartitioningBox.cpp'; then $(CYGPATH_W) '../src/utilities/PartitioningBox.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/PartitioningBox.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/PartitioningBox.cpp' object='../src/utilities/libIBTK3d_a-PartitioningBox.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-PartitioningBox.obj `if test -f '../src/utilities/PartitioningBox.cpp'; then $(CYGPATH_W) '../src/utilities/PartitioningBox.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/PartitioningBox.cpp'; fi`
+
 ../src/utilities/libIBTK3d_a-RefinePatchStrategySet.o: ../src/utilities/RefinePatchStrategySet.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-RefinePatchStrategySet.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Tpo -c -o ../src/utilities/libIBTK3d_a-RefinePatchStrategySet.o `test -f '../src/utilities/RefinePatchStrategySet.cpp' || echo '$(srcdir)/'`../src/utilities/RefinePatchStrategySet.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Po
@@ -6373,6 +6450,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/muParserCartGridFunction.cpp' object='../src/utilities/libIBTK3d_a-muParserCartGridFunction.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-muParserCartGridFunction.obj `if test -f '../src/utilities/muParserCartGridFunction.cpp'; then $(CYGPATH_W) '../src/utilities/muParserCartGridFunction.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/muParserCartGridFunction.cpp'; fi`
+
+../src/lagrangian/libIBTK3d_a-BoxPartitioner.o: ../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK3d_a-BoxPartitioner.o -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Tpo -c -o ../src/lagrangian/libIBTK3d_a-BoxPartitioner.o `test -f '../src/lagrangian/BoxPartitioner.cpp' || echo '$(srcdir)/'`../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Tpo ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/lagrangian/BoxPartitioner.cpp' object='../src/lagrangian/libIBTK3d_a-BoxPartitioner.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK3d_a-BoxPartitioner.o `test -f '../src/lagrangian/BoxPartitioner.cpp' || echo '$(srcdir)/'`../src/lagrangian/BoxPartitioner.cpp
+
+../src/lagrangian/libIBTK3d_a-BoxPartitioner.obj: ../src/lagrangian/BoxPartitioner.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK3d_a-BoxPartitioner.obj -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Tpo -c -o ../src/lagrangian/libIBTK3d_a-BoxPartitioner.obj `if test -f '../src/lagrangian/BoxPartitioner.cpp'; then $(CYGPATH_W) '../src/lagrangian/BoxPartitioner.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/BoxPartitioner.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Tpo ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/lagrangian/BoxPartitioner.cpp' object='../src/lagrangian/libIBTK3d_a-BoxPartitioner.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK3d_a-BoxPartitioner.obj `if test -f '../src/lagrangian/BoxPartitioner.cpp'; then $(CYGPATH_W) '../src/lagrangian/BoxPartitioner.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/BoxPartitioner.cpp'; fi`
 
 ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.o: ../src/lagrangian/FEDataInterpolation.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.o -MD -MP -MF ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataInterpolation.Tpo -c -o ../src/lagrangian/libIBTK3d_a-FEDataInterpolation.o `test -f '../src/lagrangian/FEDataInterpolation.cpp' || echo '$(srcdir)/'`../src/lagrangian/FEDataInterpolation.cpp
@@ -6649,6 +6740,7 @@ distclean: distclean-am
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleCubicCoarsen.Po
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleRT0Coarsen.Po
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-LMarkerCoarsen.Po
+	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataInterpolation.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataManager.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LData.Po
@@ -6669,6 +6761,7 @@ distclean: distclean-am
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSetVariable.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSiloDataWriter.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LTransaction.Po
+	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataInterpolation.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataManager.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-LData.Po
@@ -6819,6 +6912,7 @@ distclean: distclean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelEdgeMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-SideDataSynchronization.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-SideNoCornersFillPattern.Po
@@ -6850,6 +6944,7 @@ distclean: distclean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelEdgeMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-SideDataSynchronization.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-SideNoCornersFillPattern.Po
@@ -6936,6 +7031,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleCubicCoarsen.Po
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-CartSideDoubleRT0Coarsen.Po
 	-rm -f ../src/coarsen_ops/$(DEPDIR)/libIBTK3d_a-LMarkerCoarsen.Po
+	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-BoxPartitioner.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataInterpolation.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-FEDataManager.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LData.Po
@@ -6956,6 +7052,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSetVariable.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LSiloDataWriter.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK2d_a-LTransaction.Po
+	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-BoxPartitioner.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataInterpolation.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-FEDataManager.Po
 	-rm -f ../src/lagrangian/$(DEPDIR)/libIBTK3d_a-LData.Po
@@ -7106,6 +7203,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelEdgeMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-ParallelSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-PartitioningBox.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-RefinePatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-SideDataSynchronization.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-SideNoCornersFillPattern.Po
@@ -7137,6 +7235,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelEdgeMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-ParallelSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-PartitioningBox.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-RefinePatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-SideDataSynchronization.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-SideNoCornersFillPattern.Po

--- a/ibtk/src/lagrangian/BoxPartitioner.cpp
+++ b/ibtk/src/lagrangian/BoxPartitioner.cpp
@@ -1,0 +1,337 @@
+// Filename: BoxPartitioner.cpp
+// Created on 6 Dec 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibtk/BoxPartitioner.h>
+#include <ibtk/PartitioningBox.h>
+#include <ibtk/namespaces.h> // IWYU pragma: keep
+
+#include <libmesh/elem.h>
+#include <libmesh/mesh_base.h>
+#include <libmesh/node.h>
+#include <libmesh/numeric_vector.h>
+#include <libmesh/point.h>
+
+#include <tbox/PIO.h>
+#include <tbox/SAMRAI_MPI.h>
+
+#include <algorithm>
+#include <vector>
+
+#include <mpi.h>
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace IBTK
+{
+/////////////////////////////// STATIC ///////////////////////////////////////
+
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+
+BoxPartitioner::BoxPartitioner(const PartitioningBoxes& bounding_boxes) : d_partitioning_boxes(bounding_boxes)
+{
+} // BoxPartitioner
+
+BoxPartitioner::BoxPartitioner(const PartitioningBoxes& bounding_boxes, const System& position_system)
+    : d_partitioning_boxes(bounding_boxes), d_position_system(&position_system)
+{
+} // BoxPartitioner
+
+std::unique_ptr<Partitioner>
+BoxPartitioner::clone() const
+{
+    return std::unique_ptr<Partitioner>(new BoxPartitioner(d_partitioning_boxes, *d_position_system));
+} // clone
+
+void
+BoxPartitioner::setLoggingEnabled(bool enable_logging)
+{
+    d_enable_logging = enable_logging;
+    return;
+} // setLoggingEnabled
+
+bool
+BoxPartitioner::getLoggingEnabled() const
+{
+    return d_enable_logging;
+} // getLoggingEnabled
+
+void
+BoxPartitioner::writePartitioning(const std::string& file_name) const
+{
+    std::stringstream current_processor_output;
+
+    const int current_rank = SAMRAI_MPI::getRank();
+    for (const PartitioningBox& box : d_partitioning_boxes)
+    {
+        const Point bottom = box.bottom();
+        const Point top = box.top();
+
+        // This reference value is chosen so that the plots look good when the
+        // domain is a square or cube with edge length 1
+        const double ref_dx = 0.0025;
+        const double dx = top[0] - bottom[0];
+        const double dy = top[1] - bottom[1];
+        const double dz = NDIM == 3 ? top[NDIM - 1] - bottom[NDIM - 1] : 0.0;
+
+        const unsigned int n_x_points = dx / ref_dx;
+        const unsigned int n_y_points = dy / ref_dx;
+        const unsigned int n_z_points = NDIM == 3 ? dz / ref_dx : 1;
+        for (unsigned int i = 0; i < n_x_points; ++i)
+        {
+            for (unsigned int j = 0; j < n_y_points; ++j)
+            {
+                for (unsigned int k = 0; k < n_z_points; ++k)
+                {
+                    const double z = NDIM == 3 ? bottom[NDIM - 1] + k / double(n_z_points) * dz : 0.0;
+                    current_processor_output << bottom[0] + i / double(n_x_points) * dx << ','
+                                             << bottom[1] + j / double(n_y_points) * dy << ',' << z << ','
+                                             << current_rank << '\n';
+                }
+            }
+        }
+    }
+
+    // clear the file before we append to it
+    if (current_rank == 0)
+    {
+        std::remove(file_name.c_str());
+    }
+    const int n_processes = SAMRAI_MPI::getNodes();
+    for (int rank = 0; rank < n_processes; ++rank)
+    {
+        if (rank == current_rank)
+        {
+            std::ofstream out(file_name, std::ios_base::app);
+            if (rank == 0)
+            {
+                out << "x,y,z,r\n";
+            }
+            out << current_processor_output.rdbuf();
+        }
+        SAMRAI_MPI::barrier();
+    }
+} // writePartitioning
+
+/////////////////////////////// PROTECTED ////////////////////////////////////
+
+void
+BoxPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
+{
+    // We assume every cell is on every processor
+    TBOX_ASSERT(mesh.is_replicated());
+    // only implemented when we use SAMRAI's partitioning
+    TBOX_ASSERT(n == static_cast<unsigned int>(SAMRAI_MPI::getNodes()));
+
+    // convert the libMesh type to an MPI type
+    MPI_Datatype pid_integral_type = 0;
+    switch (sizeof(processor_id_type))
+    {
+    case 1:
+        pid_integral_type = MPI_UNSIGNED_CHAR;
+        break;
+    case 2:
+        pid_integral_type = MPI_UNSIGNED_SHORT;
+        break;
+    case 4:
+        pid_integral_type = MPI_UNSIGNED;
+        break;
+    case 8:
+        pid_integral_type = MPI_UNSIGNED_LONG;
+        break;
+    }
+
+    const int current_rank = SAMRAI_MPI::getRank();
+    auto to_ibtk_point = [](const libMesh::Point& p) -> IBTK::Point {
+        IBTK::Point point;
+        for (unsigned int d = 0; d < NDIM; ++d) point[d] = p(d);
+        return point;
+    };
+
+    // TODO this partitioning algorithm is not scalable since every processor
+    // looks at every cell. This will ultimately be replaced by an approach
+    // driven by SAMRAI, where SAMRAI propagates nodes and cells in a
+    // particle-like fashion.
+    //
+    // Step 0: determine the current location of the Mesh nodes.
+    const bool use_position_vector = d_position_system != nullptr;
+    const unsigned int position_system_n = use_position_vector ? d_position_system->number() : 0;
+    std::vector<double> position;
+    if (use_position_vector)
+    {
+        TBOX_ASSERT(&d_position_system->get_mesh() == &mesh);
+        NumericVector<double>* position_solution = d_position_system->solution.get();
+        position.resize(position_solution->size());
+        position_solution->localize(position);
+    }
+    std::vector<libMesh::Point> node_positions(mesh.parallel_n_nodes());
+    std::size_t node_n = 0;
+    for (auto node_it = mesh.nodes_begin(); node_it != mesh.nodes_end(); ++node_it)
+    {
+        const Node* const node = *node_it;
+        TBOX_ASSERT(node->id() == node_n);
+        libMesh::Point node_position;
+        if (use_position_vector)
+        {
+            if (node->n_vars(position_system_n))
+            {
+                TBOX_ASSERT(node->n_vars(position_system_n) == NDIM);
+                for (unsigned int d = 0; d < NDIM; ++d)
+                {
+                    node_position(d) = position[node->dof_number(position_system_n, d, 0)];
+                }
+            }
+        }
+        else
+        {
+            node_position = *node;
+        }
+        node_positions[node_n] = node_position;
+        ++node_n;
+    }
+    TBOX_ASSERT(node_n == node_positions.size());
+
+    // Step 1: determine which elements belong to which processor and
+    // communicate the partitioning information across the network.
+    //
+    // We offset the processor ids by 1 so that we can check, by summation,
+    // that each Elem and Node is given exactly one processor id.
+    std::vector<processor_id_type> elem_ids(mesh.parallel_n_elem());
+    std::vector<dof_id_type> local_elem_ids;
+    std::size_t elem_n = 0;
+    const auto end_elem = mesh.active_elements_end();
+    for (auto elem = mesh.active_elements_begin(); elem != end_elem; ++elem)
+    {
+        libMesh::Point centroid;
+        const unsigned int n_nodes = (*elem)->n_nodes();
+        for (unsigned int node_n = 0; node_n < n_nodes; ++node_n)
+        {
+            centroid += node_positions[(*elem)->node_id(node_n)];
+        }
+        centroid *= 1.0 / n_nodes;
+
+        if (d_partitioning_boxes.contains(to_ibtk_point(centroid)))
+        {
+            local_elem_ids.push_back(elem_n);
+            TBOX_ASSERT(elem_n < elem_ids.size());
+            elem_ids[elem_n] = current_rank + 1;
+        }
+        ++elem_n;
+    }
+
+    std::vector<processor_id_type> node_ids(mesh.parallel_n_nodes());
+    std::vector<dof_id_type> local_node_ids;
+    std::size_t n_local_nodes = 0;
+    node_n = 0;
+    const auto end_node = mesh.active_nodes_end();
+    for (auto node = mesh.active_nodes_begin(); node != end_node; ++node)
+    {
+        if (d_partitioning_boxes.contains(to_ibtk_point(node_positions[node_n])))
+        {
+            local_node_ids.push_back(node_n);
+            TBOX_ASSERT(node_n < node_ids.size());
+            node_ids[node_n] = current_rank + 1;
+            ++n_local_nodes;
+        }
+        ++node_n;
+    }
+
+    // step 1.5: log the current state of affairs:
+    if (d_enable_logging)
+    {
+        const int n_processes = SAMRAI_MPI::getNodes();
+        std::vector<unsigned long> nodes_on_processors(n_processes);
+        nodes_on_processors[current_rank] = n_local_nodes;
+        const int ierr = MPI_Allreduce(MPI_IN_PLACE,
+                                       nodes_on_processors.data(),
+                                       nodes_on_processors.size(),
+                                       MPI_UNSIGNED_LONG,
+                                       MPI_SUM,
+                                       SAMRAI_MPI::commWorld);
+        TBOX_ASSERT(ierr == 0);
+        if (current_rank == 0)
+        {
+            for (int rank = 0; rank < n_processes; ++rank)
+            {
+                plog << "nodes on processor " << rank << " = " << nodes_on_processors[rank] << '\n';
+            }
+        }
+    }
+
+    // step 2: communicate the partitioning across all processors:
+    int ierr = MPI_Allreduce(
+        MPI_IN_PLACE, elem_ids.data(), elem_ids.size(), pid_integral_type, MPI_SUM, SAMRAI_MPI::commWorld);
+    TBOX_ASSERT(ierr == 0);
+    ierr = MPI_Allreduce(
+        MPI_IN_PLACE, node_ids.data(), node_ids.size(), pid_integral_type, MPI_SUM, SAMRAI_MPI::commWorld);
+    TBOX_ASSERT(ierr == 0);
+
+    // step 3: verify that we partitioned each elem and node exactly once:
+    for (const dof_id_type id : local_elem_ids)
+    {
+        TBOX_ASSERT(id < elem_ids.size());
+        TBOX_ASSERT(elem_ids[id] == current_rank + 1);
+    }
+    for (const dof_id_type id : local_node_ids)
+    {
+        TBOX_ASSERT(id < node_ids.size());
+        TBOX_ASSERT(node_ids[id] == current_rank + 1);
+    }
+
+    TBOX_ASSERT(std::find(elem_ids.begin(), elem_ids.end(), 0) == elem_ids.end());
+    TBOX_ASSERT(std::find(node_ids.begin(), node_ids.end(), 0) == node_ids.end());
+
+    // Step 4: label all elements and nodes with the correct processor id.
+    elem_n = 0;
+    for (auto elem = mesh.active_elements_begin(); elem != end_elem; ++elem)
+    {
+        TBOX_ASSERT(elem_n < elem_ids.size());
+        (*elem)->processor_id() = elem_ids[elem_n] - 1;
+        ++elem_n;
+    }
+
+    node_n = 0;
+    for (auto node = mesh.active_nodes_begin(); node != end_node; ++node)
+    {
+        TBOX_ASSERT(node_n < node_ids.size());
+        (*node)->processor_id() = node_ids[node_n] - 1;
+        ++node_n;
+    }
+} // _do_partition
+
+/////////////////////////////// PRIVATE //////////////////////////////////////
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+} // namespace IBTK
+
+/////////////////////////////////////////////////////////////////////////////

--- a/ibtk/src/utilities/PartitioningBox.cpp
+++ b/ibtk/src/utilities/PartitioningBox.cpp
@@ -1,0 +1,111 @@
+// Filename: PartitioningBox.cpp
+// Created on 06 Dec 2018 by David Wells
+//
+// Copyright (c) 2018, Boyce Griffith, David Wells
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibtk/PartitioningBox.h>
+#include <ibtk/ibtk_utilities.h>
+#include <ibtk/namespaces.h> // IWYU pragma: keep
+
+#include <CartesianPatchGeometry.h>
+
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+namespace IBTK
+{
+PartitioningBox::PartitioningBox()
+{
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+    {
+        d_bounding_points.first[dim_n] = std::numeric_limits<double>::infinity();
+        d_bounding_points.second[dim_n] = std::numeric_limits<double>::infinity();
+    }
+} // PartitioningBox
+
+PartitioningBox::PartitioningBox(const Point& bottom_point, const Point& top_point)
+    : d_bounding_points(bottom_point, top_point)
+{
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+    {
+        // Do not permit negative volume boxes
+        TBOX_ASSERT(bottom()[dim_n] <= top()[dim_n]);
+    }
+} // PartitioningBox
+
+PartitioningBox::PartitioningBox(const CartesianPatchGeometry<NDIM>& patch)
+{
+    std::copy(patch.getXLower(), patch.getXLower() + NDIM, d_bounding_points.first.data());
+    std::copy(patch.getXUpper(), patch.getXUpper() + NDIM, d_bounding_points.second.data());
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+    {
+        // Do not permit negative volume boxes
+        TBOX_ASSERT(bottom()[dim_n] <= top()[dim_n]);
+    }
+} // PartitioningBox
+
+double
+PartitioningBox::volume() const
+{
+    // The bounds may be infinite: check for point equality first to avoid
+    // evaluating oo - oo
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+    {
+        if (d_bounding_points.first[dim_n] == d_bounding_points.second[dim_n]) return 0.0;
+    }
+    double vol = 1.0;
+    for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
+    {
+        vol *= d_bounding_points.second[dim_n] - d_bounding_points.first[dim_n];
+    }
+    return vol;
+} // volume
+
+PartitioningBoxes::PartitioningBoxes(const PatchHierarchy<NDIM>& hierarchy)
+{
+    std::vector<IBTK::PartitioningBox> boxes;
+    const int finest_level = hierarchy.getFinestLevelNumber();
+    Pointer<PatchLevel<NDIM> > level = hierarchy.getPatchLevel(finest_level);
+    for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+    {
+        const Patch<NDIM>& patch = *level->getPatch(p());
+        Pointer<CartesianPatchGeometry<NDIM> > patch_geometry = patch.getPatchGeometry();
+        boxes.emplace_back(*patch_geometry);
+    }
+
+    *this = PartitioningBoxes(boxes.begin(), boxes.end());
+}
+
+} // namespace IBTK
+//////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Another spinoff from #396.

This PR adds the actual partitioner class as well as a 'partitioning box' class. The former inherits from `libMesh::Partitioner` and implements all functionality necessary for integration with libMesh's partitioning code. The later is like a bounding box but uniquely chops up the domain with a tensor product of half-open intervals.

None of this code is actually used in the library at present: I will put up a PR for that once this, #462, and #461 are merged.