### PR TITLE
Suppress another boost warning.

### DIFF
--- a/ibtk/include/ibtk/ibtk_macros.h
+++ b/ibtk/include/ibtk/ibtk_macros.h
@@ -52,6 +52,7 @@ _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"") \
 _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")  \
 _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")     \
 _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")     \
+_Pragma("GCC diagnostic ignored \"-Wunused-local-typedefs\"")   \
 _Pragma("GCC diagnostic ignored \"-Wunneeded-internal-declaration\"")
 
 #define IBTK_ENABLE_EXTRA_WARNINGS _Pragma("GCC diagnostic pop")


### PR DESCRIPTION
This one shows up in the multi_array header.