### PR TITLE
Partitioning 2g

### DIFF
--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -60,6 +60,7 @@
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
+#include <ibtk/BoxPartitioner.h>
 
 // Set up application namespace declarations
 #include <ibamr/app_namespaces.h>
@@ -244,6 +245,13 @@ bool run_example(int argc, char** argv)
         // Create major algorithm and data objects that comprise the
         // application.  These objects are configured from the input database
         // and, if this is a restarted run, from the restart database.
+        Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<LoadBalancer<NDIM> > load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<BergerRigoutsos<NDIM> > box_generator = new BergerRigoutsos<NDIM>();
+
         Pointer<INSHierarchyIntegrator> navier_stokes_integrator;
         const string solver_type = app_initializer->getComponentDatabase("Main")->getString("solver_type");
         if (solver_type == "STAGGERED")
@@ -273,16 +281,12 @@ bool run_example(int argc, char** argv)
                                               app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
                                               ib_method_ops,
                                               navier_stokes_integrator);
-        Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
-            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
-        Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        time_integrator->registerLoadBalancer(load_balancer);
+
         Pointer<StandardTagAndInitialize<NDIM> > error_detector =
             new StandardTagAndInitialize<NDIM>("StandardTagAndInitialize",
                                                time_integrator,
                                                app_initializer->getComponentDatabase("StandardTagAndInitialize"));
-        Pointer<BergerRigoutsos<NDIM> > box_generator = new BergerRigoutsos<NDIM>();
-        Pointer<LoadBalancer<NDIM> > load_balancer =
-            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
         Pointer<GriddingAlgorithm<NDIM> > gridding_algorithm =
             new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
                                         app_initializer->getComponentDatabase("GriddingAlgorithm"),
@@ -402,6 +406,8 @@ bool run_example(int argc, char** argv)
         if (uses_visit)
         {
             time_integrator->registerVisItDataWriter(visit_data_writer);
+            visit_data_writer->registerPlotQuantity("workload", "SCALAR",
+                                                    time_integrator->getWorkloadDataIndex());
         }
         std::unique_ptr<ExodusII_IO> exodus_io(uses_exodus ? new ExodusII_IO(mesh) : NULL);
 
@@ -425,8 +431,18 @@ bool run_example(int argc, char** argv)
             pout << "\n\nWriting visualization files...\n\n";
             if (uses_visit)
             {
+                const System& position_system = equation_systems->get_system(IBFEMethod::COORDS_SYSTEM_NAME);
                 time_integrator->setupPlotData();
                 visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+                {
+                    IBTK::BoxPartitioner partitioner(*patch_hierarchy,
+                                                     position_system);
+                    partitioner.writePartitioning("patch-part-" + std::to_string(iteration_num) + ".txt");
+                }
+
+                // Write partitioning data from libMesh.
+                IBTK::write_node_partitioning("node-part-" + std::to_string(iteration_num) + ".txt",
+                                              position_system);
             }
             if (uses_exodus)
             {
@@ -476,8 +492,18 @@ bool run_example(int argc, char** argv)
                 pout << "\nWriting visualization files...\n\n";
                 if (uses_visit)
                 {
+                    const System& position_system = equation_systems->get_system(IBFEMethod::COORDS_SYSTEM_NAME);
                     time_integrator->setupPlotData();
                     visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+                    {
+                        IBTK::BoxPartitioner partitioner(*patch_hierarchy,
+                                                         position_system);
+                        partitioner.writePartitioning("patch-part-" + std::to_string(iteration_num) + ".txt");
+                    }
+
+                    // Write partitioning data from libMesh.
+                    IBTK::write_node_partitioning("node-part-" + std::to_string(iteration_num) + ".txt",
+                                                  position_system);
                 }
                 if (uses_exodus)
                 {

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -2629,7 +2629,7 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
                     SAMRAI::tbox::plog << "quadrature points on processor "
                                        << std::setw(right_padding) << std::left << rank
                                        << " = "
-                                       << n_q_points_on_processors[rank] << '\n'
+                                       << n_q_points_on_processors[rank]
                                        << " (pid is " << pids[rank] << ")\n";
                 }
             }

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -554,6 +554,16 @@ HierarchyIntegrator::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_bala
     return;
 } // registerLoadBalancer
 
+int
+HierarchyIntegrator::getWorkloadDataIndex() const
+{
+    if (d_parent_integrator)
+    {
+        return d_parent_integrator->getWorkloadDataIndex();
+    }
+    return d_workload_idx;
+}
+
 void
 HierarchyIntegrator::registerVisItDataWriter(Pointer<VisItDataWriter<NDIM> > visit_writer)
 {

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -46,6 +46,7 @@
 #include "PatchHierarchy.h"
 #include "ibamr/IBFEDirectForcingKinematics.h"
 #include "ibamr/IBStrategy.h"
+#include "ibamr/ibamr_enums.h"
 #include "ibtk/FEDataManager.h"
 #include "ibtk/libmesh_utilities.h"
 #include "libmesh/enum_fe_family.h"
@@ -101,6 +102,47 @@ namespace IBAMR
  * \brief Class IBFEMethod is an implementation of the abstract base class
  * IBStrategy that provides functionality required by the IB method with finite
  * element elasticity.
+ *
+ * By default, the libMesh data is partitioned once at the beginning of the
+ * computation by libMesh's default partitioner.
+ *
+ * This class can repartition libMesh data in a way that matches SAMRAI's
+ * distribution of patches; put another way, if a certain region of space on
+ * the finest level is assigned to processor N, then all libMesh nodes and
+ * elements within that region will also be assigned to processor N. The
+ * actual partitioning here is done by the IBTK::BoxPartitioner class. See the
+ * discussion in HierarchyIntegrator and FEDataManager for descriptions on how
+ * this partitioning is performed.
+ *
+ * The choice of libMesh partitioner depends on the libmesh_partitioner_type
+ * parameter in the input database and whether or not workload estimates are
+ * available (it is assumed that if workload estimates are available then a
+ * load balancer is being used). More exactly:
+ * <ul>
+ *  <li>If <code>libmesh_partitioner_type</code> is <code>AUTOMATIC</code>
+ *      and workload estimates are available then this class will use the
+ *      IBTK::BoxPartitioner class to repartition libMesh data after the SAMRAI
+ *      data is regridded.</li>
+ *
+ *  <li>If <code>libmesh_partitioner_type</code> is <code>AUTOMATIC</code> and
+ *      workload estimates are not available then this class will never
+ *      repartition libMesh data.</li>
+ *
+ *  <li>If <code>libmesh_partitioner_type</code> is
+ *      <code>LIBMESH_DEFAULT</code> then this class will never repartition
+ *      libMesh data, since the default libMesh partitioner is already used at
+ *      the beginning of the computation and, since no degrees of freedom are
+ *      added or removed, any subsequent partitioning would have no
+ *      effect.</li>
+ *
+ *  <li>If <code>libmesh_partitioner_type</code> is <code>SAMRAI_BOX</code>
+ *      then this class will always repartition the libMesh data with
+ *      IBTK::BoxPartitioner every time the Eulerian data is regridded.</li>
+ * </ul>
+ * The default value for <code>libmesh_partitioner_type</code> is
+ * <code>AUTOMATIC</code>. The intent of these choices is to automatically use
+ * the fairest (that is, partitioning based on workload estimation)
+ * partitioner.
  */
 class IBFEMethod : public IBStrategy
 {
@@ -793,6 +835,12 @@ protected:
     std::vector<libMesh::PetscVector<double>*> d_Phi_half_vecs, d_Phi_rhs_vecs;
 
     bool d_fe_equation_systems_initialized = false, d_fe_data_initialized = false;
+
+    /*
+     * Type of partitioner to use. See the main documentation of this class
+     * for more information.
+     */
+    LibmeshPartitionerType d_libmesh_partitioner_type = AUTOMATIC;
 
     /*
      * Method paramters.

--- a/include/ibamr/ibamr_enums.h
+++ b/include/ibamr/ibamr_enums.h
@@ -445,6 +445,37 @@ enum_to_string<MobilityMatrixInverseType>(MobilityMatrixInverseType val)
     return "UNKNOWN_MOBILITY_MATRIX_INVERSE_TYPE";
 } // enum_to_string
 
+/*!
+ * \brief Enumerated type for different possible libMesh partitioners.
+ */
+enum LibmeshPartitionerType
+{
+    AUTOMATIC,
+    LIBMESH_DEFAULT,
+    SAMRAI_BOX,
+    UNKNOWN_LIBMESH_PARTITIONER_TYPE = -1
+};
+
+template <>
+inline LibmeshPartitionerType
+string_to_enum<LibmeshPartitionerType>(const std::string& val)
+{
+    if (strcasecmp(val.c_str(), "AUTOMATIC") == 0) return AUTOMATIC;
+    if (strcasecmp(val.c_str(), "LIBMESH_DEFAULT") == 0) return LIBMESH_DEFAULT;
+    if (strcasecmp(val.c_str(), "SAMRAI_BOX") == 0) return SAMRAI_BOX;
+    return UNKNOWN_LIBMESH_PARTITIONER_TYPE;
+} // string_to_enum
+
+template <>
+inline std::string
+enum_to_string<LibmeshPartitionerType>(LibmeshPartitionerType val)
+{
+    if (val == AUTOMATIC) return "AUTOMATIC";
+    if (val == LIBMESH_DEFAULT) return "LIBMESH_DEFAULT";
+    if (val == SAMRAI_BOX) return "SAMRAI_BOX";
+    return "UNKNOWN_LIBMESH_PARTITIONER_TYPE";
+} // enum_to_string
+
 } // namespace IBAMR
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1689,11 +1689,6 @@ IBFEMethod::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_balancer, int
     TBOX_ASSERT(load_balancer);
     d_load_balancer = load_balancer;
     d_workload_idx = workload_data_idx;
-
-    for (unsigned int part = 0; part < d_num_parts; ++part)
-    {
-        d_fe_data_managers[part]->registerLoadBalancer(load_balancer, workload_data_idx);
-    }
     return;
 } // registerLoadBalancer
 

--- a/src/IB/IBHierarchyIntegrator.cpp
+++ b/src/IB/IBHierarchyIntegrator.cpp
@@ -470,6 +470,11 @@ IBHierarchyIntegrator::regridHierarchy()
         LMarkerUtilities::pruneInvalidMarkers(d_mark_current_idx, d_hierarchy);
     }
 
+    if (d_enable_logging)
+    {
+        updateWorkloadEstimates();
+    }
+
     // Reset the regrid CFL estimate.
     d_regrid_cfl_estimate = 0.0;
     return;


### PR DESCRIPTION
This is the last partitioning change :tada: 

I want to run some more tests before we merge this, so I am marking it as a work in progress for now.

@cpuelz If you want to give this a spin with the heart model, use this branch and attach the load balancer to the time integrator. Look at how I modified example 4 to see how this is done. You can check the logs to see how it repartitions:

```
workload estimate on processor 0  = 136880 (pid is 19028)
workload estimate on processor 1  = 124576 (pid is 19029)
workload estimate on processor 2  = 126832 (pid is 19030)
workload estimate on processor 3  = 156626 (pid is 19031)
workload estimate on processor 4  = 124834 (pid is 19032)
workload estimate on processor 5  = 143008 (pid is 19033)
workload estimate on processor 6  = 133872 (pid is 19034)
workload estimate on processor 7  = 132770 (pid is 19035)
workload estimate on processor 8  = 128098 (pid is 19036)
workload estimate on processor 9  = 139744 (pid is 19037)
workload estimate on processor 10 = 135072 (pid is 19038)
workload estimate on processor 11 = 128354 (pid is 19039)
workload estimate on processor 12 = 141834 (pid is 19040)
workload estimate on processor 13 = 121366 (pid is 19041)
workload estimate on processor 14 = 129468 (pid is 19042)
workload estimate on processor 15 = 130472 (pid is 19043)
local active DoFs on processor 0  = 177674 (pid is 19028)
local active DoFs on processor 1  = 168746 (pid is 19029)
local active DoFs on processor 2  = 168720 (pid is 19030)
local active DoFs on processor 3  = 200760 (pid is 19031)
local active DoFs on processor 4  = 165180 (pid is 19032)
local active DoFs on processor 5  = 189079 (pid is 19033)
local active DoFs on processor 6  = 178133 (pid is 19034)
local active DoFs on processor 7  = 173842 (pid is 19035)
local active DoFs on processor 8  = 168656 (pid is 19036)
local active DoFs on processor 9  = 185534 (pid is 19037)
local active DoFs on processor 10 = 179810 (pid is 19038)
local active DoFs on processor 11 = 170213 (pid is 19039)
local active DoFs on processor 12 = 189811 (pid is 19040)
local active DoFs on processor 13 = 160696 (pid is 19041)
local active DoFs on processor 14 = 165431 (pid is 19042)
local active DoFs on processor 15 = 139953 (pid is 19043)
```
which is a beautiful partitioning. You will also need to adjust `max_workload_factor` (the value 0.25 seems to work well) so that we can split enough patches.