### PR TITLE
Do not remove an unused patch data index.

### DIFF
--- a/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
@@ -186,7 +186,10 @@ IBHydrodynamicSurfaceForceEvaluator::~IBHydrodynamicSurfaceForceEvaluator()
     var_db->removePatchDataIndex(d_ls_solid_idx);
     var_db->removePatchDataIndex(d_u_idx);
     var_db->removePatchDataIndex(d_p_idx);
-    var_db->removePatchDataIndex(d_mu_idx);
+    if (!d_mu_is_const)
+    {
+        var_db->removePatchDataIndex(d_mu_idx);
+    }
 
     return;
 } // ~IBHydrodynamicSurfaceForceEvaluator


### PR DESCRIPTION
Fix for the issue in #550: we were removing patch data that was not allocated which causes SAMRAI to segfault, even in debug mode.

I am writing up some notes on how to debug things with valgrind (and other tools) with MPI so that everyone can learn the tricks that I just learned.