### PR TITLE
Update deprecated lib mesh

### DIFF
--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -265,13 +265,13 @@ public:
      * \brief The libMesh boundary IDs to use for specifying essential boundary
      * conditions.
      */
-    static const short int ZERO_DISPLACEMENT_X_BDRY_ID;
-    static const short int ZERO_DISPLACEMENT_Y_BDRY_ID;
-    static const short int ZERO_DISPLACEMENT_Z_BDRY_ID;
-    static const short int ZERO_DISPLACEMENT_XY_BDRY_ID;
-    static const short int ZERO_DISPLACEMENT_XZ_BDRY_ID;
-    static const short int ZERO_DISPLACEMENT_YZ_BDRY_ID;
-    static const short int ZERO_DISPLACEMENT_XYZ_BDRY_ID;
+    static const libMesh::boundary_id_type ZERO_DISPLACEMENT_X_BDRY_ID;
+    static const libMesh::boundary_id_type ZERO_DISPLACEMENT_Y_BDRY_ID;
+    static const libMesh::boundary_id_type ZERO_DISPLACEMENT_Z_BDRY_ID;
+    static const libMesh::boundary_id_type ZERO_DISPLACEMENT_XY_BDRY_ID;
+    static const libMesh::boundary_id_type ZERO_DISPLACEMENT_XZ_BDRY_ID;
+    static const libMesh::boundary_id_type ZERO_DISPLACEMENT_YZ_BDRY_ID;
+    static const libMesh::boundary_id_type ZERO_DISPLACEMENT_XYZ_BDRY_ID;
 
     /*!
      * Return a pointer to the instance of the Lagrangian data manager

--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -635,8 +635,8 @@ intersect_line_with_edge(std::vector<std::pair<double, libMesh::Point> >& t_vals
         //
         //    a = 0.5*(-p0+p1)
         //    b = 0.5*(p0+p1) - r
-        const libMesh::Point& p0 = *elem->get_node(0);
-        const libMesh::Point& p1 = *elem->get_node(1);
+        const libMesh::Point& p0 = *elem->node_ptr(0);
+        const libMesh::Point& p1 = *elem->node_ptr(1);
         double a, b;
         if (q(0) != 0.0)
         {
@@ -688,9 +688,9 @@ intersect_line_with_edge(std::vector<std::pair<double, libMesh::Point> >& t_vals
         //    a = (0.5*p0+0.5*p1-p2)
         //    b = 0.5*(p1-p0)
         //    c = p2-r
-        const libMesh::Point& p0 = *elem->get_node(0);
-        const libMesh::Point& p1 = *elem->get_node(1);
-        const libMesh::Point& p2 = *elem->get_node(2);
+        const libMesh::Point& p0 = *elem->node_ptr(0);
+        const libMesh::Point& p1 = *elem->node_ptr(1);
+        const libMesh::Point& p2 = *elem->node_ptr(2);
         double a, b, c;
         if (q(0) != 0.0)
         {
@@ -775,9 +775,9 @@ intersect_line_with_face(std::vector<std::pair<double, libMesh::Point> >& t_vals
         //
         // https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm
         // http://www.lighthouse3d.com/tutorials/maths/ray-triangle-intersection/
-        const libMesh::Point& p0 = *elem->get_node(0);
-        const libMesh::Point& p1 = *elem->get_node(1);
-        const libMesh::Point& p2 = *elem->get_node(2);
+        const libMesh::Point& p0 = *elem->node_ptr(0);
+        const libMesh::Point& p1 = *elem->node_ptr(1);
+        const libMesh::Point& p2 = *elem->node_ptr(2);
 
         const libMesh::VectorValue<double> e1 = p1 - p0;
         const libMesh::VectorValue<double> e2 = p2 - p0;
@@ -803,10 +803,10 @@ intersect_line_with_face(std::vector<std::pair<double, libMesh::Point> >& t_vals
     }
     case libMesh::QUAD4:
     {
-        const libMesh::Point& p00 = *elem->get_node(0);
-        const libMesh::Point& p10 = *elem->get_node(1);
-        const libMesh::Point& p11 = *elem->get_node(2);
-        const libMesh::Point& p01 = *elem->get_node(3);
+        const libMesh::Point& p00 = *elem->node_ptr(0);
+        const libMesh::Point& p10 = *elem->node_ptr(1);
+        const libMesh::Point& p11 = *elem->node_ptr(2);
+        const libMesh::Point& p01 = *elem->node_ptr(3);
 
         const libMesh::Point a = p11 - p10 - p01 + p00;
         const libMesh::Point b = p10 - p00;

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -1869,19 +1869,20 @@ FEDataManager::buildL2ProjectionSolver(const std::string& system_name)
             Elem* const elem = *el_it;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                if (elem->neighbor(side)) continue;
-                const short int dirichlet_bdry_ids =
-                    get_dirichlet_bdry_ids(mesh.boundary_info->boundary_ids(elem, side));
+                if (elem->neighbor_ptr(side)) continue;
                 static const boundary_id_type dirichlet_bdry_id_set[3] = { ZERO_DISPLACEMENT_X_BDRY_ID,
                                                                            ZERO_DISPLACEMENT_Y_BDRY_ID,
                                                                            ZERO_DISPLACEMENT_Z_BDRY_ID };
+                std::vector<boundary_id_type> bdry_ids;
+                mesh.boundary_info->boundary_ids(elem, side, bdry_ids);
+                const boundary_id_type dirichlet_bdry_ids = get_dirichlet_bdry_ids(bdry_ids);
                 if (!dirichlet_bdry_ids) continue;
                 fe->reinit(elem);
                 for (unsigned int n = 0; n < elem->n_nodes(); ++n)
                 {
                     if (elem->is_node_on_side(n, side))
                     {
-                        Node* node = elem->get_node(n);
+                        const Node* const node = elem->node_ptr(n);
                         const auto& dof_indices = dof_map_cache.dof_indices(elem);
                         for (unsigned int var_num = 0; var_num < dof_map.n_variables(); ++var_num)
                         {
@@ -2002,19 +2003,20 @@ FEDataManager::buildDiagonalL2MassMatrix(const std::string& system_name)
             Elem* const elem = *el_it;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                if (elem->neighbor(side)) continue;
-                const short int dirichlet_bdry_ids =
-                    get_dirichlet_bdry_ids(mesh.boundary_info->boundary_ids(elem, side));
+                if (elem->neighbor_ptr(side)) continue;
                 static const boundary_id_type dirichlet_bdry_id_set[3] = { ZERO_DISPLACEMENT_X_BDRY_ID,
                                                                            ZERO_DISPLACEMENT_Y_BDRY_ID,
                                                                            ZERO_DISPLACEMENT_Z_BDRY_ID };
+                std::vector<boundary_id_type> bdry_ids;
+                mesh.boundary_info->boundary_ids(elem, side, bdry_ids);
+                const boundary_id_type dirichlet_bdry_ids = get_dirichlet_bdry_ids(bdry_ids);
                 if (!dirichlet_bdry_ids) continue;
                 fe->reinit(elem);
                 for (unsigned int n = 0; n < elem->n_nodes(); ++n)
                 {
                     if (elem->is_node_on_side(n, side))
                     {
-                        Node* node = elem->get_node(n);
+                        const Node* const node = elem->node_ptr(n);
                         for (unsigned int var_num = 0; var_num < dof_map.n_variables(); ++var_num)
                         {
                             const unsigned int n_comp = node->n_comp(sys_num, var_num);
@@ -2636,7 +2638,7 @@ FEDataManager::computeActiveElementBoundingBoxes()
         dof_indices.clear();
         for (unsigned int k = 0; k < n_nodes; ++k)
         {
-            Node* node = elem->get_node(k);
+            const Node* const node = elem->node_ptr(k);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 TBOX_ASSERT(node->n_dofs(X_sys_num, d) == 1);
@@ -2855,7 +2857,7 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
             {
                 for (unsigned int n = 0; n < elem->n_neighbors(); ++n)
                 {
-                    Elem* const nghbr_elem = elem->neighbor(n);
+                    Elem* const nghbr_elem = elem->neighbor_ptr(n);
                     if (nghbr_elem)
                     {
                         const bool is_local_elem = local_elems.find(nghbr_elem) != local_elems.end();
@@ -2969,7 +2971,7 @@ FEDataManager::collectGhostDOFIndices(std::vector<unsigned int>& ghost_dofs,
         // DOFs associated with the nodes of the element.
         for (unsigned int k = 0; k < elem->n_nodes(); ++k)
         {
-            Node* node = elem->get_node(k);
+            const Node* const node = elem->node_ptr(k);
             for (unsigned int var_num = 0; var_num < node->n_vars(sys_num); ++var_num)
             {
                 if (node->n_dofs(sys_num, var_num) > 0)

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -197,10 +197,10 @@ collect_unique_elems(std::vector<Elem*>& elems, const ContainerOfContainers& ele
     return;
 } // collect_unique_elems
 
-inline short int
-get_dirichlet_bdry_ids(const std::vector<short int>& bdry_ids)
+inline boundary_id_type
+get_dirichlet_bdry_ids(const std::vector<boundary_id_type>& bdry_ids)
 {
-    short int dirichlet_bdry_ids = 0;
+    boundary_id_type dirichlet_bdry_ids = 0;
     for (const auto& bdry_id : bdry_ids)
     {
         if (bdry_id == FEDataManager::ZERO_DISPLACEMENT_X_BDRY_ID ||
@@ -304,13 +304,13 @@ getQuadratureKey(const QuadratureType quad_type,
 }
 }
 
-const short int FEDataManager::ZERO_DISPLACEMENT_X_BDRY_ID = 0x100;
-const short int FEDataManager::ZERO_DISPLACEMENT_Y_BDRY_ID = 0x200;
-const short int FEDataManager::ZERO_DISPLACEMENT_Z_BDRY_ID = 0x400;
-const short int FEDataManager::ZERO_DISPLACEMENT_XY_BDRY_ID = 0x100 | 0x200;
-const short int FEDataManager::ZERO_DISPLACEMENT_XZ_BDRY_ID = 0x100 | 0x400;
-const short int FEDataManager::ZERO_DISPLACEMENT_YZ_BDRY_ID = 0x200 | 0x400;
-const short int FEDataManager::ZERO_DISPLACEMENT_XYZ_BDRY_ID = 0x100 | 0x200 | 0x400;
+const boundary_id_type FEDataManager::ZERO_DISPLACEMENT_X_BDRY_ID = 0x100;
+const boundary_id_type FEDataManager::ZERO_DISPLACEMENT_Y_BDRY_ID = 0x200;
+const boundary_id_type FEDataManager::ZERO_DISPLACEMENT_Z_BDRY_ID = 0x400;
+const boundary_id_type FEDataManager::ZERO_DISPLACEMENT_XY_BDRY_ID = 0x100 | 0x200;
+const boundary_id_type FEDataManager::ZERO_DISPLACEMENT_XZ_BDRY_ID = 0x100 | 0x400;
+const boundary_id_type FEDataManager::ZERO_DISPLACEMENT_YZ_BDRY_ID = 0x200 | 0x400;
+const boundary_id_type FEDataManager::ZERO_DISPLACEMENT_XYZ_BDRY_ID = 0x100 | 0x200 | 0x400;
 std::map<std::string, FEDataManager*> FEDataManager::s_data_manager_instances;
 bool FEDataManager::s_registered_callback = false;
 unsigned char FEDataManager::s_shutdown_priority = 200;
@@ -1870,11 +1870,11 @@ FEDataManager::buildL2ProjectionSolver(const std::string& system_name)
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
                 if (elem->neighbor(side)) continue;
-                static const short int dirichlet_bdry_id_set[3] = { ZERO_DISPLACEMENT_X_BDRY_ID,
-                                                                    ZERO_DISPLACEMENT_Y_BDRY_ID,
-                                                                    ZERO_DISPLACEMENT_Z_BDRY_ID };
                 const short int dirichlet_bdry_ids =
                     get_dirichlet_bdry_ids(mesh.boundary_info->boundary_ids(elem, side));
+                static const boundary_id_type dirichlet_bdry_id_set[3] = { ZERO_DISPLACEMENT_X_BDRY_ID,
+                                                                           ZERO_DISPLACEMENT_Y_BDRY_ID,
+                                                                           ZERO_DISPLACEMENT_Z_BDRY_ID };
                 if (!dirichlet_bdry_ids) continue;
                 fe->reinit(elem);
                 for (unsigned int n = 0; n < elem->n_nodes(); ++n)
@@ -2003,11 +2003,11 @@ FEDataManager::buildDiagonalL2MassMatrix(const std::string& system_name)
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
                 if (elem->neighbor(side)) continue;
-                static const short int dirichlet_bdry_id_set[3] = { ZERO_DISPLACEMENT_X_BDRY_ID,
-                                                                    ZERO_DISPLACEMENT_Y_BDRY_ID,
-                                                                    ZERO_DISPLACEMENT_Z_BDRY_ID };
                 const short int dirichlet_bdry_ids =
                     get_dirichlet_bdry_ids(mesh.boundary_info->boundary_ids(elem, side));
+                static const boundary_id_type dirichlet_bdry_id_set[3] = { ZERO_DISPLACEMENT_X_BDRY_ID,
+                                                                           ZERO_DISPLACEMENT_Y_BDRY_ID,
+                                                                           ZERO_DISPLACEMENT_Z_BDRY_ID };
                 if (!dirichlet_bdry_ids) continue;
                 fe->reinit(elem);
                 for (unsigned int n = 0; n < elem->n_nodes(); ++n)

--- a/include/ibamr/IBFEPostProcessor.h
+++ b/include/ibamr/IBFEPostProcessor.h
@@ -189,7 +189,7 @@ public:
         libMesh::VectorValue<double> f0;
         for (unsigned int d = 0; d < NDIM; ++d) f0(d) = (*system_var_data[0])[d];
         const libMesh::VectorValue<double> f = FF * f0;
-        lambda = f.size() / f0.size();
+        lambda = f.norm() / f0.norm();
         return;
     } // material_axis_stretch_fcn
 

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -338,7 +338,17 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
     std::vector<std::set<dof_id_type> > temp_node_dof_ID_sets;
     std::vector<std::vector<libMesh::Point> > temp_nodes;
     std::vector<libMesh::Point> meter_centroids;
+    // new API in 1.4.0
+#if 1 <= LIBMESH_MAJOR_VERSION && 4 <= LIBMESH_MINOR_VERSION
+    const std::vector<std::tuple<dof_id_type, boundary_id_type> > node_list = boundary_info.build_node_list();
+    for (const std::tuple<dof_id_type, boundary_id_type>& pair : node_list)
+    {
+        nodes.push_back(std::get<0>(pair));
+        bcs.push_back(std::get<1>(pair));
+    }
+#else
     boundary_info.build_node_list(nodes, bcs);
+#endif
 
     // check to make sure there are node sets to work with
     if (nodes.size() == 0 || bcs.size() == 0 || (nodes.size() != bcs.size()))

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1597,9 +1597,9 @@ IBFEMethod::doInitializeFEData(const bool use_present_data)
                 const bool at_mesh_bdry = !elem->neighbor(side);
                 if (!at_mesh_bdry) continue;
 
-                static const short int dirichlet_bdry_id_set[3] = { FEDataManager::ZERO_DISPLACEMENT_X_BDRY_ID,
-                                                                    FEDataManager::ZERO_DISPLACEMENT_Y_BDRY_ID,
-                                                                    FEDataManager::ZERO_DISPLACEMENT_Z_BDRY_ID };
+                static const boundary_id_type dirichlet_bdry_id_set[3] = { FEDataManager::ZERO_DISPLACEMENT_X_BDRY_ID,
+                                                                           FEDataManager::ZERO_DISPLACEMENT_Y_BDRY_ID,
+                                                                           FEDataManager::ZERO_DISPLACEMENT_Z_BDRY_ID };
                 const short int dirichlet_bdry_ids =
                     get_dirichlet_bdry_ids(mesh.boundary_info->boundary_ids(elem, side));
                 if (!dirichlet_bdry_ids) continue;

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -146,10 +146,10 @@ namespace
 // Version of IBFEMethod restart file data.
 static const int IBFE_METHOD_VERSION = 1;
 
-inline short int
-get_dirichlet_bdry_ids(const std::vector<short int>& bdry_ids)
+inline boundary_id_type
+get_dirichlet_bdry_ids(const std::vector<boundary_id_type>& bdry_ids)
 {
-    short int dirichlet_bdry_ids = 0;
+    boundary_id_type dirichlet_bdry_ids = 0;
     for (const auto& bdry_id : bdry_ids)
     {
         if (bdry_id == FEDataManager::ZERO_DISPLACEMENT_X_BDRY_ID ||
@@ -172,8 +172,9 @@ is_physical_bdry(const Elem* elem,
                  const BoundaryInfo& boundary_info,
                  const DofMap& dof_map)
 {
-    const std::vector<short int>& bdry_ids = boundary_info.boundary_ids(elem, side);
-    bool at_physical_bdry = !elem->neighbor(side);
+    std::vector<boundary_id_type> bdry_ids;
+    boundary_info.boundary_ids(elem, side, bdry_ids);
+    bool at_physical_bdry = !elem->neighbor_ptr(side);
     for (const auto& bdry_id : bdry_ids)
     {
         if (dof_map.is_periodic_boundary(bdry_id)) at_physical_bdry = false;
@@ -188,7 +189,8 @@ is_dirichlet_bdry(const Elem* elem,
                   const DofMap& dof_map)
 {
     if (!is_physical_bdry(elem, side, boundary_info, dof_map)) return false;
-    const std::vector<short int>& bdry_ids = boundary_info.boundary_ids(elem, side);
+    std::vector<boundary_id_type> bdry_ids;
+    boundary_info.boundary_ids(elem, side, bdry_ids);
     return get_dirichlet_bdry_ids(bdry_ids) != 0;
 }
 
@@ -1594,21 +1596,22 @@ IBFEMethod::doInitializeFEData(const bool use_present_data)
             Elem* const elem = *el_it;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                const bool at_mesh_bdry = !elem->neighbor(side);
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (!at_mesh_bdry) continue;
 
                 static const boundary_id_type dirichlet_bdry_id_set[3] = { FEDataManager::ZERO_DISPLACEMENT_X_BDRY_ID,
                                                                            FEDataManager::ZERO_DISPLACEMENT_Y_BDRY_ID,
                                                                            FEDataManager::ZERO_DISPLACEMENT_Z_BDRY_ID };
-                const short int dirichlet_bdry_ids =
-                    get_dirichlet_bdry_ids(mesh.boundary_info->boundary_ids(elem, side));
+                std::vector<boundary_id_type> bdry_ids;
+                mesh.boundary_info->boundary_ids(elem, side, bdry_ids);
+                const boundary_id_type dirichlet_bdry_ids = get_dirichlet_bdry_ids(bdry_ids);
                 if (!dirichlet_bdry_ids) continue;
 
                 for (unsigned int n = 0; n < elem->n_nodes(); ++n)
                 {
                     if (!elem->is_node_on_side(n, side)) continue;
 
-                    Node* node = elem->get_node(n);
+                    const Node* const node = elem->node_ptr(n);
                     mesh.boundary_info->add_node(node, dirichlet_bdry_ids);
                     for (unsigned int d = 0; d < NDIM; ++d)
                     {
@@ -2941,7 +2944,7 @@ IBFEMethod::spreadTransmissionForceDensity(const int f_data_idx,
                 if (is_dirichlet_bdry(elem, side, boundary_info, G_dof_map)) continue;
 
                 // Construct a side element.
-                std::unique_ptr<Elem> side_elem = elem->build_side(side, /*proxy*/ false);
+                std::unique_ptr<Elem> side_elem = elem->build_side_ptr(side, /*proxy*/ false);
                 const bool qrule_changed = d_fe_data_managers[part]->updateSpreadQuadratureRule(
                     qrule_face, d_spread_spec[part], side_elem.get(), X_node, patch_dx_min);
                 if (qrule_changed)
@@ -3208,7 +3211,7 @@ IBFEMethod::imposeJumpConditions(const int f_data_idx,
                 if (is_dirichlet_bdry(elem, side, boundary_info, G_dof_map)) continue;
 
                 // Construct a side element.
-                std::unique_ptr<Elem> side_elem = elem->build_side(side, /*proxy*/ false);
+                std::unique_ptr<Elem> side_elem = elem->build_side_ptr(side, /*proxy*/ false);
                 const unsigned int n_node_side = side_elem->n_nodes();
                 for (int d = 0; d < NDIM; ++d)
                 {


### PR DESCRIPTION
We use a lot of deprecated libMesh functions. I went through and got rid of everything that is deprecated as of 1.4.0 where possible: in one case I had to use the preprocessor to keep compatibility with 1.1.0. This stops a lot of annoying warnings.

Since we require 1.1.0 or newer this shouldn't break anything.

Candidate for inclusion in 0.4; see #424.

