### PR TITLE
Fix compilation without libMesh.

### DIFF
--- a/configure
+++ b/configure
@@ -42379,16 +42379,18 @@ CONTRIB_LIBS="$PACKAGE_CONTRIB_LIBS $CONTRIB_LIBS"
 LIBS="$LIBS $PACKAGE_CONTRIB_LIBS"
 
 # Check that SAMRAI and LIBMESH have mutually compatible debug settings:
-if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
-  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
-    : # do nothing
-  else
-    as_fn_error $? "The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method." "$LINENO" 5
-  fi
-else # SAMRAI is in release mode
-  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
-    as_fn_error $? "The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method." "$LINENO" 5
-  fi
+if test "$LIBMESH_ENABLED" = yes; then
+    if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
+        if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+        : # do nothing
+        else
+            as_fn_error $? "The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method." "$LINENO" 5
+        fi
+        else # SAMRAI is in release mode
+        if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+            as_fn_error $? "The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method." "$LINENO" 5
+        fi
+    fi
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -107,16 +107,18 @@ PACKAGE_SETUP_ENVIRONMENT
 LIBS="$LIBS $PACKAGE_CONTRIB_LIBS"
 
 # Check that SAMRAI and LIBMESH have mutually compatible debug settings:
-if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
-  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
-    : # do nothing
-  else
-    AC_MSG_ERROR([The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method.])
-  fi
-else # SAMRAI is in release mode
-  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
-    AC_MSG_ERROR([The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method.])
-  fi
+if test "$LIBMESH_ENABLED" = yes; then
+    if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
+        if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+        : # do nothing
+        else
+            AC_MSG_ERROR([The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method.])
+        fi
+        else # SAMRAI is in release mode
+        if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+            AC_MSG_ERROR([The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method.])
+        fi
+    fi
 fi
 
 AC_SUBST(MPIEXEC)

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -43084,17 +43084,20 @@ CONTRIB_LIBS="$PACKAGE_CONTRIB_LIBS $CONTRIB_LIBS"
 LIBS="$LIBS $PACKAGE_CONTRIB_LIBS"
 
 # Check that SAMRAI and LIBMESH have mutually compatible debug settings:
-if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
-  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
-    : # do nothing
-  else
-    as_fn_error $? "The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method." "$LINENO" 5
-  fi
-else # SAMRAI is in release mode
-  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
-    as_fn_error $? "The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method." "$LINENO" 5
-  fi
+if test "$LIBMESH_ENABLED" = yes; then
+    if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
+        if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+        : # do nothing
+        else
+            as_fn_error $? "The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method." "$LINENO" 5
+        fi
+        else # SAMRAI is in release mode
+        if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+            as_fn_error $? "The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method." "$LINENO" 5
+        fi
+    fi
 fi
+
 
 ###########################################################################
 # Additional header configuration.

--- a/ibtk/configure.ac
+++ b/ibtk/configure.ac
@@ -93,17 +93,20 @@ PACKAGE_SETUP_ENVIRONMENT
 LIBS="$LIBS $PACKAGE_CONTRIB_LIBS"
 
 # Check that SAMRAI and LIBMESH have mutually compatible debug settings:
-if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
-  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
-    : # do nothing
-  else
-    AC_MSG_ERROR([The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method.])
-  fi
-else # SAMRAI is in release mode
-  if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
-    AC_MSG_ERROR([The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method.])
-  fi
+if test "$LIBMESH_ENABLED" = yes; then
+    if test "$SAMRAI_DEBUG_CHECK_ASSERTIONS" = true; then
+        if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+        : # do nothing
+        else
+            AC_MSG_ERROR([The detected SAMRAI library was compiled with debugging support enabled but the detected libMesh library was not. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either a devel or debug libMesh method.])
+        fi
+        else # SAMRAI is in release mode
+        if test "$LIBMESH_METHOD" = dbg || test "$LIBMESH_METHOD" = devel; then
+            AC_MSG_ERROR([The detected SAMRAI library was compiled without debugging support enabled but the detected libMesh library was. This incompatibility is not allowed since different debug macros can lead to linkage errors. Please reconfigure IBAMR with either an opt, pro, or oprof libMesh method.])
+        fi
+    fi
 fi
+
 
 ###########################################################################
 # Additional header configuration.


### PR DESCRIPTION
The test suite doesn't work without libMesh (though we can compile and run a subset of tests), but I am willing to let that pass for now.