### PR TITLE
Fix template bounds

### DIFF
--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -643,6 +643,7 @@ sum_weighted_elem_solution_n_vars(const int n_basis,
         SWITCH_CASE(5)
         SWITCH_CASE(6)
         SWITCH_CASE(8)
+        SWITCH_CASE(9)
         SWITCH_CASE(10)
         SWITCH_CASE(27)
 #undef SWITCH_CASE
@@ -1348,6 +1349,7 @@ integrate_elem_rhs_n_vars(const int n_basis,
         SWITCH_CASE(5)
         SWITCH_CASE(6)
         SWITCH_CASE(8)
+        SWITCH_CASE(9)
         SWITCH_CASE(10)
         SWITCH_CASE(27)
 #undef SWITCH_CASE

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -593,7 +593,7 @@ sum_weighted_elem_solution_n_vars_n_basis(const int qp_offset,
     if (n_vars == -1 || n_basis == -1)
     {
         const int n_basis_ = phi_F.size();
-        const int n_vars_ = F_node.shape()[0];
+        const int n_vars_ = F_node.shape()[1];
         for (int qp = 0; qp < n_qp; ++qp)
         {
             const int idx = n_vars_ * (qp_offset + qp);


### PR DESCRIPTION
With apologies to @cpuelz.

Using biquadratic elements in 2D revealed a bug and a problem:
1. We do a run-time calculation of the number of variables incorrectly (we should use the second entry in the shape array)
2. We should provide instantiations for biquadratic elements since we use them in the examples.

This PR fixes the bug (sorry) and also adds instantiations so we can get a nice speed-up for biquadratic elements too.