### PR TITLE
Use F95's FLOOR instead of lagrangian_floor.

### DIFF
--- a/ibtk/src/lagrangian/fortran/lagrangian_delta.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_delta.f.m4
@@ -36,23 +36,6 @@ c     SUCH DAMAGE.
 c
 define(REAL,`double precision')dnl
 define(INTEGER,`integer')dnl
-ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-c
-c     Returns the greatest integer less than or equal to x.
-c
-ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-c
-      function lagrangian_floor(x)
-c
-      implicit none
-      integer lagrangian_floor
-      double precision x
-c
-      lagrangian_floor = int(x)
-      if ( x.lt.0.d0 ) lagrangian_floor = lagrangian_floor - 1
-c
-      return
-      end
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -675,8 +675,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_piecewise_cubic_delta
 c
 c     Input.
@@ -718,10 +716,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -803,8 +801,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_piecewise_cubic_delta
 c
 c     Input.
@@ -846,10 +842,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -929,8 +925,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_ib_3_delta
 c
 c     Input.
@@ -972,10 +966,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -1052,8 +1046,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_ib_3_delta
 c
 c     Input.
@@ -1095,10 +1087,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -1680,8 +1672,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
 c
 c     Input.
 c
@@ -1728,10 +1718,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -1836,8 +1826,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
 c
 c     Input.
 c
@@ -1883,10 +1871,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -2318,8 +2306,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_3_delta
 c
 c     Input.
@@ -2361,10 +2347,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -2441,8 +2427,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_3_delta
 c
 c     Input.
@@ -2484,10 +2468,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -2562,8 +2546,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_4_delta
 c
 c     Input.
@@ -2605,10 +2587,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -2690,8 +2672,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_4_delta
 c
 c     Input.
@@ -2733,10 +2713,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -2816,8 +2796,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_5_delta
 c
 c     Input.
@@ -2859,10 +2837,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -2939,8 +2917,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_5_delta
 c
 c     Input.
@@ -2982,10 +2958,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -3060,8 +3036,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_6_delta
 c
 c     Input.
@@ -3103,10 +3077,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -3188,8 +3162,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_6_delta
 c
 c     Input.
@@ -3231,10 +3203,10 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
@@ -701,8 +701,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_piecewise_cubic_delta
 c
 c     Input.
@@ -744,13 +742,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -846,8 +844,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_piecewise_cubic_delta
 c
 c     Input.
@@ -889,13 +885,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -989,8 +985,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_ib_3_delta
 c
 c     Input.
@@ -1032,13 +1026,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -1129,8 +1123,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_ib_3_delta
 c
 c     Input.
@@ -1172,13 +1164,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -1868,8 +1860,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
 c
 c     Input.
 c
@@ -1916,13 +1906,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -2054,8 +2044,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
 c
 c     Input.
 c
@@ -2101,13 +2089,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -2649,8 +2637,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_3_delta
 c
 c     Input.
@@ -2692,13 +2678,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -2789,8 +2775,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_3_delta
 c
 c     Input.
@@ -2832,13 +2816,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -2927,8 +2911,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_4_delta
 c
 c     Input.
@@ -2970,13 +2952,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -3072,8 +3054,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_4_delta
 c
 c     Input.
@@ -3115,13 +3095,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -3215,8 +3195,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_5_delta
 c
 c     Input.
@@ -3258,13 +3236,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -3355,8 +3333,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_5_delta
 c
 c     Input.
@@ -3398,13 +3374,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -3493,8 +3469,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_6_delta
 c
 c     Input.
@@ -3536,13 +3510,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
@@ -3638,8 +3612,6 @@ c
 c
 c     Functions.
 c
-      EXTERNAL lagrangian_floor
-      INTEGER lagrangian_floor
       REAL lagrangian_bspline_6_delta
 c
 c     Input.
@@ -3681,13 +3653,13 @@ c
 c     Determine the Cartesian cell in which X(s) is located.
 c
          ic_center(0) =
-     &        lagrangian_floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
+     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
      &        + ilower0
          ic_center(1) =
-     &        lagrangian_floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
+     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
      &        + ilower1
          ic_center(2) =
-     &        lagrangian_floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
+     &        floor((X(2,s)+Xshift(2,l)-x_lower(2))/dx(2))
      &        + ilower2
 
          X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)


### PR DESCRIPTION
This can be better inlined by the compiler: callgrind reports that we use about 10% less instructions in the IB kernels with this switch. More precisely: since `lagrangian_floor` is `EXTERNAL` *and* in another translation unit the compiler cannot optimize it without something very fancy like `-fwhole-program` or link-time optimization.

One minor change in this patch is that `lagrangian_floor(-42)` is `-43` while `floor(-42)` is `-42`. I don't think this is a big deal since we are `floor`ing structure coordinates which are not going to end up at integer multiples of `dx` anyway.