### PR TITLE
Rearrange workload estimation

### DIFF
--- a/doc/news/changes/incompatibilities/20190213DavidWells
+++ b/doc/news/changes/incompatibilities/20190213DavidWells
@@ -1,0 +1,23 @@
+Changed: The way that workload estimation is handled in IBAMR has been
+completely rewritten and is largely incompatible with the previous
+system. Unfortunately, there was no way to consistently allow multiple objects
+to contribute workload estimations under the old scheme, so the changes were
+incompatible. The newer version permits all hierarchy integrators owned by the
+parent object to add workload contributions (i.e., estimates of work per cell
+that they do beyond what must already happen on one cell of the Eulerian
+discretization).
+
+Classes inheriting from HierarchyIntegrator that need to do work with anything
+but non-SAMRAI data (e.g., finite element meshes owned by FEDataManager) should
+override the new HierarchyIntegrator::addWorkloadEstimate method to add their
+workload estimate on each cell into the same workload array owned by the parent
+integrator. The parent integrator assumes that the sum of all such workload
+estimates are a reasonable approximation of the computational work required per
+cell.
+
+Many non-hierarchy classes, such as LDataManager, were also modified in this
+step to use addWorkloadEstimate instead of the previous and ambiguous
+updateWorkloadEstimates function.
+
+<br>
+(David Wells, 2019/02/13)

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -320,6 +320,9 @@ public:
 
     /*!
      * \brief Register a load balancer for non-uniform load balancing.
+     *
+     * @deprecated Since the correct workload index is passed in via
+     * addWorkloadEstimate this function is no longer necessary.
      */
     void registerLoadBalancer(SAMRAI::tbox::Pointer<SAMRAI::mesh::LoadBalancer<NDIM> > load_balancer,
                               int workload_data_idx);
@@ -630,11 +633,12 @@ public:
                                            double dx_min);
 
     /*!
-     * \brief Update the cell workload estimate. Does nothing unless a
-     * workload variable was previously registered via
-     * FEDataManager::registerLoadBalancer.
+     * \brief Update the cell workload estimate by adding a value (see the
+     * main documentation of this class for information on how this is
+     * computed) to the <code>d_workload_idx</code> cell variable.
      */
-    void updateWorkloadEstimates(int coarsest_ln = -1, int finest_ln = -1);
+    void addWorkloadEstimate(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                             const int workload_data_idx, const int coarsest_ln = -1, const int finest_ln = -1);
 
     /*!
      * Initialize data on a new level after it is inserted into an AMR patch
@@ -848,6 +852,9 @@ private:
 
     /*
      * We cache a pointer to the load balancer.
+     *
+     * @deprecated This pointer is never used and will be removed in the
+     * future.
      */
     SAMRAI::tbox::Pointer<SAMRAI::mesh::LoadBalancer<NDIM> > d_load_balancer;
 
@@ -880,6 +887,10 @@ private:
      * SAMRAI::hier::Variable pointer and patch data descriptor indices for the
      * cell variable used to determine the workload for nonuniform load
      * balancing.
+     *
+     * @deprecated d_workload_var and d_workload_idx will not be stored in a
+     * future release since the correct workload index will be provided as an
+     * argument to addWorkloadEstimate.
      */
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_workload_var;
     int d_workload_idx = IBTK::invalid_index;

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -239,11 +239,6 @@ public:
      */
     struct WorkloadSpec
     {
-        /// Whether or not to clear the workload index arrays at the start of
-        /// the calculation. This should be true unless some other object is
-        /// also adding values into the workload estimate.
-        bool clear_estimate = true;
-
         /// The multiplier applied to each quadrature point.
         double q_point_weight = 2.0;
     };

--- a/ibtk/include/ibtk/LDataManager.h
+++ b/ibtk/include/ibtk/LDataManager.h
@@ -501,6 +501,10 @@ public:
 
     /*!
      * \brief Register a load balancer for non-uniform load balancing.
+     *
+     * @deprecated This method is deprecated since the current strategy for
+     * handling non-uniform load balancing does not require that this object
+     * store a pointer to the load balancer.
      */
     void registerLoadBalancer(SAMRAI::tbox::Pointer<SAMRAI::mesh::LoadBalancer<NDIM> > load_balancer,
                               int workload_data_idx);
@@ -577,6 +581,10 @@ public:
 
     /*!
      * \brief Get the patch data descriptor index for the workload cell data.
+     *
+     * @deprecated This method is deprecated since, in future versions of
+     * IBAMR, this value will no longer be stored and will only be available
+     * via the parent hierarchy integrator.
      */
     int getWorkloadPatchDescriptorIndex() const;
 
@@ -801,7 +809,8 @@ public:
      *
      * in which alpha and beta are parameters that each default to the value 1.
      */
-    void updateWorkloadEstimates(int coarsest_ln = -1, int finest_ln = -1);
+    void addWorkloadEstimate(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                             const int workload_data_idx, const int coarsest_ln = -1, const int finest_ln = -1);
 
     /*!
      * \brief Update the count of nodes per cell.
@@ -1058,6 +1067,8 @@ private:
 
     /*
      * We cache a pointer to the load balancer.
+     *
+     * @deprecated This will be removed in a future release since it is no longer necessary.
      */
     SAMRAI::tbox::Pointer<SAMRAI::mesh::LoadBalancer<NDIM> > d_load_balancer;
 
@@ -1080,6 +1091,10 @@ private:
      * SAMRAI::hier::Variable pointer and patch data descriptor indices for the
      * cell variable used to determine the workload for nonuniform load
      * balancing.
+     *
+     * @deprecated d_workload_var and d_workload_idx will not be stored in a
+     * future release since the correct workload index will be provided as an
+     * argument to addWorkloadEstimate.
      */
     double d_beta_work = 1.0;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_workload_var;

--- a/ibtk/include/ibtk/private/LDataManager-inl.h
+++ b/ibtk/include/ibtk/private/LDataManager-inl.h
@@ -35,6 +35,7 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include "ibtk/ibtk_utilities.h"
 #include "ibtk/LDataManager.h"
 #include "ibtk/LMesh.h"
 
@@ -149,6 +150,7 @@ LDataManager::getLNodePatchDescriptorIndex() const
 inline int
 LDataManager::getWorkloadPatchDescriptorIndex() const
 {
+    IBTK_DEPRECATED_MEMBER_FUNCTION1("LDataManager", "getWorkloadPatchDescriptorIndex");
     return d_workload_idx;
 } // getWorkloadPatchDescriptorIndex
 

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -369,6 +369,7 @@ FEDataManager::freeAllManagers()
 void
 FEDataManager::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, int workload_data_idx)
 {
+    IBTK_DEPRECATED_MEMBER_FUNCTION1("FEDataManager", "registerLoadBalancer");
     TBOX_ASSERT(load_balancer);
     d_load_balancer = load_balancer;
     d_workload_idx = workload_data_idx;
@@ -2180,10 +2181,9 @@ FEDataManager::updateSpreadQuadratureRule(std::unique_ptr<QBase>& qrule,
 }
 
 void
-FEDataManager::updateWorkloadEstimates(const int coarsest_ln_in, const int finest_ln_in)
+FEDataManager::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy,
+                                   const int workload_data_idx, const int coarsest_ln_in, const int finest_ln_in)
 {
-    if (d_workload_idx == IBTK::invalid_index) return;
-
     IBTK_TIMER_START(t_update_workload_estimates);
 
     const int coarsest_ln = (coarsest_ln_in == -1) ? d_coarsest_ln : coarsest_ln_in;
@@ -2197,18 +2197,14 @@ FEDataManager::updateWorkloadEstimates(const int coarsest_ln_in, const int fines
     if (coarsest_ln <= ln && ln <= finest_ln)
     {
         updateQuadPointCountData(ln, ln);
-        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(d_hierarchy, ln, ln);
-        if (d_default_workload_spec.clear_estimate)
-        {
-            hier_cc_data_ops.setToScalar(d_workload_idx, 0.0);
-        }
-        hier_cc_data_ops.axpy(d_workload_idx, d_default_workload_spec.q_point_weight,
-                              d_qp_count_idx, d_workload_idx);
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(hierarchy, ln, ln);
+        hier_cc_data_ops.axpy(workload_data_idx, d_default_workload_spec.q_point_weight,
+                              d_qp_count_idx, workload_data_idx);
     }
 
     IBTK_TIMER_STOP(t_update_workload_estimates);
     return;
-} // updateWorkloadEstimates
+} // addWorkloadEstimate
 
 void
 FEDataManager::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> > hierarchy,

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -87,6 +87,7 @@
 #include "boost/math/special_functions/round.hpp"
 #include "boost/multi_array.hpp"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/ibtk_utilities.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LData.h"
 #include "ibtk/LDataManager.h"
@@ -883,6 +884,7 @@ LDataManager::registerLSiloDataWriter(Pointer<LSiloDataWriter> silo_writer)
 void
 LDataManager::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, int workload_idx)
 {
+    IBTK_DEPRECATED_MEMBER_FUNCTION1("LDataManager", "registerLoadBalancer");
 #if !defined(NDEBUG)
     TBOX_ASSERT(load_balancer);
 #endif
@@ -1975,10 +1977,9 @@ LDataManager::endDataRedistribution(const int coarsest_ln_in, const int finest_l
 } // endDataRedistribution
 
 void
-LDataManager::updateWorkloadEstimates(const int coarsest_ln_in, const int finest_ln_in)
+LDataManager::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM>> hierarchy, const int workload_data_idx,
+                                  const int coarsest_ln_in, const int finest_ln_in)
 {
-    if (!d_load_balancer) return;
-
     IBTK_TIMER_START(t_update_workload_estimates);
 
     const int coarsest_ln = (coarsest_ln_in == -1) ? d_coarsest_ln : coarsest_ln_in;
@@ -1990,12 +1991,12 @@ LDataManager::updateWorkloadEstimates(const int coarsest_ln_in, const int finest
 #endif
 
     updateNodeCountData(coarsest_ln, finest_ln);
-    HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(d_hierarchy, coarsest_ln, finest_ln);
-    hier_cc_data_ops.axpy(d_workload_idx, d_beta_work, d_node_count_idx, d_workload_idx);
+    HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(hierarchy, coarsest_ln, finest_ln);
+    hier_cc_data_ops.axpy(workload_data_idx, d_beta_work, d_node_count_idx, workload_data_idx);
 
     IBTK_TIMER_STOP(t_update_workload_estimates);
     return;
-} // updateWorkloadEstimates
+} // addWorkloadEstimate
 
 void
 LDataManager::updateNodeCountData(const int coarsest_ln_in, const int finest_ln_in)

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -508,6 +508,24 @@ HierarchyIntegrator::stepsRemaining() const
             !MathUtilities<double>::equalEps(d_integrator_time, d_end_time));
 } // stepsRemaining
 
+void
+HierarchyIntegrator::updateWorkloadEstimates()
+{
+    if (d_workload_idx != IBTK::invalid_index)
+    {
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(d_hierarchy);
+        hier_cc_data_ops.setToScalar(d_workload_idx, 1.0, /*interior_only*/ false);
+
+        addWorkloadEstimate(d_hierarchy, d_workload_idx);
+        for (HierarchyIntegrator *child : d_child_integrators)
+        {
+            child->addWorkloadEstimate(d_hierarchy, d_workload_idx);
+        }
+    }
+
+    return;
+} // updateWorkloadEstimates
+
 Pointer<PatchHierarchy<NDIM> >
 HierarchyIntegrator::getPatchHierarchy() const
 {
@@ -532,6 +550,7 @@ HierarchyIntegrator::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_bala
         d_workload_var = new CellVariable<NDIM, double>(d_object_name + "::workload");
         registerVariable(d_workload_idx, d_workload_var, 0, getCurrentContext());
     }
+    d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx);
     return;
 } // registerLoadBalancer
 
@@ -1310,6 +1329,14 @@ void HierarchyIntegrator::putToDatabaseSpecialized(Pointer<Database> /*db*/)
     // intentionally blank
     return;
 } // putToDatabaseSpecialized
+
+void HierarchyIntegrator::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> >,
+                                              const int)
+{
+    // intentionally blank
+    return;
+} // addWorkloadEstimate
+
 
 void
 HierarchyIntegrator::executePreprocessIntegrateHierarchyCallbackFcns(double current_time,

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -593,18 +593,19 @@ public:
     /*!
      * Register a load balancer and work load patch data index with the IB
      * strategy object.
+     *
+     * This function should be called before IBFEMethod::initializeFEData().
      */
     void registerLoadBalancer(SAMRAI::tbox::Pointer<SAMRAI::mesh::LoadBalancer<NDIM> > load_balancer,
                               int workload_data_idx) override;
 
     /*!
-     * Update work load estimates on each level of the patch hierarchy. If a
-     * load balancer and workload variable have been previously specified by
-     * IBFEMethod::register_load_balancer then the workload_data_idx variable
-     * index must be the same.
+     * Add the estimated computational work from the current object (i.e., the
+     * work required by the owned Lagrangian objects) per cell into the
+     * specified <code>workload_data_idx</code>.
      */
-    void updateWorkloadEstimates(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
-                                 int workload_data_idx) override;
+    void addWorkloadEstimate(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                             const int workload_data_idx) override;
 
     /*!
      * Begin redistributing Lagrangian data prior to regridding the patch

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -535,13 +535,6 @@ public:
 
     /*!
      * Set the workload spec object used with a particular mesh part.
-     *
-     * @note Since the individual mesh parts do not know anything about
-     * each-other this class will always set
-     * FEDataManager::WorkloadSpec::clear_estimate to false in the value
-     * supplied to FEDataManager and zero the data once itself if
-     * requested. This prevents parts from zeroing data provided by other
-     * parts.
      */
     void setWorkloadSpec(const IBTK::FEDataManager::WorkloadSpec& workload_spec, unsigned int part = 0);
 
@@ -609,11 +602,6 @@ public:
      * load balancer and workload variable have been previously specified by
      * IBFEMethod::register_load_balancer then the workload_data_idx variable
      * index must be the same.
-     *
-     * @note This function computes workloads by setting the estimated work
-     * value on all cells to 1 and then using
-     * FEDataManager::updateWorkloadEstimates to compute the estimated
-     * Lagrangian contribution to the total amount of work.
      */
     void updateWorkloadEstimates(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
                                  int workload_data_idx) override;

--- a/include/ibamr/IBFESurfaceMethod.h
+++ b/include/ibamr/IBFESurfaceMethod.h
@@ -397,10 +397,13 @@ public:
                               int workload_data_idx) override;
 
     /*!
-     * Update work load estimates on each level of the patch hierarchy.
+     * Add the estimated computational work from the current object (i.e., the
+     * work required by the owned Lagrangian objects) per cell into the
+     * specified <code>workload_data_idx</code>.
      */
-    void updateWorkloadEstimates(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
-                                 int workload_data_idx) override;
+    void addWorkloadEstimate(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                             const int workload_data_idx) override;
+
 
     /*!
      * Begin redistributing Lagrangian data prior to regridding the patch

--- a/include/ibamr/IBHierarchyIntegrator.h
+++ b/include/ibamr/IBHierarchyIntegrator.h
@@ -252,6 +252,16 @@ protected:
      */
     void putToDatabaseSpecialized(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
 
+    /*!
+     * Add the work contributions (excluding the background grid) for the
+     * current hierarchy into the variable with index
+     * <code>workload_data_idx</code>. The only direct workload contribution
+     * of this hierarchy manager is usually the work done by the IBStrategy
+     * object.
+     */
+    virtual void addWorkloadEstimate(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                                     const int workload_data_idx) override;
+
     /*
      * Boolean value that indicates whether the integrator has been initialized.
      */

--- a/include/ibamr/IBMethod.h
+++ b/include/ibamr/IBMethod.h
@@ -371,10 +371,11 @@ public:
                               int workload_data_idx) override;
 
     /*!
-     * Update work load estimates on each level of the patch hierarchy.
+     * Add the estimated computational work from the current object per cell
+     * into the specified <code>workload_data_idx</code>.
      */
-    void updateWorkloadEstimates(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
-                                 int workload_data_idx) override;
+    void addWorkloadEstimate(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                             const int workload_data_idx) override;
 
     /*!
      * Begin redistributing Lagrangian data prior to regridding the patch

--- a/include/ibamr/IBStrategy.h
+++ b/include/ibamr/IBStrategy.h
@@ -341,12 +341,14 @@ public:
                                       int workload_data_idx);
 
     /*!
-     * Update work load estimates on each level of the patch hierarchy.
+     * Add the estimated computational work from the current object per cell
+     * into the specified <code>workload_data_idx</code>.
      *
      * An empty default implementation is provided.
      */
-    virtual void updateWorkloadEstimates(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
-                                         int workload_data_idx);
+    virtual void addWorkloadEstimate(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                                     const int workload_data_idx);
+
 
     /*!
      * Begin redistributing Lagrangian data prior to regridding the patch

--- a/include/ibamr/IBStrategySet.h
+++ b/include/ibamr/IBStrategySet.h
@@ -272,10 +272,11 @@ public:
                               int workload_data_idx) override;
 
     /*!
-     * Update work load estimates on each level of the patch hierarchy.
+     * Add the estimated computational work from the current object per cell
+     * into the specified <code>workload_data_idx</code>.
      */
-    void updateWorkloadEstimates(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
-                                 int workload_data_idx) override;
+    void addWorkloadEstimate(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                             const int workload_data_idx) override;
 
     /*!
      * Begin redistributing Lagrangian data prior to regridding the patch

--- a/include/ibamr/IMPMethod.h
+++ b/include/ibamr/IMPMethod.h
@@ -245,10 +245,11 @@ public:
                               int workload_data_idx) override;
 
     /*!
-     * Update work load estimates on each level of the patch hierarchy.
+     * Add the estimated computational work from the current object per cell
+     * into the specified <code>workload_data_idx</code>.
      */
-    void updateWorkloadEstimates(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
-                                 int workload_data_idx) override;
+    void addWorkloadEstimate(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                             const int workload_data_idx) override;
 
     /*!
      * Begin redistributing Lagrangian data prior to regridding the patch

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1391,10 +1391,8 @@ IBFEMethod::initializeFEEquationSystems()
         std::ostringstream manager_stream;
         manager_stream << "IBFEMethod FEDataManager::" << part;
         const std::string& manager_name = manager_stream.str();
-        FEDataManager::WorkloadSpec workload_spec = d_workload_spec[part];
-        // See the documentation of setWorkloadSpec for an explanation
-        workload_spec.clear_estimate = false;
-        d_fe_data_managers[part] = FEDataManager::getManager(manager_name, d_interp_spec[part], d_spread_spec[part], workload_spec);
+        d_fe_data_managers[part] = FEDataManager::getManager(manager_name, d_interp_spec[part], d_spread_spec[part], d_workload_spec[part]);
+
         d_fe_data_managers[part]->setLoggingEnabled(d_do_log);
         d_ghosts = IntVector<NDIM>::max(d_ghosts, d_fe_data_managers[part]->getGhostCellWidth());
 
@@ -1701,25 +1699,6 @@ IBFEMethod::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, int
 void
 IBFEMethod::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > hierarchy, int workload_data_idx)
 {
-    if (workload_data_idx == IBTK::invalid_index) return;
-    TBOX_ASSERT(workload_data_idx == d_workload_idx);
-
-    // Since there may be multiple parts, and the parts know nothing about
-    // each-other, we have to set up the default workload value here and then
-    // add into it on each part. All Eulerian cells are assumed to have an
-    // equal workload.
-    HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(hierarchy);
-
-    for (const FEDataManager::WorkloadSpec &workload_spec : d_workload_spec)
-    {
-        if (workload_spec.clear_estimate)
-        {
-            hier_cc_data_ops.setToScalar(d_workload_idx, 1.0,
-                                         /*interior_only*/ false);
-            break;
-        }
-    }
-
     for (unsigned int part = 0; part < d_num_parts; ++part)
     {
         d_fe_data_managers[part]->updateWorkloadEstimates();
@@ -1739,6 +1718,7 @@ IBFEMethod::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > hierarchy, in
         TBOX_ASSERT(ierr == 0);
 
         std::vector<double> workload_per_processor(n_processes);
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(hierarchy);
         workload_per_processor[current_rank] = hier_cc_data_ops.L1Norm(d_workload_idx, -1, true);
 
         const auto right_padding = std::size_t(std::log10(n_processes)) + 1;
@@ -1799,7 +1779,7 @@ void IBFEMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierar
     return;
 } // beginDataRedistribution
 
-void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > hierarchy,
+void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
                                        Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     // if we are not initialized then there is nothing to do
@@ -1841,7 +1821,6 @@ IBFEMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
             hierarchy, level_number, init_data_time, can_be_refined, initial_time, old_level, allocate_data);
         if (d_load_balancer && level_number == d_fe_data_managers[part]->getLevelNumber())
         {
-            d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number);
             d_fe_data_managers[part]->updateWorkloadEstimates(level_number, level_number);
         }
     }

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1819,10 +1819,6 @@ IBFEMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
         d_fe_data_managers[part]->setPatchLevels(0, finest_hier_level);
         d_fe_data_managers[part]->initializeLevelData(
             hierarchy, level_number, init_data_time, can_be_refined, initial_time, old_level, allocate_data);
-        if (d_load_balancer && level_number == d_fe_data_managers[part]->getLevelNumber())
-        {
-            d_fe_data_managers[part]->updateWorkloadEstimates(level_number, level_number);
-        }
     }
     return;
 } // initializeLevelData

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1793,13 +1793,6 @@ void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarch
             d_fe_data_managers[part]->reinitElementMappings();
         }
     }
-
-    // for debugging: print workload estimates here
-    const int current_rank = SAMRAI::tbox::SAMRAI_MPI::getRank();
-    if (d_do_log && current_rank == 0)
-        SAMRAI::tbox::plog << "Regridding finished. Updating workload estimates.\n";
-    updateWorkloadEstimates(hierarchy, d_workload_idx);
-
     return;
 } // endDataRedistribution
 

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1697,11 +1697,11 @@ IBFEMethod::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, int
 } // registerLoadBalancer
 
 void
-IBFEMethod::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > hierarchy, int workload_data_idx)
+IBFEMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const int workload_data_idx)
 {
     for (unsigned int part = 0; part < d_num_parts; ++part)
     {
-        d_fe_data_managers[part]->updateWorkloadEstimates();
+        d_fe_data_managers[part]->addWorkloadEstimate(hierarchy, workload_data_idx);
     }
 
     if (d_do_log)
@@ -1770,7 +1770,7 @@ IBFEMethod::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > hierarchy, in
     }
 
     return;
-} // updateWorkloadEstimates
+} // addWorkloadEstimate
 
 void IBFEMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
                                          Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -1404,7 +1404,6 @@ IBFESurfaceMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierar
             hierarchy, level_number, init_data_time, can_be_refined, initial_time, old_level, allocate_data);
         if (d_load_balancer && level_number == d_fe_data_managers[part]->getLevelNumber())
         {
-            d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number);
             d_fe_data_managers[part]->updateWorkloadEstimates(level_number, level_number);
         }
     }

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -1357,14 +1357,14 @@ IBFESurfaceMethod::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balanc
 } // registerLoadBalancer
 
 void
-IBFESurfaceMethod::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/, int /*workload_data_idx*/)
+IBFESurfaceMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const int workload_data_idx)
 {
     for (unsigned int part = 0; part < d_num_parts; ++part)
     {
-        d_fe_data_managers[part]->updateWorkloadEstimates();
+        d_fe_data_managers[part]->addWorkloadEstimate(hierarchy, workload_data_idx);
     }
     return;
-} // updateWorkloadEstimates
+} // addWorkloadEstimate
 
 void IBFESurfaceMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
                                                 Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -1402,10 +1402,6 @@ IBFESurfaceMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierar
         d_fe_data_managers[part]->setPatchLevels(0, finest_hier_level);
         d_fe_data_managers[part]->initializeLevelData(
             hierarchy, level_number, init_data_time, can_be_refined, initial_time, old_level, allocate_data);
-        if (d_load_balancer && level_number == d_fe_data_managers[part]->getLevelNumber())
-        {
-            d_fe_data_managers[part]->updateWorkloadEstimates(level_number, level_number);
-        }
     }
     return;
 } // initializeLevelData

--- a/src/IB/IBHierarchyIntegrator.cpp
+++ b/src/IB/IBHierarchyIntegrator.cpp
@@ -441,13 +441,9 @@ IBHierarchyIntegrator::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > h
 void
 IBHierarchyIntegrator::regridHierarchy()
 {
-    // Update the workload pre-regridding.
-    if (d_load_balancer)
-    {
-        if (d_enable_logging) plog << d_object_name << "::regridHierarchy(): updating workload estimates\n";
-        d_hier_cc_data_ops->setToScalar(d_workload_idx, 1.0);
-        d_ib_method_ops->updateWorkloadEstimates(d_hierarchy, d_workload_idx);
-    }
+    // This must be done here since (if a load balancer is used) it effects
+    // the distribution of patches.
+    updateWorkloadEstimates();
 
     // Collect the marker particles to level 0 of the patch hierarchy.
     if (d_mark_var)
@@ -570,14 +566,6 @@ IBHierarchyIntegrator::initializeLevelDataSpecialized(const Pointer<BasePatchHie
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
 #endif
 
-    // Initialize workload data.
-    if (d_workload_idx != IBTK::invalid_index)
-    {
-        HierarchyCellDataOpsReal<NDIM, double> level_cc_data_ops(hierarchy, level_number, level_number);
-        level_cc_data_ops.setToScalar(d_workload_idx, 1.0);
-        d_load_balancer->setUniformWorkload(level_number);
-    }
-
     // Initialize marker data
     if (d_mark_var)
     {
@@ -644,6 +632,13 @@ IBHierarchyIntegrator::putToDatabaseSpecialized(Pointer<Database> db)
     db->putDouble("d_regrid_cfl_estimate", d_regrid_cfl_estimate);
     return;
 } // putToDatabaseSpecialized
+
+void
+IBHierarchyIntegrator::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM>> hierarchy, const int workload_data_idx)
+{
+    d_ib_method_ops->addWorkloadEstimate(hierarchy, workload_data_idx);
+    return;
+} // addWorkloadEstimate
 
 /////////////////////////////// PRIVATE //////////////////////////////////////
 

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -1569,7 +1569,6 @@ IBMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
     {
         Pointer<LData> F_data = d_l_data_manager->createLData("F", level_number, NDIM, /*manage_data*/ true);
     }
-    d_l_data_manager->updateWorkloadEstimates(level_number, level_number);
     return;
 } // initializeLevelData
 

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -1480,11 +1480,11 @@ IBMethod::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, int w
 } // registerLoadBalancer
 
 void
-IBMethod::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/, int /*workload_data_idx*/)
+IBMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const int workload_data_idx)
 {
-    d_l_data_manager->updateWorkloadEstimates();
+    d_l_data_manager->addWorkloadEstimate(hierarchy, workload_data_idx);
     return;
-} // updateWorkloadEstimates
+} // addWorkloadEstimate
 
 void IBMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
                                        Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
@@ -1569,11 +1569,7 @@ IBMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
     {
         Pointer<LData> F_data = d_l_data_manager->createLData("F", level_number, NDIM, /*manage_data*/ true);
     }
-    if (d_load_balancer && d_l_data_manager->levelContainsLagrangianData(level_number))
-    {
-        d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number);
-        d_l_data_manager->updateWorkloadEstimates(level_number, level_number);
-    }
+    d_l_data_manager->updateWorkloadEstimates(level_number, level_number);
     return;
 } // initializeLevelData
 

--- a/src/IB/IBStrategy.cpp
+++ b/src/IB/IBStrategy.cpp
@@ -237,11 +237,11 @@ IBStrategy::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > /*load_balancer*/,
 } // registerLoadBalancer
 
 void
-IBStrategy::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/, int /*workload_data_idx*/)
+IBStrategy::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/, const int /*workload_data_idx*/)
 {
     // intentionally blank
     return;
-} // updateWorkloadEstimates
+} // addWorkloadEstimate
 
 void IBStrategy::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
                                          Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)

--- a/src/IB/IBStrategySet.cpp
+++ b/src/IB/IBStrategySet.cpp
@@ -339,14 +339,14 @@ IBStrategySet::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, 
 } // registerLoadBalancer
 
 void
-IBStrategySet::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > hierarchy, int workload_data_idx)
+IBStrategySet::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const int workload_data_idx)
 {
     for (const auto& strategy : d_strategy_set)
     {
-        strategy->updateWorkloadEstimates(hierarchy, workload_data_idx);
+        strategy->addWorkloadEstimate(hierarchy, workload_data_idx);
     }
     return;
-} // updateWorkloadEstimates
+} // addWorkloadEstimate
 
 void
 IBStrategySet::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > hierarchy,

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -1049,7 +1049,6 @@ IMPMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
             }
         }
     }
-    d_l_data_manager->updateWorkloadEstimates(level_number, level_number);
     return;
 } // initializeLevelData
 

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -974,11 +974,11 @@ IMPMethod::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, int 
 } // registerLoadBalancer
 
 void
-IMPMethod::updateWorkloadEstimates(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/, int /*workload_data_idx*/)
+IMPMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const int workload_data_idx)
 {
-    d_l_data_manager->updateWorkloadEstimates();
+    d_l_data_manager->addWorkloadEstimate(hierarchy, workload_data_idx);
     return;
-} // updateWorkloadEstimates
+} // addWorkloadEstimate
 
 void IMPMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
                                         Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
@@ -1049,11 +1049,7 @@ IMPMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierarchy,
             }
         }
     }
-    if (d_load_balancer && d_l_data_manager->levelContainsLagrangianData(level_number))
-    {
-        d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx, level_number);
-        d_l_data_manager->updateWorkloadEstimates(level_number, level_number);
-    }
+    d_l_data_manager->updateWorkloadEstimates(level_number, level_number);
     return;
 } // initializeLevelData
 


### PR DESCRIPTION
A (larger) spinoff from #396, with some more fixes.

This came out of a conversation I had with @boyceg this afternoon: we don't really have a consistent way of setting up workload estimates. However, most of the necessary infrastructure to do this is already there. The new version assumes that the parent hierarchy integrator (i.e., whatever we call `advanceHierarchy` on) 'owns' the workload estimate array. To estimate the work, it sets all cells to one and then asks each child integrator to add in its own contributions. Things like `IBFEMethod`, `LDataManager`, etc. do not need to know anything about load balancers or store the workload index (or even store a pointer to the hierarchy): they just add their contribution when asked via `addWorkloadEstimate`.

I am labeling this as 'do not merge' since I want to do some more testing to guarantee that all the old code paths actually still work (they should; they've just been deprecated) and that this fits with the rest of the load balancing stack.