### PR TITLE
remove some deprecated libMesh functions

### DIFF
--- a/examples/IBFE/explicit/ex10/example.cpp
+++ b/examples/IBFE/explicit/ex10/example.cpp
@@ -196,12 +196,12 @@ run_example(int argc, char** argv)
             Elem* const elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                const bool at_mesh_bdry = !elem->neighbor(side);
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (!at_mesh_bdry) continue;
                 for (unsigned int k = 0; k < elem->n_nodes(); ++k)
                 {
                     if (!elem->is_node_on_side(k, side)) continue;
-                    Node& n = *elem->get_node(k);
+                    Node& n = elem->node_ref(k);
                     n = R * n.unit();
                 }
             }

--- a/examples/IBFE/explicit/ex11/example.cpp
+++ b/examples/IBFE/explicit/ex11/example.cpp
@@ -233,12 +233,12 @@ run_example(int argc, char** argv)
             Elem* const elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                const bool at_mesh_bdry = !elem->neighbor(side);
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (!at_mesh_bdry) continue;
                 for (unsigned int k = 0; k < elem->n_nodes(); ++k)
                 {
                     if (!elem->is_node_on_side(k, side)) continue;
-                    Node& n = *elem->get_node(k);
+                    Node& n = elem->node_ref(k);
                     n = R * n.unit();
                 }
             }

--- a/examples/IBFE/explicit/ex2/example.cpp
+++ b/examples/IBFE/explicit/ex2/example.cpp
@@ -211,7 +211,7 @@ run_example(int argc, char* argv[])
             Elem* const elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                const bool at_mesh_bdry = !elem->neighbor(side);
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (at_mesh_bdry)
                 {
                     BoundaryInfo* boundary_info = mesh.boundary_info.get();

--- a/examples/IBFE/explicit/ex3/example.cpp
+++ b/examples/IBFE/explicit/ex3/example.cpp
@@ -191,7 +191,7 @@ bool run_example(int argc, char** argv)
             Elem* const elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                const bool at_mesh_bdry = !elem->neighbor(side);
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (at_mesh_bdry)
                 {
                     BoundaryInfo* boundary_info = mesh.boundary_info.get();

--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -226,12 +226,12 @@ bool run_example(int argc, char** argv)
             Elem* const elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                const bool at_mesh_bdry = !elem->neighbor(side);
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (!at_mesh_bdry) continue;
                 for (unsigned int k = 0; k < elem->n_nodes(); ++k)
                 {
                     if (!elem->is_node_on_side(k, side)) continue;
-                    Node& n = *elem->get_node(k);
+                    Node& n = elem->node_ref(k);
                     n = R * n.unit();
                 }
             }

--- a/examples/IBFE/explicit/ex5/example.cpp
+++ b/examples/IBFE/explicit/ex5/example.cpp
@@ -314,12 +314,12 @@ run_example(int argc, char** argv)
             Elem* const elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                const bool at_mesh_bdry = !elem->neighbor(side);
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (!at_mesh_bdry) continue;
                 for (unsigned int k = 0; k < elem->n_nodes(); ++k)
                 {
                     if (!elem->is_node_on_side(k, side)) continue;
-                    Node& n = *elem->get_node(k);
+                    Node& n = elem->node_ref(k);
                     n = R * n.unit();
                 }
             }
@@ -716,7 +716,7 @@ postprocess_data(Pointer<Database> input_db,
         }
         for (unsigned short int side = 0; side < elem->n_sides(); ++side)
         {
-            if (elem->neighbor(side)) continue;
+            if (elem->neighbor_ptr(side)) continue;
             fe_face->reinit(elem, side);
             const unsigned int n_qp_face = qrule_face->n_points();
             for (unsigned int qp = 0; qp < n_qp_face; ++qp)

--- a/examples/IBFE/explicit/ex9/example.cpp
+++ b/examples/IBFE/explicit/ex9/example.cpp
@@ -214,12 +214,12 @@ bool run_example(int argc, char** argv)
             Elem* const elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                const bool at_mesh_bdry = !elem->neighbor(side);
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (!at_mesh_bdry) continue;
                 for (unsigned int k = 0; k < elem->n_nodes(); ++k)
                 {
                     if (!elem->is_node_on_side(k, side)) continue;
-                    Node& n = *elem->get_node(k);
+                    Node& n = elem->node_ref(k);
                     n = R * n.unit();
                 }
             }

--- a/examples/IMP/explicit/ex0/main.cpp
+++ b/examples/IMP/explicit/ex0/main.cpp
@@ -174,12 +174,12 @@ main(int argc, char* argv[])
             Elem* const elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                const bool at_mesh_bdry = !elem->neighbor(side);
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (!at_mesh_bdry) continue;
                 for (unsigned int k = 0; k < elem->n_nodes(); ++k)
                 {
                     if (!elem->is_node_on_side(k, side)) continue;
-                    Node& n = *elem->get_node(k);
+                    Node& n = elem->node_ref(k);
                     n = R * n.unit();
                 }
             }

--- a/src/IB/IBFEPatchRecoveryPostProcessor.cpp
+++ b/src/IB/IBFEPatchRecoveryPostProcessor.cpp
@@ -225,7 +225,7 @@ IBFEPatchRecoveryPostProcessor::initializeFEData(const PeriodicBoundaries* const
         for (unsigned int n = 0; n < elem->n_nodes(); ++n)
         {
             // Only set up patches for local nodes.
-            const Node* const node = elem->get_node(n);
+            const Node* const node = elem->get_node_ptr(n);
             if (node->processor_id() != mpi_rank) continue;
 
             // Only set up patches once for each node.
@@ -255,7 +255,7 @@ IBFEPatchRecoveryPostProcessor::initializeFEData(const PeriodicBoundaries* const
                     TBOX_ASSERT(elem->contains_point(p));
                     for (unsigned int i = 0; i < elem->n_neighbors(); ++i)
                     {
-                        if (!elem->neighbor(i))
+                        if (!elem->neighbor_ptr(i))
                         {
                             const std::vector<boundary_id_type>& boundary_ids =
                                 d_mesh->boundary_info->boundary_ids(elem, i);
@@ -270,7 +270,7 @@ IBFEPatchRecoveryPostProcessor::initializeFEData(const PeriodicBoundaries* const
                                 {
                                     const libMesh::Point periodic_image = periodic_boundary->get_corresponding_pos(p);
                                     const Elem* neighbor =
-                                        d_periodic_boundaries->neighbor(boundary_id, *point_locator, elem, i);
+                                        d_periodic_boundaries->neighbor_ptr(boundary_id, *point_locator, elem, i);
                                     if (elem->level() < neighbor->level())
                                     {
                                         neighbor = neighbor->parent();
@@ -417,7 +417,7 @@ IBFEPatchRecoveryPostProcessor::initializeCauchyStressSystem()
             std::string var_name = "sigma_";
             var_name += (i == 0 ? 'x') : i == 1 ? 'y' : 'z');
             var_name += (j == 0 ? 'x') : j == 1 ? 'y' : 'z');
-            
+
             sigma_system->add_variable(var_name), d_interp_order, LAGRANGE);
         }
     }

--- a/tests/IBFE/explicit_ex4.cpp
+++ b/tests/IBFE/explicit_ex4.cpp
@@ -198,12 +198,12 @@ int main(int argc, char** argv)
             Elem* const elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
-                const bool at_mesh_bdry = !elem->neighbor(side);
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (!at_mesh_bdry) continue;
                 for (unsigned int k = 0; k < elem->n_nodes(); ++k)
                 {
                     if (!elem->is_node_on_side(k, side)) continue;
-                    Node& n = *elem->get_node(k);
+                    Node& n = elem->node_ref(k);
                     n = R * n.unit();
                 }
             }


### PR DESCRIPTION
This may break compatibility with some older versions of libMesh, but seems to be needed to avoid configuring libMesh `master` with `--enable-deprecated`.