### PR TITLE
Added memory header file.

### DIFF
--- a/ibtk/include/ibtk/HierarchyGhostCellInterpolation.h
+++ b/ibtk/include/ibtk/HierarchyGhostCellInterpolation.h
@@ -35,6 +35,7 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include <memory>
 #include <ostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Follow up from #570. I needed to add in `#include <memory>` to get IBAMR to compile with certain older compilers (gcc 4.8.4 in particular).