### PR TITLE
Fix elem_hmax_02's link libraries.

### DIFF
--- a/tests/IBTK/Makefile.am
+++ b/tests/IBTK/Makefile.am
@@ -11,7 +11,7 @@ elem_hmax_01_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 elem_hmax_01_SOURCES = elem_hmax_01.cpp
 
 elem_hmax_02_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=3
-elem_hmax_02_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+elem_hmax_02_LDADD = $(IBAMR_LDFLAGS) $(IBAMR3d_LIBS) $(IBAMR_LIBS)
 elem_hmax_02_SOURCES = elem_hmax_02.cpp
 
 mpi_type_wrappers_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2

--- a/tests/IBTK/Makefile.in
+++ b/tests/IBTK/Makefile.in
@@ -141,7 +141,7 @@ elem_hmax_01_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 am_elem_hmax_02_OBJECTS = elem_hmax_02-elem_hmax_02.$(OBJEXT)
 elem_hmax_02_OBJECTS = $(am_elem_hmax_02_OBJECTS)
-elem_hmax_02_DEPENDENCIES = $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+elem_hmax_02_DEPENDENCIES = $(IBAMR3d_LIBS) $(IBAMR_LIBS)
 elem_hmax_02_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(elem_hmax_02_CXXFLAGS) \
 	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
@@ -662,7 +662,7 @@ elem_hmax_01_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 elem_hmax_01_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 elem_hmax_01_SOURCES = elem_hmax_01.cpp
 elem_hmax_02_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=3
-elem_hmax_02_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+elem_hmax_02_LDADD = $(IBAMR_LDFLAGS) $(IBAMR3d_LIBS) $(IBAMR_LIBS)
 elem_hmax_02_SOURCES = elem_hmax_02.cpp
 mpi_type_wrappers_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 mpi_type_wrappers_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)


### PR DESCRIPTION
This was caught by @abarret. Fortunately, since the test doesn't use SAMRAI and dimensionality is a run-time parameter for libMesh, the error is harmless.