### PR TITLE
Add unrolled variants of some kernels

### DIFF
--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -704,7 +704,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:3),w1(0:3)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -750,14 +750,14 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_piecewise_cubic_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_piecewise_cubic_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -769,8 +769,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
-     &                 +w0(ic0-ic_lower(0))
-     &                 *w1(ic1-ic_lower(1))
+     &                 +w(0,ic0-ic_lower(0))
+     &                 *w(1,ic1-ic_lower(1))
      &                 *u(ic0,ic1,d)
                enddo
             enddo
@@ -832,7 +832,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:3),w1(0:3)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -878,14 +878,14 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_piecewise_cubic_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_piecewise_cubic_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -896,8 +896,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w0(ic0-ic_lower(0))*
-     &                 w1(ic1-ic_lower(1))*
+     &                 w(0,ic0-ic_lower(0))*
+     &                 w(1,ic1-ic_lower(1))*
      &                 V(d,s)/(dx(0)*dx(1)))
                enddo
             enddo
@@ -958,7 +958,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:2),w1(0:2)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -999,14 +999,14 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_ib_3_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_ib_3_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -1018,8 +1018,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
-     &                 +w0(ic0-ic_lower(0))
-     &                 *w1(ic1-ic_lower(1))
+     &                 +w(0,ic0-ic_lower(0))
+     &                 *w(1,ic1-ic_lower(1))
      &                 *u(ic0,ic1,d)
                enddo
             enddo
@@ -1081,7 +1081,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:2),w1(0:2)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -1122,14 +1122,14 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_ib_3_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_ib_3_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -1140,8 +1140,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w0(ic0-ic_lower(0))*
-     &                 w1(ic1-ic_lower(1))*
+     &                 w(0,ic0-ic_lower(0))*
+     &                 w(1,ic1-ic_lower(1))*
      &                 V(d,s)/(dx(0)*dx(1)))
                enddo
             enddo
@@ -1712,7 +1712,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:4),w1(0:4)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:4)
 
       PARAMETER (K = (38.0d0 - sqrt(69.0d0))/60.0d0)
 c
@@ -1763,14 +1763,14 @@ c
      &          - 8400.0d0*K*(r**4) - 1400.0d0*(r**6)))
      &          /280.0d0
 
-         w0(0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
+         w(0,0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
      &                         r - 3.0d0*K*r + 2.0d0*r**2 - r**3)
-         w0(1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
+         w(0,1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
      &                   4.0d0*r + 3.0d0*K*r -       r**2 + r**3)
-         w0(2) = phi
-         w0(3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
+         w(0,2) = phi
+         w(0,3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
      &                   4.0d0*r - 3.0d0*K*r -       r**2 - r**3)
-         w0(4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
+         w(0,4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
      &                         r + 3.0d0*K*r + 2.0d0*r**2 + r**3)
 
          ic1 = ic_center(1)
@@ -1783,14 +1783,14 @@ c
      &          - 8400.0d0*K*(r**4) - 1400.0d0*(r**6)))
      &          /280.0d0
 
-         w1(0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
+         w(1,0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
      &                         r - 3.0d0*K*r + 2.0d0*r**2 - r**3)
-         w1(1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
+         w(1,1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
      &                   4.0d0*r + 3.0d0*K*r -       r**2 + r**3)
-         w1(2) = phi
-         w1(3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
+         w(1,2) = phi
+         w(1,3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
      &                   4.0d0*r - 3.0d0*K*r -       r**2 - r**3)
-         w1(4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
+         w(1,4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
      &                         r + 3.0d0*K*r + 2.0d0*r**2 + r**3)
 
 c
@@ -1801,8 +1801,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
-     &                 +w0(ic0-ic_lower(0))
-     &                 *w1(ic1-ic_lower(1))
+     &                 +w(0,ic0-ic_lower(0))
+     &                 *w(1,ic1-ic_lower(1))
      &                 *u(ic0,ic1,d)
                enddo
             enddo
@@ -1867,7 +1867,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:4),w1(0:4)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:4)
 
       PARAMETER (K = (38.0d0 - sqrt(69.0d0))/60.0d0)
 c
@@ -1919,14 +1919,14 @@ c
      &          - 8400.0d0*K*(r**4) - 1400.0d0*(r**6)))
      &          /280.0d0
 
-         w0(0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
+         w(0,0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
      &                         r - 3.0d0*K*r + 2.0d0*r**2 - r**3)
-         w0(1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
+         w(0,1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
      &                   4.0d0*r + 3.0d0*K*r -       r**2 + r**3)
-         w0(2) = phi
-         w0(3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
+         w(0,2) = phi
+         w(0,3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
      &                   4.0d0*r - 3.0d0*K*r -       r**2 - r**3)
-         w0(4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
+         w(0,4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
      &                         r + 3.0d0*K*r + 2.0d0*r**2 + r**3)
 
          ic1 = ic_center(1)
@@ -1939,14 +1939,14 @@ c
      &          - 8400.0d0*K*(r**4) - 1400.0d0*(r**6)))
      &          /280.0d0
 
-         w1(0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
+         w(1,0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
      &                         r - 3.0d0*K*r + 2.0d0*r**2 - r**3)
-         w1(1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
+         w(1,1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
      &                   4.0d0*r + 3.0d0*K*r -       r**2 + r**3)
-         w1(2) = phi
-         w1(3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
+         w(1,2) = phi
+         w(1,3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
      &                   4.0d0*r - 3.0d0*K*r -       r**2 - r**3)
-         w1(4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
+         w(1,4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
      &                         r + 3.0d0*K*r + 2.0d0*r**2 + r**3)
 
 c
@@ -1956,8 +1956,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w0(ic0-ic_lower(0))*
-     &                 w1(ic1-ic_lower(1))*
+     &                 w(0,ic0-ic_lower(0))*
+     &                 w(1,ic1-ic_lower(1))*
      &                 V(d,s)/(dx(0)*dx(1)))
                enddo
             enddo
@@ -2347,7 +2347,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:2),w1(0:2)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -2388,14 +2388,14 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_3_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_3_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -2407,8 +2407,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
-     &                 +w0(ic0-ic_lower(0))
-     &                 *w1(ic1-ic_lower(1))
+     &                 +w(0,ic0-ic_lower(0))
+     &                 *w(1,ic1-ic_lower(1))
      &                 *u(ic0,ic1,d)
                enddo
             enddo
@@ -2470,7 +2470,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:2),w1(0:2)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -2511,14 +2511,14 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_3_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_3_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -2529,8 +2529,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w0(ic0-ic_lower(0))*
-     &                 w1(ic1-ic_lower(1))*
+     &                 w(0,ic0-ic_lower(0))*
+     &                 w(1,ic1-ic_lower(1))*
      &                 V(d,s)/(dx(0)*dx(1)))
                enddo
             enddo
@@ -2591,7 +2591,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:3),w1(0:3)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -2637,14 +2637,14 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_4_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_4_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -2656,8 +2656,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
-     &                 +w0(ic0-ic_lower(0))
-     &                 *w1(ic1-ic_lower(1))
+     &                 +w(0,ic0-ic_lower(0))
+     &                 *w(1,ic1-ic_lower(1))
      &                 *u(ic0,ic1,d)
                enddo
             enddo
@@ -2719,7 +2719,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:3),w1(0:3)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -2765,14 +2765,14 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_4_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_4_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -2783,8 +2783,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w0(ic0-ic_lower(0))*
-     &                 w1(ic1-ic_lower(1))*
+     &                 w(0,ic0-ic_lower(0))*
+     &                 w(1,ic1-ic_lower(1))*
      &                 V(d,s)/(dx(0)*dx(1)))
                enddo
             enddo
@@ -2845,7 +2845,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:4),w1(0:4)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:4)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -2886,14 +2886,14 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_5_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_5_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -2905,8 +2905,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
-     &                 +w0(ic0-ic_lower(0))
-     &                 *w1(ic1-ic_lower(1))
+     &                 +w(0,ic0-ic_lower(0))
+     &                 *w(1,ic1-ic_lower(1))
      &                 *u(ic0,ic1,d)
                enddo
             enddo
@@ -2968,7 +2968,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:4),w1(0:4)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:4)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -3009,14 +3009,14 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_5_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_5_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -3027,8 +3027,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w0(ic0-ic_lower(0))*
-     &                 w1(ic1-ic_lower(1))*
+     &                 w(0,ic0-ic_lower(0))*
+     &                 w(1,ic1-ic_lower(1))*
      &                 V(d,s)/(dx(0)*dx(1)))
                enddo
             enddo
@@ -3089,7 +3089,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:5),w1(0:5)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:5)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -3135,14 +3135,14 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_6_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_6_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -3154,8 +3154,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   V(d,s) = V(d,s)
-     &                 +w0(ic0-ic_lower(0))
-     &                 *w1(ic1-ic_lower(1))
+     &                 +w(0,ic0-ic_lower(0))
+     &                 *w(1,ic1-ic_lower(1))
      &                 *u(ic0,ic1,d)
                enddo
             enddo
@@ -3217,7 +3217,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:5),w1(0:5)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:5)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -3263,14 +3263,14 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_6_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_6_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
@@ -3281,8 +3281,8 @@ c
             do ic1 = ic_lower(1),ic_upper(1)
                do ic0 = ic_lower(0),ic_upper(0)
                   u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w0(ic0-ic_lower(0))*
-     &                 w1(ic1-ic_lower(1))*
+     &                 w(0,ic0-ic_lower(0))*
+     &                 w(1,ic1-ic_lower(1))*
      &                 V(d,s)/(dx(0)*dx(1)))
                enddo
             enddo

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -797,17 +797,8 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  V(d,s) = V(d,s)
-     &                 +w(0,ic0-ic_lower(0))
-     &                 *w(1,ic1-ic_lower(1))
-     &                 *u(ic0,ic1,d)
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0), 4)
 c
 c     End loop over points.
 c
@@ -1046,17 +1037,8 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  V(d,s) = V(d,s)
-     &                 +w(0,ic0-ic_lower(0))
-     &                 *w(1,ic1-ic_lower(1))
-     &                 *u(ic0,ic1,d)
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0), 3)
 c
 c     End loop over points.
 c
@@ -1829,17 +1811,8 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  V(d,s) = V(d,s)
-     &                 +w(0,ic0-ic_lower(0))
-     &                 *w(1,ic1-ic_lower(1))
-     &                 *u(ic0,ic1,d)
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0), 5)
 c
 c     End loop over points.
 c
@@ -2435,17 +2408,8 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  V(d,s) = V(d,s)
-     &                 +w(0,ic0-ic_lower(0))
-     &                 *w(1,ic1-ic_lower(1))
-     &                 *u(ic0,ic1,d)
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0), 3)
 c
 c     End loop over points.
 c
@@ -2684,17 +2648,8 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  V(d,s) = V(d,s)
-     &                 +w(0,ic0-ic_lower(0))
-     &                 *w(1,ic1-ic_lower(1))
-     &                 *u(ic0,ic1,d)
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0), 4)
 c
 c     End loop over points.
 c
@@ -2933,17 +2888,8 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  V(d,s) = V(d,s)
-     &                 +w(0,ic0-ic_lower(0))
-     &                 *w(1,ic1-ic_lower(1))
-     &                 *u(ic0,ic1,d)
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0), 5)
 c
 c     End loop over points.
 c
@@ -3182,17 +3128,8 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  V(d,s) = V(d,s)
-     &                 +w(0,ic0-ic_lower(0))
-     &                 *w(1,ic1-ic_lower(1))
-     &                 *u(ic0,ic1,d)
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0), 6)
 c
 c     End loop over points.
 c

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
@@ -730,7 +730,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:3),w1(0:3),w2(0:3)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -783,21 +783,21 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_piecewise_cubic_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_piecewise_cubic_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_piecewise_cubic_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -810,9 +810,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
-     &                    +w0(ic0-ic_lower(0))
-     &                    *w1(ic1-ic_lower(1))
-     &                    *w2(ic2-ic_lower(2))
+     &                    +w(0,ic0-ic_lower(0))
+     &                    *w(1,ic1-ic_lower(1))
+     &                    *w(2,ic2-ic_lower(2))
      &                    *u(ic0,ic1,ic2,d)
                   enddo
                enddo
@@ -875,7 +875,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:3),w1(0:3),w2(0:3)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -928,21 +928,21 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_piecewise_cubic_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_piecewise_cubic_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_piecewise_cubic_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -954,9 +954,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      u(ic0,ic1,ic2,d) = u(ic0,ic1,ic2,d)+(
-     &                    w0(ic0-ic_lower(0))*
-     &                    w1(ic1-ic_lower(1))*
-     &                    w2(ic2-ic_lower(2))*
+     &                    w(0,ic0-ic_lower(0))*
+     &                    w(1,ic1-ic_lower(1))*
+     &                    w(2,ic2-ic_lower(2))*
      &                    V(d,s)/(dx(0)*dx(1)*dx(2)))
                   enddo
                enddo
@@ -1018,7 +1018,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:2),w1(0:2),w2(0:2)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -1066,21 +1066,21 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_ib_3_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_ib_3_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_ib_3_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -1093,9 +1093,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
-     &                    +w0(ic0-ic_lower(0))
-     &                    *w1(ic1-ic_lower(1))
-     &                    *w2(ic2-ic_lower(2))
+     &                    +w(0,ic0-ic_lower(0))
+     &                    *w(1,ic1-ic_lower(1))
+     &                    *w(2,ic2-ic_lower(2))
      &                    *u(ic0,ic1,ic2,d)
                   enddo
                enddo
@@ -1158,7 +1158,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:2),w1(0:2),w2(0:2)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -1206,21 +1206,21 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_ib_3_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_ib_3_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_ib_3_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -1232,9 +1232,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      u(ic0,ic1,ic2,d) = u(ic0,ic1,ic2,d)+(
-     &                    w0(ic0-ic_lower(0))*
-     &                    w1(ic1-ic_lower(1))*
-     &                    w2(ic2-ic_lower(2))*
+     &                    w(0,ic0-ic_lower(0))*
+     &                    w(1,ic1-ic_lower(1))*
+     &                    w(2,ic2-ic_lower(2))*
      &                    V(d,s)/(dx(0)*dx(1)*dx(2)))
                   enddo
                enddo
@@ -1900,7 +1900,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:4),w1(0:4),w2(0:4)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:4)
 
       PARAMETER (K = (38.0d0 - sqrt(69.0d0))/60.0d0)
 c
@@ -1958,14 +1958,14 @@ c
      &          - 8400.0d0*K*(r**4) - 1400.0d0*(r**6)))
      &          /280.0d0
 
-         w0(0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
+         w(0,0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
      &                         r - 3.0d0*K*r + 2.0d0*r**2 - r**3)
-         w0(1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
+         w(0,1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
      &                   4.0d0*r + 3.0d0*K*r -       r**2 + r**3)
-         w0(2) = phi
-         w0(3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
+         w(0,2) = phi
+         w(0,3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
      &                   4.0d0*r - 3.0d0*K*r -       r**2 - r**3)
-         w0(4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
+         w(0,4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
      &                         r + 3.0d0*K*r + 2.0d0*r**2 + r**3)
 
          ic1 = ic_center(1)
@@ -1978,14 +1978,14 @@ c
      &          - 8400.0d0*K*(r**4) - 1400.0d0*(r**6)))
      &          /280.0d0
 
-         w1(0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
+         w(1,0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
      &                         r - 3.0d0*K*r + 2.0d0*r**2 - r**3)
-         w1(1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
+         w(1,1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
      &                   4.0d0*r + 3.0d0*K*r -       r**2 + r**3)
-         w1(2) = phi
-         w1(3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
+         w(1,2) = phi
+         w(1,3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
      &                   4.0d0*r - 3.0d0*K*r -       r**2 - r**3)
-         w1(4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
+         w(1,4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
      &                         r + 3.0d0*K*r + 2.0d0*r**2 + r**3)
 
          ic2 = ic_center(2)
@@ -1998,14 +1998,14 @@ c
      &          - 8400.0d0*K*(r**4) - 1400.0d0*(r**6)))
      &          /280.0d0
 
-         w2(0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
+         w(2,0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
      &                         r - 3.0d0*K*r + 2.0d0*r**2 - r**3)
-         w2(1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
+         w(2,1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
      &                   4.0d0*r + 3.0d0*K*r -       r**2 + r**3)
-         w2(2) = phi
-         w2(3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
+         w(2,2) = phi
+         w(2,3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
      &                   4.0d0*r - 3.0d0*K*r -       r**2 - r**3)
-         w2(4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
+         w(2,4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
      &                         r + 3.0d0*K*r + 2.0d0*r**2 + r**3)
 
 c
@@ -2017,9 +2017,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
-     &                    +w0(ic0-ic_lower(0))
-     &                    *w1(ic1-ic_lower(1))
-     &                    *w2(ic2-ic_lower(2))
+     &                    +w(0,ic0-ic_lower(0))
+     &                    *w(1,ic1-ic_lower(1))
+     &                    *w(2,ic2-ic_lower(2))
      &                    *u(ic0,ic1,ic2,d)
                   enddo
                enddo
@@ -2085,7 +2085,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:4),w1(0:4),w2(0:4)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:4)
 
       PARAMETER (K = (38.0d0 - sqrt(69.0d0))/60.0d0)
 c
@@ -2143,14 +2143,14 @@ c
      &          - 8400.0d0*K*(r**4) - 1400.0d0*(r**6)))
      &          /280.0d0
 
-         w0(0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
+         w(0,0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
      &                         r - 3.0d0*K*r + 2.0d0*r**2 - r**3)
-         w0(1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
+         w(0,1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
      &                   4.0d0*r + 3.0d0*K*r -       r**2 + r**3)
-         w0(2) = phi
-         w0(3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
+         w(0,2) = phi
+         w(0,3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
      &                   4.0d0*r - 3.0d0*K*r -       r**2 - r**3)
-         w0(4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
+         w(0,4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
      &                         r + 3.0d0*K*r + 2.0d0*r**2 + r**3)
 
          ic1 = ic_center(1)
@@ -2163,14 +2163,14 @@ c
      &          - 8400.0d0*K*(r**4) - 1400.0d0*(r**6)))
      &          /280.0d0
 
-         w1(0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
+         w(1,0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
      &                         r - 3.0d0*K*r + 2.0d0*r**2 - r**3)
-         w1(1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
+         w(1,1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
      &                   4.0d0*r + 3.0d0*K*r -       r**2 + r**3)
-         w1(2) = phi
-         w1(3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
+         w(1,2) = phi
+         w(1,3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
      &                   4.0d0*r - 3.0d0*K*r -       r**2 - r**3)
-         w1(4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
+         w(1,4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
      &                         r + 3.0d0*K*r + 2.0d0*r**2 + r**3)
 
          ic2 = ic_center(2)
@@ -2183,14 +2183,14 @@ c
      &          - 8400.0d0*K*(r**4) - 1400.0d0*(r**6)))
      &          /280.0d0
 
-         w2(0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
+         w(2,0) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K +
      &                         r - 3.0d0*K*r + 2.0d0*r**2 - r**3)
-         w2(1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
+         w(2,1) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K -
      &                   4.0d0*r + 3.0d0*K*r -       r**2 + r**3)
-         w2(2) = phi
-         w2(3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
+         w(2,2) = phi
+         w(2,3) = (1.0d0/ 6.0d0) * ( 4.0d0 - 4.0d0*phi -       K +
      &                   4.0d0*r - 3.0d0*K*r -       r**2 - r**3)
-         w2(4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
+         w(2,4) = (1.0d0/12.0d0) * (-2.0d0 + 2.0d0*phi + 2.0d0*K -
      &                         r + 3.0d0*K*r + 2.0d0*r**2 + r**3)
 
 c
@@ -2201,9 +2201,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      u(ic0,ic1,ic2,d) = u(ic0,ic1,ic2,d)+(
-     &                    w0(ic0-ic_lower(0))*
-     &                    w1(ic1-ic_lower(1))*
-     &                    w2(ic2-ic_lower(2))*
+     &                    w(0,ic0-ic_lower(0))*
+     &                    w(1,ic1-ic_lower(1))*
+     &                    w(2,ic2-ic_lower(2))*
      &                    V(d,s)/(dx(0)*dx(1)*dx(2)))
                   enddo
                enddo
@@ -2678,7 +2678,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:2),w1(0:2),w2(0:2)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -2726,21 +2726,21 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_3_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_3_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_bspline_3_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -2818,7 +2818,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:2),w1(0:2),w2(0:2)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -2866,21 +2866,21 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_3_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_3_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_bspline_3_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -2892,9 +2892,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      u(ic0,ic1,ic2,d) = u(ic0,ic1,ic2,d)+(
-     &                    w0(ic0-ic_lower(0))*
-     &                    w1(ic1-ic_lower(1))*
-     &                    w2(ic2-ic_lower(2))*
+     &                    w(0,ic0-ic_lower(0))*
+     &                    w(1,ic1-ic_lower(1))*
+     &                    w(2,ic2-ic_lower(2))*
      &                    V(d,s)/(dx(0)*dx(1)*dx(2)))
                   enddo
                enddo
@@ -2956,7 +2956,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:3),w1(0:3),w2(0:3)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -3009,21 +3009,21 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_4_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_4_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_bspline_4_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -3036,9 +3036,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
-     &                    +w0(ic0-ic_lower(0))
-     &                    *w1(ic1-ic_lower(1))
-     &                    *w2(ic2-ic_lower(2))
+     &                    +w(0,ic0-ic_lower(0))
+     &                    *w(1,ic1-ic_lower(1))
+     &                    *w(2,ic2-ic_lower(2))
      &                    *u(ic0,ic1,ic2,d)
                   enddo
                enddo
@@ -3101,7 +3101,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:3),w1(0:3),w2(0:3)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -3154,21 +3154,21 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_4_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_4_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_bspline_4_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -3180,9 +3180,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      u(ic0,ic1,ic2,d) = u(ic0,ic1,ic2,d)+(
-     &                    w0(ic0-ic_lower(0))*
-     &                    w1(ic1-ic_lower(1))*
-     &                    w2(ic2-ic_lower(2))*
+     &                    w(0,ic0-ic_lower(0))*
+     &                    w(1,ic1-ic_lower(1))*
+     &                    w(2,ic2-ic_lower(2))*
      &                    V(d,s)/(dx(0)*dx(1)*dx(2)))
                   enddo
                enddo
@@ -3244,7 +3244,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:4),w1(0:4),w2(0:4)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:4)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -3292,21 +3292,21 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_5_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_5_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_bspline_5_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -3319,9 +3319,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
-     &                    +w0(ic0-ic_lower(0))
-     &                    *w1(ic1-ic_lower(1))
-     &                    *w2(ic2-ic_lower(2))
+     &                    +w(0,ic0-ic_lower(0))
+     &                    *w(1,ic1-ic_lower(1))
+     &                    *w(2,ic2-ic_lower(2))
      &                    *u(ic0,ic1,ic2,d)
                   enddo
                enddo
@@ -3384,7 +3384,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:4),w1(0:4),w2(0:4)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:4)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -3432,21 +3432,21 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_5_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_5_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_bspline_5_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -3458,9 +3458,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      u(ic0,ic1,ic2,d) = u(ic0,ic1,ic2,d)+(
-     &                    w0(ic0-ic_lower(0))*
-     &                    w1(ic1-ic_lower(1))*
-     &                    w2(ic2-ic_lower(2))*
+     &                    w(0,ic0-ic_lower(0))*
+     &                    w(1,ic1-ic_lower(1))*
+     &                    w(2,ic2-ic_lower(2))*
      &                    V(d,s)/(dx(0)*dx(1)*dx(2)))
                   enddo
                enddo
@@ -3522,7 +3522,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:5),w1(0:5),w2(0:5)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:5)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -3575,21 +3575,21 @@ c     Compute the interpolation weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_6_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_6_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_bspline_6_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -3602,9 +3602,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      V(d,s) = V(d,s)
-     &                    +w0(ic0-ic_lower(0))
-     &                    *w1(ic1-ic_lower(1))
-     &                    *w2(ic2-ic_lower(2))
+     &                    +w(0,ic0-ic_lower(0))
+     &                    *w(1,ic1-ic_lower(1))
+     &                    *w(2,ic2-ic_lower(2))
      &                    *u(ic0,ic1,ic2,d)
                   enddo
                enddo
@@ -3667,7 +3667,7 @@ c
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
       INTEGER d,l,s
 
-      REAL X_cell(0:NDIM-1),w0(0:5),w1(0:5),w2(0:5)
+      REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:5)
 c
 c     Prevent compiler warning about unused variables.
 c
@@ -3720,21 +3720,21 @@ c     Compute the spreading weights.
 c
          do ic0 = ic_lower(0),ic_upper(0)
             X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w0(ic0-ic_lower(0)) =
+            w(0,ic0-ic_lower(0)) =
      &           lagrangian_bspline_6_delta(
      &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
          enddo
 
          do ic1 = ic_lower(1),ic_upper(1)
             X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w1(ic1-ic_lower(1)) =
+            w(1,ic1-ic_lower(1)) =
      &           lagrangian_bspline_6_delta(
      &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
          enddo
 
          do ic2 = ic_lower(2),ic_upper(2)
             X_cell(2) = x_lower(2)+(dble(ic2-ilower2)+0.5d0)*dx(2)
-            w2(ic2-ic_lower(2)) =
+            w(2,ic2-ic_lower(2)) =
      &           lagrangian_bspline_6_delta(
      &           (X(2,s)+Xshift(2,l)-X_cell(2))/dx(2))
          enddo
@@ -3746,9 +3746,9 @@ c
                do ic1 = ic_lower(1),ic_upper(1)
                   do ic0 = ic_lower(0),ic_upper(0)
                      u(ic0,ic1,ic2,d) = u(ic0,ic1,ic2,d)+(
-     &                    w0(ic0-ic_lower(0))*
-     &                    w1(ic1-ic_lower(1))*
-     &                    w2(ic2-ic_lower(2))*
+     &                    w(0,ic0-ic_lower(0))*
+     &                    w(1,ic1-ic_lower(1))*
+     &                    w(2,ic2-ic_lower(2))*
      &                    V(d,s)/(dx(0)*dx(1)*dx(2)))
                   enddo
                enddo

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
@@ -843,20 +843,10 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
-               do ic1 = ic_lower(1),ic_upper(1)
-                  do ic0 = ic_lower(0),ic_upper(0)
-                     V(d,s) = V(d,s)
-     &                    +w(0,ic0-ic_lower(0))
-     &                    *w(1,ic1-ic_lower(1))
-     &                    *w(2,ic2-ic_lower(2))
-     &                    *u(ic0,ic1,ic2,d)
-                  enddo
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_3D_SPECIALIZE_FIXED_WIDTH(ic_lower(2), ic_upper(2),
+                                               ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0),
+                                               4)
 c
 c     End loop over points.
 c
@@ -1126,20 +1116,10 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
-               do ic1 = ic_lower(1),ic_upper(1)
-                  do ic0 = ic_lower(0),ic_upper(0)
-                     V(d,s) = V(d,s)
-     &                    +w(0,ic0-ic_lower(0))
-     &                    *w(1,ic1-ic_lower(1))
-     &                    *w(2,ic2-ic_lower(2))
-     &                    *u(ic0,ic1,ic2,d)
-                  enddo
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_3D_SPECIALIZE_FIXED_WIDTH(ic_lower(2), ic_upper(2),
+                                               ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0),
+                                               3)
 c
 c     End loop over points.
 c
@@ -2050,20 +2030,10 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
-               do ic1 = ic_lower(1),ic_upper(1)
-                  do ic0 = ic_lower(0),ic_upper(0)
-                     V(d,s) = V(d,s)
-     &                    +w(0,ic0-ic_lower(0))
-     &                    *w(1,ic1-ic_lower(1))
-     &                    *w(2,ic2-ic_lower(2))
-     &                    *u(ic0,ic1,ic2,d)
-                  enddo
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_3D_SPECIALIZE_FIXED_WIDTH(ic_lower(2), ic_upper(2),
+                                               ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0),
+                                               5)
 c
 c     End loop over points.
 c
@@ -2786,20 +2756,10 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
-               do ic1 = ic_lower(1),ic_upper(1)
-                  do ic0 = ic_lower(0),ic_upper(0)
-                     V(d,s) = V(d,s)
-     &                    +w0(ic0-ic_lower(0))
-     &                    *w1(ic1-ic_lower(1))
-     &                    *w2(ic2-ic_lower(2))
-     &                    *u(ic0,ic1,ic2,d)
-                  enddo
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_3D_SPECIALIZE_FIXED_WIDTH(ic_lower(2), ic_upper(2),
+                                               ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0),
+                                               3)
 c
 c     End loop over points.
 c
@@ -3069,20 +3029,10 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
-               do ic1 = ic_lower(1),ic_upper(1)
-                  do ic0 = ic_lower(0),ic_upper(0)
-                     V(d,s) = V(d,s)
-     &                    +w(0,ic0-ic_lower(0))
-     &                    *w(1,ic1-ic_lower(1))
-     &                    *w(2,ic2-ic_lower(2))
-     &                    *u(ic0,ic1,ic2,d)
-                  enddo
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_3D_SPECIALIZE_FIXED_WIDTH(ic_lower(2), ic_upper(2),
+                                               ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0),
+                                               4)
 c
 c     End loop over points.
 c
@@ -3352,20 +3302,10 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
-               do ic1 = ic_lower(1),ic_upper(1)
-                  do ic0 = ic_lower(0),ic_upper(0)
-                     V(d,s) = V(d,s)
-     &                    +w(0,ic0-ic_lower(0))
-     &                    *w(1,ic1-ic_lower(1))
-     &                    *w(2,ic2-ic_lower(2))
-     &                    *u(ic0,ic1,ic2,d)
-                  enddo
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_3D_SPECIALIZE_FIXED_WIDTH(ic_lower(2), ic_upper(2),
+                                               ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0),
+                                               5)
 c
 c     End loop over points.
 c
@@ -3635,20 +3575,10 @@ c
 c
 c     Interpolate u onto V.
 c
-         do d = 0,depth-1
-            V(d,s) = 0.d0
-            do ic2 = ic_lower(2),ic_upper(2)
-               do ic1 = ic_lower(1),ic_upper(1)
-                  do ic0 = ic_lower(0),ic_upper(0)
-                     V(d,s) = V(d,s)
-     &                    +w(0,ic0-ic_lower(0))
-     &                    *w(1,ic1-ic_lower(1))
-     &                    *w(2,ic2-ic_lower(2))
-     &                    *u(ic0,ic1,ic2,d)
-                  enddo
-               enddo
-            enddo
-         enddo
+         INTERPOLATE_3D_SPECIALIZE_FIXED_WIDTH(ic_lower(2), ic_upper(2),
+                                               ic_lower(1), ic_upper(1),
+                                               ic_lower(0), ic_upper(0),
+                                               6)
 c
 c     End loop over points.
 c


### PR DESCRIPTION
This lowers the cost of these corners (by counting instructions in callgrind) by about 25%. 