### PR TITLE
Add a missing symbolic link.

### DIFF
--- a/ibtk/m4/configure_petsc.m4
+++ b/ibtk/m4/configure_petsc.m4
@@ -1,0 +1,1 @@
+../../m4/configure_petsc.m4


### PR DESCRIPTION
This was somehow omitted from #601. I am not sure how we managed to configure IBTK given this problem.