### PR TITLE
Consistently check ifstream states.

### DIFF
--- a/doc/news/changes/minor/20190919DavidWells
+++ b/doc/news/changes/minor/20190919DavidWells
@@ -1,0 +1,4 @@
+Fixed: Fixed a problem where <code>rpath</code> arguments to the linker were
+incorrectly formatted, resulting in missing libraries at run time.
+<br>
+(David Wells, 2019/09/19)

--- a/doc/news/changes/minor/20190920DavidWells
+++ b/doc/news/changes/minor/20190920DavidWells
@@ -1,4 +1,4 @@
-Fixed: Fixed a problem where <code>rpath</code> arguments to the linker were
-incorrectly formatted, resulting in missing libraries at run time.
+Improved: IBStandardInitializer will now log a message explaining what happened
+when optional input files (e.g., rod input files) are not available.
 <br>
-(David Wells, 2019/09/19)
+(David Wells, 2019/09/20)

--- a/examples/ConstraintIB/flow_past_cylinder_HF/HydroForceEval.cpp
+++ b/examples/ConstraintIB/flow_past_cylinder_HF/HydroForceEval.cpp
@@ -436,8 +436,8 @@ HydroForceEval::readVertexFiles(const std::string& extension)
 
         // Ensure that the file exists.
         const std::string vertex_filename = d_struct_names[j] + extension;
-        std::ifstream file_stream;
-        file_stream.open(vertex_filename.c_str(), std::ios::in);
+        std::ifstream file_stream(vertex_filename);
+
         if (file_stream.is_open())
         {
             plog << d_object_name << ":  "
@@ -537,8 +537,7 @@ HydroForceEval::readElemFiles(const std::string& extension)
 
         // Ensure that the file exists.
         const std::string elem_filename = d_struct_names[j] + extension;
-        std::ifstream file_stream;
-        file_stream.open(elem_filename.c_str(), std::ios::in);
+        std::ifstream file_stream(elem_filename);
         if (file_stream.is_open())
         {
             plog << d_object_name << ":  "

--- a/ibtk/src/utilities/LMarkerUtilities.cpp
+++ b/ibtk/src/utilities/LMarkerUtilities.cpp
@@ -149,7 +149,12 @@ LMarkerUtilities::readMarkerPositions(std::vector<Point>& mark_init_posns,
         if (rank == mpi_rank)
         {
             std::string line_string;
-            std::ifstream file_stream(mark_input_file_name.c_str(), std::ios::in);
+            std::ifstream file_stream(mark_input_file_name);
+            if (!file_stream.is_open())
+            {
+                TBOX_ERROR("LMarkerUtilities::readMarkerPositions()"
+                           << "could not open file " << mark_input_file_name << std::endl);
+            }
 
             // The first entry in the file is the number of markers.
             if (!std::getline(file_stream, line_string))

--- a/include/ibamr/IBStandardInitializer.h
+++ b/include/ibamr/IBStandardInitializer.h
@@ -440,6 +440,15 @@ public:
 
     /*!
      * \brief Initialize structure specific configurations.
+     *
+     * This function will attempt to load, in sequence, the vertex, spring,
+     * xspring, beam, rod, target point, anchor point, boundary mass,
+     * director, instrumentation, and source files. Of these, only the vertex
+     * files are required. The instrumentation and source files will only be
+     * loaded if both enable_instrumentation or enable_sources are enabled on
+     * the input database and the input files exist. The rest will only be
+     * loaded if files with matching suffixes (e.g., <code>.beam</code>) are
+     * in the current working directory.
      */
     void init() override;
 

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -1823,11 +1823,11 @@ CIBMethod::setRegularizationWeight(const int level_number)
         }
 
         // Read weights from file and set it.
-        std::ifstream reg_filestream(d_reg_filename[struct_no].c_str(), std::ifstream::in);
+        std::ifstream reg_filestream(d_reg_filename[struct_no]);
         if (!reg_filestream.is_open())
         {
             TBOX_ERROR("CIBMethod::setRegularizationWeight()"
-                       << "could not open file" << d_reg_filename[struct_no] << std::endl);
+                       << " could not open file " << d_reg_filename[struct_no] << std::endl);
         }
 
         std::string line_f;
@@ -1916,11 +1916,11 @@ CIBMethod::setInitialLambda(const int level_number)
         const std::pair<int, int> lag_idx_range = d_struct_lag_idx_range[struct_no];
         if (d_lambda_filename[struct_no].empty()) continue;
 
-        std::ifstream lambda_filestream(d_lambda_filename[struct_no].c_str(), std::ifstream::in);
+        std::ifstream lambda_filestream(d_lambda_filename[struct_no]);
         if (!lambda_filestream.is_open())
         {
             TBOX_ERROR("CIBMethod::setInitialLambda()"
-                       << "could not open file" << d_lambda_filename[struct_no] << std::endl);
+                       << " could not open file " << d_lambda_filename[struct_no] << std::endl);
         }
 
         std::string line_f;

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -254,8 +254,7 @@ IBStandardInitializer::readVertexFiles(const std::string& extension)
 
             // Ensure that the file exists.
             const std::string vertex_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(vertex_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(vertex_filename);
             if (file_stream.is_open())
             {
                 plog << d_object_name << ":  "
@@ -366,8 +365,7 @@ IBStandardInitializer::readSpringFiles(const std::string& extension, const bool 
 
             // Ensure that the file exists.
             const std::string spring_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(spring_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(spring_filename);
             if (file_stream.is_open())
             {
                 plog << d_object_name << ":  "
@@ -595,8 +593,7 @@ IBStandardInitializer::readXSpringFiles(const std::string& extension, const bool
 
             // Ensure that the file exists.
             const std::string xspring_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(xspring_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(xspring_filename);
             if (file_stream.is_open())
             {
                 plog << d_object_name << ":  "
@@ -823,8 +820,7 @@ IBStandardInitializer::readBeamFiles(const std::string& extension, const bool in
             if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
 
             const std::string beam_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(beam_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(beam_filename);
             if (file_stream.is_open())
             {
                 plog << d_object_name << ":  "
@@ -1056,8 +1052,7 @@ IBStandardInitializer::readRodFiles(const std::string& extension, const bool inp
             if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
 
             const std::string rod_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(rod_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(rod_filename);
             if (file_stream.is_open())
             {
                 plog << d_object_name << ":  "
@@ -1373,8 +1368,7 @@ IBStandardInitializer::readTargetPointFiles(const std::string& extension)
             d_target_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
 
             const std::string target_point_stiffness_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(target_point_stiffness_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(target_point_stiffness_filename);
             if (file_stream.is_open())
             {
                 plog << d_object_name << ":  "
@@ -1563,8 +1557,7 @@ IBStandardInitializer::readAnchorPointFiles(const std::string& extension)
             d_anchor_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
 
             const std::string anchor_point_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(anchor_point_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(anchor_point_filename);
             if (file_stream.is_open())
             {
                 plog << d_object_name << ":  "
@@ -1685,8 +1678,7 @@ IBStandardInitializer::readBoundaryMassFiles(const std::string& extension)
             d_bdry_mass_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
 
             const std::string bdry_mass_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(bdry_mass_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(bdry_mass_filename);
             if (file_stream.is_open())
             {
                 plog << d_object_name << ":  "
@@ -1851,8 +1843,7 @@ IBStandardInitializer::readDirectorFiles(const std::string& extension)
             d_directors[ln][j].resize(d_num_vertex[ln][j], std::vector<double>(3 * 3, 0.0));
 
             const std::string directors_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(directors_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(directors_filename);
             if (file_stream.is_open())
             {
                 plog << d_object_name << ":  "
@@ -1970,8 +1961,7 @@ IBStandardInitializer::readInstrumentationFiles(const std::string& extension)
             if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
 
             const std::string inst_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(inst_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(inst_filename);
             if (file_stream.is_open() && d_enable_instrumentation[ln][j])
             {
                 plog << d_object_name << ":  "
@@ -2210,8 +2200,7 @@ IBStandardInitializer::readSourceFiles(const std::string& extension)
             if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
 
             const std::string source_filename = d_base_filename[ln][j] + extension;
-            std::ifstream file_stream;
-            file_stream.open(source_filename.c_str(), std::ios::in);
+            std::ifstream file_stream(source_filename);
             if (file_stream.is_open() && d_enable_sources[ln][j])
             {
                 plog << d_object_name << ":  "

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -553,6 +553,14 @@ IBStandardInitializer::readSpringFiles(const std::string& extension, const bool 
                      << "read " << num_edges << " edges from ASCII input file named " << spring_filename << std::endl
                      << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
             }
+            else
+            {
+                plog << d_object_name << ":  "
+                     << " file " << spring_filename
+                     << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " does not exist: skipping read." << std::endl;
+
+            }
 
             // Free the next MPI process to start reading the current file.
             if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
@@ -782,6 +790,15 @@ IBStandardInitializer::readXSpringFiles(const std::string& extension, const bool
                      << "read " << num_edges << " edges from ASCII input file named " << xspring_filename << std::endl
                      << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
             }
+            else
+            {
+                plog << d_object_name << ":  "
+                     << " file " << xspring_filename
+                     << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " does not exist: skipping read." << std::endl;
+
+            }
+
 
             // Free the next MPI process to start reading the current file.
             if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
@@ -1014,6 +1031,14 @@ IBStandardInitializer::readBeamFiles(const std::string& extension, const bool in
                 plog << d_object_name << ":  "
                      << "read " << num_beams << " beams from ASCII input file named " << beam_filename << std::endl
                      << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+            }
+            else
+            {
+                plog << d_object_name << ":  "
+                     << " file " << beam_filename
+                     << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " does not exist: skipping read." << std::endl;
+
             }
 
             // Free the next MPI process to start reading the current file.
@@ -1326,6 +1351,14 @@ IBStandardInitializer::readRodFiles(const std::string& extension, const bool inp
                      << "read " << num_rods << " rods from ASCII input file named " << rod_filename << std::endl
                      << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
             }
+            else
+            {
+                plog << d_object_name << ":  "
+                     << " file " << rod_filename
+                     << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " does not exist: skipping read." << std::endl;
+
+            }
 
             // Free the next MPI process to start reading the current file.
             if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
@@ -1489,6 +1522,14 @@ IBStandardInitializer::readTargetPointFiles(const std::string& extension)
                      << target_point_stiffness_filename << std::endl
                      << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
             }
+            else
+            {
+                plog << d_object_name << ":  "
+                     << " file " << target_point_stiffness_filename
+                     << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " does not exist: skipping read." << std::endl;
+
+            }
 
             // Modify the target point stiffness constants according to whether
             // target point penalty forces are enabled, or whether uniform
@@ -1641,6 +1682,14 @@ IBStandardInitializer::readAnchorPointFiles(const std::string& extension)
                      << anchor_point_filename << std::endl
                      << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
             }
+            else
+            {
+                plog << d_object_name << ":  "
+                     << " file " << anchor_point_filename
+                     << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " does not exist: skipping read." << std::endl;
+
+            }
 
             // Free the next MPI process to start reading the current file.
             if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
@@ -1785,6 +1834,14 @@ IBStandardInitializer::readBoundaryMassFiles(const std::string& extension)
                      << bdry_mass_filename << std::endl
                      << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
             }
+            else
+            {
+                plog << d_object_name << ":  "
+                     << " file " << bdry_mass_filename
+                     << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " does not exist: skipping read." << std::endl;
+
+            }
 
             // Modify the boundary masses and boundary mass stiffness constants
             // according to whether boundary mass is enabled, or whether uniform
@@ -1927,6 +1984,14 @@ IBStandardInitializer::readDirectorFiles(const std::string& extension)
                      << "read " << num_directors_pts << " director triads from ASCII input file named "
                      << directors_filename << std::endl
                      << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+            }
+            else
+            {
+                plog << d_object_name << ":  "
+                     << " file " << directors_filename
+                     << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " does not exist: skipping read." << std::endl;
+
             }
 
             // Free the next MPI process to start reading the current file.
@@ -2165,6 +2230,14 @@ IBStandardInitializer::readInstrumentationFiles(const std::string& extension)
                      << inst_filename << std::endl
                      << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
             }
+            else
+            {
+                plog << d_object_name << ":  "
+                     << " Either file " << inst_filename
+                     << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " does not exist or instrumentation is disabled : skipping read." << std::endl;
+
+            }
 
             // Free the next MPI process to start reading the current file.
             if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
@@ -2363,6 +2436,14 @@ IBStandardInitializer::readSourceFiles(const std::string& extension)
                      << "read " << num_source_pts << " source points from ASCII input file named " << source_filename
                      << std::endl
                      << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+            }
+            else
+            {
+                plog << d_object_name << ":  "
+                     << " Either file " << source_filename
+                     << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " does not exist or sources are disabled : skipping read." << std::endl;
+
             }
 
             // Free the next MPI process to start reading the current file.


### PR DESCRIPTION
Ensure that we actually opened the file in all cases.

Fixes #413 and #643.