### PR TITLE
Add a switch for the vector type for U's RHS.

### DIFF
--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -106,6 +106,19 @@ namespace IBAMR
  * By default, the libMesh data is partitioned once at the beginning of the
  * computation by libMesh's default partitioner.
  *
+ * <h2>Options Controlling Finite Element Vector Data Layout</h2>
+ * IBFEMethod performs an L2 projection to transfer the velocity of the fluid
+ * from the Eulerian grid to the finite element representation. The parallel
+ * performance of this operation can be substantially improved by doing
+ * assembly into the ghost region of each vector (instead of accumulating into
+ * an internal PETSc object). By default this class will use the 'accumulate
+ * into the ghost region' assembly strategy. The assembly strategy can be
+ * selected by changing the database variable vector_assembly_accumulation
+ * from <code>GHOSTED</code>, the default, to <code>CACHE</code>, which will
+ * use PETSc's VecCache object to distribute data.
+ *
+ * <h2>Options Controlling Partitioning</h2>
+ *
  * This class can repartition libMesh data in a way that matches SAMRAI's
  * distribution of patches; put another way, if a certain region of space on
  * the finest level is assigned to processor N, then all libMesh nodes and
@@ -871,11 +884,20 @@ protected:
     /**
      * Vectors containing entries for relevant IB ghost data: see
      * FEDataManager::buildIBGhostedVector.
+     *
+     * Unlike the other vectors, d_U_IB_rhs_vecs is for assembly and may not
+     * be used: see the main documentation of this class for more information.
      */
     std::vector<std::unique_ptr<libMesh::PetscVector<double> > > d_F_IB_solution_vecs;
     std::vector<std::unique_ptr<libMesh::PetscVector<double> > > d_Q_IB_solution_vecs;
     std::vector<std::unique_ptr<libMesh::PetscVector<double> > > d_U_IB_rhs_vecs;
     std::vector<std::unique_ptr<libMesh::PetscVector<double> > > d_X_IB_solution_vecs;
+
+    /*
+     * Whether or not to use the ghost region for velocity assembly. See the
+     * main documentation of this class for more information.
+     */
+    bool d_use_ghosted_velocity_rhs = true;
 
     /*!
      * Whether or not the libMesh equation systems objects have been

--- a/tests/IBFE/interpolate_velocity_01.d.cached.mpirun=4.input
+++ b/tests/IBFE/interpolate_velocity_01.d.cached.mpirun=4.input
@@ -1,0 +1,61 @@
+// Same as interpolate_velocity_01.d.mpirun=4.input, but uses the old VecCache
+// based accumulation.
+
+L   = 1.0
+MAX_LEVELS = 3
+REF_RATIO  = 4
+N = 32
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N
+DX  = L/NFINEST
+MFAC = 2.0
+ELEM_TYPE = "TRI3"
+
+VelocityInitialConditions {
+function_0 = "X_0 + 2*X_1*X_1"
+function_1 = "2*X_0 + 3*X_0*X_0 - 2*X_1"
+}
+
+PressureInitialConditions {function = "42.0"}
+
+IBHierarchyIntegrator {}
+IBFEMethod
+{
+enable_logging = FALSE
+vector_assembly_accumulation = "CACHED"
+}
+
+INSStaggeredHierarchyIntegrator {
+   mu             = 1
+   rho            = 1
+}
+
+Main {
+   solver_type   = "STAGGERED"
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {tagging_method = "GRADIENT_DETECTOR"}
+LoadBalancer {}

--- a/tests/IBFE/interpolate_velocity_01.d.cached.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01.d.cached.mpirun=4.output
@@ -1,0 +1,1 @@
+interpolate_velocity_01.d.mpirun=4.output

--- a/tests/IBFE/interpolate_velocity_01.d.ghosted.mpirun=4.input
+++ b/tests/IBFE/interpolate_velocity_01.d.ghosted.mpirun=4.input
@@ -1,0 +1,61 @@
+// Same as interpolate_velocity_01.d.mpirun=4.input, but explicitly use the
+// ghost vector based accumulation.
+
+L   = 1.0
+MAX_LEVELS = 3
+REF_RATIO  = 4
+N = 32
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N
+DX  = L/NFINEST
+MFAC = 2.0
+ELEM_TYPE = "TRI3"
+
+VelocityInitialConditions {
+function_0 = "X_0 + 2*X_1*X_1"
+function_1 = "2*X_0 + 3*X_0*X_0 - 2*X_1"
+}
+
+PressureInitialConditions {function = "42.0"}
+
+IBHierarchyIntegrator {}
+IBFEMethod
+{
+enable_logging = FALSE
+vector_assembly_accumulation = "GHOSTED"
+}
+
+INSStaggeredHierarchyIntegrator {
+   mu             = 1
+   rho            = 1
+}
+
+Main {
+   solver_type   = "STAGGERED"
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {tagging_method = "GRADIENT_DETECTOR"}
+LoadBalancer {}

--- a/tests/IBFE/interpolate_velocity_01.d.ghosted.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01.d.ghosted.mpirun=4.output
@@ -1,0 +1,1 @@
+interpolate_velocity_01.d.mpirun=4.output


### PR DESCRIPTION
This allows us to switch back to the old VecCache based implementation.

I added two tests where we explicitly use one option or the other when setting up IBFEMethod. They both work.

Part of #492.