### PR TITLE
Remove some incorrect assertions.

### DIFF
--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -986,10 +986,6 @@ template <class MultiArray>
 inline double
 get_max_edge_length(const libMesh::Elem* const elem, const MultiArray& X_node)
 {
-#ifndef NDEBUG
-    TBOX_ASSERT(elem->n_nodes() == X_node.shape()[0]);
-    TBOX_ASSERT(elem->dim() == X_node.shape()[1]);
-#endif
     const libMesh::ElemType elem_type = elem->type();
 
     double max_edge_length_2 = 0.0;


### PR DESCRIPTION
We sometimes call this function with edge elements: in that case these assertions don't make sense.