### PR TITLE
update Sublime project template

### DIFF
--- a/scripts/project_templates/sublime/ibamr.sublime-project.template
+++ b/scripts/project_templates/sublime/ibamr.sublime-project.template
@@ -43,6 +43,7 @@
         ],
         "SublimeLinter.linters.cppcheck.disable": false,
         "SublimeLinter.linters.cppcheck.enable": "information,performance,portability,style,warning",
-        "SublimeLinter.linters.cppcheck.std": ["c++11","c99"],
+        "SublimeLinter.linters.cppcheck.language": "c++",
+        "SublimeLinter.linters.cppcheck.std": ["c++11"],
     }
 }


### PR DESCRIPTION
These settings tell `cppcheck` to assume that header (`.h`) files are in C++ and not C.