### PR TITLE
Disable PID printing.

### DIFF
--- a/doc/news/changes/incompatibilities/20180412DavidWells
+++ b/doc/news/changes/incompatibilities/20180412DavidWells
@@ -1,0 +1,4 @@
+Changed: FEDataManager and IBFEMethod no longer log the PID of the current
+process.
+<br>
+(David Wells, 2019/04/12)

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -45,8 +45,6 @@
 #include <utility>
 #include <vector>
 
-#include <unistd.h>
-
 #include "BasePatchHierarchy.h"
 #include "BasePatchLevel.h"
 #include "Box.h"
@@ -2569,19 +2567,10 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
             const int current_rank = SAMRAI::tbox::SAMRAI_MPI::getRank();
             const auto right_padding = std::size_t(std::log10(n_processes)) + 1;
 
-
-            std::vector<int> pids(n_processes);
-            pids[current_rank] = getpid();
-            int ierr = MPI_Allreduce(
-                MPI_IN_PLACE, pids.data(),
-                pids.size(), MPI_INT,
-                MPI_SUM, SAMRAI::tbox::SAMRAI_MPI::commWorld);
-            TBOX_ASSERT(ierr == 0);
-
             std::vector<unsigned long> n_q_points_on_processors(n_processes);
             n_q_points_on_processors[current_rank] = n_local_q_points;
 
-            ierr = MPI_Allreduce(
+            const int ierr = MPI_Allreduce(
                 MPI_IN_PLACE, n_q_points_on_processors.data(),
                 n_q_points_on_processors.size(), MPI_UNSIGNED_LONG,
                 MPI_SUM, SAMRAI::tbox::SAMRAI_MPI::commWorld);
@@ -2594,7 +2583,7 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
                                        << std::setw(right_padding) << std::left << rank
                                        << " = "
                                        << n_q_points_on_processors[rank]
-                                       << " (pid is " << pids[rank] << ")\n";
+                                       << '\n';
                 }
             }
         }


### PR DESCRIPTION
This was a bad idea since it makes the log output unreproducible. I doubt anyone but me ever looked at this so I think its okay to remove this misfeature from the logs.

Part of #494.