### PR TITLE
Add more interpolation tests.

### DIFF
--- a/tests/IBFE/interpolate_velocity_01.b.bspline-3.input
+++ b/tests/IBFE/interpolate_velocity_01.b.bspline-3.input
@@ -1,0 +1,60 @@
+// same as interpolate_velocity_01.b.input, but explicitly for bspline 3
+
+L   = 1.0
+MAX_LEVELS = 3
+REF_RATIO  = 4
+N = 16
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N
+DX  = L/NFINEST
+MFAC = 2.0
+ELEM_TYPE = "TRI3"
+
+VelocityInitialConditions {
+function_0 = "X_0 + 2*X_1*X_1"
+function_1 = "2*X_0 + 3*X_0*X_0 - 2*X_1"
+}
+
+PressureInitialConditions {function = "42.0"}
+
+IBHierarchyIntegrator {}
+
+IBFEMethod {
+   IB_delta_fcn = "BSPLINE_3"
+   enable_logging = FALSE
+}
+
+INSStaggeredHierarchyIntegrator {
+   mu             = 1
+   rho            = 1
+}
+
+Main {
+   solver_type   = "STAGGERED"
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 32,32  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {tagging_method = "GRADIENT_DETECTOR"}
+LoadBalancer {}

--- a/tests/IBFE/interpolate_velocity_01.b.bspline-3.output
+++ b/tests/IBFE/interpolate_velocity_01.b.bspline-3.output
@@ -1,0 +1,7 @@
+Number of elements: 4813
+
+IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
+
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
+max vertex distance: 0.0135775
+max norm errors: 5.1673437618804385352e-05   7.7181857464303504912e-05

--- a/tests/IBFE/interpolate_velocity_01.b.bspline-4.input
+++ b/tests/IBFE/interpolate_velocity_01.b.bspline-4.input
@@ -1,0 +1,61 @@
+// same as interpolate_velocity_01.b.input, but explicitly for bspline 4
+
+L   = 1.0
+MAX_LEVELS = 3
+REF_RATIO  = 4
+N = 16
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N
+DX  = L/NFINEST
+MFAC = 2.0
+ELEM_TYPE = "TRI3"
+
+VelocityInitialConditions {
+function_0 = "X_0 + 2*X_1*X_1"
+function_1 = "2*X_0 + 3*X_0*X_0 - 2*X_1"
+}
+
+PressureInitialConditions {function = "42.0"}
+
+IBHierarchyIntegrator {}
+
+IBFEMethod {
+   IB_delta_fcn = "BSPLINE_4"
+   enable_logging = FALSE
+}
+
+
+INSStaggeredHierarchyIntegrator {
+   mu             = 1
+   rho            = 1
+}
+
+Main {
+   solver_type   = "STAGGERED"
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 32,32  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {tagging_method = "GRADIENT_DETECTOR"}
+LoadBalancer {}

--- a/tests/IBFE/interpolate_velocity_01.b.bspline-4.output
+++ b/tests/IBFE/interpolate_velocity_01.b.bspline-4.output
@@ -1,0 +1,7 @@
+Number of elements: 4813
+
+IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
+
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
+max vertex distance: 0.0135775
+max norm errors: 5.4216569129295066887e-05   8.099655472981748261e-05

--- a/tests/IBFE/interpolate_velocity_01.b.bspline-5.input
+++ b/tests/IBFE/interpolate_velocity_01.b.bspline-5.input
@@ -1,0 +1,62 @@
+// same as interpolate_velocity_01.b.input, but explicitly for bspline 5
+
+L   = 1.0
+MAX_LEVELS = 3
+REF_RATIO  = 4
+N = 16
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N
+DX  = L/NFINEST
+MFAC = 2.0
+ELEM_TYPE = "TRI3"
+
+VelocityInitialConditions {
+function_0 = "X_0 + 2*X_1*X_1"
+function_1 = "2*X_0 + 3*X_0*X_0 - 2*X_1"
+}
+
+PressureInitialConditions {function = "42.0"}
+
+IBHierarchyIntegrator {}
+
+IBFEMethod {
+   IB_delta_fcn = "BSPLINE_5"
+   min_ghost_cell_width = 4
+   enable_logging = FALSE
+}
+
+
+INSStaggeredHierarchyIntegrator {
+   mu             = 1
+   rho            = 1
+}
+
+Main {
+   solver_type   = "STAGGERED"
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 32,32  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {tagging_method = "GRADIENT_DETECTOR"}
+LoadBalancer {}

--- a/tests/IBFE/interpolate_velocity_01.b.bspline-5.output
+++ b/tests/IBFE/interpolate_velocity_01.b.bspline-5.output
@@ -1,0 +1,7 @@
+Number of elements: 4813
+
+IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
+
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 2 4
+max vertex distance: 0.0135775
+max norm errors: 5.6759700633346454879e-05   8.4811251997551906356e-05

--- a/tests/IBFE/interpolate_velocity_01.b.bspline-6.input
+++ b/tests/IBFE/interpolate_velocity_01.b.bspline-6.input
@@ -1,0 +1,62 @@
+// same as interpolate_velocity_01.b.input, but explicitly for bspline 6
+
+L   = 1.0
+MAX_LEVELS = 3
+REF_RATIO  = 4
+N = 16
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N
+DX  = L/NFINEST
+MFAC = 2.0
+ELEM_TYPE = "TRI3"
+
+VelocityInitialConditions {
+function_0 = "X_0 + 2*X_1*X_1"
+function_1 = "2*X_0 + 3*X_0*X_0 - 2*X_1"
+}
+
+PressureInitialConditions {function = "42.0"}
+
+IBHierarchyIntegrator {}
+
+IBFEMethod {
+   IB_delta_fcn = "BSPLINE_6"
+   min_ghost_cell_width = 4
+   enable_logging = FALSE
+}
+
+
+INSStaggeredHierarchyIntegrator {
+   mu             = 1
+   rho            = 1
+}
+
+Main {
+   solver_type   = "STAGGERED"
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 32,32  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {tagging_method = "GRADIENT_DETECTOR"}
+LoadBalancer {}

--- a/tests/IBFE/interpolate_velocity_01.b.bspline-6.output
+++ b/tests/IBFE/interpolate_velocity_01.b.bspline-6.output
@@ -1,0 +1,7 @@
+Number of elements: 4813
+
+IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
+
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 2 4
+max vertex distance: 0.0135775
+max norm errors: 5.9302832162710927832e-05   8.8625949240750401259e-05

--- a/tests/IBFE/interpolate_velocity_01.b.ib-3.input
+++ b/tests/IBFE/interpolate_velocity_01.b.ib-3.input
@@ -1,0 +1,61 @@
+// same as interpolate_velocity_01.b.input, but explicitly for IB 3
+
+L   = 1.0
+MAX_LEVELS = 3
+REF_RATIO  = 4
+N = 16
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N
+DX  = L/NFINEST
+MFAC = 2.0
+ELEM_TYPE = "TRI3"
+
+VelocityInitialConditions {
+function_0 = "X_0 + 2*X_1*X_1"
+function_1 = "2*X_0 + 3*X_0*X_0 - 2*X_1"
+}
+
+PressureInitialConditions {function = "42.0"}
+
+IBHierarchyIntegrator {}
+
+IBFEMethod {
+   IB_delta_fcn = "IB_3"
+   enable_logging = FALSE
+}
+
+
+INSStaggeredHierarchyIntegrator {
+   mu             = 1
+   rho            = 1
+}
+
+Main {
+   solver_type   = "STAGGERED"
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 32,32  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {tagging_method = "GRADIENT_DETECTOR"}
+LoadBalancer {}

--- a/tests/IBFE/interpolate_velocity_01.b.ib-3.output
+++ b/tests/IBFE/interpolate_velocity_01.b.ib-3.output
@@ -1,0 +1,7 @@
+Number of elements: 4813
+
+IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
+
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
+max vertex distance: 0.0135775
+max norm errors: 5.312930355816369854e-05   7.939582292382230122e-05

--- a/tests/IBFE/interpolate_velocity_01.b.piecewise-cubic.input
+++ b/tests/IBFE/interpolate_velocity_01.b.piecewise-cubic.input
@@ -1,0 +1,61 @@
+// same as interpolate_velocity_01.b.input, but explicitly for piecewise cubic
+
+L   = 1.0
+MAX_LEVELS = 3
+REF_RATIO  = 4
+N = 16
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N
+DX  = L/NFINEST
+MFAC = 2.0
+ELEM_TYPE = "TRI3"
+
+VelocityInitialConditions {
+function_0 = "X_0 + 2*X_1*X_1"
+function_1 = "2*X_0 + 3*X_0*X_0 - 2*X_1"
+}
+
+PressureInitialConditions {function = "42.0"}
+
+IBHierarchyIntegrator {}
+
+IBFEMethod {
+   IB_delta_fcn = "PIECEWISE_CUBIC"
+   enable_logging = FALSE
+}
+
+
+INSStaggeredHierarchyIntegrator {
+   mu             = 1
+   rho            = 1
+}
+
+Main {
+   solver_type   = "STAGGERED"
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 32,32  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {tagging_method = "GRADIENT_DETECTOR"}
+LoadBalancer {}

--- a/tests/IBFE/interpolate_velocity_01.b.piecewise-cubic.output
+++ b/tests/IBFE/interpolate_velocity_01.b.piecewise-cubic.output
@@ -1,0 +1,7 @@
+Number of elements: 4813
+
+IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
+
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
+max vertex distance: 0.0135775
+max norm errors: 4.4044043089108697586e-05   6.5737765667983616424e-05

--- a/tests/IBFE/interpolate_velocity_01.cpp
+++ b/tests/IBFE/interpolate_velocity_01.cpp
@@ -275,7 +275,13 @@ main(int argc, char** argv)
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         const Pointer<SAMRAI::hier::Variable<NDIM> > u_var = time_integrator->getVelocityVariable();
         const Pointer<VariableContext> u_ghost_ctx = var_db->getContext("u_ghost");
-        const int u_ghost_idx = var_db->registerVariableAndContext(u_var, u_ghost_ctx, 3);
+
+        int n_ghosts = 3;
+        if (app_initializer->getComponentDatabase("IBFEMethod")->keyExists("min_ghost_cell_width"))
+        {
+            n_ghosts = app_initializer->getComponentDatabase("IBFEMethod")->getInteger("min_ghost_cell_width");
+        }
+        const int u_ghost_idx = var_db->registerVariableAndContext(u_var, u_ghost_ctx, n_ghosts);
 
         for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
         {


### PR DESCRIPTION
These explicitly use different interpolation kernels. The error is about equal to other interpolation results at the same grid resolution.

After several missteps I found a way to finally improve the performance of these FORTRAN kernels, but we should add tests first to guarantee I didn't break anything.