### PR TITLE
Don't use -L with ln.

### DIFF
--- a/tests/IBFE/Makefile.am
+++ b/tests/IBFE/Makefile.am
@@ -26,7 +26,7 @@ spread_01_SOURCES = spread_01.cpp
 
 tests: $(EXTRA_PROGRAMS)
 	if test "$(top_srcdir)" != "$(top_builddir)" ; then \
-	  ln -L -f -s $(srcdir)/*input $(PWD) ; \
-	  ln -L -f -s $(srcdir)/*output $(PWD) ; \
+	  ln -f -s $(srcdir)/*input $(PWD) ; \
+	  ln -f -s $(srcdir)/*output $(PWD) ; \
 	fi ;
 .PHONY: tests

--- a/tests/IBFE/Makefile.in
+++ b/tests/IBFE/Makefile.in
@@ -943,8 +943,8 @@ uninstall-am:
 
 tests: $(EXTRA_PROGRAMS)
 	if test "$(top_srcdir)" != "$(top_builddir)" ; then \
-	  ln -L -f -s $(srcdir)/*input $(PWD) ; \
-	  ln -L -f -s $(srcdir)/*output $(PWD) ; \
+	  ln -f -s $(srcdir)/*input $(PWD) ; \
+	  ln -f -s $(srcdir)/*output $(PWD) ; \
 	fi ;
 .PHONY: tests
 

--- a/tests/IBTK/Makefile.am
+++ b/tests/IBTK/Makefile.am
@@ -16,7 +16,7 @@ mpi_type_wrappers_SOURCES = mpi_type_wrappers.cpp
 
 tests: $(EXTRA_PROGRAMS)
 	if test "$(top_srcdir)" != "$(top_builddir)" ; then \
-	  ln -L -f -s $(srcdir)/*input $(PWD) ; \
-	  ln -L -f -s $(srcdir)/*output $(PWD) ; \
+	  ln -f -s $(srcdir)/*input $(PWD) ; \
+	  ln -f -s $(srcdir)/*output $(PWD) ; \
 	fi ;
 .PHONY: tests

--- a/tests/IBTK/Makefile.in
+++ b/tests/IBTK/Makefile.in
@@ -872,8 +872,8 @@ uninstall-am:
 
 tests: $(EXTRA_PROGRAMS)
 	if test "$(top_srcdir)" != "$(top_builddir)" ; then \
-	  ln -L -f -s $(srcdir)/*input $(PWD) ; \
-	  ln -L -f -s $(srcdir)/*output $(PWD) ; \
+	  ln -f -s $(srcdir)/*input $(PWD) ; \
+	  ln -f -s $(srcdir)/*output $(PWD) ; \
 	fi ;
 .PHONY: tests
 


### PR DESCRIPTION
Its not necessary to create a symbolic link and doesn't work on macs.

Some context: some tests use identical input files aside from the mpirun directive. Its a little better to dereference the symbolic link (instead of having a link to a link) but not necessary.