### PR TITLE
Move regrid hierarchy calls

### DIFF
--- a/doc/news/changes/incompatibilities/20190416DavidWells
+++ b/doc/news/changes/incompatibilities/20190416DavidWells
@@ -1,0 +1,9 @@
+Fixed: The four Navier-Stokes integrators (INSCollocatedHierarchyIntegrator,
+INSStaggeredHierarchyIntegrator, INSVCStaggeredConservativeHierarchyIntegrator,
+and INSVCStaggeredNonConservativeHierarchyIntegrator) no longer reimplement the
+regridHierarchy function: instead, they use the new
+regridHierarchyBeginSpecialized and regridHierarchyEndSpecialized functions to
+do the same work. This fixes a bug where regridProjection would not necessarily
+be called when an NSE integrator was a child integrator.
+<br>
+(David Wells, 2019/04/16)

--- a/doc/news/changes/minor/20190415DavidWells
+++ b/doc/news/changes/minor/20190415DavidWells
@@ -1,0 +1,6 @@
+New: IBTK::HierarchyIntegrator gained two new functions:
+regridHierarchyBeginSpecialized and regridHierarchyEndSpecialized. These two
+functions perform class-specific tasks (such as communicating non-SAMRAI data or
+projecting a velocity onto a divergence-free solution space).
+<br>
+(David Wells, Nishant Nangia, Boyce Griffith, Amneet Bhalla, 2019/04/15)

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -220,6 +220,22 @@ public:
      * GriddingAlgorithm::regidAllFinerLevels() to regrid the patch hierarchy.
      * Subclasses can control the method used to regrid the patch hierarchy by
      * overriding this public virtual member function.
+     *
+     * Before regridding, this method calls regridHierarchyBeginSpecialized()
+     * on the current integrator and all child integrators.
+     *
+     * After regridding and (optionally) checking the new grid volume, this
+     * method calls regridHierarchyEndSpecialized() on the current integrator
+     * and all child integrators. It then calls the following methods (and,
+     * therefore, the specialized methods on the current and all child
+     * integrators) in the following order:
+     *
+     * 1. initializeCompositeHierarchyData
+     * 2. synchronizeHierarchyData
+     *
+     * @warning This class assumes, but does not enforce, that this method is
+     * only called on the parent integrator. A future release of IBAMR will
+     * enforce this assumption.
      */
     virtual void regridHierarchy();
 
@@ -672,6 +688,20 @@ public:
     void putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
 
 protected:
+    /*!
+     * Perform any necessary work relevant to data owned by the current
+     * integrator prior to regridding (e.g., calculating divergences). An
+     * empty default implementation is provided.
+     */
+    virtual void regridHierarchyBeginSpecialized();
+
+    /*!
+     * Perform any necessary work relevant to data owned by the current
+     * integrator after regridding (e.g., calculating divergences). An empty
+     * default implementation is provided.
+     */
+    virtual void regridHierarchyEndSpecialized();
+
     /*!
      * Virtual method to compute an implementation-specific minimum stable time
      * step size.

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -418,8 +418,21 @@ HierarchyIntegrator::regridHierarchy()
 {
     const int coarsest_ln = 0;
 
+    if (d_parent_integrator != nullptr)
+    {
+        TBOX_WARNING(d_object_name << "::regridHierarchy():\n"
+                                   << "  Calling regridHierarchy() on integrators with parent integrators is\n"
+                                   << "  deprecated and will not be permitted in a future version of IBAMR.");
+    }
+
     bool check_volume_change = !d_parent_integrator && d_hierarchy_is_initialized;
     const double old_volume = check_volume_change ? d_hier_math_ops->getVolumeOfPhysicalDomain() : 0.0;
+
+    regridHierarchyBeginSpecialized();
+    for (const auto& child_integrator : d_child_integrators)
+    {
+        child_integrator->regridHierarchyBeginSpecialized();
+    }
 
     // Regrid the hierarchy.
     switch (d_regrid_mode)
@@ -449,6 +462,12 @@ HierarchyIntegrator::regridHierarchy()
                           << "    old volume = " << old_volume << "\n"
                           << "    new volume = " << new_volume << "\n"
                           << "  this may indicate overlapping patches in the AMR grid hierarchy.");
+    }
+
+    regridHierarchyEndSpecialized();
+    for (const auto& child_integrator : d_child_integrators)
+    {
+        child_integrator->regridHierarchyEndSpecialized();
     }
 
     // Reinitialize composite grid data.
@@ -1165,6 +1184,16 @@ HierarchyIntegrator::putToDatabase(Pointer<Database> db)
 } // putToDatabase
 
 /////////////////////////////// PROTECTED ////////////////////////////////////
+
+void
+HierarchyIntegrator::regridHierarchyBeginSpecialized()
+{
+} // regridHierarchyBeginSpecialized
+
+void
+HierarchyIntegrator::regridHierarchyEndSpecialized()
+{
+} // regridHierarchyEndSpecialized
 
 double
 HierarchyIntegrator::getMinimumTimeStepSizeSpecialized()

--- a/include/ibamr/IBHierarchyIntegrator.h
+++ b/include/ibamr/IBHierarchyIntegrator.h
@@ -187,12 +187,18 @@ public:
     void initializePatchHierarchy(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
                                   SAMRAI::tbox::Pointer<SAMRAI::mesh::GriddingAlgorithm<NDIM> > gridding_alg) override;
 
-    /*!
-     * Regrid the hierarchy.
-     */
-    void regridHierarchy() override;
-
 protected:
+    /*!
+     * Perform necessary data movement, workload estimation, and logging prior
+     * to regridding.
+     */
+    void regridHierarchyBeginSpecialized() override;
+
+    /*!
+     * Perform necessary data movement and logging after regridding.
+     */
+    void regridHierarchyEndSpecialized() override;
+
     /*!
      * The constructor for class IBHierarchyIntegrator sets some default values,
      * reads in configuration information from input and restart databases, and

--- a/include/ibamr/INSCollocatedHierarchyIntegrator.h
+++ b/include/ibamr/INSCollocatedHierarchyIntegrator.h
@@ -183,12 +183,14 @@ public:
                                        bool skip_synchronize_new_state_data,
                                        int num_cycles = 1) override;
 
-    /*!
-     * Regrid the patch hierarchy.
-     */
-    void regridHierarchy() override;
-
 protected:
+    /*
+     * Since (unlike the staggered case) there is no local divergence-preserving
+     * interpolation scheme for collocated velocity fields, the velocity must
+     * always be projected onto the grid after regridding. Do that here.
+     */
+    void regridHierarchyEndSpecialized() override;
+
     /*!
      * Determine the largest stable timestep on an individual patch.
      */

--- a/include/ibamr/INSCollocatedHierarchyIntegrator.h
+++ b/include/ibamr/INSCollocatedHierarchyIntegrator.h
@@ -230,6 +230,11 @@ protected:
      */
     void setupPlotDataSpecialized() override;
 
+    /*!
+     * Project the velocity field following a regridding operation.
+     */
+    void regridProjection() override;
+
 private:
     /*!
      * \brief Default constructor.
@@ -268,11 +273,6 @@ private:
      * Reinitialize the operators and solvers used by the hierarchy integrator.
      */
     void reinitializeOperatorsAndSolvers(double current_time, double new_time);
-
-    /*!
-     * Project the velocity field following a regridding operation.
-     */
-    void regridProjection();
 
     /*!
      * Value determining the type of projection method to use.

--- a/include/ibamr/INSHierarchyIntegrator.h
+++ b/include/ibamr/INSHierarchyIntegrator.h
@@ -357,6 +357,11 @@ public:
 
 protected:
     /*!
+     * Pure virtual method to project the velocity field following a regridding operation.
+     */
+    virtual void regridProjection() = 0;
+
+    /*!
      * The constructor for class INSHierarchyIntegrator sets some default
      * values, reads in configuration information from input and restart
      * databases, and registers the integrator object with the restart manager

--- a/include/ibamr/INSStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSStaggeredHierarchyIntegrator.h
@@ -273,6 +273,11 @@ protected:
      */
     void setupPlotDataSpecialized() override;
 
+    /*!
+     * Project the velocity field following a regridding operation.
+     */
+    void regridProjection() override;
+
 private:
     /*!
      * \brief Default constructor.
@@ -311,11 +316,6 @@ private:
      * Reinitialize the operators and solvers used by the hierarchy integrator.
      */
     void reinitializeOperatorsAndSolvers(double current_time, double new_time);
-
-    /*!
-     * Project the velocity field following a regridding operation.
-     */
-    void regridProjection();
 
     /*!
      * Determine the convective time stepping type for the current time step and

--- a/include/ibamr/INSStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSStaggeredHierarchyIntegrator.h
@@ -201,11 +201,6 @@ public:
                                        int num_cycles = 1) override;
 
     /*!
-     * Regrid the patch hierarchy.
-     */
-    void regridHierarchy() override;
-
-    /*!
      * Setup solution and RHS vectors using state data maintained by the
      * integrator.
      */
@@ -232,6 +227,34 @@ public:
     void removeNullSpace(const SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double> >& sol_vec);
 
 protected:
+    /*!
+     * L1 norm of the fluid velocity before regridding.
+     */
+    double d_div_U_norm_1_pre = 0.0;
+
+    /*!
+     * L2 norm of the fluid velocity before regridding.
+     */
+    double d_div_U_norm_2_pre = 0.0;
+
+    /*!
+     * L-infinity norm of the fluid velocity before regridding.
+     */
+    double d_div_U_norm_oo_pre = 0.0;
+
+    /*!
+     * Prepare the current hierarchy for regridding. Here we calculate the divergence.
+     */
+    void regridHierarchyBeginSpecialized() override;
+
+    /*!
+     * Update the current hierarchy data after regridding. Here we recalculate
+     * the divergence and, if it has grown by a factor more than
+     * d_regrid_max_div_growth_factor, we then project the velocity field onto
+     * a divergence-free set of grid functions.
+     */
+    void regridHierarchyEndSpecialized() override;
+
     /*!
      * Determine the largest stable timestep on an individual patch.
      */

--- a/include/ibamr/INSVCStaggeredConservativeHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredConservativeHierarchyIntegrator.h
@@ -141,11 +141,6 @@ public:
                                        int num_cycles = 1) override;
 
     /*!
-     * Regrid the patch hierarchy.
-     */
-    void regridHierarchy() override;
-
-    /*!
      * Explicitly remove nullspace components from a solution vector.
      */
     void removeNullSpace(const SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double> >& sol_vec);

--- a/include/ibamr/INSVCStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredHierarchyIntegrator.h
@@ -440,11 +440,6 @@ protected:
     virtual void setupPlotDataSpecialized() override;
 
     /*!
-     * Pure virtual method to project the velocity field following a regridding operation.
-     */
-    virtual void regridProjection() = 0;
-
-    /*!
      * Copy data from a side-centered variable to a face-centered variable.
      */
     void copySideToFace(const int U_fc_idx,

--- a/include/ibamr/INSVCStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredHierarchyIntegrator.h
@@ -229,11 +229,6 @@ public:
                                                int num_cycles = 1) override;
 
     /*!
-     * Virtual method to regrid the patch hierarchy.
-     */
-    virtual void regridHierarchy() override;
-
-    /*!
      * Explicitly remove nullspace components from a solution vector.
      */
     void removeNullSpace(const SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double> >& sol_vec);
@@ -396,6 +391,34 @@ public:
     }
 
 protected:
+    /*!
+     * L1 norm of the fluid velocity before regridding.
+     */
+    double d_div_U_norm_1_pre = 0.0;
+
+    /*!
+     * L2 norm of the fluid velocity before regridding.
+     */
+    double d_div_U_norm_2_pre = 0.0;
+
+    /*!
+     * L-infinity norm of the fluid velocity before regridding.
+     */
+    double d_div_U_norm_oo_pre = 0.0;
+
+    /*!
+     * Prepare the current hierarchy for regridding. Here we calculate the divergence.
+     */
+    void regridHierarchyBeginSpecialized() override;
+
+    /*!
+     * Update the current hierarchy data after regridding. Here we recalculate
+     * the divergence and, if it has grown by a factor more than
+     * d_regrid_max_div_growth_factor, we then project the velocity field onto
+     * a divergence-free set of grid functions.
+     */
+    void regridHierarchyEndSpecialized() override;
+
     /*!
      * Determine the largest stable timestep on an individual patch.
      */

--- a/include/ibamr/INSVCStaggeredNonConservativeHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredNonConservativeHierarchyIntegrator.h
@@ -142,11 +142,6 @@ public:
                                        int num_cycles = 1) override;
 
     /*!
-     * Regrid the patch hierarchy.
-     */
-    void regridHierarchy() override;
-
-    /*!
      * Explicitly remove nullspace components from a solution vector.
      */
     void removeNullSpace(const SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double> >& sol_vec);

--- a/src/IB/IBHierarchyIntegrator.cpp
+++ b/src/IB/IBHierarchyIntegrator.cpp
@@ -437,8 +437,10 @@ IBHierarchyIntegrator::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > h
     return;
 } // initializePatchHierarchy
 
+/////////////////////////////// PROTECTED ////////////////////////////////////
+
 void
-IBHierarchyIntegrator::regridHierarchy()
+IBHierarchyIntegrator::regridHierarchyBeginSpecialized()
 {
     // This must be done here since (if a load balancer is used) it effects
     // the distribution of patches.
@@ -453,11 +455,13 @@ IBHierarchyIntegrator::regridHierarchy()
     // Before regridding, begin Lagrangian data movement.
     if (d_enable_logging) plog << d_object_name << "::regridHierarchy(): starting Lagrangian data movement\n";
     d_ib_method_ops->beginDataRedistribution(d_hierarchy, d_gridding_alg);
-
-    // Use the INSHierarchyIntegrator to handle Eulerian data management.
     if (d_enable_logging) plog << d_object_name << "::regridHierarchy(): regridding the patch hierarchy\n";
-    HierarchyIntegrator::regridHierarchy();
+    return;
+} // regridHierarchyBeginSpecialized
 
+void
+IBHierarchyIntegrator::regridHierarchyEndSpecialized()
+{
     // After regridding, finish Lagrangian data movement.
     if (d_enable_logging) plog << d_object_name << "::regridHierarchy(): finishing Lagrangian data movement\n";
     d_ib_method_ops->endDataRedistribution(d_hierarchy, d_gridding_alg);
@@ -477,9 +481,7 @@ IBHierarchyIntegrator::regridHierarchy()
     // Reset the regrid CFL estimate.
     d_regrid_cfl_estimate = 0.0;
     return;
-} // regridHierarchy
-
-/////////////////////////////// PROTECTED ////////////////////////////////////
+} // regridHierarchyEndSpecialized
 
 IBHierarchyIntegrator::IBHierarchyIntegrator(const std::string& object_name,
                                              Pointer<Database> input_db,

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1534,40 +1534,14 @@ INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(const double cur
     return;
 } // postprocessIntegrateHierarchy
 
-void
-INSCollocatedHierarchyIntegrator::regridHierarchy()
-{
-    const int coarsest_ln = 0;
-
-    // Regrid the hierarchy.
-    switch (d_regrid_mode)
-    {
-    case STANDARD:
-        d_gridding_alg->regridAllFinerLevels(d_hierarchy, coarsest_ln, d_integrator_time, d_tag_buffer);
-        break;
-    case AGGRESSIVE:
-        for (int k = 0; k < d_gridding_alg->getMaxLevels(); ++k)
-        {
-            d_gridding_alg->regridAllFinerLevels(d_hierarchy, coarsest_ln, d_integrator_time, d_tag_buffer);
-        }
-        break;
-    default:
-        TBOX_ERROR(d_object_name << "::regridHierarchy():\n"
-                                 << "  unrecognized regrid mode: "
-                                 << IBTK::enum_to_string<RegridMode>(d_regrid_mode)
-                                 << "."
-                                 << std::endl);
-    }
-
-    // Project the interpolated velocity.
-    regridProjection();
-
-    // Synchronize the state data on the patch hierarchy.
-    synchronizeHierarchyData(CURRENT_DATA);
-    return;
-} // regridHierarchy
-
 /////////////////////////////// PROTECTED ////////////////////////////////////
+
+void
+INSCollocatedHierarchyIntegrator::regridHierarchyEndSpecialized()
+{
+    regridProjection();
+    return;
+} // regridHierarchyEndSpecialized
 
 void
 INSCollocatedHierarchyIntegrator::initializeLevelDataSpecialized(

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1420,79 +1420,6 @@ INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double curr
 } // postprocessIntegrateHierarchy
 
 void
-INSStaggeredHierarchyIntegrator::regridHierarchy()
-{
-    const int coarsest_ln = 0;
-
-    // Determine the divergence of the velocity field before regridding.
-    d_hier_math_ops->div(d_Div_U_idx,
-                         d_Div_U_var,
-                         1.0,
-                         d_U_current_idx,
-                         d_U_var,
-                         d_no_fill_op,
-                         d_integrator_time,
-                         /*synch_cf_bdry*/ false,
-                         -1.0,
-                         d_Q_current_idx,
-                         d_Q_var);
-    const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
-    const double Div_U_norm_1_pre = d_hier_cc_data_ops->L1Norm(d_Div_U_idx, wgt_cc_idx);
-    const double Div_U_norm_2_pre = d_hier_cc_data_ops->L2Norm(d_Div_U_idx, wgt_cc_idx);
-    const double Div_U_norm_oo_pre = d_hier_cc_data_ops->maxNorm(d_Div_U_idx, wgt_cc_idx);
-
-    // Regrid the hierarchy.
-    switch (d_regrid_mode)
-    {
-    case STANDARD:
-        d_gridding_alg->regridAllFinerLevels(d_hierarchy, coarsest_ln, d_integrator_time, d_tag_buffer);
-        break;
-    case AGGRESSIVE:
-        for (int k = 0; k < d_gridding_alg->getMaxLevels(); ++k)
-        {
-            d_gridding_alg->regridAllFinerLevels(d_hierarchy, coarsest_ln, d_integrator_time, d_tag_buffer);
-        }
-        break;
-    default:
-        TBOX_ERROR(d_object_name << "::regridHierarchy():\n"
-                                 << "  unrecognized regrid mode: "
-                                 << IBTK::enum_to_string<RegridMode>(d_regrid_mode)
-                                 << "."
-                                 << std::endl);
-    }
-
-    // Determine the divergence of the velocity field after regridding.
-    d_hier_math_ops->div(d_Div_U_idx,
-                         d_Div_U_var,
-                         1.0,
-                         d_U_current_idx,
-                         d_U_var,
-                         d_no_fill_op,
-                         d_integrator_time,
-                         /*synch_cf_bdry*/ true,
-                         -1.0,
-                         d_Q_current_idx,
-                         d_Q_var);
-    const double Div_U_norm_1_post = d_hier_cc_data_ops->L1Norm(d_Div_U_idx, wgt_cc_idx);
-    const double Div_U_norm_2_post = d_hier_cc_data_ops->L2Norm(d_Div_U_idx, wgt_cc_idx);
-    const double Div_U_norm_oo_post = d_hier_cc_data_ops->maxNorm(d_Div_U_idx, wgt_cc_idx);
-
-    // Project the interpolated velocity if needed.
-    if (Div_U_norm_1_post > d_regrid_max_div_growth_factor * Div_U_norm_1_pre ||
-        Div_U_norm_2_post > d_regrid_max_div_growth_factor * Div_U_norm_2_pre ||
-        Div_U_norm_oo_post > d_regrid_max_div_growth_factor * Div_U_norm_oo_pre)
-    {
-        pout << d_object_name << "::regridHierarchy():\n"
-             << "  WARNING: projecting the interpolated velocity field\n";
-        regridProjection();
-    }
-
-    // Synchronize the state data on the patch hierarchy.
-    synchronizeHierarchyData(CURRENT_DATA);
-    return;
-} // regridHierarchy
-
-void
 INSStaggeredHierarchyIntegrator::setupSolverVectors(const Pointer<SAMRAIVectorReal<NDIM, double> >& sol_vec,
                                                     const Pointer<SAMRAIVectorReal<NDIM, double> >& rhs_vec,
                                                     const double current_time,
@@ -1707,6 +1634,61 @@ INSStaggeredHierarchyIntegrator::removeNullSpace(const Pointer<SAMRAIVectorReal<
 }
 
 /////////////////////////////// PROTECTED ////////////////////////////////////
+
+void
+INSStaggeredHierarchyIntegrator::regridHierarchyBeginSpecialized()
+{
+    // Determine the divergence of the velocity field before regridding.
+    d_hier_math_ops->div(d_Div_U_idx,
+                         d_Div_U_var,
+                         1.0,
+                         d_U_current_idx,
+                         d_U_var,
+                         d_no_fill_op,
+                         d_integrator_time,
+                         /*synch_cf_bdry*/ false,
+                         -1.0,
+                         d_Q_current_idx,
+                         d_Q_var);
+    const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
+    d_div_U_norm_1_pre = d_hier_cc_data_ops->L1Norm(d_Div_U_idx, wgt_cc_idx);
+    d_div_U_norm_2_pre = d_hier_cc_data_ops->L2Norm(d_Div_U_idx, wgt_cc_idx);
+    d_div_U_norm_oo_pre = d_hier_cc_data_ops->maxNorm(d_Div_U_idx, wgt_cc_idx);
+
+    return;
+} // regridHierarchyBeginSpecialized
+
+void
+INSStaggeredHierarchyIntegrator::regridHierarchyEndSpecialized()
+{
+    const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
+    // Determine the divergence of the velocity field after regridding.
+    d_hier_math_ops->div(d_Div_U_idx,
+                         d_Div_U_var,
+                         1.0,
+                         d_U_current_idx,
+                         d_U_var,
+                         d_no_fill_op,
+                         d_integrator_time,
+                         /*synch_cf_bdry*/ true,
+                         -1.0,
+                         d_Q_current_idx,
+                         d_Q_var);
+    const double Div_U_norm_1_post = d_hier_cc_data_ops->L1Norm(d_Div_U_idx, wgt_cc_idx);
+    const double Div_U_norm_2_post = d_hier_cc_data_ops->L2Norm(d_Div_U_idx, wgt_cc_idx);
+    const double Div_U_norm_oo_post = d_hier_cc_data_ops->maxNorm(d_Div_U_idx, wgt_cc_idx);
+
+    // Project the interpolated velocity if needed.
+    if (Div_U_norm_1_post > d_regrid_max_div_growth_factor * d_div_U_norm_1_pre ||
+        Div_U_norm_2_post > d_regrid_max_div_growth_factor * d_div_U_norm_2_pre ||
+        Div_U_norm_oo_post > d_regrid_max_div_growth_factor * d_div_U_norm_oo_pre)
+    {
+        pout << d_object_name << "::regridHierarchy():\n"
+             << "  WARNING: projecting the interpolated velocity field\n";
+        regridProjection();
+    }
+    return;
+} // regridHierarchyEndSpecialized
 
 void
 INSStaggeredHierarchyIntegrator::initializeLevelDataSpecialized(const Pointer<BasePatchHierarchy<NDIM> > base_hierarchy,

--- a/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
@@ -836,13 +836,6 @@ INSVCStaggeredConservativeHierarchyIntegrator::postprocessIntegrateHierarchy(con
 } // postprocessIntegrateHierarchy
 
 void
-INSVCStaggeredConservativeHierarchyIntegrator::regridHierarchy()
-{
-    INSVCStaggeredHierarchyIntegrator::regridHierarchy();
-    return;
-} // regridHierarchy
-
-void
 INSVCStaggeredConservativeHierarchyIntegrator::removeNullSpace(const Pointer<SAMRAIVectorReal<NDIM, double> >& sol_vec)
 {
     INSVCStaggeredHierarchyIntegrator::removeNullSpace(sol_vec);

--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -1300,77 +1300,6 @@ INSVCStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double cu
 } // postprocessIntegrateHierarchy
 
 void
-INSVCStaggeredHierarchyIntegrator::regridHierarchy()
-{
-    const int coarsest_ln = 0;
-
-    // Determine the divergence of the velocity field before regridding.
-    d_hier_math_ops->div(d_Div_U_idx,
-                         d_Div_U_var,
-                         1.0,
-                         d_U_current_idx,
-                         d_U_var,
-                         d_no_fill_op,
-                         d_integrator_time,
-                         /*synch_cf_bdry*/ false,
-                         -1.0,
-                         d_Q_current_idx,
-                         d_Q_var);
-    const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
-    const double Div_U_norm_1_pre = d_hier_cc_data_ops->L1Norm(d_Div_U_idx, wgt_cc_idx);
-    const double Div_U_norm_2_pre = d_hier_cc_data_ops->L2Norm(d_Div_U_idx, wgt_cc_idx);
-    const double Div_U_norm_oo_pre = d_hier_cc_data_ops->maxNorm(d_Div_U_idx, wgt_cc_idx);
-
-    // Regrid the hierarchy.
-    switch (d_regrid_mode)
-    {
-    case STANDARD:
-        d_gridding_alg->regridAllFinerLevels(d_hierarchy, coarsest_ln, d_integrator_time, d_tag_buffer);
-        break;
-    case AGGRESSIVE:
-        for (int k = 0; k < d_gridding_alg->getMaxLevels(); ++k)
-        {
-            d_gridding_alg->regridAllFinerLevels(d_hierarchy, coarsest_ln, d_integrator_time, d_tag_buffer);
-        }
-        break;
-    default:
-        TBOX_ERROR(d_object_name << "::regridHierarchy():\n"
-                                 << "  unrecognized regrid mode: " << IBTK::enum_to_string<RegridMode>(d_regrid_mode)
-                                 << "." << std::endl);
-    }
-
-    // Determine the divergence of the velocity field after regridding.
-    d_hier_math_ops->div(d_Div_U_idx,
-                         d_Div_U_var,
-                         1.0,
-                         d_U_current_idx,
-                         d_U_var,
-                         d_no_fill_op,
-                         d_integrator_time,
-                         /*synch_cf_bdry*/ true,
-                         -1.0,
-                         d_Q_current_idx,
-                         d_Q_var);
-    const double Div_U_norm_1_post = d_hier_cc_data_ops->L1Norm(d_Div_U_idx, wgt_cc_idx);
-    const double Div_U_norm_2_post = d_hier_cc_data_ops->L2Norm(d_Div_U_idx, wgt_cc_idx);
-    const double Div_U_norm_oo_post = d_hier_cc_data_ops->maxNorm(d_Div_U_idx, wgt_cc_idx);
-
-    // Project the interpolated velocity if needed.
-    if (Div_U_norm_1_post > d_regrid_max_div_growth_factor * Div_U_norm_1_pre ||
-        Div_U_norm_2_post > d_regrid_max_div_growth_factor * Div_U_norm_2_pre ||
-        Div_U_norm_oo_post > d_regrid_max_div_growth_factor * Div_U_norm_oo_pre)
-    {
-        pout << d_object_name << "::regridHierarchy():\n"
-             << "  WARNING: projecting the interpolated velocity field\n";
-        regridProjection();
-    }
-
-    // Synchronize the state data on the patch hierarchy.
-    synchronizeHierarchyData(CURRENT_DATA);
-    return;
-} // regridHierarchy
-
-void
 INSVCStaggeredHierarchyIntegrator::removeNullSpace(const Pointer<SAMRAIVectorReal<NDIM, double> >& sol_vec)
 {
     if (d_nul_vecs.empty()) return;
@@ -1494,6 +1423,61 @@ INSVCStaggeredHierarchyIntegrator::getTransportedViscosityVariable() const
 } // getTransportedViscosityVariable
 
 /////////////////////////////// PROTECTED ////////////////////////////////////
+
+void
+INSVCStaggeredHierarchyIntegrator::regridHierarchyBeginSpecialized()
+{
+    // Determine the divergence of the velocity field before regridding.
+    d_hier_math_ops->div(d_Div_U_idx,
+                         d_Div_U_var,
+                         1.0,
+                         d_U_current_idx,
+                         d_U_var,
+                         d_no_fill_op,
+                         d_integrator_time,
+                         /*synch_cf_bdry*/ false,
+                         -1.0,
+                         d_Q_current_idx,
+                         d_Q_var);
+    const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
+    d_div_U_norm_1_pre = d_hier_cc_data_ops->L1Norm(d_Div_U_idx, wgt_cc_idx);
+    d_div_U_norm_2_pre = d_hier_cc_data_ops->L2Norm(d_Div_U_idx, wgt_cc_idx);
+    d_div_U_norm_oo_pre = d_hier_cc_data_ops->maxNorm(d_Div_U_idx, wgt_cc_idx);
+
+    return;
+} // regridHierarchyBeginSpecialized
+
+void
+INSVCStaggeredHierarchyIntegrator::regridHierarchyEndSpecialized()
+{
+    const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
+    // Determine the divergence of the velocity field after regridding.
+    d_hier_math_ops->div(d_Div_U_idx,
+                         d_Div_U_var,
+                         1.0,
+                         d_U_current_idx,
+                         d_U_var,
+                         d_no_fill_op,
+                         d_integrator_time,
+                         /*synch_cf_bdry*/ true,
+                         -1.0,
+                         d_Q_current_idx,
+                         d_Q_var);
+    const double Div_U_norm_1_post = d_hier_cc_data_ops->L1Norm(d_Div_U_idx, wgt_cc_idx);
+    const double Div_U_norm_2_post = d_hier_cc_data_ops->L2Norm(d_Div_U_idx, wgt_cc_idx);
+    const double Div_U_norm_oo_post = d_hier_cc_data_ops->maxNorm(d_Div_U_idx, wgt_cc_idx);
+
+    // Project the interpolated velocity if needed.
+    if (Div_U_norm_1_post > d_regrid_max_div_growth_factor * d_div_U_norm_1_pre ||
+        Div_U_norm_2_post > d_regrid_max_div_growth_factor * d_div_U_norm_2_pre ||
+        Div_U_norm_oo_post > d_regrid_max_div_growth_factor * d_div_U_norm_oo_pre)
+    {
+        pout << d_object_name << "::regridHierarchy():\n"
+             << "  WARNING: projecting the interpolated velocity field\n";
+        regridProjection();
+    }
+    return;
+} // regridHierarchyEndSpecialized
 
 void
 INSVCStaggeredHierarchyIntegrator::initializeLevelDataSpecialized(

--- a/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
@@ -894,13 +894,6 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::postprocessIntegrateHierarchy(
 } // postprocessIntegrateHierarchy
 
 void
-INSVCStaggeredNonConservativeHierarchyIntegrator::regridHierarchy()
-{
-    INSVCStaggeredHierarchyIntegrator::regridHierarchy();
-    return;
-} // regridHierarchy
-
-void
 INSVCStaggeredNonConservativeHierarchyIntegrator::removeNullSpace(
     const Pointer<SAMRAIVectorReal<NDIM, double> >& sol_vec)
 {


### PR DESCRIPTION
`IBTK::HierarchyIntegrator::regridHierarchy` currently calls both `initializeCompositeHierarchyDataSpecialized` and `synchronizeHierarchyDataSpecialized` on itself and all child integrators. However, No class actually implements a nonempty `synchronizeHierarchyDataSpecialized` method aside from `IBTK::HierarchyIntegrator`, and putting everything in a routine named `initialize` is confusing. Hence I added (I am not in love with the names) `regridHierarchyBeginSpecialized` and `regridHierarchyEndSpecialized` which are called immediately before and after we do the actual regridding inside SAMRAI.

From the discussion in #343: I am now convinced that this is the correct way to handle this since a lot of classes need to do stuff immediately before or after regridding and there is no way to do it at the present aside from reimplementing `regridHierarchy` and remembering to call all setup/synch/etc functions on all child integrators.

I still need to move around some SAMRAI variables (this doesn't compile right now) so this is a work in progress.
