### PR TITLE
Fix compatibility with libMesh 1.3.x. (0.4.1)

### DIFF
--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -338,8 +338,8 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
     std::vector<std::set<dof_id_type> > temp_node_dof_ID_sets;
     std::vector<std::vector<libMesh::Point> > temp_nodes;
     std::vector<libMesh::Point> meter_centroids;
-    // new API in 1.3.0
-#if 1 <= LIBMESH_MAJOR_VERSION && 3 <= LIBMESH_MINOR_VERSION
+    // new API in 1.4.0
+#if 1 <= LIBMESH_MAJOR_VERSION && 4 <= LIBMESH_MINOR_VERSION
     const std::vector<std::tuple<dof_id_type, boundary_id_type> > node_list = boundary_info.build_node_list();
     for (const std::tuple<dof_id_type, boundary_id_type>& pair : node_list)
     {


### PR DESCRIPTION
This change to the libMesh API did not occur until version 1.4.