### PR TITLE
Add a missing call to PetscFinalize().

### DIFF
--- a/tests/IBTK/ldata_01.cpp
+++ b/tests/IBTK/ldata_01.cpp
@@ -248,4 +248,5 @@ main(int argc, char** argv)
     }
 
     SAMRAIManager::shutdown();
+    PetscFinalize();
 } // main


### PR DESCRIPTION
For some reason mpich was okay with omitting this so I did not catch it before.