### PR TITLE
Optimize bspline 3 spread

### DIFF
--- a/ibtk/src/lagrangian/LEInteractor.cpp
+++ b/ibtk/src/lagrangian/LEInteractor.cpp
@@ -4264,6 +4264,7 @@ LEInteractor::spread(double* const q_data,
     const int stencil_size = getStencilSize(spread_fcn);
     const int min_ghosts = getMinimumGhostWidth(spread_fcn);
     const int q_gcw_min = q_gcw.min();
+    TBOX_ASSERT(0 <= q_gcw_min);
     bool patch_touches_physical_bdry = false;
     for (unsigned int d = 0; d < NDIM; ++d)
     {

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -2450,6 +2450,7 @@ c
       INTEGER depth
       INTEGER nindices
       INTEGER ilower0,iupper0,ilower1,iupper1
+c     This assumes nugc0, nugc1, nugc2 are all positive, which *should* always be true.
       INTEGER nugc0,nugc1
 
       INTEGER indices(0:nindices-1)
@@ -2501,11 +2502,6 @@ c
             ic_upper(d) = ic_center(d)+1
          enddo
 
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
 c
 c     Compute the spreading weights.
 c

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -2505,16 +2505,18 @@ c
 c
 c     Compute the spreading weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+         do ic0 = 0,2
+            X_cell(0) = x_lower(0)+(dble(ic0 + ic_lower(0) - ilower0)
+     &           + 0.5d0)*dx(0)
+            w0(ic0) =
      &           lagrangian_bspline_3_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+         do ic1 = 0,2
+            X_cell(1) = x_lower(1)+(dble(ic1 + ic_lower(1) - ilower1)
+     &      + 0.5d0)*dx(1)
+            w1(ic1) =
      &           lagrangian_bspline_3_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -2522,11 +2524,12 @@ c
 c     Spread V onto u.
 c
          do d = 0,depth-1
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w0(ic0-ic_lower(0))*
-     &                 w1(ic1-ic_lower(1))*
+            do ic1 = 0,2
+               do ic0 = 0,2
+                  u(ic0 + ic_lower(0), ic1 + ic_lower(1), d) =
+     &                 u(ic0 + ic_lower(0), ic1 + ic_lower(1), d) + (
+     &                 w0(ic0)*
+     &                 w1(ic1)*
      &                 V(d,s)/(dx(0)*dx(1)))
                enddo
             enddo

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
@@ -2798,6 +2798,7 @@ c
       INTEGER depth
       INTEGER nindices
       INTEGER ilower0,iupper0,ilower1,iupper1,ilower2,iupper2
+c     This assumes nugc0, nugc1, nugc2 are all positive, which *should* always be true.
       INTEGER nugc0,nugc1,nugc2
 
       INTEGER indices(0:nindices-1)
@@ -2853,14 +2854,7 @@ c
             ic_upper(d) = ic_center(d)+1
          enddo
 
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
 
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
-
-         ic_lower(2) = max(ic_lower(2),ilower2-nugc2)
-         ic_upper(2) = min(ic_upper(2),iupper2+nugc2)
 c
 c     Compute the spreading weights.
 c

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
@@ -2858,23 +2858,26 @@ c
 c
 c     Compute the spreading weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+         do ic0 = 0,2
+            X_cell(0) = x_lower(0)+(dble(ic0 + ic_lower(0) - ilower0)
+     &           + 0.5d0)*dx(0)
+            w0(ic0) =
      &           lagrangian_bspline_3_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+         do ic1 = 0,2
+            X_cell(1) = x_lower(1)+(dble(ic1 + ic_lower(1) - ilower1)
+     &           + 0.5d0)*dx(1)
+            w1(ic1) =
      &           lagrangian_bspline_3_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
-         do ic2 = ic_lower(2),ic_upper(2)
-            X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+         do ic2 = 0,2
+            X_cell(2) = x_lower(2)+(dble(ic2 + ic_lower(2) - ilower2)
+     &           + 0.5d0)*dx(2)
+            w2(ic2) =
      &           lagrangian_bspline_3_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -2882,13 +2885,16 @@ c
 c     Spread V onto u.
 c
          do d = 0,depth-1
-            do ic2 = ic_lower(2),ic_upper(2)
-               do ic1 = ic_lower(1),ic_upper(1)
-                  do ic0 = ic_lower(0),ic_upper(0)
-                     u(ic0,ic1,ic2,d) = u(ic0,ic1,ic2,d)+(
-     &                    w0(ic0-ic_lower(0))*
-     &                    w1(ic1-ic_lower(1))*
-     &                    w2(ic2-ic_lower(2))*
+            do ic2 = 0,2
+               do ic1 = 0,2
+                  do ic0 = 0,2
+                     u(ic0 + ic_lower(0), ic1 + ic_lower(1),
+     &                 ic2 + ic_lower(2), d) =
+     &                    u(ic0 + ic_lower(0), ic1 + ic_lower(1),
+     &                      ic2 + ic_lower(2), d) + (
+     &                    w0(ic0)*
+     &                    w1(ic1)*
+     &                    w2(ic2)*
      &                    V(d,s)/(dx(0)*dx(1)*dx(2)))
                   enddo
                enddo


### PR DESCRIPTION
I noticed this when reading some callgrind output: these loop bounds can be fixed by moving around some index computations. callgrind reports that we spend about 9% of our instructions in this function. These changes make it cost about 25% less: a very easy to implement performance improvement.

This change was easy to do since we have tests for the spread kernels. We can do the same thing for interpolation but we will have to come up with better interpolation kernel tests first.