### PR TITLE
Fix some code to work with surface meshes.

### DIFF
--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -1032,7 +1032,7 @@ get_max_edge_length(const libMesh::Elem* const elem, const MultiArray& X_node)
 {
 #ifndef NDEBUG
     TBOX_ASSERT(elem->n_nodes() == X_node.shape()[0]);
-    TBOX_ASSERT(elem->dim() == X_node.shape()[1]);
+    TBOX_ASSERT(NDIM <= X_node.shape()[1]);
 #endif
     const libMesh::ElemType elem_type = elem->type();
 


### PR DESCRIPTION
We only really require that X_node have NDIM columns. This should make the code work correctly for surface meshes in debug mode.

I thought we had fixed this, but alas, we did not. Caught by @xxjaehoxx.