### PR TITLE
Updates to a c++11 update script.

### DIFF
--- a/scripts/misc_cpp11_updates.pl
+++ b/scripts/misc_cpp11_updates.pl
@@ -1,7 +1,10 @@
 #! /usr/bin/perl
-# This script replaces UniquePtr and AutoPtr with std::unique_ptr.
+# This script does a few miscellaneous C++11 updates such as:
+#   -- replacing UniquePtr and AutoPtr with std::unique_ptr
+#   -- replacing libMesh UniquePtr header with <memory> system header
+#   -- replacing boost objects with corresponding std objects.
 # To use this file, use the command
-# perl replaceUnique.pl <directory>
+# perl misc_cpp11_updates.pl <directory>
 # where <directory> is the base path to be changed.
 use strict;
 
@@ -45,6 +48,18 @@ for my $file (@filesToProcess) {
 
         # Replace Pointer<STUFF> with unique_ptr<STUFF>
         $str =~ s/(libMesh::)?(UniquePtr|AutoPtr)\</std::unique_ptr\</g;
+
+        # Replace boost::array<> with std::array<>
+        $str =~ s/boost::array</std::array</g;
+
+        # Replace boost::unordered_map<> with std::unordered_map<>
+        $str =~ s/boost::unordered_map</std::unordered_map</g;
+
+        # Replace boost::tuple<> with std::tuple<>
+        $str =~ s/boost::tuple</std::tuple</g;
+
+        # Replace boost::make_tuple
+        $str =~ s/boost::make_tuple</std::make_tuple</g;
 
         print TEMPFILE $str;
     }


### PR DESCRIPTION
This updates the script that replaces `UniquePtr` with `unique_ptr` to also replace `boost::array` with `std::array`. @drwells Are there any other simple changes like this that would be useful to include?

@AminKolah You can use this script to do some of the dull search and replaces on #240.