### PR TITLE
Conditionally disable logging of solver iterations.

### DIFF
--- a/doc/news/changes/minor/20191304DavidWells
+++ b/doc/news/changes/minor/20191304DavidWells
@@ -1,0 +1,9 @@
+New: IBTK::HierarchyIntegrator can now log everything except the number of
+linear solver iterations by passing <code>enable_logging = TRUE</code> and
+<code>enable_logging_solver_iterations = FALSE</code> in the input
+database. Since the number of solver iterations may change by a small amount
+(usually plus or minus one) when the same code is run multiple times, disabling
+this allows log files to be identical (up to roundoff) across runs.
+
+<br>
+(David Wells, 2019/04/13)

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -1044,6 +1044,19 @@ protected:
     bool d_enable_logging = false;
 
     /*
+     * Indicates whether the integrator should, if
+     * <code>d_enable_logging</code> is <code>true</code>, also log the number
+     * of solver iterations required for convergence. This value is separate
+     * since the number of solver iterations is, in general, subject to small
+     * changes (usually plus or minus one) even when the same program is run.
+     *
+     * If <code>enable_logging_solver_iterations</code> is not provided in the
+     * input database then the value assigned to <code>d_enable_logging</code>
+     * is also assigned to <code>d_enable_logging_solver_iterations</code>.
+     */
+    bool d_enable_logging_solver_iterations = false;
+
+    /*
      * The type of extrapolation to use at physical boundaries when prolonging
      * data during regridding.
      */

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -1158,6 +1158,7 @@ HierarchyIntegrator::putToDatabase(Pointer<Database> db)
     db->putInteger("d_regrid_interval", d_regrid_interval);
     db->putString("d_regrid_mode", enum_to_string<RegridMode>(d_regrid_mode));
     db->putBool("d_enable_logging", d_enable_logging);
+    db->putBool("d_enable_logging_solver_iterations", d_enable_logging_solver_iterations);
     db->putIntegerArray("d_tag_buffer", d_tag_buffer);
     db->putString("d_bdry_extrap_type", d_bdry_extrap_type);
     putToDatabaseSpecialized(db);
@@ -1589,7 +1590,18 @@ HierarchyIntegrator::getFromInput(Pointer<Database> db, bool is_from_restart)
     if (db->keyExists("num_cycles")) d_num_cycles = db->getInteger("num_cycles");
     if (db->keyExists("regrid_interval")) d_regrid_interval = db->getInteger("regrid_interval");
     if (db->keyExists("regrid_mode")) d_regrid_mode = string_to_enum<RegridMode>(db->getString("regrid_mode"));
-    if (db->keyExists("enable_logging")) d_enable_logging = db->getBool("enable_logging");
+    if (db->keyExists("enable_logging"))
+    {
+        d_enable_logging = db->getBool("enable_logging");
+        if (db->keyExists("enable_logging_solver_iterations"))
+        {
+            d_enable_logging_solver_iterations = db->getBool("enable_logging_solver_iterations");
+        }
+        else
+        {
+            d_enable_logging_solver_iterations = d_enable_logging;
+        }
+    }
     if (db->keyExists("bdry_extrap_type")) d_bdry_extrap_type = db->getString("bdry_extrap_type");
     if (db->keyExists("tag_buffer")) d_tag_buffer = db->getIntegerArray("tag_buffer");
     return;
@@ -1637,6 +1649,7 @@ HierarchyIntegrator::getFromRestart()
     d_regrid_interval = db->getInteger("d_regrid_interval");
     d_regrid_mode = string_to_enum<RegridMode>(db->getString("d_regrid_mode"));
     d_enable_logging = db->getBool("d_enable_logging");
+    d_enable_logging_solver_iterations = db->getBool("d_enable_logging_solver_iterations");
     d_bdry_extrap_type = db->getString("d_bdry_extrap_type");
     d_tag_buffer = db->getIntegerArray("d_tag_buffer");
     return;

--- a/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
@@ -594,7 +594,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
         // Solve for Q(n+1).
         helmholtz_solver->solveSystem(*d_sol_vecs[l], *d_rhs_vecs[l]);
         d_hier_cc_data_ops->copyData(Q_new_idx, Q_scratch_idx);
-        if (d_enable_logging)
+        if (d_enable_logging && d_enable_logging_solver_iterations)
             plog << d_object_name << "::integrateHierarchy(): linear solve number of iterations = "
                  << helmholtz_solver->getNumIterations() << "\n";
         if (d_enable_logging)

--- a/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
@@ -829,7 +829,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchy(const double current_
         Pointer<PoissonSolver> helmholtz_solver = d_helmholtz_solvers[l];
         helmholtz_solver->solveSystem(*d_sol_vecs[l], *d_rhs_vecs[l]);
         d_hier_cc_data_ops->copyData(Q_new_idx, Q_scratch_idx);
-        if (d_enable_logging)
+        if (d_enable_logging && d_enable_logging_solver_iterations)
             plog << d_object_name << "::integrateHierarchy(): diffusion solve number of iterations = "
                  << helmholtz_solver->getNumIterations() << "\n";
         if (d_enable_logging)

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1252,7 +1252,7 @@ INSCollocatedHierarchyIntegrator::integrateHierarchy(const double current_time,
     // Solve for U(*) and compute u_ADV(*).
     d_hier_cc_data_ops->copyData(d_U_scratch_idx, d_U_new_idx);
     d_velocity_solver->solveSystem(*d_U_scratch_vec, *d_U_rhs_vec);
-    if (d_enable_logging)
+    if (d_enable_logging && d_enable_logging_solver_iterations)
         plog << d_object_name << "::integrateHierarchy(): velocity solve number of iterations = "
              << d_velocity_solver->getNumIterations() << "\n";
     if (d_enable_logging)
@@ -1297,7 +1297,7 @@ INSCollocatedHierarchyIntegrator::integrateHierarchy(const double current_time,
         d_hier_cc_data_ops->setToScalar(d_Phi_idx, 0.0);
     }
     d_pressure_solver->solveSystem(*d_Phi_vec, *d_Phi_rhs_vec);
-    if (d_enable_logging)
+    if (d_enable_logging && d_enable_logging_solver_iterations)
         plog << d_object_name << "::integrateHierarchy(): pressure solve number of iterations = "
              << d_pressure_solver->getNumIterations() << "\n";
     if (d_enable_logging)
@@ -1949,7 +1949,7 @@ INSCollocatedHierarchyIntegrator::regridProjection()
 
     // Solve the projection pressure-Poisson problem.
     regrid_projection_solver->solveSystem(sol_vec, rhs_vec);
-    if (d_enable_logging)
+    if (d_enable_logging && d_enable_logging_solver_iterations)
         plog << d_object_name << "::regridProjection(): projection solve number of iterations = "
              << regrid_projection_solver->getNumIterations() << "\n";
     if (d_enable_logging)

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1276,7 +1276,7 @@ INSStaggeredHierarchyIntegrator::integrateHierarchy(const double current_time,
 
     // Solve for u(n+1), p(n+1/2).
     d_stokes_solver->solveSystem(*d_sol_vec, *d_rhs_vec);
-    if (d_enable_logging)
+    if (d_enable_logging && d_enable_logging_solver_iterations)
         plog << d_object_name
              << "::integrateHierarchy(): stokes solve number of iterations = " << d_stokes_solver->getNumIterations()
              << "\n";
@@ -2185,7 +2185,7 @@ INSStaggeredHierarchyIntegrator::regridProjection()
 
     // Solve the projection pressure-Poisson problem.
     regrid_projection_solver->solveSystem(sol_vec, rhs_vec);
-    if (d_enable_logging)
+    if (d_enable_logging && d_enable_logging_solver_iterations)
         plog << d_object_name << "::regridProjection(): regrid projection solve number of iterations = "
              << regrid_projection_solver->getNumIterations() << "\n";
     if (d_enable_logging)

--- a/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
@@ -747,7 +747,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::integrateHierarchy(const double c
         d_hier_sc_data_ops->resetLevels(coarsest_ln, finest_ln);
     }
 
-    if (d_enable_logging)
+    if (d_enable_logging && d_enable_logging_solver_iterations)
         plog << d_object_name
              << "::integrateHierarchy(): stokes solve number of iterations = " << d_stokes_solver->getNumIterations()
              << "\n";
@@ -1079,7 +1079,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::regridProjection()
 
     // Solve the projection pressure-Poisson problem.
     regrid_projection_solver->solveSystem(sol_vec, rhs_vec);
-    if (d_enable_logging)
+    if (d_enable_logging && d_enable_logging_solver_iterations)
         plog << d_object_name << "::regridProjection(): regrid projection solve number of iterations = "
              << regrid_projection_solver->getNumIterations() << "\n";
     if (d_enable_logging)

--- a/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
@@ -781,7 +781,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::integrateHierarchy(const doubl
         d_hier_sc_data_ops->resetLevels(coarsest_ln, finest_ln);
     }
 
-    if (d_enable_logging)
+    if (d_enable_logging && d_enable_logging_solver_iterations)
         plog << d_object_name
              << "::integrateHierarchy(): stokes solve number of iterations = " << d_stokes_solver->getNumIterations()
              << "\n";
@@ -1147,7 +1147,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::regridProjection()
 
     // Solve the projection pressure-Poisson problem.
     regrid_projection_solver->solveSystem(sol_vec, rhs_vec);
-    if (d_enable_logging)
+    if (d_enable_logging && d_enable_logging_solver_iterations)
         plog << d_object_name << "::regridProjection(): regrid projection solve number of iterations = "
              << regrid_projection_solver->getNumIterations() << "\n";
     if (d_enable_logging)


### PR DESCRIPTION
I think this is the last prerequisite patch for the test suite.

The number of solver iterations is not stable in the sense that small perturbations (the way a vector is aligned, order of operations in floating point, etc.) can change it by O(1), e.g., some solvers in the test suite take 6 iterations 90% of the time and 7 iterations 10% of the time. The best way to fix this is to simply not log the number of solver iterations.

This PR adds a new boolean that controls this. The default is to simply copy the value 