### PR TITLE
Use a more stable partitioner.

### DIFF
--- a/tests/IBFE/interpolate_velocity_01.cpp
+++ b/tests/IBFE/interpolate_velocity_01.cpp
@@ -47,6 +47,7 @@
 // Headers for basic libMesh objects
 #include <libmesh/boundary_info.h>
 #include <libmesh/equation_systems.h>
+#include <libmesh/linear_partitioner.h>
 #include <libmesh/mesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_triangle_interface.h>
@@ -179,6 +180,12 @@ main(int argc, char** argv)
         const int n_refinements = int(std::log2(R / dx));
         MeshTools::Generation::build_sphere(mesh, R, n_refinements, Utility::string_to_enum<ElemType>(elem_type), 10);
         mesh.prepare_for_use();
+        // metis does a good job partitioning, but the partitioning relies on
+        // random numbers: the seed changed in libMesh commit
+        // 98cede90ca8837688ee13aac5e299a3765f083da (between 1.3.1 and
+        // 1.4.0). Hence, to achieve consistent partitioning, use a simpler partitioning scheme:
+        LinearPartitioner partitioner;
+        partitioner.partition(mesh);
 
         plog << "Number of elements: " << mesh.n_active_elem() << std::endl;
 

--- a/tests/IBFE/interpolate_velocity_01_2d.a.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.a.mpirun=4.output
@@ -4,4 +4,4 @@ IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
 
 IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 max vertex distance: 0.0236627
-max norm errors: 0.00017567228356929476263   0.00026357631227225120085
+max norm errors: 0.0001756721356397372702   0.00021896759573336588289

--- a/tests/IBFE/interpolate_velocity_01_2d.b.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.mpirun=4.output
@@ -4,4 +4,4 @@ IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
 
 IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 max vertex distance: 0.0127652
-max norm errors: 4.6873248912282505785e-05   7.2113280273677915488e-05
+max norm errors: 4.8066888366338211824e-05   5.4930730361668622663e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.c.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.c.mpirun=4.output
@@ -4,4 +4,4 @@ IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
 
 IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 max vertex distance: 0.00668694
-max norm errors: 1.2820255439693895028e-05   1.9229647464591437256e-05
+max norm errors: 1.2820255439027761213e-05   1.3889043202819362222e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.d.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.d.mpirun=4.output
@@ -4,4 +4,4 @@ IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
 
 IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 max vertex distance: 0.00348279
-max norm errors: 3.2085871877196581181e-06   4.8141662443157429152e-06
+max norm errors: 3.2305877768479263068e-06   3.6510271375078673373e-06

--- a/tests/IBFE/interpolate_velocity_01_3d.a.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.a.mpirun=4.output
@@ -4,4 +4,4 @@ IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
 
 IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 max vertex distance: 0.112856
-max norm errors: 0.00093667747957293379102   0.0016180953166274880672   0.0012822607172290334532
+max norm errors: 0.00093667747957248970181   0.0016901433827078427008   0.0013516244805421573361

--- a/tests/IBFE/interpolate_velocity_01_3d.b.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.mpirun=4.output
@@ -4,4 +4,4 @@ IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
 
 IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 max vertex distance: 0.0632458
-max norm errors: 0.000200482980059923932   0.00029859939530796353324   0.00027823845380359202295
+max norm errors: 0.00020177932299292322682   0.00031747846973390059233   0.00030694718823986999467

--- a/tests/IBFE/interpolate_velocity_01_3d.c.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.c.mpirun=4.output
@@ -4,4 +4,4 @@ IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
 
 IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 max vertex distance: 0.0328818
-max norm errors: 6.3268666427251929463e-05   7.8795249760732488653e-05   7.7374204886515585144e-05
+max norm errors: 4.6699731008126299514e-05   9.2891170307640713588e-05   7.6211749438059861461e-05


### PR DESCRIPTION
The default partitioner for libMesh, metis, does a good job, but the way it is seeded changed in libMesh 1.4.0: i.e., we get different partitionings with different versions of libMesh. This results in (for reasons I don't fully understand) slightly different solutions to the velocity projection problem.

Get around the issue by using libMesh's linear partitioner, which is much more consistent than metis (and always available).

Fixes #636. I don't like that we can get different answers with different partitioners but this gives us the same numbers across different libMesh versions.