### PR TITLE
NWT: correctly normalize quaternions.

### DIFF
--- a/doc/news/changes/minor/20181210AmneetBhalla
+++ b/doc/news/changes/minor/20181210AmneetBhalla
@@ -1,0 +1,4 @@
+Fixed: IBAMR now correctly normalizes quaternions in CIBFEMethod, CIBMethod, and
+IBFEDirectForcingKinematics.
+<br>
+(Amneet Bhalla, 2018/12/10)

--- a/src/IB/CIBFEMethod.cpp
+++ b/src/IB/CIBFEMethod.cpp
@@ -1309,7 +1309,7 @@ CIBFEMethod::getFromRestart()
         d_quaternion_current[part].x() = Q_coeffs[1];
         d_quaternion_current[part].y() = Q_coeffs[2];
         d_quaternion_current[part].z() = Q_coeffs[3];
-        d_quaternion_current[part].normalized();
+        d_quaternion_current[part].normalize();
     }
 } // getFromRestart
 

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -1717,7 +1717,7 @@ CIBMethod::getFromRestart()
         d_quaternion_current[struct_no].x() = Q_coeffs[1];
         d_quaternion_current[struct_no].y() = Q_coeffs[2];
         d_quaternion_current[struct_no].z() = Q_coeffs[3];
-        d_quaternion_current[struct_no].normalized();
+        d_quaternion_current[struct_no].normalize();
     }
 
     return;

--- a/src/IB/IBFEDirectForcingKinematics.cpp
+++ b/src/IB/IBFEDirectForcingKinematics.cpp
@@ -479,9 +479,9 @@ IBFEDirectForcingKinematics::getFromInput(Pointer<Database> input_db, bool is_fr
         d_quaternion_half = d_quaternion_current;
         d_quaternion_new = d_quaternion_current;
 
-        d_quaternion_current.normalized();
-        d_quaternion_half.normalized();
-        d_quaternion_new.normalized();
+        d_quaternion_current.normalize();
+        d_quaternion_half.normalize();
+        d_quaternion_new.normalize();
     }
 
     return;
@@ -513,7 +513,7 @@ IBFEDirectForcingKinematics::getFromRestart()
     d_quaternion_current.x() = Q_coeffs[1];
     d_quaternion_current.y() = Q_coeffs[2];
     d_quaternion_current.z() = Q_coeffs[3];
-    d_quaternion_current.normalized();
+    d_quaternion_current.normalize();
 
     return;
 } // getFromRestart


### PR DESCRIPTION
This was done on the NWT branch, though its a bug in IBAMR. In Eigen, `Quaterniond::normalize()` normalizes the quaternion, while `Quaterniond::normalized()` copies the current object and normalizes the copy.

I searched through the rest of the library to make sure that we always do this correctly. 