### PR TITLE
Add a quadratic interpolation option at codim 1 physical boundaries.

### DIFF
--- a/ibtk/include/ibtk/CartCellRobinPhysBdryOp.h
+++ b/ibtk/include/ibtk/CartCellRobinPhysBdryOp.h
@@ -107,39 +107,48 @@ public:
      * \param patch_data_index  Patch data index requiring ghost cell filling.
      * \param bc_coef           Robin boundary conditions to use with this class.
      * \param homogeneous_bc    Whether to employ the homogeneous form of the boundary
-     *conditions.
+     * conditions.
+     * \param type              Type of interpolation to use. Valid options are "LINEAR"
+     * or "QUADRATIC". Defaults to "LINEAR".
      */
     CartCellRobinPhysBdryOp(int patch_data_index,
                             SAMRAI::solv::RobinBcCoefStrategy<NDIM>* bc_coef,
-                            bool homogeneous_bc = false);
+                            bool homogeneous_bc = false,
+                            std::string type = "LINEAR");
 
     /*!
      * \brief Constructor to fill boundary conditions for scalar-valued
      * quantities.
      *
      * \param patch_data_indices  Collection of patch data indices which require ghost cell
-     *filling.
+     * filling.
      * \param bc_coef             Robin boundary conditions to use with this class.
      * \param homogeneous_bc      Whether to employ the homogeneous form of the boundary
-     *conditions.
+     * conditions.
+     * \param type              Type of interpolation to use. Valid options are "LINEAR"
+     * or "QUADRATIC". Defaults to "LINEAR".
      */
     CartCellRobinPhysBdryOp(const std::set<int>& patch_data_indices,
                             SAMRAI::solv::RobinBcCoefStrategy<NDIM>* bc_coef,
-                            bool homogeneous_bc = false);
+                            bool homogeneous_bc = false,
+                            std::string type = "LINEAR");
 
     /*!
      * \brief Constructor to fill boundary conditions for scalar-valued
      * quantities.
      *
      * \param patch_data_indices  Collection of patch data indices which require ghost cell
-     *filling.
+     * filling.
      * \param bc_coef             Robin boundary conditions to use with this class.
      * \param homogeneous_bc      Whether to employ the homogeneous form of the boundary
-     *conditions.
+     * conditions.
+     * \param type              Type of interpolation to use. Valid options are "LINEAR"
+     * or "QUADRATIC". Defaults to "LINEAR".
      */
     CartCellRobinPhysBdryOp(const SAMRAI::hier::ComponentSelector& patch_data_indices,
                             SAMRAI::solv::RobinBcCoefStrategy<NDIM>* bc_coef,
-                            bool homogeneous_bc = false);
+                            bool homogeneous_bc = false,
+                            std::string type = "LINEAR");
 
     /*!
      * \brief Constructor to fill boundary conditions for vector-valued
@@ -149,39 +158,48 @@ public:
      * \param patch_data_index  Patch data index requiring ghost cell filling.
      * \param bc_coefs          Robin boundary conditions to use with this class.
      * \param homogeneous_bc    Whether to employ the homogeneous form of the boundary
-     *conditions.
+     * conditions.
+     * \param type              Type of interpolation to use. Valid options are "LINEAR"
+     * or "QUADRATIC". Defaults to "LINEAR".
      */
     CartCellRobinPhysBdryOp(int patch_data_index,
                             const std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                            bool homogeneous_bc = false);
+                            bool homogeneous_bc = false,
+                            std::string type = "LINEAR");
 
     /*!
      * \brief Constructor to fill boundary conditions for vector-valued
      * quantities.
      *
      * \param patch_data_indices  Collection of patch data indices which require ghost cell
-     *filling.
+     * filling.
      * \param bc_coefs            Robin boundary conditions to use with this class.
      * \param homogeneous_bc      Whether to employ the homogeneous form of the boundary
-     *conditions.
+     * conditions.
+     * \param type              Type of interpolation to use. Valid options are "LINEAR"
+     * or "QUADRATIC". Defaults to "LINEAR".
      */
     CartCellRobinPhysBdryOp(const std::set<int>& patch_data_indices,
                             const std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                            bool homogeneous_bc = false);
+                            bool homogeneous_bc = false,
+                            std::string type = "LINEAR");
 
     /*!
      * \brief Constructor to fill boundary conditions for vector-valued
      * quantities.
      *
      * \param patch_data_indices  Collection of patch data indices which require ghost cell
-     *filling.
+     * filling.
      * \param bc_coefs            Robin boundary conditions to use with this class.
      * \param homogeneous_bc      Whether to employ the homogeneous form of the boundary
-     *conditions.
+     * conditions.
+     * \param type              Type of interpolation to use. Valid options are "LINEAR"
+     * or "QUADRATIC". Defaults to "LINEAR".
      */
     CartCellRobinPhysBdryOp(const SAMRAI::hier::ComponentSelector& patch_data_indices,
                             const std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                            bool homogeneous_bc = false);
+                            bool homogeneous_bc = false,
+                            std::string type = "LINEAR");
 
     /*!
      * \brief Destructor.
@@ -203,8 +221,7 @@ public:
      * \param patch                Patch on which to fill boundary data.
      * \param fill_time            Double simulation time for boundary filling.
      * \param ghost_width_to_fill  Integer vector describing maximum ghost width to fill over
-     *all
-     *registered scratch components.
+     * all registered scratch components.
      */
     void setPhysicalBoundaryConditions(SAMRAI::hier::Patch<NDIM>& patch,
                                        double fill_time,
@@ -228,8 +245,7 @@ public:
      * \param patch                Patch on which to fill boundary data.
      * \param fill_time            Double simulation time for boundary filling.
      * \param ghost_width_to_fill  Integer vector describing maximum ghost width to fill over
-     *all
-     *registered scratch components.
+     * all registered scratch components.
      */
     void accumulateFromPhysicalBoundaryData(SAMRAI::hier::Patch<NDIM>& patch,
                                             double fill_time,
@@ -286,6 +302,8 @@ private:
                                    const SAMRAI::hier::Patch<NDIM>& patch,
                                    bool adjoint_op);
 #endif
+
+    std::string d_type = "LINEAR";
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/CartSideRobinPhysBdryOp.h
+++ b/ibtk/include/ibtk/CartSideRobinPhysBdryOp.h
@@ -103,11 +103,14 @@ public:
      * \param patch_data_index  Patch data index requiring ghost cell filling.
      * \param bc_coefs          Robin boundary conditions to use with this class.
      * \param homogeneous_bc    Whether to employ the homogeneous form of the boundary
-     *conditions.
+     * conditions.
+     * \param type              Type of interpolation to use. Valid options are "LINEAR"
+     * or "QUADRATIC". Defaults to "LINEAR".
      */
     CartSideRobinPhysBdryOp(int patch_data_index,
                             const std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                            bool homogeneous_bc = false);
+                            bool homogeneous_bc = false,
+                            std::string type = "LINEAR");
 
     /*!
      * \brief Constructor to fill boundary conditions for vector-valued
@@ -115,14 +118,17 @@ public:
      * vector component.
      *
      * \param patch_data_indices  Collection of patch data indices which require ghost cell
-     *filling.
+     * filling.
      * \param bc_coefs            Robin boundary conditions to use with this class.
      * \param homogeneous_bc      Whether to employ the homogeneous form of the boundary
-     *conditions.
+     * conditions.
+     * \param type              Type of interpolation to use. Valid options are "LINEAR"
+     * or "QUADRATIC". Defaults to "LINEAR".
      */
     CartSideRobinPhysBdryOp(const std::set<int>& patch_data_indices,
                             const std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                            bool homogeneous_bc = false);
+                            bool homogeneous_bc = false,
+                            std::string type = "LINEAR");
 
     /*!
      * \brief Constructor to fill boundary conditions for vector-valued
@@ -130,14 +136,17 @@ public:
      * vector component.
      *
      * \param patch_data_indices  Collection of patch data indices which require ghost cell
-     *filling.
+     * filling.
      * \param bc_coefs            Robin boundary conditions to use with this class.
      * \param homogeneous_bc      Whether to employ the homogeneous form of the boundary
-     *conditions.
+     * conditions.
+     * \param type              Type of interpolation to use. Valid options are "LINEAR"
+     * or "QUADRATIC". Defaults to "LINEAR".
      */
     CartSideRobinPhysBdryOp(const SAMRAI::hier::ComponentSelector& patch_data_indices,
                             const std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                            bool homogeneous_bc = false);
+                            bool homogeneous_bc = false,
+                            std::string type = "LINEAR");
 
     /*!
      * \brief Destructor.
@@ -159,8 +168,7 @@ public:
      * \param patch                Patch on which to fill boundary data.
      * \param fill_time            Double simulation time for boundary filling.
      * \param ghost_width_to_fill  Integer vector describing maximum ghost width to fill over
-     *all
-     *registered scratch components.
+     * all registered scratch components.
      */
     void setPhysicalBoundaryConditions(SAMRAI::hier::Patch<NDIM>& patch,
                                        double fill_time,
@@ -184,8 +192,7 @@ public:
      * \param patch                Patch on which to fill boundary data.
      * \param fill_time            Double simulation time for boundary filling.
      * \param ghost_width_to_fill  Integer vector describing maximum ghost width to fill over
-     *all
-     *registered scratch components.
+     * all registered scratch components.
      */
     void accumulateFromPhysicalBoundaryData(SAMRAI::hier::Patch<NDIM>& patch,
                                             double fill_time,
@@ -256,6 +263,8 @@ private:
                                    const SAMRAI::hier::Patch<NDIM>& patch,
                                    bool adjoint_op);
 #endif
+
+    std::string d_type = "LINEAR";
 };
 } // namespace IBTK
 

--- a/ibtk/include/ibtk/HierarchyGhostCellInterpolation.h
+++ b/ibtk/include/ibtk/HierarchyGhostCellInterpolation.h
@@ -118,7 +118,8 @@ public:
             const std::string& phys_bdry_extrap_type = "NONE",
             bool consistent_type_2_bdry = false,
             SAMRAI::solv::RobinBcCoefStrategy<NDIM>* robin_bc_coef = NULL,
-            SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM> > fill_pattern = NULL)
+            SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM> > fill_pattern = NULL,
+            const std::string& phys_bdry_type = "LINEAR")
             : d_dst_data_idx(data_idx),
               d_src_data_idx(data_idx),
               d_refine_op_name(refine_op_name),
@@ -128,7 +129,8 @@ public:
               d_consistent_type_2_bdry(consistent_type_2_bdry),
               d_robin_bc_coefs(robin_bc_coef ? std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>(1, robin_bc_coef) :
                                                std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>()),
-              d_fill_pattern(fill_pattern ? fill_pattern : new SAMRAI::xfer::BoxGeometryFillPattern<NDIM>())
+              d_fill_pattern(fill_pattern ? fill_pattern : new SAMRAI::xfer::BoxGeometryFillPattern<NDIM>()),
+              d_phys_bdry_type(phys_bdry_type)
         {
             // intentionally blank
             return;
@@ -145,7 +147,8 @@ public:
             const std::string& phys_bdry_extrap_type,
             bool consistent_type_2_bdry,
             const std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>& robin_bc_coefs,
-            SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM> > fill_pattern = NULL)
+            SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM> > fill_pattern = NULL,
+            const std::string& phys_bdry_type = "LINEAR")
             : d_dst_data_idx(data_idx),
               d_src_data_idx(data_idx),
               d_refine_op_name(refine_op_name),
@@ -154,7 +157,8 @@ public:
               d_phys_bdry_extrap_type(phys_bdry_extrap_type),
               d_consistent_type_2_bdry(consistent_type_2_bdry),
               d_robin_bc_coefs(robin_bc_coefs),
-              d_fill_pattern(fill_pattern ? fill_pattern : new SAMRAI::xfer::BoxGeometryFillPattern<NDIM>())
+              d_fill_pattern(fill_pattern ? fill_pattern : new SAMRAI::xfer::BoxGeometryFillPattern<NDIM>()),
+              d_phys_bdry_type(phys_bdry_type)
         {
             // intentionally blank
             return;
@@ -172,7 +176,8 @@ public:
             const std::string& phys_bdry_extrap_type,
             bool consistent_type_2_bdry,
             SAMRAI::solv::RobinBcCoefStrategy<NDIM>* robin_bc_coef,
-            SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM> > fill_pattern = NULL)
+            SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM> > fill_pattern = NULL,
+            const std::string& phys_bdry_type = "LINEAR")
             : d_dst_data_idx(dst_data_idx),
               d_src_data_idx(src_data_idx),
               d_refine_op_name(refine_op_name),
@@ -182,7 +187,8 @@ public:
               d_consistent_type_2_bdry(consistent_type_2_bdry),
               d_robin_bc_coefs(robin_bc_coef ? std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>(1, robin_bc_coef) :
                                                std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>()),
-              d_fill_pattern(fill_pattern ? fill_pattern : new SAMRAI::xfer::BoxGeometryFillPattern<NDIM>())
+              d_fill_pattern(fill_pattern ? fill_pattern : new SAMRAI::xfer::BoxGeometryFillPattern<NDIM>()),
+              d_phys_bdry_type(phys_bdry_type)
         {
             // intentionally blank
             return;
@@ -200,7 +206,8 @@ public:
             const std::string& phys_bdry_extrap_type,
             bool consistent_type_2_bdry,
             const std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>& robin_bc_coefs,
-            SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM> > fill_pattern = NULL)
+            SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM> > fill_pattern = NULL,
+            const std::string& phys_bdry_type = "LINEAR")
             : d_dst_data_idx(dst_data_idx),
               d_src_data_idx(src_data_idx),
               d_refine_op_name(refine_op_name),
@@ -209,7 +216,8 @@ public:
               d_phys_bdry_extrap_type(phys_bdry_extrap_type),
               d_consistent_type_2_bdry(consistent_type_2_bdry),
               d_robin_bc_coefs(robin_bc_coefs),
-              d_fill_pattern(fill_pattern ? fill_pattern : new SAMRAI::xfer::BoxGeometryFillPattern<NDIM>())
+              d_fill_pattern(fill_pattern ? fill_pattern : new SAMRAI::xfer::BoxGeometryFillPattern<NDIM>()),
+              d_phys_bdry_type(phys_bdry_type)
         {
             // intentionally blank
             return;
@@ -229,7 +237,8 @@ public:
               d_phys_bdry_extrap_type(from.d_phys_bdry_extrap_type),
               d_consistent_type_2_bdry(from.d_consistent_type_2_bdry),
               d_robin_bc_coefs(from.d_robin_bc_coefs),
-              d_fill_pattern(from.d_fill_pattern)
+              d_fill_pattern(from.d_fill_pattern),
+              d_phys_bdry_type(from.d_phys_bdry_type)
         {
             // intentionally blank
             return;
@@ -255,6 +264,7 @@ public:
                 d_consistent_type_2_bdry = that.d_consistent_type_2_bdry;
                 d_robin_bc_coefs = that.d_robin_bc_coefs;
                 d_fill_pattern = that.d_fill_pattern;
+                d_phys_bdry_type = that.d_phys_bdry_type;
             }
             return *this;
         } // operator=
@@ -277,6 +287,7 @@ public:
         bool d_consistent_type_2_bdry;
         std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*> d_robin_bc_coefs;
         SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM> > d_fill_pattern;
+        std::string d_phys_bdry_type;
     };
 
     /*!

--- a/ibtk/src/boundary/HierarchyGhostCellInterpolation.cpp
+++ b/ibtk/src/boundary/HierarchyGhostCellInterpolation.cpp
@@ -236,6 +236,7 @@ HierarchyGhostCellInterpolation::initializeOperatorState(
     {
         const int dst_data_idx = d_transaction_comps[comp_idx].d_dst_data_idx;
         const int src_data_idx = d_transaction_comps[comp_idx].d_src_data_idx;
+        const std::string& phys_bdry_type = d_transaction_comps[comp_idx].d_phys_bdry_type;
         Pointer<Variable<NDIM> > var;
         var_db->mapIndexToVariable(src_data_idx, var);
         Pointer<CellVariable<NDIM, double> > cc_var = var;
@@ -324,14 +325,16 @@ HierarchyGhostCellInterpolation::initializeOperatorState(
         }
         if (!null_bc_coefs && cc_var)
         {
-            d_cc_robin_bc_ops[comp_idx] = new CartCellRobinPhysBdryOp(dst_data_idx, robin_bc_coefs, d_homogeneous_bc);
+            d_cc_robin_bc_ops[comp_idx] =
+                new CartCellRobinPhysBdryOp(dst_data_idx, robin_bc_coefs, d_homogeneous_bc, phys_bdry_type);
         }
         if (!null_bc_coefs && sc_var)
         {
 #if !defined(NDEBUG)
             TBOX_ASSERT(robin_bc_coefs.size() == NDIM);
 #endif
-            d_sc_robin_bc_ops[comp_idx] = new CartSideRobinPhysBdryOp(dst_data_idx, robin_bc_coefs, d_homogeneous_bc);
+            d_sc_robin_bc_ops[comp_idx] =
+                new CartSideRobinPhysBdryOp(dst_data_idx, robin_bc_coefs, d_homogeneous_bc, phys_bdry_type);
         }
     }
 

--- a/ibtk/src/boundary/physical_boundary/CartCellRobinPhysBdryOp.cpp
+++ b/ibtk/src/boundary/physical_boundary/CartCellRobinPhysBdryOp.cpp
@@ -63,6 +63,8 @@
 #if (NDIM == 2)
 #define CC_ROBIN_PHYS_BDRY_OP_1_X_FC IBTK_FC_FUNC(ccrobinphysbdryop1x2d, CCROBINPHYSBDRYOP1X2D)
 #define CC_ROBIN_PHYS_BDRY_OP_1_Y_FC IBTK_FC_FUNC(ccrobinphysbdryop1y2d, CCROBINPHYSBDRYOP1Y2D)
+#define CC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC IBTK_FC_FUNC(ccrobinphysbdryquadop1x2d, CCROBINPHYSBDRYQUADOP1X2D)
+#define CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC IBTK_FC_FUNC(ccrobinphysbdryquadop1y2d, CCROBINPHYSBDRYQUADOP1Y2D)
 #define CC_ROBIN_PHYS_BDRY_OP_2_FC IBTK_FC_FUNC(ccrobinphysbdryop22d, CCROBINPHYSBDRYOP22D)
 #endif // if (NDIM == 2)
 
@@ -70,6 +72,9 @@
 #define CC_ROBIN_PHYS_BDRY_OP_1_X_FC IBTK_FC_FUNC(ccrobinphysbdryop1x3d, CCROBINPHYSBDRYOP1X3D)
 #define CC_ROBIN_PHYS_BDRY_OP_1_Y_FC IBTK_FC_FUNC(ccrobinphysbdryop1y3d, CCROBINPHYSBDRYOP1Y3D)
 #define CC_ROBIN_PHYS_BDRY_OP_1_Z_FC IBTK_FC_FUNC(ccrobinphysbdryop1z3d, CCROBINPHYSBDRYOP1Z3D)
+#define CC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC IBTK_FC_FUNC(ccrobinphysbdryquadop1x3d, CCROBINPHYSBDRYQUADOP1X3D)
+#define CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC IBTK_FC_FUNC(ccrobinphysbdryquadop1y3d, CCROBINPHYSBDRYQUADOP1Y3D)
+#define CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Z_FC IBTK_FC_FUNC(ccrobinphysbdryquadop1z3d, CCROBINPHYSBDRYQUADOP1Z3D)
 #define CC_ROBIN_PHYS_BDRY_OP_2_FC IBTK_FC_FUNC(ccrobinphysbdryop23d, CCROBINPHYSBDRYOP23D)
 #define CC_ROBIN_PHYS_BDRY_OP_3_FC IBTK_FC_FUNC(ccrobinphysbdryop33d, CCROBINPHYSBDRYOP33D)
 #endif // if (NDIM == 3)
@@ -99,6 +104,28 @@ extern "C"
                                       const double* dx,
                                       const int& adjoint_op);
 
+    void CC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC(double* U,
+                                           const int& U_gcw,
+                                           const double* acoef,
+                                           const double* bcoef,
+                                           const double* gcoef,
+                                           const int& location_index,
+                                           const int& ilower0,
+                                           const int& iupper0,
+                                           const int& ilower1,
+                                           const int& iupper1,
+#if (NDIM == 3)
+                                           const int& ilower2,
+                                           const int& iupper2,
+#endif
+                                           const int& blower1,
+                                           const int& bupper1,
+#if (NDIM == 3)
+                                           const int& blower2,
+                                           const int& bupper2,
+#endif
+                                           const double* dx);
+
     void CC_ROBIN_PHYS_BDRY_OP_1_Y_FC(double* U,
                                       const int& U_gcw,
                                       const double* acoef,
@@ -122,6 +149,28 @@ extern "C"
                                       const double* dx,
                                       const int& adjoint_op);
 
+    void CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC(double* U,
+                                           const int& U_gcw,
+                                           const double* acoef,
+                                           const double* bcoef,
+                                           const double* gcoef,
+                                           const int& location_index,
+                                           const int& ilower0,
+                                           const int& iupper0,
+                                           const int& ilower1,
+                                           const int& iupper1,
+#if (NDIM == 3)
+                                           const int& ilower2,
+                                           const int& iupper2,
+#endif
+                                           const int& blower0,
+                                           const int& bupper0,
+#if (NDIM == 3)
+                                           const int& blower2,
+                                           const int& bupper2,
+#endif
+                                           const double* dx);
+
 #if (NDIM == 3)
     void CC_ROBIN_PHYS_BDRY_OP_1_Z_FC(double* U,
                                       const int& U_gcw,
@@ -141,6 +190,24 @@ extern "C"
                                       const int& bupper1,
                                       const double* dx,
                                       const int& adjoint_op);
+
+    void CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Z_FC(double* U,
+                                           const int& U_gcw,
+                                           const double* acoef,
+                                           const double* bcoef,
+                                           const double* gcoef,
+                                           const int& location_index,
+                                           const int& ilower0,
+                                           const int& iupper0,
+                                           const int& ilower1,
+                                           const int& iupper1,
+                                           const int& ilower2,
+                                           const int& iupper2,
+                                           const int& blower0,
+                                           const int& bupper0,
+                                           const int& blower1,
+                                           const int& bupper1,
+                                           const double* dx);
 #endif
 
     void CC_ROBIN_PHYS_BDRY_OP_2_FC(double* U,
@@ -205,9 +272,13 @@ CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp() : RobinPhysBdryPatchStrategy(
 
 CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const int patch_data_index,
                                                  RobinBcCoefStrategy<NDIM>* const bc_coef,
-                                                 const bool homogeneous_bc)
-    : RobinPhysBdryPatchStrategy()
+                                                 const bool homogeneous_bc,
+                                                 std::string type)
+    : RobinPhysBdryPatchStrategy(), d_type(std::move(type))
 {
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_type == "LINEAR" || d_type == "QUADRATIC");
+#endif
     setPatchDataIndex(patch_data_index);
     setPhysicalBcCoef(bc_coef);
     setHomogeneousBc(homogeneous_bc);
@@ -216,9 +287,13 @@ CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const int patch_data_index,
 
 CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const std::set<int>& patch_data_indices,
                                                  RobinBcCoefStrategy<NDIM>* const bc_coef,
-                                                 const bool homogeneous_bc)
-    : RobinPhysBdryPatchStrategy()
+                                                 const bool homogeneous_bc,
+                                                 std::string type)
+    : RobinPhysBdryPatchStrategy(), d_type(std::move(type))
 {
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_type == "LINEAR" || d_type == "QUADRATIC");
+#endif
     setPatchDataIndices(patch_data_indices);
     setPhysicalBcCoef(bc_coef);
     setHomogeneousBc(homogeneous_bc);
@@ -227,9 +302,13 @@ CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const std::set<int>& patch_data
 
 CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const ComponentSelector& patch_data_indices,
                                                  RobinBcCoefStrategy<NDIM>* const bc_coef,
-                                                 const bool homogeneous_bc)
-    : RobinPhysBdryPatchStrategy()
+                                                 const bool homogeneous_bc,
+                                                 std::string type)
+    : RobinPhysBdryPatchStrategy(), d_type(std::move(type))
 {
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_type == "LINEAR" || d_type == "QUADRATIC");
+#endif
     setPatchDataIndices(patch_data_indices);
     setPhysicalBcCoef(bc_coef);
     setHomogeneousBc(homogeneous_bc);
@@ -238,9 +317,13 @@ CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const ComponentSelector& patch_
 
 CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const int patch_data_index,
                                                  const std::vector<RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                                                 const bool homogeneous_bc)
-    : RobinPhysBdryPatchStrategy()
+                                                 const bool homogeneous_bc,
+                                                 std::string type)
+    : RobinPhysBdryPatchStrategy(), d_type(std::move(type))
 {
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_type == "LINEAR" || d_type == "QUADRATIC");
+#endif
     setPatchDataIndex(patch_data_index);
     setPhysicalBcCoefs(bc_coefs);
     setHomogeneousBc(homogeneous_bc);
@@ -249,9 +332,13 @@ CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const int patch_data_index,
 
 CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const std::set<int>& patch_data_indices,
                                                  const std::vector<RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                                                 const bool homogeneous_bc)
-    : RobinPhysBdryPatchStrategy()
+                                                 const bool homogeneous_bc,
+                                                 std::string type)
+    : RobinPhysBdryPatchStrategy(), d_type(std::move(type))
 {
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_type == "LINEAR" || d_type == "QUADRATIC");
+#endif
     setPatchDataIndices(patch_data_indices);
     setPhysicalBcCoefs(bc_coefs);
     setHomogeneousBc(homogeneous_bc);
@@ -260,9 +347,13 @@ CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const std::set<int>& patch_data
 
 CartCellRobinPhysBdryOp::CartCellRobinPhysBdryOp(const ComponentSelector& patch_data_indices,
                                                  const std::vector<RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                                                 const bool homogeneous_bc)
-    : RobinPhysBdryPatchStrategy()
+                                                 const bool homogeneous_bc,
+                                                 std::string type)
+    : RobinPhysBdryPatchStrategy(), d_type(std::move(type))
 {
+#if !defined(NDEBUG)
+    TBOX_ASSERT(d_type == "LINEAR" || d_type == "QUADRATIC");
+#endif
     setPatchDataIndices(patch_data_indices);
     setPhysicalBcCoefs(bc_coefs);
     setHomogeneousBc(homogeneous_bc);
@@ -345,6 +436,10 @@ CartCellRobinPhysBdryOp::accumulateFromPhysicalBoundaryData(Patch<NDIM>& patch,
                                                             const IntVector<NDIM>& ghost_width_to_fill)
 {
     if (ghost_width_to_fill == IntVector<NDIM>(0)) return;
+    if (d_type == "QUADRATIC")
+    {
+        TBOX_ERROR("Accumulating from physical boundaries not supported for QUADRATIC interpolation.");
+    }
 
     // Ensure the target patch data corresponds to a cell centered variable and
     // that the proper number of boundary condition objects have been provided.
@@ -459,75 +554,152 @@ CartCellRobinPhysBdryOp::fillGhostCellValuesCodim1(const int patch_data_idx,
             {
             case 0: // lower x
             case 1: // upper x
-                CC_ROBIN_PHYS_BDRY_OP_1_X_FC(patch_data->getPointer(d),
-                                             patch_data_gcw,
-                                             acoef_data->getPointer(),
-                                             bcoef_data->getPointer(),
-                                             gcoef_data->getPointer(),
-                                             location_index,
-                                             patch_box.lower(0),
-                                             patch_box.upper(0),
-                                             patch_box.lower(1),
-                                             patch_box.upper(1),
+                if (d_type == "LINEAR")
+                {
+                    CC_ROBIN_PHYS_BDRY_OP_1_X_FC(patch_data->getPointer(d),
+                                                 patch_data_gcw,
+                                                 acoef_data->getPointer(),
+                                                 bcoef_data->getPointer(),
+                                                 gcoef_data->getPointer(),
+                                                 location_index,
+                                                 patch_box.lower(0),
+                                                 patch_box.upper(0),
+                                                 patch_box.lower(1),
+                                                 patch_box.upper(1),
 #if (NDIM == 3)
-                                             patch_box.lower(2),
-                                             patch_box.upper(2),
+                                                 patch_box.lower(2),
+                                                 patch_box.upper(2),
 #endif
-                                             bc_fill_box.lower(1),
-                                             bc_fill_box.upper(1),
+                                                 bc_fill_box.lower(1),
+                                                 bc_fill_box.upper(1),
 #if (NDIM == 3)
-                                             bc_fill_box.lower(2),
-                                             bc_fill_box.upper(2),
+                                                 bc_fill_box.lower(2),
+                                                 bc_fill_box.upper(2),
 #endif
-                                             dx,
-                                             adjoint_op ? 1 : 0);
+                                                 dx,
+                                                 adjoint_op ? 1 : 0);
+                }
+                else
+                {
+                    CC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC(patch_data->getPointer(d),
+                                                      patch_data_gcw,
+                                                      acoef_data->getPointer(),
+                                                      bcoef_data->getPointer(),
+                                                      gcoef_data->getPointer(),
+                                                      location_index,
+                                                      patch_box.lower(0),
+                                                      patch_box.upper(0),
+                                                      patch_box.lower(1),
+                                                      patch_box.upper(1),
+#if (NDIM == 3)
+                                                      patch_box.lower(2),
+                                                      patch_box.upper(2),
+#endif
+                                                      bc_fill_box.lower(1),
+                                                      bc_fill_box.upper(1),
+#if (NDIM == 3)
+                                                      bc_fill_box.lower(2),
+                                                      bc_fill_box.upper(2),
+#endif
+                                                      dx);
+                }
                 break;
             case 2: // lower y
             case 3: // upper y
-                CC_ROBIN_PHYS_BDRY_OP_1_Y_FC(patch_data->getPointer(d),
-                                             patch_data_gcw,
-                                             acoef_data->getPointer(),
-                                             bcoef_data->getPointer(),
-                                             gcoef_data->getPointer(),
-                                             location_index,
-                                             patch_box.lower(0),
-                                             patch_box.upper(0),
-                                             patch_box.lower(1),
-                                             patch_box.upper(1),
+                if (d_type == "LINEAR")
+                {
+                    CC_ROBIN_PHYS_BDRY_OP_1_Y_FC(patch_data->getPointer(d),
+                                                 patch_data_gcw,
+                                                 acoef_data->getPointer(),
+                                                 bcoef_data->getPointer(),
+                                                 gcoef_data->getPointer(),
+                                                 location_index,
+                                                 patch_box.lower(0),
+                                                 patch_box.upper(0),
+                                                 patch_box.lower(1),
+                                                 patch_box.upper(1),
 #if (NDIM == 3)
-                                             patch_box.lower(2),
-                                             patch_box.upper(2),
+                                                 patch_box.lower(2),
+                                                 patch_box.upper(2),
 #endif
-                                             bc_fill_box.lower(0),
-                                             bc_fill_box.upper(0),
+                                                 bc_fill_box.lower(0),
+                                                 bc_fill_box.upper(0),
 #if (NDIM == 3)
-                                             bc_fill_box.lower(2),
-                                             bc_fill_box.upper(2),
+                                                 bc_fill_box.lower(2),
+                                                 bc_fill_box.upper(2),
 #endif
-                                             dx,
-                                             adjoint_op ? 1 : 0);
+                                                 dx,
+                                                 adjoint_op ? 1 : 0);
+                }
+                else
+                {
+                    CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC(patch_data->getPointer(d),
+                                                      patch_data_gcw,
+                                                      acoef_data->getPointer(),
+                                                      bcoef_data->getPointer(),
+                                                      gcoef_data->getPointer(),
+                                                      location_index,
+                                                      patch_box.lower(0),
+                                                      patch_box.upper(0),
+                                                      patch_box.lower(1),
+                                                      patch_box.upper(1),
+#if (NDIM == 3)
+                                                      patch_box.lower(2),
+                                                      patch_box.upper(2),
+#endif
+                                                      bc_fill_box.lower(0),
+                                                      bc_fill_box.upper(0),
+#if (NDIM == 3)
+                                                      bc_fill_box.lower(2),
+                                                      bc_fill_box.upper(2),
+#endif
+                                                      dx);
+                }
                 break;
 #if (NDIM == 3)
             case 4: // lower z
             case 5: // upper z
-                CC_ROBIN_PHYS_BDRY_OP_1_Z_FC(patch_data->getPointer(d),
-                                             patch_data_gcw,
-                                             acoef_data->getPointer(),
-                                             bcoef_data->getPointer(),
-                                             gcoef_data->getPointer(),
-                                             location_index,
-                                             patch_box.lower(0),
-                                             patch_box.upper(0),
-                                             patch_box.lower(1),
-                                             patch_box.upper(1),
-                                             patch_box.lower(2),
-                                             patch_box.upper(2),
-                                             bc_fill_box.lower(0),
-                                             bc_fill_box.upper(0),
-                                             bc_fill_box.lower(1),
-                                             bc_fill_box.upper(1),
-                                             dx,
-                                             adjoint_op ? 1 : 0);
+                if (d_type == "LINEAR")
+                {
+                    CC_ROBIN_PHYS_BDRY_OP_1_Z_FC(patch_data->getPointer(d),
+                                                 patch_data_gcw,
+                                                 acoef_data->getPointer(),
+                                                 bcoef_data->getPointer(),
+                                                 gcoef_data->getPointer(),
+                                                 location_index,
+                                                 patch_box.lower(0),
+                                                 patch_box.upper(0),
+                                                 patch_box.lower(1),
+                                                 patch_box.upper(1),
+                                                 patch_box.lower(2),
+                                                 patch_box.upper(2),
+                                                 bc_fill_box.lower(0),
+                                                 bc_fill_box.upper(0),
+                                                 bc_fill_box.lower(1),
+                                                 bc_fill_box.upper(1),
+                                                 dx,
+                                                 adjoint_op ? 1 : 0);
+                }
+                else
+                {
+                    CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Z_FC(patch_data->getPointer(d),
+                                                      patch_data_gcw,
+                                                      acoef_data->getPointer(),
+                                                      bcoef_data->getPointer(),
+                                                      gcoef_data->getPointer(),
+                                                      location_index,
+                                                      patch_box.lower(0),
+                                                      patch_box.upper(0),
+                                                      patch_box.lower(1),
+                                                      patch_box.upper(1),
+                                                      patch_box.lower(2),
+                                                      patch_box.upper(2),
+                                                      bc_fill_box.lower(0),
+                                                      bc_fill_box.upper(0),
+                                                      bc_fill_box.lower(1),
+                                                      bc_fill_box.upper(1),
+                                                      dx);
+                }
                 break;
 #endif
             default:

--- a/ibtk/src/boundary/physical_boundary/CartSideRobinPhysBdryOp.cpp
+++ b/ibtk/src/boundary/physical_boundary/CartSideRobinPhysBdryOp.cpp
@@ -67,8 +67,12 @@
 #if (NDIM == 2)
 #define CC_ROBIN_PHYS_BDRY_OP_1_X_FC IBTK_FC_FUNC(ccrobinphysbdryop1x2d, CCROBINPHYSBDRYOP1X2D)
 #define CC_ROBIN_PHYS_BDRY_OP_1_Y_FC IBTK_FC_FUNC(ccrobinphysbdryop1y2d, CCROBINPHYSBDRYOP1Y2D)
+#define CC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC IBTK_FC_FUNC(ccrobinphysbdryquadop1x2d, CCROBINPHYSBDRYQUADOP1X2D)
+#define CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC IBTK_FC_FUNC(ccrobinphysbdryquadop1y2d, CCROBINPHYSBDRYQUADOP1Y2D)
 #define SC_ROBIN_PHYS_BDRY_OP_1_X_FC IBTK_FC_FUNC(scrobinphysbdryop1x2d, SCROBINPHYSBDRYOP1X2D)
 #define SC_ROBIN_PHYS_BDRY_OP_1_Y_FC IBTK_FC_FUNC(scrobinphysbdryop1y2d, SCROBINPHYSBDRYOP1Y2D)
+#define SC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC IBTK_FC_FUNC(scrobinphysbdryquadop1x2d, SCROBINPHYSBDRYQUADOP1X2D)
+#define SC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC IBTK_FC_FUNC(scrobinphysbdryquadop1y2d, SCROBINPHYSBDRYQUADOP1Y2D)
 #define SC_ROBIN_PHYS_BDRY_OP_2_FC IBTK_FC_FUNC(scrobinphysbdryop22d, SCROBINPHYSBDRYOP22D)
 #endif // if (NDIM == 2)
 
@@ -76,9 +80,15 @@
 #define CC_ROBIN_PHYS_BDRY_OP_1_X_FC IBTK_FC_FUNC(ccrobinphysbdryop1x3d, CCROBINPHYSBDRYOP1X3D)
 #define CC_ROBIN_PHYS_BDRY_OP_1_Y_FC IBTK_FC_FUNC(ccrobinphysbdryop1y3d, CCROBINPHYSBDRYOP1Y3D)
 #define CC_ROBIN_PHYS_BDRY_OP_1_Z_FC IBTK_FC_FUNC(ccrobinphysbdryop1z3d, CCROBINPHYSBDRYOP1Z3D)
+#define CC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC IBTK_FC_FUNC(ccrobinphysbdryquadop1x3d, CCROBINPHYSBDRYQUADOP1X3D)
+#define CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC IBTK_FC_FUNC(ccrobinphysbdryquadop1y3d, CCROBINPHYSBDRYQUADOP1Y3D)
+#define CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Z_FC IBTK_FC_FUNC(ccrobinphysbdryquadop1z3d, CCROBINPHYSBDRYQUADOP1Z3D)
 #define SC_ROBIN_PHYS_BDRY_OP_1_X_FC IBTK_FC_FUNC(scrobinphysbdryop1x3d, SCROBINPHYSBDRYOP1X3D)
 #define SC_ROBIN_PHYS_BDRY_OP_1_Y_FC IBTK_FC_FUNC(scrobinphysbdryop1y3d, SCROBINPHYSBDRYOP1Y3D)
 #define SC_ROBIN_PHYS_BDRY_OP_1_Z_FC IBTK_FC_FUNC(scrobinphysbdryop1z3d, SCROBINPHYSBDRYOP1Z3D)
+#define SC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC IBTK_FC_FUNC(scrobinphysbdryquadop1x3d, SCROBINPHYSBDRYQUADOP1X3D)
+#define SC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC IBTK_FC_FUNC(scrobinphysbdryquadop1y3d, SCROBINPHYSBDRYQUADOP1Y3D)
+#define SC_ROBIN_PHYS_BDRY_QUAD_OP_1_Z_FC IBTK_FC_FUNC(scrobinphysbdryquadop1z3d, SCROBINPHYSBDRYQUADOP1Z3D)
 #define SC_ROBIN_PHYS_BDRY_OP_2_FC IBTK_FC_FUNC(scrobinphysbdryop23d, SCROBINPHYSBDRYOP22D)
 #define CC_ROBIN_PHYS_BDRY_OP_2_FC IBTK_FC_FUNC(ccrobinphysbdryop23d, CCROBINPHYSBDRYOP23D)
 #define SC_ROBIN_PHYS_BDRY_OP_3_FC IBTK_FC_FUNC(scrobinphysbdryop33d, SCROBINPHYSBDRYOP32D)
@@ -86,8 +96,8 @@
 
 extern "C"
 {
-    void CC_ROBIN_PHYS_BDRY_OP_1_X_FC(double* u,
-                                      const int& u_gcw,
+    void CC_ROBIN_PHYS_BDRY_OP_1_X_FC(double* U,
+                                      const int& U_gcw,
                                       const double* acoef,
                                       const double* bcoef,
                                       const double* gcoef,
@@ -109,8 +119,30 @@ extern "C"
                                       const double* dx,
                                       const int& adjoint_op);
 
-    void CC_ROBIN_PHYS_BDRY_OP_1_Y_FC(double* u,
-                                      const int& u_gcw,
+    void CC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC(double* U,
+                                           const int& U_gcw,
+                                           const double* acoef,
+                                           const double* bcoef,
+                                           const double* gcoef,
+                                           const int& location_index,
+                                           const int& ilower0,
+                                           const int& iupper0,
+                                           const int& ilower1,
+                                           const int& iupper1,
+#if (NDIM == 3)
+                                           const int& ilower2,
+                                           const int& iupper2,
+#endif
+                                           const int& blower1,
+                                           const int& bupper1,
+#if (NDIM == 3)
+                                           const int& blower2,
+                                           const int& bupper2,
+#endif
+                                           const double* dx);
+
+    void CC_ROBIN_PHYS_BDRY_OP_1_Y_FC(double* U,
+                                      const int& U_gcw,
                                       const double* acoef,
                                       const double* bcoef,
                                       const double* gcoef,
@@ -131,6 +163,28 @@ extern "C"
 #endif
                                       const double* dx,
                                       const int& adjoint_op);
+
+    void CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC(double* U,
+                                           const int& U_gcw,
+                                           const double* acoef,
+                                           const double* bcoef,
+                                           const double* gcoef,
+                                           const int& location_index,
+                                           const int& ilower0,
+                                           const int& iupper0,
+                                           const int& ilower1,
+                                           const int& iupper1,
+#if (NDIM == 3)
+                                           const int& ilower2,
+                                           const int& iupper2,
+#endif
+                                           const int& blower0,
+                                           const int& bupper0,
+#if (NDIM == 3)
+                                           const int& blower2,
+                                           const int& bupper2,
+#endif
+                                           const double* dx);
 
 #if (NDIM == 3)
     void CC_ROBIN_PHYS_BDRY_OP_1_Z_FC(double* U,
@@ -151,6 +205,24 @@ extern "C"
                                       const int& bupper1,
                                       const double* dx,
                                       const int& adjoint_op);
+
+    void CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Z_FC(double* U,
+                                           const int& U_gcw,
+                                           const double* acoef,
+                                           const double* bcoef,
+                                           const double* gcoef,
+                                           const int& location_index,
+                                           const int& ilower0,
+                                           const int& iupper0,
+                                           const int& ilower1,
+                                           const int& iupper1,
+                                           const int& ilower2,
+                                           const int& iupper2,
+                                           const int& blower0,
+                                           const int& bupper0,
+                                           const int& blower1,
+                                           const int& bupper1,
+                                           const double* dx);
 #endif
 
     void SC_ROBIN_PHYS_BDRY_OP_1_X_FC(double* u0,
@@ -218,6 +290,70 @@ extern "C"
                                       const int& bupper1,
                                       const double* dx,
                                       const int& adjoint_op);
+#endif
+
+    void SC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC(double* u1,
+                                           const int& u_gcw,
+                                           const double* acoef,
+                                           const double* bcoef,
+                                           const double* gcoef,
+                                           const int& location_index,
+                                           const int& ilower0,
+                                           const int& iupper0,
+                                           const int& ilower1,
+                                           const int& iupper1,
+#if (NDIM == 3)
+                                           const int& ilower2,
+                                           const int& iupper2,
+#endif
+                                           const int& blower0,
+                                           const int& bupper0,
+#if (NDIM == 3)
+                                           const int& blower2,
+                                           const int& bupper2,
+#endif
+                                           const double* dx);
+
+    void SC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC(double* u1,
+                                           const int& u_gcw,
+                                           const double* acoef,
+                                           const double* bcoef,
+                                           const double* gcoef,
+                                           const int& location_index,
+                                           const int& ilower0,
+                                           const int& iupper0,
+                                           const int& ilower1,
+                                           const int& iupper1,
+#if (NDIM == 3)
+                                           const int& ilower2,
+                                           const int& iupper2,
+#endif
+                                           const int& blower0,
+                                           const int& bupper0,
+#if (NDIM == 3)
+                                           const int& blower2,
+                                           const int& bupper2,
+#endif
+                                           const double* dx);
+
+#if (NDIM == 3)
+    void SC_ROBIN_PHYS_BDRY_QUAD_OP_1_Z_FC(double* u2,
+                                           const int& u_gcw,
+                                           const double* acoef,
+                                           const double* bcoef,
+                                           const double* gcoef,
+                                           const int& location_index,
+                                           const int& ilower0,
+                                           const int& iupper0,
+                                           const int& ilower1,
+                                           const int& iupper1,
+                                           const int& ilower2,
+                                           const int& iupper2,
+                                           const int& blower0,
+                                           const int& bupper0,
+                                           const int& blower1,
+                                           const int& bupper1,
+                                           const double* dx);
 #endif
 
     void SC_ROBIN_PHYS_BDRY_OP_2_FC(double* u0,
@@ -313,11 +449,13 @@ CartSideRobinPhysBdryOp::CartSideRobinPhysBdryOp() : RobinPhysBdryPatchStrategy(
 
 CartSideRobinPhysBdryOp::CartSideRobinPhysBdryOp(const int patch_data_index,
                                                  const std::vector<RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                                                 const bool homogeneous_bc)
-    : RobinPhysBdryPatchStrategy()
+                                                 const bool homogeneous_bc,
+                                                 std::string type)
+    : RobinPhysBdryPatchStrategy(), d_type(std::move(type))
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(bc_coefs.size() == NDIM);
+    TBOX_ASSERT(d_type == "LINEAR" || d_type == "QUADRATIC");
 #endif
     setPatchDataIndex(patch_data_index);
     setPhysicalBcCoefs(bc_coefs);
@@ -327,11 +465,13 @@ CartSideRobinPhysBdryOp::CartSideRobinPhysBdryOp(const int patch_data_index,
 
 CartSideRobinPhysBdryOp::CartSideRobinPhysBdryOp(const std::set<int>& patch_data_indices,
                                                  const std::vector<RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                                                 const bool homogeneous_bc)
-    : RobinPhysBdryPatchStrategy()
+                                                 const bool homogeneous_bc,
+                                                 std::string type)
+    : RobinPhysBdryPatchStrategy(), d_type(std::move(type))
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(bc_coefs.size() == NDIM);
+    TBOX_ASSERT(d_type == "LINEAR" || d_type == "QUADRATIC");
 #endif
     setPatchDataIndices(patch_data_indices);
     setPhysicalBcCoefs(bc_coefs);
@@ -341,11 +481,13 @@ CartSideRobinPhysBdryOp::CartSideRobinPhysBdryOp(const std::set<int>& patch_data
 
 CartSideRobinPhysBdryOp::CartSideRobinPhysBdryOp(const ComponentSelector& patch_data_indices,
                                                  const std::vector<RobinBcCoefStrategy<NDIM>*>& bc_coefs,
-                                                 const bool homogeneous_bc)
-    : RobinPhysBdryPatchStrategy()
+                                                 const bool homogeneous_bc,
+                                                 std::string type)
+    : RobinPhysBdryPatchStrategy(), d_type(std::move(type))
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(bc_coefs.size() == NDIM);
+    TBOX_ASSERT(d_type == "LINEAR" || d_type == "QUADRATIC");
 #endif
     setPatchDataIndices(patch_data_indices);
     setPhysicalBcCoefs(bc_coefs);
@@ -434,6 +576,10 @@ CartSideRobinPhysBdryOp::accumulateFromPhysicalBoundaryData(Patch<NDIM>& patch,
                                                             const IntVector<NDIM>& ghost_width_to_fill)
 {
     if (ghost_width_to_fill == IntVector<NDIM>(0)) return;
+    if (d_type == "QUADRATIC")
+    {
+        TBOX_ERROR("Accumulating from physical boundaries not currently supported for QUADRATIC interpolation.");
+    }
 
     // Ensure the target patch data corresponds to a side centered variable and
     // that the proper number of boundary condition objects have been provided.
@@ -554,75 +700,164 @@ CartSideRobinPhysBdryOp::fillGhostCellValuesCodim1Normal(const int patch_data_id
             if (extended_bc_coef) extended_bc_coef->clearTargetPatchDataIndex();
             if (location_index == 0 || location_index == 1)
             {
-                SC_ROBIN_PHYS_BDRY_OP_1_X_FC(patch_data->getPointer(bdry_normal_axis, d),
-                                             patch_data_gcw,
-                                             acoef_data->getPointer(),
-                                             bcoef_data->getPointer(),
-                                             gcoef_data->getPointer(),
-                                             location_index,
-                                             patch_box.lower(0),
-                                             patch_box.upper(0),
-                                             patch_box.lower(1),
-                                             patch_box.upper(1),
+                if (d_type == "LINEAR")
+                {
+                    SC_ROBIN_PHYS_BDRY_OP_1_X_FC(patch_data->getPointer(bdry_normal_axis, d),
+                                                 patch_data_gcw,
+                                                 acoef_data->getPointer(),
+                                                 bcoef_data->getPointer(),
+                                                 gcoef_data->getPointer(),
+                                                 location_index,
+                                                 patch_box.lower(0),
+                                                 patch_box.upper(0),
+                                                 patch_box.lower(1),
+                                                 patch_box.upper(1),
 #if (NDIM == 3)
-                                             patch_box.lower(2),
-                                             patch_box.upper(2),
+                                                 patch_box.lower(2),
+                                                 patch_box.upper(2),
 #endif
-                                             bc_coef_box.lower(1),
-                                             bc_coef_box.upper(1),
+                                                 bc_coef_box.lower(1),
+                                                 bc_coef_box.upper(1),
 #if (NDIM == 3)
-                                             bc_coef_box.lower(2),
-                                             bc_coef_box.upper(2),
+                                                 bc_coef_box.lower(2),
+                                                 bc_coef_box.upper(2),
 #endif
-                                             dx,
-                                             adjoint_op ? 1 : 0);
+                                                 dx,
+                                                 adjoint_op ? 1 : 0);
+                }
+                else if (d_type == "QUADRATIC")
+                {
+                    SC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC(patch_data->getPointer(bdry_normal_axis, d),
+                                                      patch_data_gcw,
+                                                      acoef_data->getPointer(),
+                                                      bcoef_data->getPointer(),
+                                                      gcoef_data->getPointer(),
+                                                      location_index,
+                                                      patch_box.lower(0),
+                                                      patch_box.upper(0),
+                                                      patch_box.lower(1),
+                                                      patch_box.upper(1),
+#if (NDIM == 3)
+                                                      patch_box.lower(2),
+                                                      patch_box.upper(2),
+#endif
+                                                      bc_coef_box.lower(1),
+                                                      bc_coef_box.upper(1),
+#if (NDIM == 3)
+                                                      bc_coef_box.lower(2),
+                                                      bc_coef_box.upper(2),
+#endif
+                                                      dx);
+                }
+                else
+                {
+                    TBOX_ERROR("Unsupported interpolation type.");
+                }
             }
             else if (location_index == 2 || location_index == 3)
             {
-                SC_ROBIN_PHYS_BDRY_OP_1_Y_FC(patch_data->getPointer(bdry_normal_axis, d),
-                                             patch_data_gcw,
-                                             acoef_data->getPointer(),
-                                             bcoef_data->getPointer(),
-                                             gcoef_data->getPointer(),
-                                             location_index,
-                                             patch_box.lower(0),
-                                             patch_box.upper(0),
-                                             patch_box.lower(1),
-                                             patch_box.upper(1),
+                if (d_type == "LINEAR")
+                {
+                    SC_ROBIN_PHYS_BDRY_OP_1_Y_FC(patch_data->getPointer(bdry_normal_axis, d),
+                                                 patch_data_gcw,
+                                                 acoef_data->getPointer(),
+                                                 bcoef_data->getPointer(),
+                                                 gcoef_data->getPointer(),
+                                                 location_index,
+                                                 patch_box.lower(0),
+                                                 patch_box.upper(0),
+                                                 patch_box.lower(1),
+                                                 patch_box.upper(1),
 #if (NDIM == 3)
-                                             patch_box.lower(2),
-                                             patch_box.upper(2),
+                                                 patch_box.lower(2),
+                                                 patch_box.upper(2),
 #endif
-                                             bc_coef_box.lower(0),
-                                             bc_coef_box.upper(0),
+                                                 bc_coef_box.lower(0),
+                                                 bc_coef_box.upper(0),
 #if (NDIM == 3)
-                                             bc_coef_box.lower(2),
-                                             bc_coef_box.upper(2),
+                                                 bc_coef_box.lower(2),
+                                                 bc_coef_box.upper(2),
 #endif
-                                             dx,
-                                             adjoint_op ? 1 : 0);
+                                                 dx,
+                                                 adjoint_op ? 1 : 0);
+                }
+                else if (d_type == "QUADRATIC")
+                {
+                    SC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC(patch_data->getPointer(bdry_normal_axis, d),
+                                                      patch_data_gcw,
+                                                      acoef_data->getPointer(),
+                                                      bcoef_data->getPointer(),
+                                                      gcoef_data->getPointer(),
+                                                      location_index,
+                                                      patch_box.lower(0),
+                                                      patch_box.upper(0),
+                                                      patch_box.lower(1),
+                                                      patch_box.upper(1),
+#if (NDIM == 3)
+                                                      patch_box.lower(2),
+                                                      patch_box.upper(2),
+#endif
+                                                      bc_coef_box.lower(0),
+                                                      bc_coef_box.upper(0),
+#if (NDIM == 3)
+                                                      bc_coef_box.lower(2),
+                                                      bc_coef_box.upper(2),
+#endif
+                                                      dx);
+                }
+                else
+                {
+                    TBOX_ERROR("Unsupported interpolation type.");
+                }
             }
 #if (NDIM == 3)
             else if (location_index == 4 || location_index == 5)
             {
-                SC_ROBIN_PHYS_BDRY_OP_1_Z_FC(patch_data->getPointer(bdry_normal_axis, d),
-                                             patch_data_gcw,
-                                             acoef_data->getPointer(),
-                                             bcoef_data->getPointer(),
-                                             gcoef_data->getPointer(),
-                                             location_index,
-                                             patch_box.lower(0),
-                                             patch_box.upper(0),
-                                             patch_box.lower(1),
-                                             patch_box.upper(1),
-                                             patch_box.lower(2),
-                                             patch_box.upper(2),
-                                             bc_coef_box.lower(0),
-                                             bc_coef_box.upper(0),
-                                             bc_coef_box.lower(1),
-                                             bc_coef_box.upper(1),
-                                             dx,
-                                             adjoint_op ? 1 : 0);
+                if (d_type == "LINEAR")
+                {
+                    SC_ROBIN_PHYS_BDRY_OP_1_Z_FC(patch_data->getPointer(bdry_normal_axis, d),
+                                                 patch_data_gcw,
+                                                 acoef_data->getPointer(),
+                                                 bcoef_data->getPointer(),
+                                                 gcoef_data->getPointer(),
+                                                 location_index,
+                                                 patch_box.lower(0),
+                                                 patch_box.upper(0),
+                                                 patch_box.lower(1),
+                                                 patch_box.upper(1),
+                                                 patch_box.lower(2),
+                                                 patch_box.upper(2),
+                                                 bc_coef_box.lower(0),
+                                                 bc_coef_box.upper(0),
+                                                 bc_coef_box.lower(1),
+                                                 bc_coef_box.upper(1),
+                                                 dx,
+                                                 adjoint_op ? 1 : 0);
+                }
+                else if (d_type == "QUADRATIC")
+                {
+                    SC_ROBIN_PHYS_BDRY_QUAD_OP_1_Z_FC(patch_data->getPointer(bdry_normal_axis, d),
+                                                      patch_data_gcw,
+                                                      acoef_data->getPointer(),
+                                                      bcoef_data->getPointer(),
+                                                      gcoef_data->getPointer(),
+                                                      location_index,
+                                                      patch_box.lower(0),
+                                                      patch_box.upper(0),
+                                                      patch_box.lower(1),
+                                                      patch_box.upper(1),
+                                                      patch_box.lower(2),
+                                                      patch_box.upper(2),
+                                                      bc_coef_box.lower(0),
+                                                      bc_coef_box.upper(0),
+                                                      bc_coef_box.lower(1),
+                                                      bc_coef_box.upper(1),
+                                                      dx);
+                }
+                else
+                {
+                    TBOX_ERROR("Unsupported interpolation type.");
+                }
             }
 #endif
         }
@@ -740,75 +975,164 @@ CartSideRobinPhysBdryOp::fillGhostCellValuesCodim1Transverse(const int patch_dat
                     // Set the boundary values.
                     if (location_index == 0 || location_index == 1)
                     {
-                        CC_ROBIN_PHYS_BDRY_OP_1_X_FC(patch_data->getPointer(axis, d),
-                                                     patch_data_gcw,
-                                                     acoef_data->getPointer(),
-                                                     bcoef_data->getPointer(),
-                                                     gcoef_data->getPointer(),
-                                                     location_index,
-                                                     side_box[axis].lower(0),
-                                                     side_box[axis].upper(0),
-                                                     side_box[axis].lower(1),
-                                                     side_box[axis].upper(1),
+                        if (d_type == "LINEAR")
+                        {
+                            CC_ROBIN_PHYS_BDRY_OP_1_X_FC(patch_data->getPointer(axis, d),
+                                                         patch_data_gcw,
+                                                         acoef_data->getPointer(),
+                                                         bcoef_data->getPointer(),
+                                                         gcoef_data->getPointer(),
+                                                         location_index,
+                                                         side_box[axis].lower(0),
+                                                         side_box[axis].upper(0),
+                                                         side_box[axis].lower(1),
+                                                         side_box[axis].upper(1),
 #if (NDIM == 3)
-                                                     side_box[axis].lower(2),
-                                                     side_box[axis].upper(2),
+                                                         side_box[axis].lower(2),
+                                                         side_box[axis].upper(2),
 #endif
-                                                     bc_coef_box.lower(1),
-                                                     bc_coef_box.upper(1),
+                                                         bc_coef_box.lower(1),
+                                                         bc_coef_box.upper(1),
 #if (NDIM == 3)
-                                                     bc_coef_box.lower(2),
-                                                     bc_coef_box.upper(2),
+                                                         bc_coef_box.lower(2),
+                                                         bc_coef_box.upper(2),
 #endif
-                                                     dx,
-                                                     adjoint_op ? 1 : 0);
+                                                         dx,
+                                                         adjoint_op ? 1 : 0);
+                        }
+                        else if (d_type == "QUADRATIC")
+                        {
+                            CC_ROBIN_PHYS_BDRY_QUAD_OP_1_X_FC(patch_data->getPointer(axis, d),
+                                                              patch_data_gcw,
+                                                              acoef_data->getPointer(),
+                                                              bcoef_data->getPointer(),
+                                                              gcoef_data->getPointer(),
+                                                              location_index,
+                                                              side_box[axis].lower(0),
+                                                              side_box[axis].upper(0),
+                                                              side_box[axis].lower(1),
+                                                              side_box[axis].upper(1),
+#if (NDIM == 3)
+                                                              side_box[axis].lower(2),
+                                                              side_box[axis].upper(2),
+#endif
+                                                              bc_coef_box.lower(1),
+                                                              bc_coef_box.upper(1),
+#if (NDIM == 3)
+                                                              bc_coef_box.lower(2),
+                                                              bc_coef_box.upper(2),
+#endif
+                                                              dx);
+                        }
+                        else
+                        {
+                            TBOX_ERROR("Unsupported interpolation type.");
+                        }
                     }
                     else if (location_index == 2 || location_index == 3)
                     {
-                        CC_ROBIN_PHYS_BDRY_OP_1_Y_FC(patch_data->getPointer(axis, d),
-                                                     patch_data_gcw,
-                                                     acoef_data->getPointer(),
-                                                     bcoef_data->getPointer(),
-                                                     gcoef_data->getPointer(),
-                                                     location_index,
-                                                     side_box[axis].lower(0),
-                                                     side_box[axis].upper(0),
-                                                     side_box[axis].lower(1),
-                                                     side_box[axis].upper(1),
+                        if (d_type == "LINEAR")
+                        {
+                            CC_ROBIN_PHYS_BDRY_OP_1_Y_FC(patch_data->getPointer(axis, d),
+                                                         patch_data_gcw,
+                                                         acoef_data->getPointer(),
+                                                         bcoef_data->getPointer(),
+                                                         gcoef_data->getPointer(),
+                                                         location_index,
+                                                         side_box[axis].lower(0),
+                                                         side_box[axis].upper(0),
+                                                         side_box[axis].lower(1),
+                                                         side_box[axis].upper(1),
 #if (NDIM == 3)
-                                                     side_box[axis].lower(2),
-                                                     side_box[axis].upper(2),
+                                                         side_box[axis].lower(2),
+                                                         side_box[axis].upper(2),
 #endif
-                                                     bc_coef_box.lower(0),
-                                                     bc_coef_box.upper(0),
+                                                         bc_coef_box.lower(0),
+                                                         bc_coef_box.upper(0),
 #if (NDIM == 3)
-                                                     bc_coef_box.lower(2),
-                                                     bc_coef_box.upper(2),
+                                                         bc_coef_box.lower(2),
+                                                         bc_coef_box.upper(2),
 #endif
-                                                     dx,
-                                                     adjoint_op ? 1 : 0);
+                                                         dx,
+                                                         adjoint_op ? 1 : 0);
+                        }
+                        else if (d_type == "QUADRATIC")
+                        {
+                            CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Y_FC(patch_data->getPointer(axis, d),
+                                                              patch_data_gcw,
+                                                              acoef_data->getPointer(),
+                                                              bcoef_data->getPointer(),
+                                                              gcoef_data->getPointer(),
+                                                              location_index,
+                                                              side_box[axis].lower(0),
+                                                              side_box[axis].upper(0),
+                                                              side_box[axis].lower(1),
+                                                              side_box[axis].upper(1),
+#if (NDIM == 3)
+                                                              side_box[axis].lower(2),
+                                                              side_box[axis].upper(2),
+#endif
+                                                              bc_coef_box.lower(0),
+                                                              bc_coef_box.upper(0),
+#if (NDIM == 3)
+                                                              bc_coef_box.lower(2),
+                                                              bc_coef_box.upper(2),
+#endif
+                                                              dx);
+                        }
+                        else
+                        {
+                            TBOX_ERROR("Unsupported interpolation type.");
+                        }
                     }
 #if (NDIM == 3)
                     else if (location_index == 4 || location_index == 5)
                     {
-                        CC_ROBIN_PHYS_BDRY_OP_1_Z_FC(patch_data->getPointer(axis, d),
-                                                     patch_data_gcw,
-                                                     acoef_data->getPointer(),
-                                                     bcoef_data->getPointer(),
-                                                     gcoef_data->getPointer(),
-                                                     location_index,
-                                                     side_box[axis].lower(0),
-                                                     side_box[axis].upper(0),
-                                                     side_box[axis].lower(1),
-                                                     side_box[axis].upper(1),
-                                                     side_box[axis].lower(2),
-                                                     side_box[axis].upper(2),
-                                                     bc_coef_box.lower(0),
-                                                     bc_coef_box.upper(0),
-                                                     bc_coef_box.lower(1),
-                                                     bc_coef_box.upper(1),
-                                                     dx,
-                                                     adjoint_op ? 1 : 0);
+                        if (d_type == "LINEAR")
+                        {
+                            CC_ROBIN_PHYS_BDRY_OP_1_Z_FC(patch_data->getPointer(axis, d),
+                                                         patch_data_gcw,
+                                                         acoef_data->getPointer(),
+                                                         bcoef_data->getPointer(),
+                                                         gcoef_data->getPointer(),
+                                                         location_index,
+                                                         side_box[axis].lower(0),
+                                                         side_box[axis].upper(0),
+                                                         side_box[axis].lower(1),
+                                                         side_box[axis].upper(1),
+                                                         side_box[axis].lower(2),
+                                                         side_box[axis].upper(2),
+                                                         bc_coef_box.lower(0),
+                                                         bc_coef_box.upper(0),
+                                                         bc_coef_box.lower(1),
+                                                         bc_coef_box.upper(1),
+                                                         dx,
+                                                         adjoint_op ? 1 : 0);
+                        }
+                        else if (d_type == "QUADRATIC")
+                        {
+                            CC_ROBIN_PHYS_BDRY_QUAD_OP_1_Z_FC(patch_data->getPointer(axis, d),
+                                                              patch_data_gcw,
+                                                              acoef_data->getPointer(),
+                                                              bcoef_data->getPointer(),
+                                                              gcoef_data->getPointer(),
+                                                              location_index,
+                                                              side_box[axis].lower(0),
+                                                              side_box[axis].upper(0),
+                                                              side_box[axis].lower(1),
+                                                              side_box[axis].upper(1),
+                                                              side_box[axis].lower(2),
+                                                              side_box[axis].upper(2),
+                                                              bc_coef_box.lower(0),
+                                                              bc_coef_box.upper(0),
+                                                              bc_coef_box.lower(1),
+                                                              bc_coef_box.upper(1),
+                                                              dx);
+                        }
+                        else
+                        {
+                            TBOX_ERROR("Unsupported interpolation type.");
+                        }
                     }
 #endif
                 }

--- a/ibtk/src/boundary/physical_boundary/fortran/cartphysbdryop2d.f.m4
+++ b/ibtk/src/boundary/physical_boundary/fortran/cartphysbdryop2d.f.m4
@@ -741,3 +741,394 @@ c
       end
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     Set cell centered boundary values using the supplied Robin
+c     coefficients along the codimension 1 upper/lower x boundary.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      subroutine ccrobinphysbdryquadop1x2d(
+     &     U,U_gcw,
+     &     acoef,bcoef,gcoef,
+     &     location_index,
+     &     ilower0,iupper0,
+     &     ilower1,iupper1,
+     &     blower1,bupper1,
+     &     dx)
+c
+      implicit none
+c
+c     Input.
+c
+      INTEGER U_gcw
+
+      INTEGER location_index
+
+      INTEGER ilower0,iupper0
+      INTEGER ilower1,iupper1
+
+      INTEGER blower1,bupper1
+
+      REAL acoef(blower1:bupper1)
+      REAL bcoef(blower1:bupper1)
+      REAL gcoef(blower1:bupper1)
+
+      REAL dx(0:NDIM-1)
+c
+c     Input/Output.
+c
+      REAL U(CELL2d(ilower,iupper,U_gcw))
+c
+c     Local variables.
+c
+      INTEGER i,i_g,i_i
+      INTEGER j
+      INTEGER sgn
+      REAL    a,b,g,h
+      REAL    f_g,f_i,f_i2,n,u_g,u_i,u_i2
+      REAL    den
+c
+c     Initialize temporary variables to yield errors.
+c
+      u_g = 2.d0**15.d0
+      u_i = 2.d0**15.d0
+c
+c     Set values along the upper/lower x side of the patch.
+c
+      if ( (location_index .eq. 0) .or.
+     &     (location_index .eq. 1) ) then
+
+         h = dx(location_index/NDIM)
+
+         if (location_index .eq. 0) then
+            sgn = -1
+            i_g = ilower0-1     ! ghost    index
+            i_i = ilower0       ! interior index
+         else
+            sgn = +1
+            i_g = iupper0+1     ! ghost    index
+            i_i = iupper0       ! interior index
+         endif
+
+         do j = blower1,bupper1
+            a = acoef(j)
+            b = bcoef(j)
+            g = gcoef(j)
+            do i = 0,U_gcw-1
+               n = 1.d0+2.d0*i
+               den = 1.d0/(4.d0*b*(1.d0+n)+a*h*n*(2.d0+n))
+               f_i = den*(1.d0+n)*(4.d0*b-a*h*n*(2.d0+n))
+               f_g = den*(4.d0*h*n*(1.d0+n))
+               f_i2 = den*(a*h*n*n*n)
+               u_i = U(i_i-sgn*i,j)
+               u_i2 = U(i_i-sgn*(i+1),j)
+               U(i_g+sgn*i,j) = f_i*u_i + f_g*g + f_i2*u_i2
+            enddo
+         enddo
+
+      endif
+c
+      return
+      end
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     Set cell centered boundary values using the supplied Robin
+c     coefficients along the codimension 1 upper/lower y boundary.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      subroutine ccrobinphysbdryquadop1y2d(
+     &     U,U_gcw,
+     &     acoef,bcoef,gcoef,
+     &     location_index,
+     &     ilower0,iupper0,
+     &     ilower1,iupper1,
+     &     blower0,bupper0,
+     &     dx)
+c
+      implicit none
+c
+c     Input.
+c
+      INTEGER U_gcw
+
+      INTEGER location_index
+
+      INTEGER ilower0,iupper0
+      INTEGER ilower1,iupper1
+
+      INTEGER blower0,bupper0
+
+      REAL acoef(blower0:bupper0)
+      REAL bcoef(blower0:bupper0)
+      REAL gcoef(blower0:bupper0)
+
+      REAL dx(0:NDIM-1)
+c
+c     Input/Output.
+c
+      REAL U(CELL2d(ilower,iupper,U_gcw))
+c
+c     Local variables.
+c
+      INTEGER i
+      INTEGER j,j_g,j_i
+      INTEGER sgn
+      REAL    a,b,g,h
+      REAL    f_g,f_i,f_i2,n,u_g,u_i,u_i2
+      REAL    den
+c
+c     Initialize temporary variables to yield errors.
+c
+      u_g = 2.d0**15.d0
+      u_i = 2.d0**15.d0
+c
+c     Set values along the upper/lower y side of the patch.
+c
+      if ( (location_index .eq. 2) .or.
+     &     (location_index .eq. 3) ) then
+
+         h = dx(location_index/NDIM)
+
+         if (location_index .eq. 2) then
+            sgn = -1
+            j_g = ilower1-1     ! ghost    index
+            j_i = ilower1       ! interior index
+         else
+            sgn = +1
+            j_g = iupper1+1     ! ghost    index
+            j_i = iupper1       ! interior index
+         endif
+
+         do i = blower0,bupper0
+            a = acoef(i)
+            b = bcoef(i)
+            g = gcoef(i)
+            do j = 0,U_gcw-1
+               n = 1.d0+2.d0*j
+               den = 1.d0/(4.d0*b*(1.d0+n)+a*h*n*(2.d0+n))
+               f_i = den*(1.d0+n)*(4.d0*b-a*h*n*(2.d0+n))
+               f_g = den*4.d0*h*n*(1.d0+n)
+               f_i2 = den*a*h*n*n*n
+               u_i = U(i,j_i-sgn*j)
+               u_i2 = U(i,j_i-sgn*(j+1))
+               U(i,j_g+sgn*j) = f_i*u_i + f_g*g + f_i2*u_i2
+            enddo
+         enddo
+
+      endif
+c
+      return
+      end
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     Set side centered boundary values using the supplied Robin
+c     coefficients along the codimension 1 upper/lower x boundary.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      subroutine scrobinphysbdryquadop1x2d(
+     &     u0,u_gcw,
+     &     acoef,bcoef,gcoef,
+     &     location_index,
+     &     ilower0,iupper0,
+     &     ilower1,iupper1,
+     &     blower1,bupper1,
+     &     dx)
+c
+      implicit none
+c
+c     Input.
+c
+      INTEGER u_gcw
+
+      INTEGER location_index
+
+      INTEGER ilower0,iupper0
+      INTEGER ilower1,iupper1
+
+      INTEGER blower1,bupper1
+
+      REAL acoef(blower1:bupper1)
+      REAL bcoef(blower1:bupper1)
+      REAL gcoef(blower1:bupper1)
+
+      REAL dx(0:NDIM-1)
+c
+c     Input/Output.
+c
+      REAL u0(SIDE2d0(ilower,iupper,u_gcw))
+c
+c     Local variables.
+c
+      INTEGER i,i_b,i_i
+      INTEGER j
+      INTEGER sgn
+      REAL    a,b,g,h,f_b,f_g,f_i,f_i2,n,u_b,u_g,u_i,u_i2
+c
+c     Initialize temporary variables to yield errors.
+c
+      u_b = 2.d0**15.d0
+      u_g = 2.d0**15.d0
+      u_i = 2.d0**15.d0
+      u_i2 = 2.d0**15.d0
+c
+c     Set values along the upper/lower x side of the patch.
+c
+      if ( (location_index .eq. 0) .or.
+     &     (location_index .eq. 1) ) then
+
+         h = dx(location_index/NDIM)
+
+         if (location_index .eq. 0) then
+            sgn = -1
+            i_b = ilower0       ! boundary index
+            i_i = ilower0+1     ! interior index
+         else
+            sgn = +1
+            i_b = iupper0+1     ! boundary index
+            i_i = iupper0       ! interior index
+         endif
+
+         do j = blower1,bupper1
+            a = acoef(j)
+            b = bcoef(j)
+            g = gcoef(j)
+            if (abs(b) .lt. 1.d-12) then
+c     Dirichlet boundary conditions
+               u_b = g/a
+               u0(i_b,j) = u_b
+               do i = 1,u_gcw
+                  f_i2 = 1.d0
+                  f_i = -3.d0
+                  f_b = 3.d0
+                  u_i = u0(i_b-sgn*i,j)
+                  u_i2 = u0(i_b-sgn*(i+1),j)
+                  u0(i_b+sgn*i,j) = f_i2*u_i2 + f_i*u_i + f_b*u_b
+               enddo
+            else
+c     Robin boundary conditions
+               u_b = u0(i_b,j)
+               do i = 1,u_gcw
+                  n = 2.d0*i
+                  f_i = 1.d0
+                  f_b = -a*n*h/b
+                  f_g = n*h/b
+                  u_i = u0(i_b-sgn*i,j)
+                  u0(i_b+sgn*i,j) = f_i*u_i + f_b*u_b + f_g*g
+               enddo
+            endif
+         enddo
+
+      endif
+c
+      return
+      end
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     Set side centered boundary values using the supplied Robin
+c     coefficients along the codimension 1 upper/lower y boundary.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      subroutine scrobinphysbdryquadop1y2d(
+     &     u1,u_gcw,
+     &     acoef,bcoef,gcoef,
+     &     location_index,
+     &     ilower0,iupper0,
+     &     ilower1,iupper1,
+     &     blower0,bupper0,
+     &     dx)
+c
+      implicit none
+c
+c     Input.
+c
+      INTEGER u_gcw
+
+      INTEGER location_index
+
+      INTEGER ilower0,iupper0
+      INTEGER ilower1,iupper1
+
+      INTEGER blower0,bupper0
+
+      REAL acoef(blower0:bupper0)
+      REAL bcoef(blower0:bupper0)
+      REAL gcoef(blower0:bupper0)
+
+      REAL dx(0:NDIM-1)
+c
+c     Input/Output.
+c
+      REAL u1(SIDE2d1(ilower,iupper,u_gcw))
+c
+c     Local variables.
+c
+      INTEGER i
+      INTEGER j,j_b,j_i
+      INTEGER sgn
+      REAL    a,b,g,h,f_b,f_g,f_i,f_i2,n,u_b,u_g,u_i,u_i2
+c
+c     Initialize temporary variables to yield errors.
+c
+      u_b = 2.d0**15.d0
+      u_g = 2.d0**15.d0
+      u_i = 2.d0**15.d0
+      u_i2 = 2.d0**15.d0
+c
+c     Set values along the upper/lower y side of the patch.
+c
+      if ( (location_index .eq. 2) .or.
+     &     (location_index .eq. 3) ) then
+
+         h = dx(location_index/NDIM)
+
+         if (location_index .eq. 2) then
+            sgn = -1
+            j_b = ilower1       ! boundary index
+            j_i = ilower1+1     ! interior index
+         else
+            sgn = +1
+            j_b = iupper1+1     ! boundary index
+            j_i = iupper1       ! interior index
+         endif
+
+         do i = blower0,bupper0
+            a = acoef(i)
+            b = bcoef(i)
+            g = gcoef(i)
+            if (abs(b) .lt. 1.d-12) then
+c     Dirichlet boundary conditions
+               u_b = g/a
+               u1(i,j_b) = u_b
+               do j = 1,u_gcw
+                  f_i2 = 1.d0
+                  f_i = -3.d0
+                  f_b = 3.d0
+                  u_i = u1(i,j_b-sgn*j)
+                  u_i2 = u1(i,j_b-sgn*(j+1))
+                  u1(i,j_b+sgn*j) = f_i2*u_i2 + f_i*u_i + f_b*u_b
+               enddo
+            else
+c     Robin boundary conditions
+               u_b = u1(i,j_b)
+               do j = 1,u_gcw
+                  n = 2.d0*j
+                  f_i = 1.d0
+                  f_b = -a*n*h/b
+                  f_g = n*h/b
+                  u_i = u1(i,j_b-sgn*j)
+                  u1(i,j_b+sgn*j) = f_i*u_i + f_b*u_b + f_g*g
+               enddo
+            endif
+         enddo
+
+      endif
+c
+      return
+      end
+c

--- a/ibtk/src/boundary/physical_boundary/fortran/cartphysbdryop3d.f.m4
+++ b/ibtk/src/boundary/physical_boundary/fortran/cartphysbdryop3d.f.m4
@@ -1697,3 +1697,635 @@ c
       end
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     Set cell centered boundary values using the supplied Robin
+c     coefficients along the codimension 1 upper/lower x boundary.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      subroutine ccrobinphysbdryquadop1x3d(
+     &     U,U_gcw,
+     &     acoef,bcoef,gcoef,
+     &     location_index,
+     &     ilower0,iupper0,
+     &     ilower1,iupper1,
+     &     ilower2,iupper2,
+     &     blower1,bupper1,
+     &     blower2,bupper2,
+     &     dx)
+c
+      implicit none
+c
+c     Input.
+c
+      INTEGER U_gcw
+
+      INTEGER location_index
+
+      INTEGER ilower0,iupper0
+      INTEGER ilower1,iupper1
+      INTEGER ilower2,iupper2
+
+      INTEGER blower1,bupper1
+      INTEGER blower2,bupper2
+
+      REAL acoef(blower1:bupper1,blower2:bupper2)
+      REAL bcoef(blower1:bupper1,blower2:bupper2)
+      REAL gcoef(blower1:bupper1,blower2:bupper2)
+
+      REAL dx(0:NDIM-1)
+c
+c     Input/Output.
+c
+      REAL U(CELL3d(ilower,iupper,U_gcw))
+c
+c     Local variables.
+c
+      INTEGER j,k
+      INTEGER i,i_g,i_i,i_i2
+      INTEGER sgn
+      REAL    a,b,g,h
+      REAL    f_g,f_i,f_i2,n,u_g,u_i,u_i2
+      REAL    den
+c
+c     Initialize temporary variables to yield errors.
+c
+      u_g = 2.d0**15.d0
+      u_i = 2.d0**15.d0
+c
+c     Set values along the upper/lower y side of the patch.
+c
+      if ( (location_index .eq. 0) .or.
+     &     (location_index .eq. 1) ) then
+
+         h = dx(location_index/NDIM)
+
+         if (location_index .eq. 0) then
+            sgn = -1
+            i_g = ilower0-1     ! ghost    index
+            i_i = ilower0       ! interior index
+            i_i2 = ilower0+1
+         else
+            sgn = +1
+            i_g = iupper0+1     ! ghost    index
+            i_i = iupper0       ! interior index
+            i_i2 = iupper0-1
+         endif
+
+         do k = blower2,bupper2
+            do j = blower1,bupper1
+               a = acoef(j,k)
+               b = bcoef(j,k)
+               g = gcoef(j,k)
+               do i = 0,U_gcw-1
+                  n = 1.d0+2.d0*i
+                  den = 1.d0/(4.d0*b*(1.d0+n)+a*h*n*(2.d0+n))
+                  f_i = den*(1.d0+n)*(4.d0*b-a*h*n*(2.d0+n))
+                  f_g = den*4.d0*h*n*(1.d0+n)
+                  f_i2 = den*a*h*n*n*n
+                  u_i = U(i_i-sgn*i,j,k)
+                  u_i2 = U(i_i2-sgn*i,j,k)
+                  U(i_g+sgn*i,j,k) = f_i*u_i + f_g*g + f_i2*u_i2
+               enddo
+            enddo
+         enddo
+
+      endif
+c
+      return
+      end
+c
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     Set cell centered boundary values using the supplied Robin
+c     coefficients along the codimension 1 upper/lower y boundary.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      subroutine ccrobinphysbdryquadop1y3d(
+     &     U,U_gcw,
+     &     acoef,bcoef,gcoef,
+     &     location_index,
+     &     ilower0,iupper0,
+     &     ilower1,iupper1,
+     &     ilower2,iupper2,
+     &     blower0,bupper0,
+     &     blower2,bupper2,
+     &     dx)
+c
+      implicit none
+c
+c     Input.
+c
+      INTEGER U_gcw
+
+      INTEGER location_index
+
+      INTEGER ilower0,iupper0
+      INTEGER ilower1,iupper1
+      INTEGER ilower2,iupper2
+
+      INTEGER blower0,bupper0
+      INTEGER blower2,bupper2
+
+      REAL acoef(blower0:bupper0,blower2:bupper2)
+      REAL bcoef(blower0:bupper0,blower2:bupper2)
+      REAL gcoef(blower0:bupper0,blower2:bupper2)
+
+      REAL dx(0:NDIM-1)
+c
+c     Input/Output.
+c
+      REAL U(CELL3d(ilower,iupper,U_gcw))
+c
+c     Local variables.
+c
+      INTEGER i,k
+      INTEGER j,j_g,j_i,j_i2
+      INTEGER sgn
+      REAL    a,b,g,h
+      REAL    f_g,f_i,f_i2,n,u_g,u_i,u_i2
+      REAL    den
+c
+c     Initialize temporary variables to yield errors.
+c
+      u_g = 2.d0**15.d0
+      u_i = 2.d0**15.d0
+c
+c     Set values along the upper/lower y side of the patch.
+c
+      if ( (location_index .eq. 2) .or.
+     &     (location_index .eq. 3) ) then
+
+         h = dx(location_index/NDIM)
+
+         if (location_index .eq. 2) then
+            sgn = -1
+            j_g = ilower1-1     ! ghost    index
+            j_i = ilower1       ! interior index
+            j_i2 = ilower1+1
+         else
+            sgn = +1
+            j_g = iupper1+1     ! ghost    index
+            j_i = iupper1       ! interior index
+            j_i2 = iupper1-1
+         endif
+
+         do k = blower2,bupper2
+            do i = blower0,bupper0
+               a = acoef(i,k)
+               b = bcoef(i,k)
+               g = gcoef(i,k)
+               do j = 0,U_gcw-1
+                  n = 1.d0+2.d0*j
+                  den = 1.d0/(4.d0*b*(1.d0+n)+a*h*n*(2.d0+n))
+                  f_i = den*(1.d0+n)*(4.d0*b-a*h*n*(2.d0+n))
+                  f_g = den*4.d0*h*n*(1.d0+n)
+                  f_i2 = den*a*h*n*n*n
+                  u_i = U(i,j_i-sgn*j,k)
+                  u_i2 = U(i,j_i2-sgn*j,k)
+                  U(i,j_g+sgn*j,k) = f_i*u_i + f_g*g + f_i2*u_i2
+               enddo
+            enddo
+         enddo
+
+      endif
+c
+      return
+      end
+c
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     Set cell centered boundary values using the supplied Robin
+c     coefficients along the codimension 1 upper/lower z boundary.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      subroutine ccrobinphysbdryquadop1z3d(
+     &     U,U_gcw,
+     &     acoef,bcoef,gcoef,
+     &     location_index,
+     &     ilower0,iupper0,
+     &     ilower1,iupper1,
+     &     ilower2,iupper2,
+     &     blower0,bupper0,
+     &     blower1,bupper1,
+     &     dx)
+c
+      implicit none
+c
+c     Input.
+c
+      INTEGER U_gcw
+
+      INTEGER location_index
+
+      INTEGER ilower0,iupper0
+      INTEGER ilower1,iupper1
+      INTEGER ilower2,iupper2
+
+      INTEGER blower0,bupper0
+      INTEGER blower1,bupper1
+
+      REAL acoef(blower0:bupper0,blower1:bupper1)
+      REAL bcoef(blower0:bupper0,blower1:bupper1)
+      REAL gcoef(blower0:bupper0,blower1:bupper1)
+
+      REAL dx(0:NDIM-1)
+c
+c     Input/Output.
+c
+      REAL U(CELL3d(ilower,iupper,U_gcw))
+c
+c     Local variables.
+c
+      INTEGER i,j
+      INTEGER k,k_g,k_i,k_i2
+      INTEGER sgn
+      REAL    a,b,g,h
+      REAL    f_g,f_i,f_i2,n,u_g,u_i,u_i2
+      REAL    den
+c
+c     Initialize temporary variables to yield errors.
+c
+      u_g = 2.d0**15.d0
+      u_i = 2.d0**15.d0
+c
+c     Set values along the upper/lower y side of the patch.
+c
+      if ( (location_index .eq. 4) .or.
+     &     (location_index .eq. 5) ) then
+
+         h = dx(location_index/NDIM)
+
+         if (location_index .eq. 4) then
+            sgn = -1
+            k_g = ilower2-1     ! ghost    index
+            k_i = ilower2       ! interior index
+            k_i2 = ilower2+1
+         else
+            sgn = +1
+            k_g = iupper2+1     ! ghost    index
+            k_i = iupper2       ! interior index
+            k_i2 = iupper2-1
+         endif
+
+         do j = blower1,bupper1
+            do i = blower0,bupper0
+               a = acoef(i,j)
+               b = bcoef(i,j)
+               g = gcoef(i,j)
+               do k = 0,U_gcw-1
+                  n = 1.d0+2.d0*k
+                  den = 1.d0/(4.d0*b*(1.d0+n)+a*h*n*(2.d0+n))
+                  f_i = den*(1.d0+n)*(4.d0*b-a*h*n*(2.d0+n))
+                  f_g = den*4.d0*h*n*(1.d0+n)
+                  f_i2 = den*a*h*n*n*n
+                  u_i = U(i,j,k_i-sgn*k)
+                  u_i2 = U(i,j,k_i2-sgn*k)
+                  U(i,j,k_g+sgn*k) = f_i*u_i + f_g*g + f_i2*u_i2
+               enddo
+            enddo
+         enddo
+
+      endif
+c
+      return
+      end
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     Set side centered boundary values using the supplied Robin
+c     coefficients along the codimension 1 upper/lower x boundary.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      subroutine scrobinphysbdryquadop1x3d(
+     &     u0,u_gcw,
+     &     acoef,bcoef,gcoef,
+     &     location_index,
+     &     ilower0,iupper0,
+     &     ilower1,iupper1,
+     &     ilower2,iupper2,
+     &     blower1,bupper1,
+     &     blower2,bupper2,
+     &     dx)
+c
+      implicit none
+c
+c     Input.
+c
+      INTEGER u_gcw
+
+      INTEGER location_index
+
+      INTEGER ilower0,iupper0
+      INTEGER ilower1,iupper1
+      INTEGER ilower2,iupper2
+
+      INTEGER blower1,bupper1
+      INTEGER blower2,bupper2
+
+      REAL acoef(blower1:bupper1,blower2:bupper2)
+      REAL bcoef(blower1:bupper1,blower2:bupper2)
+      REAL gcoef(blower1:bupper1,blower2:bupper2)
+
+      REAL dx(0:NDIM-1)
+c
+c     Input/Output.
+c
+      REAL u0(SIDE3d0(ilower,iupper,u_gcw))
+c
+c     Local variables.
+c
+      INTEGER i,i_b,i_i
+      INTEGER j
+      INTEGER k
+      INTEGER sgn
+      REAL    a,b,f_b,f_g,f_i,f_i2,g,h,n,u_b,u_g,u_i,u_i2
+c
+c     Initialize temporary variables to yield errors.
+c
+      u_b = 2.d0**15.d0
+      u_g = 2.d0**15.d0
+      u_i = 2.d0**15.d0
+      u_i2 = 2.d0**15.d0
+c
+c     Set values along the upper/lower x side of the patch.
+c
+      if ( (location_index .eq. 0) .or.
+     &     (location_index .eq. 1) ) then
+
+         h = dx(location_index/NDIM)
+
+         if (location_index .eq. 0) then
+            sgn = -1
+            i_b = ilower0       ! boundary index
+            i_i = ilower0+1     ! interior index
+         else
+            sgn = +1
+            i_b = iupper0+1     ! boundary index
+            i_i = iupper0       ! interior index
+         endif
+
+         do k = blower2,bupper2
+            do j = blower1,bupper1
+               a = acoef(j,k)
+               b = bcoef(j,k)
+               g = gcoef(j,k)
+               if (abs(b) .lt. 1.d-12) then
+c     Dirichlet boundary conditions
+                  u_b = g/a
+                  u0(i_b,j,k) = u_b
+                  do i = 1,u_gcw
+                     f_i = -3.d0
+                     f_i2 = 1.d0
+                     f_b = 3.d0
+                     u_i = u0(i_b-sgn*i,j,k)
+                     u_i2 = u0(i_b-sgn*(i+1),j,k)
+                     u0(i_b+sgn*i,j,k) = f_i2*u_i2+f_i*u_i+f_b*u_b
+                  enddo
+               else
+c     Robin boundary conditions
+                  u_b = u0(i_b,j,k)
+                  do i = 1,u_gcw
+                     n = 2.d0*i
+                     f_i = 1.d0
+                     f_b = -a*n*h/b
+                     f_g = n*h/b
+                     u_i = u0(i_b-sgn*i,j,k)
+                     u0(i_b+sgn*i,j,k) = f_i*u_i + f_b*u_b + f_g*g
+                  enddo
+               endif
+            enddo
+         enddo
+
+      endif
+c
+      return
+      end
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     Set side centered boundary values using the supplied Robin
+c     coefficients along the codimension 1 upper/lower y boundary.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      subroutine scrobinphysbdryquadop1y3d(
+     &     u1,u_gcw,
+     &     acoef,bcoef,gcoef,
+     &     location_index,
+     &     ilower0,iupper0,
+     &     ilower1,iupper1,
+     &     ilower2,iupper2,
+     &     blower0,bupper0,
+     &     blower2,bupper2,
+     &     dx)
+c
+      implicit none
+c
+c     Input.
+c
+      INTEGER u_gcw
+
+      INTEGER location_index
+
+      INTEGER ilower0,iupper0
+      INTEGER ilower1,iupper1
+      INTEGER ilower2,iupper2
+
+      INTEGER blower0,bupper0
+      INTEGER blower2,bupper2
+
+      REAL acoef(blower0:bupper0,blower2:bupper2)
+      REAL bcoef(blower0:bupper0,blower2:bupper2)
+      REAL gcoef(blower0:bupper0,blower2:bupper2)
+
+      REAL dx(0:NDIM-1)
+c
+c     Input/Output.
+c
+      REAL u1(SIDE3d1(ilower,iupper,u_gcw))
+c
+c     Local variables.
+c
+      INTEGER i
+      INTEGER j,j_b,j_i
+      INTEGER k
+      INTEGER sgn
+      REAL    a,b,f_b,f_g,f_i,f_i2,g,h,n,u_b,u_g,u_i,u_i2
+c
+c     Initialize temporary variables to yield errors.
+c
+      u_b = 2.d0**15.d0
+      u_g = 2.d0**15.d0
+      u_i = 2.d0**15.d0
+      u_i2 = 2.d0**15.d0
+c
+c     Set values along the upper/lower y side of the patch.
+c
+      if ( (location_index .eq. 2) .or.
+     &     (location_index .eq. 3) ) then
+
+         h = dx(location_index/NDIM)
+
+         if (location_index .eq. 2) then
+            sgn = -1
+            j_b = ilower1       ! boundary index
+            j_i = ilower1+1     ! interior index
+         else
+            sgn = +1
+            j_b = iupper1+1     ! boundary index
+            j_i = iupper1       ! interior index
+         endif
+
+         do k = blower2,bupper2
+            do i = blower0,bupper0
+               a = acoef(i,k)
+               b = bcoef(i,k)
+               g = gcoef(i,k)
+               if (abs(b) .lt. 1.d-12) then
+c     Dirichlet boundary conditions
+                  u_b = g/a
+                  u1(i,j_b,k) = u_b
+                  do j = 1,u_gcw
+                     f_i = -3.d0
+                     f_i2 = 1.d0
+                     f_b = 3.d0
+                     u_i = u1(i,j_b-sgn*j,k)
+                     u_i2 = u1(i,j_b-sgn*(j+1),k)
+                     u1(i,j_b+sgn*j,k) = f_i2*u_i2+f_i*u_i+f_b*u_b
+                  enddo
+               else
+c     Robin boundary conditions
+                  u_b = u1(i,j_b,k)
+                  do j = 1,u_gcw
+                     n = 2.d0*j
+                     f_i = 1.d0
+                     f_b = -a*n*h/b
+                     f_g = n*h/b
+                     u_i = u1(i,j_b-sgn*j,k)
+                     u1(i,j_b+sgn*j,k) = f_i*u_i + f_b*u_b + f_g*g
+                  enddo
+               endif
+            enddo
+         enddo
+
+      endif
+c
+      return
+      end
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     Set side centered boundary values using the supplied Robin
+c     coefficients along the codimension 1 upper/lower z boundary.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      subroutine scrobinphysbdryquadop1z3d(
+     &     u2,u_gcw,
+     &     acoef,bcoef,gcoef,
+     &     location_index,
+     &     ilower0,iupper0,
+     &     ilower1,iupper1,
+     &     ilower2,iupper2,
+     &     blower0,bupper0,
+     &     blower1,bupper1,
+     &     dx)
+c
+      implicit none
+c
+c     Input.
+c
+      INTEGER u_gcw
+
+      INTEGER location_index
+
+      INTEGER ilower0,iupper0
+      INTEGER ilower1,iupper1
+      INTEGER ilower2,iupper2
+
+      INTEGER blower0,bupper0
+      INTEGER blower1,bupper1
+
+      REAL acoef(blower0:bupper0,blower1:bupper1)
+      REAL bcoef(blower0:bupper0,blower1:bupper1)
+      REAL gcoef(blower0:bupper0,blower1:bupper1)
+
+      REAL dx(0:NDIM-1)
+c
+c     Input/Output.
+c
+      REAL u2(SIDE3d2(ilower,iupper,u_gcw))
+c
+c     Local variables.
+c
+      INTEGER i
+      INTEGER j
+      INTEGER k,k_b,k_i
+      INTEGER sgn
+      REAL    a,b,f_b,f_g,f_i,f_i2,g,h,n,u_b,u_g,u_i,u_i2
+c
+c     Initialize temporary variables to yield errors.
+c
+      u_b = 2.d0**15.d0
+      u_g = 2.d0**15.d0
+      u_i = 2.d0**15.d0
+      u_i2 = 2.d0**15.d0
+c
+c     Set values along the upper/lower z side of the patch.
+c
+      if ( (location_index .eq. 4) .or.
+     &     (location_index .eq. 5) ) then
+
+         h = dx(location_index/NDIM)
+
+         if (location_index .eq. 4) then
+            sgn = -1
+            k_b = ilower2       ! boundary index
+            k_i = ilower2+1     ! interior index
+         else
+            sgn = +1
+            k_b = iupper2+1     ! boundary index
+            k_i = iupper2       ! interior index
+         endif
+
+         do j = blower1,bupper1
+            do i = blower0,bupper0
+               a = acoef(i,j)
+               b = bcoef(i,j)
+               g = gcoef(i,j)
+               if (abs(b) .lt. 1.d-12) then
+c     Dirichlet boundary conditions
+                  u_b = g/a
+                  u2(i,j,k_b) = u_b
+                  do k = 1,u_gcw
+                     f_i = -3.d0
+                     f_i2 = 1.d0
+                     f_b = 3.d0
+                     u_i = u2(i,j,k_b-sgn*k)
+                     u_i2 = u2(i,j,k_b-sgn*(k+1))
+                     u2(i,j,k_b+sgn*k) = f_i2*u_i2 + f_i*u_i + f_b*u_b
+                  enddo
+               else
+c     Robin boundary conditions
+                  u_b = u2(i,j,k_b)
+                  do k = 1,u_gcw
+                     n = 2.d0*k
+                     f_i = 1.d0
+                     f_b = -a*n*h/b
+                     f_g = n*h/b
+                     u_i = u2(i,j,k_b-sgn*k)
+                     u2(i,j,k_b+sgn*k) = f_i*u_i + f_b*u_b + f_g*g
+                  enddo
+               endif
+            enddo
+         enddo
+
+      endif
+c
+      return
+      end
+c

--- a/tests/physical_boundary/Makefile.am
+++ b/tests/physical_boundary/Makefile.am
@@ -1,10 +1,18 @@
 include $(top_srcdir)/config/Make-rules
 
-EXTRA_PROGRAMS = extrapolation_01
+EXTRA_PROGRAMS = extrapolation_01 physical_boundary_2d_01 physical_boundary_3d_01
 
 extrapolation_01_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 extrapolation_01_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 extrapolation_01_SOURCES = extrapolation_01.cpp
+
+physical_boundary_2d_01_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
+physical_boundary_2d_01_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+physical_boundary_2d_01_SOURCES = physical_boundary_01.cpp
+
+physical_boundary_3d_01_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=3
+physical_boundary_3d_01_LDADD = $(IBAMR_LDFLAGS) $(IBAMR3d_LIBS) $(IBAMR_LIBS)
+physical_boundary_3d_01_SOURCES = physical_boundary_01.cpp
 
 tests: $(EXTRA_PROGRAMS)
 	if test "$(top_srcdir)" != "$(top_builddir)" ; then \

--- a/tests/physical_boundary/Makefile.in
+++ b/tests/physical_boundary/Makefile.in
@@ -87,7 +87,9 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
-EXTRA_PROGRAMS = extrapolation_01$(EXEEXT)
+EXTRA_PROGRAMS = extrapolation_01$(EXEEXT) \
+	physical_boundary_2d_01$(EXEEXT) \
+	physical_boundary_3d_01$(EXEEXT)
 subdir = tests/physical_boundary
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/add_rpath.m4 \
@@ -132,6 +134,24 @@ extrapolation_01_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(extrapolation_01_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
+am_physical_boundary_2d_01_OBJECTS =  \
+	physical_boundary_2d_01-physical_boundary_01.$(OBJEXT)
+physical_boundary_2d_01_OBJECTS =  \
+	$(am_physical_boundary_2d_01_OBJECTS)
+physical_boundary_2d_01_DEPENDENCIES = $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+physical_boundary_2d_01_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
+	$(physical_boundary_2d_01_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
+	$(LDFLAGS) -o $@
+am_physical_boundary_3d_01_OBJECTS =  \
+	physical_boundary_3d_01-physical_boundary_01.$(OBJEXT)
+physical_boundary_3d_01_OBJECTS =  \
+	$(am_physical_boundary_3d_01_OBJECTS)
+physical_boundary_3d_01_DEPENDENCIES = $(IBAMR3d_LIBS) $(IBAMR_LIBS)
+physical_boundary_3d_01_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
+	$(physical_boundary_3d_01_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
+	$(LDFLAGS) -o $@
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -148,7 +168,9 @@ DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)/config
 depcomp = $(SHELL) $(top_srcdir)/config/depcomp
 am__maybe_remake_depfiles = depfiles
 am__depfiles_remade =  \
-	./$(DEPDIR)/extrapolation_01-extrapolation_01.Po
+	./$(DEPDIR)/extrapolation_01-extrapolation_01.Po \
+	./$(DEPDIR)/physical_boundary_2d_01-physical_boundary_01.Po \
+	./$(DEPDIR)/physical_boundary_3d_01-physical_boundary_01.Po
 am__mv = mv -f
 CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
@@ -168,8 +190,12 @@ AM_V_CXXLD = $(am__v_CXXLD_@AM_V@)
 am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
 am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
-SOURCES = $(extrapolation_01_SOURCES)
-DIST_SOURCES = $(extrapolation_01_SOURCES)
+SOURCES = $(extrapolation_01_SOURCES) \
+	$(physical_boundary_2d_01_SOURCES) \
+	$(physical_boundary_3d_01_SOURCES)
+DIST_SOURCES = $(extrapolation_01_SOURCES) \
+	$(physical_boundary_2d_01_SOURCES) \
+	$(physical_boundary_3d_01_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -472,6 +498,12 @@ SUFFIXES = .f.m4
 extrapolation_01_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 extrapolation_01_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 extrapolation_01_SOURCES = extrapolation_01.cpp
+physical_boundary_2d_01_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
+physical_boundary_2d_01_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+physical_boundary_2d_01_SOURCES = physical_boundary_01.cpp
+physical_boundary_3d_01_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=3
+physical_boundary_3d_01_LDADD = $(IBAMR_LDFLAGS) $(IBAMR3d_LIBS) $(IBAMR_LIBS)
+physical_boundary_3d_01_SOURCES = physical_boundary_01.cpp
 all: all-am
 
 .SUFFIXES:
@@ -511,6 +543,14 @@ extrapolation_01$(EXEEXT): $(extrapolation_01_OBJECTS) $(extrapolation_01_DEPEND
 	@rm -f extrapolation_01$(EXEEXT)
 	$(AM_V_CXXLD)$(extrapolation_01_LINK) $(extrapolation_01_OBJECTS) $(extrapolation_01_LDADD) $(LIBS)
 
+physical_boundary_2d_01$(EXEEXT): $(physical_boundary_2d_01_OBJECTS) $(physical_boundary_2d_01_DEPENDENCIES) $(EXTRA_physical_boundary_2d_01_DEPENDENCIES) 
+	@rm -f physical_boundary_2d_01$(EXEEXT)
+	$(AM_V_CXXLD)$(physical_boundary_2d_01_LINK) $(physical_boundary_2d_01_OBJECTS) $(physical_boundary_2d_01_LDADD) $(LIBS)
+
+physical_boundary_3d_01$(EXEEXT): $(physical_boundary_3d_01_OBJECTS) $(physical_boundary_3d_01_DEPENDENCIES) $(EXTRA_physical_boundary_3d_01_DEPENDENCIES) 
+	@rm -f physical_boundary_3d_01$(EXEEXT)
+	$(AM_V_CXXLD)$(physical_boundary_3d_01_LINK) $(physical_boundary_3d_01_OBJECTS) $(physical_boundary_3d_01_LDADD) $(LIBS)
+
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
 
@@ -518,6 +558,8 @@ distclean-compile:
 	-rm -f *.tab.c
 
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/extrapolation_01-extrapolation_01.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/physical_boundary_2d_01-physical_boundary_01.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/physical_boundary_3d_01-physical_boundary_01.Po@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
 	@$(MKDIR_P) $(@D)
@@ -562,6 +604,34 @@ extrapolation_01-extrapolation_01.obj: extrapolation_01.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='extrapolation_01.cpp' object='extrapolation_01-extrapolation_01.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(extrapolation_01_CXXFLAGS) $(CXXFLAGS) -c -o extrapolation_01-extrapolation_01.obj `if test -f 'extrapolation_01.cpp'; then $(CYGPATH_W) 'extrapolation_01.cpp'; else $(CYGPATH_W) '$(srcdir)/extrapolation_01.cpp'; fi`
+
+physical_boundary_2d_01-physical_boundary_01.o: physical_boundary_01.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(physical_boundary_2d_01_CXXFLAGS) $(CXXFLAGS) -MT physical_boundary_2d_01-physical_boundary_01.o -MD -MP -MF $(DEPDIR)/physical_boundary_2d_01-physical_boundary_01.Tpo -c -o physical_boundary_2d_01-physical_boundary_01.o `test -f 'physical_boundary_01.cpp' || echo '$(srcdir)/'`physical_boundary_01.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/physical_boundary_2d_01-physical_boundary_01.Tpo $(DEPDIR)/physical_boundary_2d_01-physical_boundary_01.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='physical_boundary_01.cpp' object='physical_boundary_2d_01-physical_boundary_01.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(physical_boundary_2d_01_CXXFLAGS) $(CXXFLAGS) -c -o physical_boundary_2d_01-physical_boundary_01.o `test -f 'physical_boundary_01.cpp' || echo '$(srcdir)/'`physical_boundary_01.cpp
+
+physical_boundary_2d_01-physical_boundary_01.obj: physical_boundary_01.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(physical_boundary_2d_01_CXXFLAGS) $(CXXFLAGS) -MT physical_boundary_2d_01-physical_boundary_01.obj -MD -MP -MF $(DEPDIR)/physical_boundary_2d_01-physical_boundary_01.Tpo -c -o physical_boundary_2d_01-physical_boundary_01.obj `if test -f 'physical_boundary_01.cpp'; then $(CYGPATH_W) 'physical_boundary_01.cpp'; else $(CYGPATH_W) '$(srcdir)/physical_boundary_01.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/physical_boundary_2d_01-physical_boundary_01.Tpo $(DEPDIR)/physical_boundary_2d_01-physical_boundary_01.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='physical_boundary_01.cpp' object='physical_boundary_2d_01-physical_boundary_01.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(physical_boundary_2d_01_CXXFLAGS) $(CXXFLAGS) -c -o physical_boundary_2d_01-physical_boundary_01.obj `if test -f 'physical_boundary_01.cpp'; then $(CYGPATH_W) 'physical_boundary_01.cpp'; else $(CYGPATH_W) '$(srcdir)/physical_boundary_01.cpp'; fi`
+
+physical_boundary_3d_01-physical_boundary_01.o: physical_boundary_01.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(physical_boundary_3d_01_CXXFLAGS) $(CXXFLAGS) -MT physical_boundary_3d_01-physical_boundary_01.o -MD -MP -MF $(DEPDIR)/physical_boundary_3d_01-physical_boundary_01.Tpo -c -o physical_boundary_3d_01-physical_boundary_01.o `test -f 'physical_boundary_01.cpp' || echo '$(srcdir)/'`physical_boundary_01.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/physical_boundary_3d_01-physical_boundary_01.Tpo $(DEPDIR)/physical_boundary_3d_01-physical_boundary_01.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='physical_boundary_01.cpp' object='physical_boundary_3d_01-physical_boundary_01.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(physical_boundary_3d_01_CXXFLAGS) $(CXXFLAGS) -c -o physical_boundary_3d_01-physical_boundary_01.o `test -f 'physical_boundary_01.cpp' || echo '$(srcdir)/'`physical_boundary_01.cpp
+
+physical_boundary_3d_01-physical_boundary_01.obj: physical_boundary_01.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(physical_boundary_3d_01_CXXFLAGS) $(CXXFLAGS) -MT physical_boundary_3d_01-physical_boundary_01.obj -MD -MP -MF $(DEPDIR)/physical_boundary_3d_01-physical_boundary_01.Tpo -c -o physical_boundary_3d_01-physical_boundary_01.obj `if test -f 'physical_boundary_01.cpp'; then $(CYGPATH_W) 'physical_boundary_01.cpp'; else $(CYGPATH_W) '$(srcdir)/physical_boundary_01.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/physical_boundary_3d_01-physical_boundary_01.Tpo $(DEPDIR)/physical_boundary_3d_01-physical_boundary_01.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='physical_boundary_01.cpp' object='physical_boundary_3d_01-physical_boundary_01.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(physical_boundary_3d_01_CXXFLAGS) $(CXXFLAGS) -c -o physical_boundary_3d_01-physical_boundary_01.obj `if test -f 'physical_boundary_01.cpp'; then $(CYGPATH_W) 'physical_boundary_01.cpp'; else $(CYGPATH_W) '$(srcdir)/physical_boundary_01.cpp'; fi`
 
 mostlyclean-libtool:
 	-rm -f *.lo
@@ -695,6 +765,8 @@ clean-am: clean-generic clean-libtool mostlyclean-am
 
 distclean: distclean-am
 		-rm -f ./$(DEPDIR)/extrapolation_01-extrapolation_01.Po
+	-rm -f ./$(DEPDIR)/physical_boundary_2d_01-physical_boundary_01.Po
+	-rm -f ./$(DEPDIR)/physical_boundary_3d_01-physical_boundary_01.Po
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -741,6 +813,8 @@ installcheck-am:
 
 maintainer-clean: maintainer-clean-am
 		-rm -f ./$(DEPDIR)/extrapolation_01-extrapolation_01.Po
+	-rm -f ./$(DEPDIR)/physical_boundary_2d_01-physical_boundary_01.Po
+	-rm -f ./$(DEPDIR)/physical_boundary_3d_01-physical_boundary_01.Po
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/tests/physical_boundary/physical_boundary_01.cpp
+++ b/tests/physical_boundary/physical_boundary_01.cpp
@@ -1,0 +1,333 @@
+// Copyright (c) 2002-2014, Boyce Griffith
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Config files
+#include <IBTK_config.h>
+
+#include <SAMRAI_config.h>
+
+// Headers for basic PETSc objects
+#include <petscsys.h>
+
+// Headers for major SAMRAI objects
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <GriddingAlgorithm.h>
+#include <LoadBalancer.h>
+#include <StandardTagAndInitialize.h>
+
+// Headers for application-specific algorithm/data structure objects
+#include <ibtk/AppInitializer.h>
+#include <ibtk/CartCellRobinPhysBdryOp.h>
+#include <ibtk/CartExtrapPhysBdryOp.h>
+#include <ibtk/CartSideRobinPhysBdryOp.h>
+#include <ibtk/muParserRobinBcCoefs.h>
+#include <ibtk/PhysicalBoundaryUtilities.h>
+#include <tbox/Array.h>
+
+// Set up application namespace declarations
+#include <ibtk/app_namespaces.h>
+
+double
+linear_f(const double* const x)
+{
+    double val = 0.0;
+    for (int d = 0; d < NDIM; ++d)
+    {
+        val += static_cast<double>(d + 1) * x[d];
+    }
+    return val;
+}
+
+double
+quadratic_f(const double* const x)
+{
+    double val = 0.0;
+    for (int d = 0; d < NDIM; ++d)
+    {
+        val += static_cast<double>(d + 1) * x[d] * x[d];
+    }
+    return val;
+}
+
+/*******************************************************************************
+ * For each run, the input filename must be given on the command line.  In all *
+ * cases, the command line is:                                                 *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize PETSc, MPI, and SAMRAI.
+    PetscInitialize(&argc, &argv, NULL, NULL);
+    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
+    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
+    SAMRAIManager::startup();
+
+    { // cleanup dynamically allocated objects prior to shutdown
+        // prevent a warning about timer initialization
+        TimerManager::createManager(nullptr);
+
+        // Parse command line options, set some standard options from the input
+        // file, and enable file logging.
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "cc_poisson.log");
+        Pointer<Database> input_db = app_initializer->getInputDatabase();
+
+        // Create major algorithm and data objects that comprise the
+        // application.  These objects are configured from the input database.
+        Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<StandardTagAndInitialize<NDIM> > error_detector = new StandardTagAndInitialize<NDIM>(
+            "StandardTagAndInitialize", NULL, app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<BergerRigoutsos<NDIM> > box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM> > load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM> > gridding_algorithm =
+            new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                        app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                        error_detector,
+                                        box_generator,
+                                        load_balancer);
+
+        // Initialize the AMR patch hierarchy.
+        gridding_algorithm->makeCoarsestLevel(patch_hierarchy, 0.0);
+        int tag_buffer = 1;
+        int level_number = 0;
+        bool done = false;
+        while (!done && (gridding_algorithm->levelCanBeRefined(level_number)))
+        {
+            gridding_algorithm->makeFinerLevel(patch_hierarchy, 0.0, 0.0, tag_buffer);
+            done = !patch_hierarchy->finerLevelExists(level_number);
+            ++level_number;
+        }
+
+        std::string var_centering = input_db->getString("VAR_CENTERING");
+        std::string extrap_type = input_db->getString("EXTRAP_TYPE");
+        TBOX_ASSERT(var_centering == "CELL" || var_centering == "SIDE");
+        TBOX_ASSERT(extrap_type == "LINEAR" || extrap_type == "QUADRATIC");
+
+        using fcn_type = double (*)(const double* const);
+        std::map<std::string, fcn_type> fcn_map;
+        fcn_map["LINEAR"] = &linear_f;
+        fcn_map["QUADRATIC"] = &quadratic_f;
+
+        // Create cell-centered data and extrapolate that data at physical
+        // boundaries to obtain ghost cell values.
+        VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
+        Pointer<VariableContext> context = var_db->getContext("CONTEXT");
+        Pointer<CellVariable<NDIM, double> > c_var = new CellVariable<NDIM, double>("c_v");
+        Pointer<SideVariable<NDIM, double> > s_var = new SideVariable<NDIM, double>("s_v");
+        const int gcw = 1;
+        const int c_idx = var_db->registerVariableAndContext(c_var, context, gcw);
+        const int s_idx = var_db->registerVariableAndContext(s_var, context, gcw);
+        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+            level->allocatePatchData(c_idx);
+            level->allocatePatchData(s_idx);
+            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+            {
+                Pointer<Patch<NDIM> > patch = level->getPatch(p());
+                const Box<NDIM>& patch_box = patch->getBox();
+                const hier::Index<NDIM>& patch_lower = patch_box.lower();
+
+                pout << "checking robin bc handling . . .\n";
+
+                Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+                const double* const x_lower = pgeom->getXLower();
+                const double* const dx = pgeom->getDx();
+                if (var_centering == "CELL")
+                {
+                    Pointer<CellData<NDIM, double> > data = patch->getPatchData(c_idx);
+                    for (CellIterator<NDIM> ci(patch_box); ci; ci++)
+                    {
+                        const CellIndex<NDIM>& i = ci();
+                        double X[NDIM];
+                        for (unsigned int d = 0; d < NDIM; ++d)
+                        {
+                            X[d] = x_lower[d] + dx[d] * (static_cast<double>(i(d) - patch_lower(d)) + 0.5);
+                        }
+                        (*data)(i) = fcn_map[extrap_type](X);
+                    }
+                }
+                else if (var_centering == "SIDE")
+                {
+                    Pointer<SideData<NDIM, double> > data = patch->getPatchData(s_idx);
+                    for (unsigned int axis = 0; axis < NDIM; ++axis)
+                    {
+                        for (SideIterator<NDIM> si(patch_box, axis); si; si++)
+                        {
+                            const SideIndex<NDIM>& i = si();
+                            double X[NDIM];
+                            for (unsigned int d = 0; d < NDIM; ++d)
+                            {
+                                X[d] = x_lower[d] +
+                                       dx[d] * (static_cast<double>(i(d) - patch_lower(d)) + (axis == d ? 0.0 : 0.5));
+                            }
+                            (*data)(i) = fcn_map[extrap_type](X);
+                        }
+                    }
+                }
+                else
+                {
+                    TBOX_ERROR("UNKNOWN DATA CENTERING: " << var_centering << "\n");
+                }
+
+                std::vector<RobinBcCoefStrategy<NDIM>*> bc_coefs;
+                if (var_centering == "CELL")
+                {
+                    bc_coefs.push_back(new muParserRobinBcCoefs(
+                        "bc_coefs", app_initializer->getComponentDatabase("bc_coefs_0"), grid_geometry));
+                }
+                else if (var_centering == "SIDE")
+                {
+                    for (int d = 0; d < NDIM; ++d)
+                    {
+                        std::string bc_name = "bc_coefs_" + std::to_string(d);
+                        bc_coefs.push_back(new muParserRobinBcCoefs(
+                            bc_name, app_initializer->getComponentDatabase(bc_name), grid_geometry));
+                    }
+                }
+                bool warning = false;
+                if (var_centering == "CELL")
+                {
+                    CartCellRobinPhysBdryOp bc_fill_op(c_idx, bc_coefs, false, extrap_type);
+                    Pointer<CellData<NDIM, double> > data = patch->getPatchData(c_idx);
+                    bc_fill_op.setPhysicalBoundaryConditions(*patch, 0.0, data->getGhostCellWidth());
+
+                    warning = false;
+                    std::vector<Box<NDIM>> ghost_boxes;
+                    if (extrap_type == "LINEAR")
+                    {
+                        ghost_boxes.push_back(data->getGhostBox());
+                    }
+                    else if (extrap_type == "QUADRATIC")
+                    {
+                        ghost_boxes.push_back(patch->getBox());
+                        const tbox::Array<BoundaryBox<NDIM>> codim1_boxes = PhysicalBoundaryUtilities::getPhysicalBoundaryCodim1Boxes(*patch);
+                        if (codim1_boxes.size() != 0)
+                        {
+                            for (int n = 0; n < codim1_boxes.size(); ++n)
+                            {
+                                const BoundaryBox<NDIM>& bdry_box = codim1_boxes[n];
+                                ghost_boxes.push_back(pgeom->getBoundaryFillBox(bdry_box, patch->getBox(), gcw));
+                            }
+                        }
+                    }
+                    for (const auto& box : ghost_boxes)
+                    {
+                        for (CellIterator<NDIM> ci(box); ci; ci++)
+                        {
+                            const CellIndex<NDIM>& i = ci();
+                            double X[NDIM];
+                            for (unsigned int d = 0; d < NDIM; ++d)
+                            {
+                                X[d] = x_lower[d] + dx[d] * (static_cast<double>(i(d) - patch_lower(d)) + 0.5);
+                            }
+                            double val = fcn_map[extrap_type](X);
+                            if (!MathUtilities<double>::equalEps(val, (*data)(i)))
+                            {
+                                warning = true;
+                                pout << "warning: value at location " << i << " is not correct\n";
+                                pout << "  expected value = " << val << "   computed value = " << (*data)(i) << "\n";
+                            }
+                        }
+                    }
+                }
+                else if (var_centering == "SIDE")
+                {
+                    CartSideRobinPhysBdryOp bc_fill_op(s_idx, bc_coefs, false, extrap_type);
+                    Pointer<SideData<NDIM, double> > data = patch->getPatchData(s_idx);
+                    bc_fill_op.setPhysicalBoundaryConditions(*patch, 0.0, data->getGhostCellWidth());
+
+                    warning = false;
+                    std::vector<Box<NDIM>> ghost_boxes;
+                    if (extrap_type == "LINEAR")
+                    {
+                        ghost_boxes.push_back(data->getGhostBox());
+                    }
+                    else if (extrap_type == "QUADRATIC")
+                    {
+                        ghost_boxes.push_back(patch->getBox());
+                        const tbox::Array<BoundaryBox<NDIM>> codim1_boxes = PhysicalBoundaryUtilities::getPhysicalBoundaryCodim1Boxes(*patch);
+                        if (codim1_boxes.size() != 0)
+                        {
+                                for (int n = 0; n < codim1_boxes.size(); ++n)
+                                {
+                                    const BoundaryBox<NDIM>& bdry_box = codim1_boxes[n];
+                                    ghost_boxes.push_back(pgeom->getBoundaryFillBox(bdry_box, patch->getBox(), gcw));
+                                }
+                        }
+                    }
+                    for (const auto& box : ghost_boxes)
+                    {
+                            for (unsigned int axis = 0; axis < NDIM; ++axis)
+                            {
+                                for (SideIterator<NDIM> si(box, axis); si; si++)
+                                {
+                                    const SideIndex<NDIM>& i = si();
+                                    double X[NDIM];
+                                    for (unsigned int d = 0; d < NDIM; ++d)
+                                    {
+                                        X[d] = x_lower[d] +
+                                               dx[d] * (static_cast<double>(i(d) - patch_lower(d)) + (axis == d ? 0.0 : 0.5));
+                                    }
+                                    double val = fcn_map[extrap_type](X);
+        
+                                    if (!MathUtilities<double>::equalEps(val, (*data)(i)))
+                                    {
+                                        warning = true;
+                                        pout << "warning: value at location " << i << " is not correct\n";
+                                        pout << "  expected value = " << val << "   computed value = " << (*data)(i) << "\n";
+                                    }
+                                }
+                            }
+                    }
+                }
+
+                if (!warning)
+                {
+                    pout << "boundary data appears to be correct.\n";
+                }
+                else
+                {
+                    pout << "possible errors encountered in extrapolated boundary data.\n";
+                }
+            }
+        }
+
+    } // cleanup dynamically allocated objects prior to shutdown
+
+    SAMRAIManager::shutdown();
+    PetscFinalize();
+    return 0;
+} // main

--- a/tests/physical_boundary/physical_boundary_2d_01.cell.dirichlet.linear.input
+++ b/tests/physical_boundary/physical_boundary_2d_01.cell.dirichlet.linear.input
@@ -1,0 +1,61 @@
+N = 8
+
+VAR_CENTERING = "CELL"
+EXTRAP_TYPE = "LINEAR"
+
+Q = "X_0 + 2.0*X_1"
+
+bc_coefs_0 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0  // lower end of computational domain.
+   x_up               = 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_2d_01.cell.dirichlet.linear.output
+++ b/tests/physical_boundary/physical_boundary_2d_01.cell.dirichlet.linear.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_2d_01.cell.dirichlet.quadratic.input
+++ b/tests/physical_boundary/physical_boundary_2d_01.cell.dirichlet.quadratic.input
@@ -1,0 +1,61 @@
+N = 8
+
+VAR_CENTERING = "CELL"
+EXTRAP_TYPE = "QUADRATIC"
+
+Q = "X_0*X_0 + 2.0*X_1*X_1"
+
+bc_coefs_0 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0  // lower end of computational domain.
+   x_up               = 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_2d_01.cell.dirichlet.quadratic.output
+++ b/tests/physical_boundary/physical_boundary_2d_01.cell.dirichlet.quadratic.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_2d_01.cell.neumann.linear.input
+++ b/tests/physical_boundary/physical_boundary_2d_01.cell.neumann.linear.input
@@ -1,0 +1,61 @@
+N = 8
+
+VAR_CENTERING = "CELL"
+EXTRAP_TYPE = "LINEAR"
+
+Q = "X_0 + 2.0*X_1"
+
+bc_coefs_0 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+
+    gcoef_function_0 = "-1.0"
+    gcoef_function_1 = "1.0"
+    gcoef_function_2 = "-2.0"
+    gcoef_function_3 = "2.0"
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0  // lower end of computational domain.
+   x_up               = 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_2d_01.cell.neumann.linear.output
+++ b/tests/physical_boundary/physical_boundary_2d_01.cell.neumann.linear.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_2d_01.cell.neumann.quadratic.input
+++ b/tests/physical_boundary/physical_boundary_2d_01.cell.neumann.quadratic.input
@@ -1,0 +1,61 @@
+N = 8
+
+VAR_CENTERING = "CELL"
+EXTRAP_TYPE = "QUADRATIC"
+
+Q = "X_0*X_0 + 2.0*X_1*X_1"
+
+bc_coefs_0 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+
+    gcoef_function_0 = "-2.0*X_0"
+    gcoef_function_1 = "2.0*X_0"
+    gcoef_function_2 = "-4.0*X_1"
+    gcoef_function_3 = "4.0*X_1"
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0  // lower end of computational domain.
+   x_up               = 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_2d_01.cell.neumann.quadratic.output
+++ b/tests/physical_boundary/physical_boundary_2d_01.cell.neumann.quadratic.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_2d_01.side.dirichlet.linear.input
+++ b/tests/physical_boundary/physical_boundary_2d_01.side.dirichlet.linear.input
@@ -1,0 +1,78 @@
+N = 8
+
+VAR_CENTERING = "SIDE"
+EXTRAP_TYPE = "LINEAR"
+
+Q = "X_0 + 2.0*X_1"
+
+bc_coefs_0 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+}
+
+bc_coefs_1 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0  // lower end of computational domain.
+   x_up               = 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_2d_01.side.dirichlet.linear.output
+++ b/tests/physical_boundary/physical_boundary_2d_01.side.dirichlet.linear.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_2d_01.side.dirichlet.quadratic.input
+++ b/tests/physical_boundary/physical_boundary_2d_01.side.dirichlet.quadratic.input
@@ -1,0 +1,78 @@
+N = 8
+
+VAR_CENTERING = "SIDE"
+EXTRAP_TYPE = "QUADRATIC"
+
+Q = "X_0*X_0 + 2.0*X_1*X_1"
+
+bc_coefs_0 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+}
+
+bc_coefs_1 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0  // lower end of computational domain.
+   x_up               = 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_2d_01.side.dirichlet.quadratic.output
+++ b/tests/physical_boundary/physical_boundary_2d_01.side.dirichlet.quadratic.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_2d_01.side.neumann.linear.input
+++ b/tests/physical_boundary/physical_boundary_2d_01.side.neumann.linear.input
@@ -1,0 +1,80 @@
+N = 8
+
+VAR_CENTERING = "SIDE"
+EXTRAP_TYPE = "LINEAR"
+
+Q = "X_0 + 2.0*X_1"
+dQdx = "1.0"
+dQdy = "2.0"
+
+bc_coefs_0 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+
+    gcoef_function_0 = "-1.0"
+    gcoef_function_1 = "1.0"
+    gcoef_function_2 = "-2.0"
+    gcoef_function_3 = "2.0"
+}
+
+bc_coefs_1 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+
+    gcoef_function_0 = "-1.0"
+    gcoef_function_1 = "1.0"
+    gcoef_function_2 = "-2.0"
+    gcoef_function_3 = "2.0"
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0  // lower end of computational domain.
+   x_up               = 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_2d_01.side.neumann.linear.output
+++ b/tests/physical_boundary/physical_boundary_2d_01.side.neumann.linear.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_2d_01.side.neumann.quadratic.input
+++ b/tests/physical_boundary/physical_boundary_2d_01.side.neumann.quadratic.input
@@ -1,0 +1,80 @@
+N = 8
+
+VAR_CENTERING = "SIDE"
+EXTRAP_TYPE = "QUADRATIC"
+
+Q = "X_0*X_0 + 2.0*X_1*X_1"
+dQdx = "2.0*X_0"
+dQdy = "4.0*X_1"
+
+bc_coefs_0 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+
+    gcoef_function_0 = "-2.0*X_0"
+    gcoef_function_1 = "2.0*X_0"
+    gcoef_function_2 = "-4.0*X_1"
+    gcoef_function_3 = "4.0*X_1"
+}
+
+bc_coefs_1 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+
+    gcoef_function_0 = "-2.0*X_0"
+    gcoef_function_1 = "2.0*X_0"
+    gcoef_function_2 = "-4.0*X_1"
+    gcoef_function_3 = "4.0*X_1"    
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0  // lower end of computational domain.
+   x_up               = 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_2d_01.side.neumann.quadratic.output
+++ b/tests/physical_boundary/physical_boundary_2d_01.side.neumann.quadratic.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_3d_01.cell.dirichlet.linear.input
+++ b/tests/physical_boundary/physical_boundary_3d_01.cell.dirichlet.linear.input
@@ -1,0 +1,68 @@
+N = 8
+
+VAR_CENTERING = "CELL"
+EXTRAP_TYPE = "LINEAR"
+
+Q = "X_0 + 2.0*X_1 + 3.0*X_2"
+
+bc_coefs_0 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    acoef_function_4 = "1.0"
+    acoef_function_5 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+    bcoef_function_4 = "0.0"
+    bcoef_function_5 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+    gcoef_function_4 = Q
+    gcoef_function_5 = Q
+}
+
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0,0), (N - 1,N - 1,N - 1)]
+   x_lo               = 0, 0, 0  // lower end of computational domain.
+   x_up               = 1, 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 = 4, 4, 4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_3d_01.cell.dirichlet.linear.output
+++ b/tests/physical_boundary/physical_boundary_3d_01.cell.dirichlet.linear.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_3d_01.cell.dirichlet.quadratic.input
+++ b/tests/physical_boundary/physical_boundary_3d_01.cell.dirichlet.quadratic.input
@@ -1,0 +1,68 @@
+N = 8
+
+VAR_CENTERING = "CELL"
+EXTRAP_TYPE = "QUADRATIC"
+
+Q = "X_0*X_0 + 2.0*X_1*X_1 + 3.0*X_2*X_2"
+
+bc_coefs_0 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    acoef_function_4 = "1.0"
+    acoef_function_5 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+    bcoef_function_4 = "0.0"
+    bcoef_function_5 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+    gcoef_function_4 = Q
+    gcoef_function_5 = Q
+}
+
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0,0), (N - 1,N - 1,N - 1)]
+   x_lo               = 0, 0, 0  // lower end of computational domain.
+   x_up               = 1, 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 = 4, 4, 4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_3d_01.cell.dirichlet.quadratic.output
+++ b/tests/physical_boundary/physical_boundary_3d_01.cell.dirichlet.quadratic.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_3d_01.cell.neumann.linear.input
+++ b/tests/physical_boundary/physical_boundary_3d_01.cell.neumann.linear.input
@@ -1,0 +1,68 @@
+N = 8
+
+VAR_CENTERING = "CELL"
+EXTRAP_TYPE = "LINEAR"
+
+Q = "X_0 + 2.0*X_1 + 3.0*X_2"
+
+bc_coefs_0 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    acoef_function_4 = "0.0"
+    acoef_function_5 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+    bcoef_function_4 = "1.0"
+    bcoef_function_5 = "1.0"
+
+    gcoef_function_0 = "-1.0"
+    gcoef_function_1 = "1.0"
+    gcoef_function_2 = "-2.0"
+    gcoef_function_3 = "2.0"
+    gcoef_function_4 = "-3.0"
+    gcoef_function_5 = "3.0"
+}
+
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0,0), (N - 1,N - 1,N - 1)]
+   x_lo               = 0, 0, 0  // lower end of computational domain.
+   x_up               = 1, 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 = 4, 4, 4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_3d_01.cell.neumann.linear.output
+++ b/tests/physical_boundary/physical_boundary_3d_01.cell.neumann.linear.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_3d_01.cell.neumann.quadratic.input
+++ b/tests/physical_boundary/physical_boundary_3d_01.cell.neumann.quadratic.input
@@ -1,0 +1,68 @@
+N = 8
+
+VAR_CENTERING = "CELL"
+EXTRAP_TYPE = "QUADRATIC"
+
+Q = "X_0*X_0 + 2.0*X_1*X_1 + 3.0*X_2*X_2"
+
+bc_coefs_0 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    acoef_function_4 = "0.0"
+    acoef_function_5 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+    bcoef_function_4 = "1.0"
+    bcoef_function_5 = "1.0"
+
+    gcoef_function_0 = "-2.0*X_0"
+    gcoef_function_1 = "2.0*X_0"
+    gcoef_function_2 = "-4.0*X_1"
+    gcoef_function_3 = "4.0*X_1"
+    gcoef_function_4 = "-6.0*X_2"
+    gcoef_function_5 = "6.0*X_2"
+}
+
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0,0), (N - 1,N - 1,N - 1)]
+   x_lo               = 0, 0, 0  // lower end of computational domain.
+   x_up               = 1, 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 = 4, 4, 4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_3d_01.cell.neumann.quadratic.output
+++ b/tests/physical_boundary/physical_boundary_3d_01.cell.neumann.quadratic.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_3d_01.side.dirichlet.linear.input
+++ b/tests/physical_boundary/physical_boundary_3d_01.side.dirichlet.linear.input
@@ -1,0 +1,113 @@
+N = 8
+
+VAR_CENTERING = "SIDE"
+EXTRAP_TYPE = "LINEAR"
+
+Q = "X_0 + 2.0*X_1 + 3.0*X_2"
+
+bc_coefs_0 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    acoef_function_4 = "1.0"
+    acoef_function_5 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+    bcoef_function_4 = "0.0"
+    bcoef_function_5 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+    gcoef_function_4 = Q
+    gcoef_function_5 = Q
+}
+
+bc_coefs_1 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    acoef_function_4 = "1.0"
+    acoef_function_5 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+    bcoef_function_4 = "0.0"
+    bcoef_function_5 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+    gcoef_function_4 = Q
+    gcoef_function_5 = Q
+}
+
+bc_coefs_2 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    acoef_function_4 = "1.0"
+    acoef_function_5 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+    bcoef_function_4 = "0.0"
+    bcoef_function_5 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+    gcoef_function_4 = Q
+    gcoef_function_5 = Q
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0,0), (N - 1,N - 1,N - 1)]
+   x_lo               = 0, 0, 0  // lower end of computational domain.
+   x_up               = 1, 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 = 4, 4, 4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_3d_01.side.dirichlet.linear.output
+++ b/tests/physical_boundary/physical_boundary_3d_01.side.dirichlet.linear.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_3d_01.side.dirichlet.quadratic.input
+++ b/tests/physical_boundary/physical_boundary_3d_01.side.dirichlet.quadratic.input
@@ -1,0 +1,113 @@
+N = 8
+
+VAR_CENTERING = "SIDE"
+EXTRAP_TYPE = "QUADRATIC"
+
+Q = "X_0*X_0 + 2.0*X_1*X_1 + 3.0*X_2*X_2"
+
+bc_coefs_0 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    acoef_function_4 = "1.0"
+    acoef_function_5 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+    bcoef_function_4 = "0.0"
+    bcoef_function_5 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+    gcoef_function_4 = Q
+    gcoef_function_5 = Q
+}
+
+bc_coefs_1 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    acoef_function_4 = "1.0"
+    acoef_function_5 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+    bcoef_function_4 = "0.0"
+    bcoef_function_5 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+    gcoef_function_4 = Q
+    gcoef_function_5 = Q
+}
+
+bc_coefs_2 {
+    acoef_function_0 = "1.0"
+    acoef_function_1 = "1.0"
+    acoef_function_2 = "1.0"
+    acoef_function_3 = "1.0"
+    acoef_function_4 = "1.0"
+    acoef_function_5 = "1.0"
+    
+    bcoef_function_0 = "0.0"
+    bcoef_function_1 = "0.0"
+    bcoef_function_2 = "0.0"
+    bcoef_function_3 = "0.0"
+    bcoef_function_4 = "0.0"
+    bcoef_function_5 = "0.0"
+
+    gcoef_function_0 = Q
+    gcoef_function_1 = Q
+    gcoef_function_2 = Q
+    gcoef_function_3 = Q
+    gcoef_function_4 = Q
+    gcoef_function_5 = Q
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0,0), (N - 1,N - 1,N - 1)]
+   x_lo               = 0, 0, 0  // lower end of computational domain.
+   x_up               = 1, 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 = 4, 4, 4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_3d_01.side.dirichlet.quadratic.output
+++ b/tests/physical_boundary/physical_boundary_3d_01.side.dirichlet.quadratic.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_3d_01.side.neumann.linear.input
+++ b/tests/physical_boundary/physical_boundary_3d_01.side.neumann.linear.input
@@ -1,0 +1,115 @@
+N = 8
+
+VAR_CENTERING = "SIDE"
+EXTRAP_TYPE = "LINEAR"
+
+Q = "X_0 + 2.0*X_1 + 3.0*X_2"
+dQdx = "1.0"
+dQdy = "2.0"
+
+bc_coefs_0 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    acoef_function_4 = "0.0"
+    acoef_function_5 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+    bcoef_function_4 = "1.0"
+    bcoef_function_5 = "1.0"
+
+    gcoef_function_0 = "-1.0"
+    gcoef_function_1 = "1.0"
+    gcoef_function_2 = "-2.0"
+    gcoef_function_3 = "2.0"
+    gcoef_function_4 = "-3.0"
+    gcoef_function_5 = "3.0"
+}
+
+bc_coefs_1 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    acoef_function_4 = "0.0"
+    acoef_function_5 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+    bcoef_function_4 = "1.0"
+    bcoef_function_5 = "1.0"
+
+    gcoef_function_0 = "-1.0"
+    gcoef_function_1 = "1.0"
+    gcoef_function_2 = "-2.0"
+    gcoef_function_3 = "2.0"
+    gcoef_function_4 = "-3.0"
+    gcoef_function_5 = "3.0"
+}
+
+bc_coefs_2 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    acoef_function_4 = "0.0"
+    acoef_function_5 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+    bcoef_function_4 = "1.0"
+    bcoef_function_5 = "1.0"
+
+    gcoef_function_0 = "-1.0"
+    gcoef_function_1 = "1.0"
+    gcoef_function_2 = "-2.0"
+    gcoef_function_3 = "2.0"
+    gcoef_function_4 = "-3.0"
+    gcoef_function_5 = "3.0"
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0,0), (N - 1,N - 1,N - 1)]
+   x_lo               = 0, 0, 0  // lower end of computational domain.
+   x_up               = 1, 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 = 4, 4, 4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_3d_01.side.neumann.linear.output
+++ b/tests/physical_boundary/physical_boundary_3d_01.side.neumann.linear.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.

--- a/tests/physical_boundary/physical_boundary_3d_01.side.neumann.quadratic.input
+++ b/tests/physical_boundary/physical_boundary_3d_01.side.neumann.quadratic.input
@@ -1,0 +1,115 @@
+N = 8
+
+VAR_CENTERING = "SIDE"
+EXTRAP_TYPE = "QUADRATIC"
+
+Q = "X_0*X_0 + 2.0*X_1*X_1 + 3.0*X_2*X_2"
+dQdx = "2.0*X_0"
+dQdy = "4.0*X_1"
+
+bc_coefs_0 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    acoef_function_4 = "0.0"
+    acoef_function_5 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+    bcoef_function_4 = "1.0"
+    bcoef_function_5 = "1.0"
+
+    gcoef_function_0 = "-2.0*X_0"
+    gcoef_function_1 = "2.0*X_0"
+    gcoef_function_2 = "-4.0*X_1"
+    gcoef_function_3 = "4.0*X_1"
+    gcoef_function_4 = "-6.0*X_2"
+    gcoef_function_5 = "6.0*X_2"
+}
+
+bc_coefs_1 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    acoef_function_4 = "0.0"
+    acoef_function_5 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+    bcoef_function_4 = "1.0"
+    bcoef_function_5 = "1.0"
+
+    gcoef_function_0 = "-2.0*X_0"
+    gcoef_function_1 = "2.0*X_0"
+    gcoef_function_2 = "-4.0*X_1"
+    gcoef_function_3 = "4.0*X_1"
+    gcoef_function_4 = "-6.0*X_2"
+    gcoef_function_5 = "6.0*X_2"
+}
+
+bc_coefs_2 {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+    acoef_function_4 = "0.0"
+    acoef_function_5 = "0.0"
+    
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+    bcoef_function_4 = "1.0"
+    bcoef_function_5 = "1.0"
+
+    gcoef_function_0 = "-2.0*X_0"
+    gcoef_function_1 = "2.0*X_0"
+    gcoef_function_2 = "-4.0*X_1"
+    gcoef_function_3 = "4.0*X_1"
+    gcoef_function_4 = "-6.0*X_2"
+    gcoef_function_5 = "6.0*X_2"
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0,0), (N - 1,N - 1,N - 1)]
+   x_lo               = 0, 0, 0  // lower end of computational domain.
+   x_up               = 1, 1, 1  // upper end of computational domain.
+   periodic_dimension = 0, 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   largest_patch_size {
+      level_0 = 512, 512, 512
+   }
+
+   smallest_patch_size {
+      level_0 = 4, 4, 4
+   }
+}
+
+StandardTagAndInitialize {
+    tagging_method = "REFINE_BOXES"
+    RefineBoxes {}
+}
+
+LoadBalancer {
+}

--- a/tests/physical_boundary/physical_boundary_3d_01.side.neumann.quadratic.output
+++ b/tests/physical_boundary/physical_boundary_3d_01.side.neumann.quadratic.output
@@ -1,0 +1,2 @@
+checking robin bc handling . . .
+boundary data appears to be correct.


### PR DESCRIPTION
This adds a quadratic interpolation option for cell- and side-centered quantities at codim 1 boundaries. To be second order, certain operations require this interpolation. This reduces to linear extrapolation at codim 2 and 3 boundaries, similar to the quadratic extrapolation code.

The interpolation is similar to the linear interpolation option. We form a quadratic polynomial `p` between the ghost cell, it's mirror interior cell, and the cell adjacent to the mirror image. We then solve for the ghost cell value in the equation
`a p(x_g) + b p'(x_g) = u_g`

An option is also added to `HierarchyGhostCellInterpolation` to allow for quadratic interpolation at the boundary. It defaults to `LINEAR`. This also adds 16 tests to ensure that the linear and quadratic interpolation interpolates the correct quantities.