### PR TITLE
Fix deletion order for some libMesh objects.

### DIFF
--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -227,14 +227,14 @@ private:
     std::vector<std::vector<libMesh::dof_id_type> > d_node_dof_IDs;
 
     /*!
-     * \brief Equation systems for the meter meshes.
-     */
-    std::vector<std::unique_ptr<libMesh::EquationSystems> > d_meter_systems;
-
-    /*!
      * \brief vector of meter meshes.
      */
     std::vector<std::unique_ptr<libMesh::SerialMesh> > d_meter_meshes;
+
+    /*!
+     * \brief Equation systems for the meter meshes.
+     */
+    std::vector<std::unique_ptr<libMesh::EquationSystems> > d_meter_systems;
 
     /*!
      * \brief names for each meter mesh.


### PR DESCRIPTION
We need to delete the meshes after the systems since the systems store pointers to the meshes.

This fixes some crashes at the end of a run for me.