### PR TITLE
break DOF cache into build and lookup phases

### DIFF
--- a/ibtk/src/lagrangian/FEDataInterpolation.cpp
+++ b/ibtk/src/lagrangian/FEDataInterpolation.cpp
@@ -391,11 +391,15 @@ FEDataInterpolation::collectDataForInterpolation(const Elem* const elem)
         const size_t num_vars = all_vars.size();
 
         // Get the DOF mappings and local data for all variables.
-        std::vector<std::vector<unsigned int> > dof_indices(num_vars);
+        std::vector<const std::vector<unsigned int>*> dof_indices(num_vars);
         NumericVector<double>* system_data = d_system_data[system_idx];
         for (size_t k = 0; k < num_vars; ++k)
         {
-            system_dof_map_cache->dof_indices(d_current_elem, dof_indices[k], all_vars[k]);
+            system_dof_map_cache->build_dof_indices(d_current_elem, all_vars[k]);
+        }
+        for (size_t k = 0; k < num_vars; ++k)
+        {
+            dof_indices[k] = system_dof_map_cache->lookup_dof_indices(d_current_elem, all_vars[k]);
         }
         boost::multi_array<double, 2>& elem_data = d_system_elem_data[system_idx];
         get_values_for_interpolation(elem_data, *system_data, dof_indices);

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -828,10 +828,6 @@ FEDataManager::spread(const int f_data_idx,
                 get_values_for_interpolation(F_node, *F_petsc_vec, F_local_soln, F_dof_indices);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {
-                    X_dof_map_cache.build_dof_indices(elem, d);
-                }
-                for (unsigned int d = 0; d < NDIM; ++d)
-                {
                     X_dof_indices[d] = X_dof_map_cache.lookup_dof_indices(elem, d);
                 }
                 get_values_for_interpolation(X_node, *X_petsc_vec, X_local_soln, X_dof_indices);
@@ -1504,11 +1500,6 @@ FEDataManager::interpWeighted(const int f_data_idx,
                     F_dof_map_cache.dof_indices(elem, F_dof_indices[i], i);
                     F_rhs_e[i].resize(static_cast<int>(F_dof_indices[i].size()));
                 }
-                for (unsigned int d = 0; d < NDIM; ++d)
-                {
-                    X_dof_indices[d] = X_dof_map_cache.lookup_dof_indices(elem, d);
-                }
-                get_values_for_interpolation(X_node, *X_petsc_vec, X_local_soln, X_dof_indices);
                 const quad_key_type &key = quad_keys[e_idx];
                 FEBase &F_fe = F_fe_cache[key];
                 FEMap &fe_map = fe_map_cache[key];


### PR DESCRIPTION
Profiling suggests that copying DOF index information out of the DOF index cache takes a surprisingly large fraction of runtime. This branch adds a method to return a pointer to the cached DOF index information. Because building the DOF index cache can invalidate pointers, there is also now a function to build (but not return) the cached DOF index data.