### PR TITLE
Conditionally log FEDataManager's workload data.

### DIFF
--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -303,6 +303,19 @@ public:
                bool register_for_restart = true);
 
     /*!
+     * \brief Enable or disable logging.
+     *
+     * @note This is usually set by the IBFEMethod which owns the current
+     * FEDataManager, which reads the relevant boolean from the database.
+     */
+    void setLoggingEnabled(bool enable_logging = true);
+
+    /*!
+     * \brief Determine whether logging is enabled or disabled.
+     */
+    bool getLoggingEnabled() const;
+
+    /*!
      * Deallocate all of the FEDataManager instances.
      *
      * It is not necessary to call this function at program termination since it
@@ -827,6 +840,16 @@ private:
      */
     std::string d_object_name;
     bool d_registered_for_restart;
+
+    /*
+     * Whether or not to log data to the screen: see
+     * FEDataManager::setLoggingEnabled() and
+     * FEDataManager::getLoggingEnabled().
+     *
+     * @note This is usually set by IBFEMethod, which reads the relevant
+     * boolean from the database.
+     */
+    bool d_enable_logging = false;
 
     /*
      * We cache a pointer to the load balancer.

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -43,6 +43,8 @@
 #include <utility>
 #include <vector>
 
+#include <unistd.h>
+
 #include "BasePatchHierarchy.h"
 #include "BasePatchLevel.h"
 #include "Box.h"
@@ -1393,6 +1395,7 @@ IBFEMethod::initializeFEEquationSystems()
         // See the documentation of setWorkloadSpec for an explanation
         workload_spec.clear_estimate = false;
         d_fe_data_managers[part] = FEDataManager::getManager(manager_name, d_interp_spec[part], d_spread_spec[part], workload_spec);
+        d_fe_data_managers[part]->setLoggingEnabled(d_do_log);
         d_ghosts = IntVector<NDIM>::max(d_ghosts, d_fe_data_managers[part]->getGhostCellWidth());
 
         // Create FE equation systems objects and corresponding variables.
@@ -1721,6 +1724,71 @@ IBFEMethod::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > hierarchy, in
     {
         d_fe_data_managers[part]->updateWorkloadEstimates();
     }
+
+    if (d_do_log)
+    {
+        const int n_processes = SAMRAI::tbox::SAMRAI_MPI::getNodes();
+        const int current_rank = SAMRAI::tbox::SAMRAI_MPI::getRank();
+
+        std::vector<int> pids(n_processes);
+        pids[current_rank] = getpid();
+        int ierr = MPI_Allreduce(
+            MPI_IN_PLACE, pids.data(),
+            pids.size(), MPI_INT,
+            MPI_SUM, SAMRAI::tbox::SAMRAI_MPI::commWorld);
+        TBOX_ASSERT(ierr == 0);
+
+        std::vector<double> workload_per_processor(n_processes);
+        workload_per_processor[current_rank] = hier_cc_data_ops.L1Norm(d_workload_idx, -1, true);
+
+        const auto right_padding = std::size_t(std::log10(n_processes)) + 1;
+
+        ierr = MPI_Allreduce(
+            MPI_IN_PLACE, workload_per_processor.data(),
+            workload_per_processor.size(), MPI_DOUBLE,
+            MPI_SUM, SAMRAI::tbox::SAMRAI_MPI::commWorld);
+        TBOX_ASSERT(ierr == 0);
+        if (current_rank == 0)
+        {
+            for (int rank = 0; rank < n_processes; ++rank)
+            {
+                SAMRAI::tbox::plog << "workload estimate on processor "
+                                   << std::setw(right_padding) << std::left << rank
+                                   << " = "
+                                   << long(workload_per_processor[rank])
+                                   << " (pid is " << pids[rank] << ")\n";
+
+            }
+        }
+
+        std::vector<std::size_t> dofs_per_processor(n_processes);
+        for (unsigned int part = 0; part < d_num_parts; ++part)
+        {
+            auto &equation_systems = *d_fe_data_managers[part]->getEquationSystems();
+            for (unsigned int system_n = 0; system_n < equation_systems.n_systems(); ++system_n)
+            {
+                dofs_per_processor[current_rank] += equation_systems.get_system(system_n).n_local_dofs();
+            }
+        }
+
+        ierr = MPI_Allreduce(
+            MPI_IN_PLACE, dofs_per_processor.data(),
+            dofs_per_processor.size(), MPI_UNSIGNED_LONG,
+            MPI_SUM, SAMRAI::tbox::SAMRAI_MPI::commWorld);
+        TBOX_ASSERT(ierr == 0);
+        if (current_rank == 0)
+        {
+            for (int rank = 0; rank < n_processes; ++rank)
+            {
+                SAMRAI::tbox::plog << "local active DoFs on processor "
+                                   << std::setw(right_padding) << std::left << rank
+                                   << " = "
+                                   << dofs_per_processor[rank]
+                                   << " (pid is " << pids[rank] << ")\n";
+            }
+        }
+    }
+
     return;
 } // updateWorkloadEstimates
 
@@ -1731,7 +1799,7 @@ void IBFEMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierar
     return;
 } // beginDataRedistribution
 
-void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > hierarchy,
                                        Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     // if we are not initialized then there is nothing to do
@@ -1745,6 +1813,13 @@ void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarch
             d_fe_data_managers[part]->reinitElementMappings();
         }
     }
+
+    // for debugging: print workload estimates here
+    const int current_rank = SAMRAI::tbox::SAMRAI_MPI::getRank();
+    if (d_do_log && current_rank == 0)
+        SAMRAI::tbox::plog << "Regridding finished. Updating workload estimates.\n";
+    updateWorkloadEstimates(hierarchy, d_workload_idx);
+
     return;
 } // endDataRedistribution
 


### PR DESCRIPTION
Each IBFEMethod propagates its settings to the FEDataManagers it owns.

This is another spinoff of #396, and, like the last four PRs, does not do a lot but add functionality that will be used by the partitioning and load balancing functions.