### PR TITLE
Verify consistent debug settings.

### DIFF
--- a/configure
+++ b/configure
@@ -42378,6 +42378,19 @@ CONTRIB_LIBS="$PACKAGE_CONTRIB_LIBS $CONTRIB_LIBS"
 
 LIBS="$LIBS $PACKAGE_CONTRIB_LIBS"
 
+# Check that SAMRAI and LIBMESH have mutually compatible debug settings:
+if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
+  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+    : # do nothing
+  else
+    as_fn_error $? "The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method." "$LINENO" 5
+  fi
+else # SAMRAI is in release mode
+  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+    as_fn_error $? "The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method." "$LINENO" 5
+  fi
+fi
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,19 @@ CONFIGURE_SAMRAI
 PACKAGE_SETUP_ENVIRONMENT
 LIBS="$LIBS $PACKAGE_CONTRIB_LIBS"
 
+# Check that SAMRAI and LIBMESH have mutually compatible debug settings:
+if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
+  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+    : # do nothing
+  else
+    AC_MSG_ERROR([The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method.])
+  fi
+else # SAMRAI is in release mode
+  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+    AC_MSG_ERROR([The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method.])
+  fi
+fi
+
 AC_SUBST(MPIEXEC)
 AC_SUBST(NUMDIFF)
 

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -43085,6 +43085,19 @@ CONTRIB_LIBS="$PACKAGE_CONTRIB_LIBS $CONTRIB_LIBS"
 
 LIBS="$LIBS $PACKAGE_CONTRIB_LIBS"
 
+# Check that SAMRAI and LIBMESH have mutually compatible debug settings:
+if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
+  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+    : # do nothing
+  else
+    as_fn_error $? "The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method." "$LINENO" 5
+  fi
+else # SAMRAI is in release mode
+  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+    as_fn_error $? "The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method." "$LINENO" 5
+  fi
+fi
+
 ###########################################################################
 # Additional header configuration.
 ###########################################################################

--- a/ibtk/configure.ac
+++ b/ibtk/configure.ac
@@ -92,6 +92,19 @@ CONFIGURE_SAMRAI
 PACKAGE_SETUP_ENVIRONMENT
 LIBS="$LIBS $PACKAGE_CONTRIB_LIBS"
 
+# Check that SAMRAI and LIBMESH have mutually compatible debug settings:
+if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
+  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+    : # do nothing
+  else
+    AC_MSG_ERROR([The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method.])
+  fi
+else # SAMRAI is in release mode
+  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+    AC_MSG_ERROR([The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method.])
+  fi
+fi
+
 ###########################################################################
 # Additional header configuration.
 ###########################################################################


### PR DESCRIPTION
Fixes #591.

We set 'NDEBUG' when SAMRAI is in release mode: hence, for compatibility with libMesh, we have to make sure libMesh is in opt or devel mode in this case so that NDEBUG is consistently defined.