### PR TITLE
Suppress a new GCC warning.

### DIFF
--- a/ibtk/include/ibtk/ibtk_macros.h
+++ b/ibtk/include/ibtk/ibtk_macros.h
@@ -53,6 +53,7 @@ _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")  \
 _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")     \
 _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")     \
 _Pragma("GCC diagnostic ignored \"-Wunused-local-typedefs\"")   \
+_Pragma("GCC diagnostic ignored \"-Wdeprecated-copy\"")         \
 _Pragma("GCC diagnostic ignored \"-Wunneeded-internal-declaration\"")
 
 #define IBTK_ENABLE_EXTRA_WARNINGS _Pragma("GCC diagnostic pop")


### PR DESCRIPTION
Implicitly-generated copy constructors where, in some circumstances, deprecated in C++11, but we are a long way from this being actually removed from C++.

Lets put this in 0.5 and then get ready to tag a release.