### PR TITLE
Silence a muParser warning.

### DIFF
--- a/ibtk/contrib/muparser/include/muParserBytecode.h
+++ b/ibtk/contrib/muparser/include/muParserBytecode.h
@@ -71,7 +71,7 @@ namespace mu
         value_type *ptr;
         int offset;
       } Oprt;
-    };
+    } u;
   };
   
   

--- a/ibtk/contrib/muparser/src/muParserBase.cpp
+++ b/ibtk/contrib/muparser/src/muParserBase.cpp
@@ -1048,9 +1048,9 @@ namespace mu
           // Bugfix for Bulkmode:
           // for details see:
           //    https://groups.google.com/forum/embed/?place=forum/muparser-dev&showsearch=true&showpopout=true&showtabs=false&parenturl=http://muparser.beltoforion.de/mup_forum.html&afterlogin&pli=1#!topic/muparser-dev/szgatgoHTws
-          --sidx; Stack[sidx] = *(pTok->Oprt.ptr + nOffset) = Stack[sidx + 1]; continue;
+          --sidx; Stack[sidx] = *(pTok->u.Oprt.ptr + nOffset) = Stack[sidx + 1]; continue;
           // original code:
-          //--sidx; Stack[sidx] = *pTok->Oprt.ptr = Stack[sidx+1]; continue;
+          //--sidx; Stack[sidx] = *pTok->u.Oprt.ptr = Stack[sidx+1]; continue;
 
       //case  cmBO:  // unused, listed for compiler optimization purposes
       //case  cmBC:
@@ -1059,11 +1059,11 @@ namespace mu
 
       case  cmIF:
             if (Stack[sidx--]==0)
-              pTok += pTok->Oprt.offset;
+              pTok += pTok->u.Oprt.offset;
             continue;
 
       case  cmELSE:
-            pTok += pTok->Oprt.offset;
+            pTok += pTok->u.Oprt.offset;
             continue;
 
       case  cmENDIF:
@@ -1074,49 +1074,49 @@ namespace mu
       //      continue;
 
       // value and variable tokens
-      case  cmVAR:    Stack[++sidx] = *(pTok->Val.ptr + nOffset);  continue;
-      case  cmVAL:    Stack[++sidx] =  pTok->Val.data2;  continue;
-      
-      case  cmVARPOW2: buf = *(pTok->Val.ptr + nOffset);
+      case  cmVAR:    Stack[++sidx] = *(pTok->u.Val.ptr + nOffset);  continue;
+      case  cmVAL:    Stack[++sidx] =  pTok->u.Val.data2;  continue;
+
+      case  cmVARPOW2: buf = *(pTok->u.Val.ptr + nOffset);
                        Stack[++sidx] = buf*buf;
                        continue;
 
-      case  cmVARPOW3: buf = *(pTok->Val.ptr + nOffset);
+      case  cmVARPOW3: buf = *(pTok->u.Val.ptr + nOffset);
                        Stack[++sidx] = buf*buf*buf;
                        continue;
 
-      case  cmVARPOW4: buf = *(pTok->Val.ptr + nOffset);
+      case  cmVARPOW4: buf = *(pTok->u.Val.ptr + nOffset);
                        Stack[++sidx] = buf*buf*buf*buf;
                        continue;
-      
-      case  cmVARMUL:  Stack[++sidx] = *(pTok->Val.ptr + nOffset) * pTok->Val.data + pTok->Val.data2;
+
+      case  cmVARMUL:  Stack[++sidx] = *(pTok->u.Val.ptr + nOffset) * pTok->u.Val.data + pTok->u.Val.data2;
                        continue;
 
       // Next is treatment of numeric functions
       case  cmFUNC:
             {
-              int iArgCount = pTok->Fun.argc;
+              int iArgCount = pTok->u.Fun.argc;
 
               // switch according to argument count
-              switch(iArgCount)  
+              switch(iArgCount)
               {
-              case 0: sidx += 1; Stack[sidx] = (*(fun_type0)pTok->Fun.ptr)(); continue;
-              case 1:            Stack[sidx] = (*(fun_type1)pTok->Fun.ptr)(Stack[sidx]);   continue;
-              case 2: sidx -= 1; Stack[sidx] = (*(fun_type2)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1]); continue;
-              case 3: sidx -= 2; Stack[sidx] = (*(fun_type3)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2]); continue;
-              case 4: sidx -= 3; Stack[sidx] = (*(fun_type4)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3]); continue;
-              case 5: sidx -= 4; Stack[sidx] = (*(fun_type5)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4]); continue;
-              case 6: sidx -= 5; Stack[sidx] = (*(fun_type6)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5]); continue;
-              case 7: sidx -= 6; Stack[sidx] = (*(fun_type7)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6]); continue;
-              case 8: sidx -= 7; Stack[sidx] = (*(fun_type8)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7]); continue;
-              case 9: sidx -= 8; Stack[sidx] = (*(fun_type9)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8]); continue;
-              case 10:sidx -= 9; Stack[sidx] = (*(fun_type10)pTok->Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8], Stack[sidx+9]); continue;
+              case 0: sidx += 1; Stack[sidx] = (*(fun_type0)pTok->u.Fun.ptr)(); continue;
+              case 1:            Stack[sidx] = (*(fun_type1)pTok->u.Fun.ptr)(Stack[sidx]);   continue;
+              case 2: sidx -= 1; Stack[sidx] = (*(fun_type2)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1]); continue;
+              case 3: sidx -= 2; Stack[sidx] = (*(fun_type3)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2]); continue;
+              case 4: sidx -= 3; Stack[sidx] = (*(fun_type4)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3]); continue;
+              case 5: sidx -= 4; Stack[sidx] = (*(fun_type5)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4]); continue;
+              case 6: sidx -= 5; Stack[sidx] = (*(fun_type6)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5]); continue;
+              case 7: sidx -= 6; Stack[sidx] = (*(fun_type7)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6]); continue;
+              case 8: sidx -= 7; Stack[sidx] = (*(fun_type8)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7]); continue;
+              case 9: sidx -= 8; Stack[sidx] = (*(fun_type9)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8]); continue;
+              case 10:sidx -= 9; Stack[sidx] = (*(fun_type10)pTok->u.Fun.ptr)(Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8], Stack[sidx+9]); continue;
               default:
                 if (iArgCount>0) // function with variable arguments store the number as a negative value
                   Error(ecINTERNAL_ERROR, 1);
 
                 sidx -= -iArgCount - 1;
-                Stack[sidx] =(*(multfun_type)pTok->Fun.ptr)(&Stack[sidx], -iArgCount);
+                Stack[sidx] =(*(multfun_type)pTok->u.Fun.ptr)(&Stack[sidx], -iArgCount);
                 continue;
               }
             }
@@ -1124,17 +1124,17 @@ namespace mu
       // Next is treatment of string functions
       case  cmFUNC_STR:
             {
-              sidx -= pTok->Fun.argc -1;
+              sidx -= pTok->u.Fun.argc -1;
 
               // The index of the string argument in the string table
-              int iIdxStack = pTok->Fun.idx;  
+              int iIdxStack = pTok->u.Fun.idx;
               MUP_ASSERT( iIdxStack>=0 && iIdxStack<(int)m_vStringBuf.size() );
 
-              switch(pTok->Fun.argc)  // switch according to argument count
+              switch(pTok->u.Fun.argc)  // switch according to argument count
               {
-              case 0: Stack[sidx] = (*(strfun_type1)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str()); continue;
-              case 1: Stack[sidx] = (*(strfun_type2)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx]); continue;
-              case 2: Stack[sidx] = (*(strfun_type3)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx], Stack[sidx+1]); continue;
+              case 0: Stack[sidx] = (*(strfun_type1)pTok->u.Fun.ptr)(m_vStringBuf[iIdxStack].c_str()); continue;
+              case 1: Stack[sidx] = (*(strfun_type2)pTok->u.Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx]); continue;
+              case 2: Stack[sidx] = (*(strfun_type3)pTok->u.Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx], Stack[sidx+1]); continue;
               }
 
               continue;
@@ -1142,22 +1142,22 @@ namespace mu
 
         case  cmFUNC_BULK:
               {
-                int iArgCount = pTok->Fun.argc;
+                int iArgCount = pTok->u.Fun.argc;
 
                 // switch according to argument count
-                switch(iArgCount)  
+                switch(iArgCount)
                 {
-                case 0: sidx += 1; Stack[sidx] = (*(bulkfun_type0 )pTok->Fun.ptr)(nOffset, nThreadID); continue;
-                case 1:            Stack[sidx] = (*(bulkfun_type1 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx]); continue;
-                case 2: sidx -= 1; Stack[sidx] = (*(bulkfun_type2 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1]); continue;
-                case 3: sidx -= 2; Stack[sidx] = (*(bulkfun_type3 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2]); continue;
-                case 4: sidx -= 3; Stack[sidx] = (*(bulkfun_type4 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3]); continue;
-                case 5: sidx -= 4; Stack[sidx] = (*(bulkfun_type5 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4]); continue;
-                case 6: sidx -= 5; Stack[sidx] = (*(bulkfun_type6 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5]); continue;
-                case 7: sidx -= 6; Stack[sidx] = (*(bulkfun_type7 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6]); continue;
-                case 8: sidx -= 7; Stack[sidx] = (*(bulkfun_type8 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7]); continue;
-                case 9: sidx -= 8; Stack[sidx] = (*(bulkfun_type9 )pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8]); continue;
-                case 10:sidx -= 9; Stack[sidx] = (*(bulkfun_type10)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8], Stack[sidx+9]); continue;
+                case 0: sidx += 1; Stack[sidx] = (*(bulkfun_type0 )pTok->u.Fun.ptr)(nOffset, nThreadID); continue;
+                case 1:            Stack[sidx] = (*(bulkfun_type1 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx]); continue;
+                case 2: sidx -= 1; Stack[sidx] = (*(bulkfun_type2 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1]); continue;
+                case 3: sidx -= 2; Stack[sidx] = (*(bulkfun_type3 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2]); continue;
+                case 4: sidx -= 3; Stack[sidx] = (*(bulkfun_type4 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3]); continue;
+                case 5: sidx -= 4; Stack[sidx] = (*(bulkfun_type5 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4]); continue;
+                case 6: sidx -= 5; Stack[sidx] = (*(bulkfun_type6 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5]); continue;
+                case 7: sidx -= 6; Stack[sidx] = (*(bulkfun_type7 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6]); continue;
+                case 8: sidx -= 7; Stack[sidx] = (*(bulkfun_type8 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7]); continue;
+                case 9: sidx -= 8; Stack[sidx] = (*(bulkfun_type9 )pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8]); continue;
+                case 10:sidx -= 9; Stack[sidx] = (*(bulkfun_type10)pTok->u.Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx+1], Stack[sidx+2], Stack[sidx+3], Stack[sidx+4], Stack[sidx+5], Stack[sidx+6], Stack[sidx+7], Stack[sidx+8], Stack[sidx+9]); continue;
                 default:
                   Error(ecINTERNAL_ERROR, 2);
                   continue;

--- a/ibtk/contrib/muparser/src/muParserBytecode.cpp
+++ b/ibtk/contrib/muparser/src/muParserBytecode.cpp
@@ -108,9 +108,9 @@ namespace mu
     // optimization does not apply
     SToken tok;
     tok.Cmd       = cmVAR;
-    tok.Val.ptr   = a_pVar;
-    tok.Val.data  = 1;
-    tok.Val.data2 = 0;
+    tok.u.Val.ptr   = a_pVar;
+    tok.u.Val.data  = 1;
+    tok.u.Val.data2 = 0;
     m_vRPN.push_back(tok);
   }
 
@@ -135,9 +135,9 @@ namespace mu
     // If optimization does not apply
     SToken tok;
     tok.Cmd = cmVAL;
-    tok.Val.ptr   = NULL;
-    tok.Val.data  = 0;
-    tok.Val.data2 = a_fVal;
+    tok.u.Val.ptr   = NULL;
+    tok.u.Val.data  = 0;
+    tok.u.Val.data2 = a_fVal;
     m_vRPN.push_back(tok);
   }
 
@@ -145,8 +145,8 @@ namespace mu
   void ParserByteCode::ConstantFolding(ECmdCode a_Oprt)
   {
     std::size_t sz = m_vRPN.size();
-    value_type &x = m_vRPN[sz-2].Val.data2,
-               &y = m_vRPN[sz-1].Val.data2;
+    value_type &x = m_vRPN[sz-2].u.Val.data2,
+               &y = m_vRPN[sz-1].u.Val.data2;
     switch (a_Oprt)
     {
     case cmLAND: x = (int)x && (int)y; m_vRPN.pop_back(); break;
@@ -216,11 +216,11 @@ namespace mu
               // Optimization for polynomials of low order
               if (m_vRPN[sz-2].Cmd == cmVAR && m_vRPN[sz-1].Cmd == cmVAL)
               {
-                if (m_vRPN[sz-1].Val.data2==2)
+                if (m_vRPN[sz-1].u.Val.data2==2)
                   m_vRPN[sz-2].Cmd = cmVARPOW2;
-                else if (m_vRPN[sz-1].Val.data2==3)
+                else if (m_vRPN[sz-1].u.Val.data2==3)
                   m_vRPN[sz-2].Cmd = cmVARPOW3;
-                else if (m_vRPN[sz-1].Val.data2==4)
+                else if (m_vRPN[sz-1].u.Val.data2==4)
                   m_vRPN[sz-2].Cmd = cmVARPOW4;
                 else
                   break;
@@ -238,19 +238,19 @@ namespace mu
                    (m_vRPN[sz-1].Cmd == cmVAL    && m_vRPN[sz-2].Cmd == cmVAR)    || 
                    (m_vRPN[sz-1].Cmd == cmVAL    && m_vRPN[sz-2].Cmd == cmVARMUL) ||
                    (m_vRPN[sz-1].Cmd == cmVARMUL && m_vRPN[sz-2].Cmd == cmVAL)    ||
-                   (m_vRPN[sz-1].Cmd == cmVAR    && m_vRPN[sz-2].Cmd == cmVAR    && m_vRPN[sz-2].Val.ptr == m_vRPN[sz-1].Val.ptr) ||
-                   (m_vRPN[sz-1].Cmd == cmVAR    && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-2].Val.ptr == m_vRPN[sz-1].Val.ptr) ||
-                   (m_vRPN[sz-1].Cmd == cmVARMUL && m_vRPN[sz-2].Cmd == cmVAR    && m_vRPN[sz-2].Val.ptr == m_vRPN[sz-1].Val.ptr) ||
-                   (m_vRPN[sz-1].Cmd == cmVARMUL && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-2].Val.ptr == m_vRPN[sz-1].Val.ptr) )
+                   (m_vRPN[sz-1].Cmd == cmVAR    && m_vRPN[sz-2].Cmd == cmVAR    && m_vRPN[sz-2].u.Val.ptr == m_vRPN[sz-1].u.Val.ptr) ||
+                   (m_vRPN[sz-1].Cmd == cmVAR    && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-2].u.Val.ptr == m_vRPN[sz-1].u.Val.ptr) ||
+                   (m_vRPN[sz-1].Cmd == cmVARMUL && m_vRPN[sz-2].Cmd == cmVAR    && m_vRPN[sz-2].u.Val.ptr == m_vRPN[sz-1].u.Val.ptr) ||
+                   (m_vRPN[sz-1].Cmd == cmVARMUL && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-2].u.Val.ptr == m_vRPN[sz-1].u.Val.ptr) )
               {
-                assert( (m_vRPN[sz-2].Val.ptr==NULL && m_vRPN[sz-1].Val.ptr!=NULL) ||
-                        (m_vRPN[sz-2].Val.ptr!=NULL && m_vRPN[sz-1].Val.ptr==NULL) || 
-                        (m_vRPN[sz-2].Val.ptr == m_vRPN[sz-1].Val.ptr) );
+                assert( (m_vRPN[sz-2].u.Val.ptr==NULL && m_vRPN[sz-1].u.Val.ptr!=NULL) ||
+                        (m_vRPN[sz-2].u.Val.ptr!=NULL && m_vRPN[sz-1].u.Val.ptr==NULL) ||
+                        (m_vRPN[sz-2].u.Val.ptr == m_vRPN[sz-1].u.Val.ptr) );
 
                 m_vRPN[sz-2].Cmd = cmVARMUL;
-                m_vRPN[sz-2].Val.ptr    = (value_type*)((long long)(m_vRPN[sz-2].Val.ptr) | (long long)(m_vRPN[sz-1].Val.ptr));    // variable
-                m_vRPN[sz-2].Val.data2 += ((a_Oprt==cmSUB) ? -1 : 1) * m_vRPN[sz-1].Val.data2;  // offset
-                m_vRPN[sz-2].Val.data  += ((a_Oprt==cmSUB) ? -1 : 1) * m_vRPN[sz-1].Val.data;   // multiplicand
+                m_vRPN[sz-2].u.Val.ptr    = (value_type*)((long long)(m_vRPN[sz-2].u.Val.ptr) | (long long)(m_vRPN[sz-1].u.Val.ptr));    // variable
+                m_vRPN[sz-2].u.Val.data2 += ((a_Oprt==cmSUB) ? -1 : 1) * m_vRPN[sz-1].u.Val.data2;  // offset
+                m_vRPN[sz-2].u.Val.data  += ((a_Oprt==cmSUB) ? -1 : 1) * m_vRPN[sz-1].u.Val.data;   // multiplicand
                 m_vRPN.pop_back();
                 bOptimized = true;
               } 
@@ -261,9 +261,9 @@ namespace mu
                    (m_vRPN[sz-1].Cmd == cmVAL && m_vRPN[sz-2].Cmd == cmVAR) ) 
               {
                 m_vRPN[sz-2].Cmd        = cmVARMUL;
-                m_vRPN[sz-2].Val.ptr    = (value_type*)((long long)(m_vRPN[sz-2].Val.ptr) | (long long)(m_vRPN[sz-1].Val.ptr));
-                m_vRPN[sz-2].Val.data   = m_vRPN[sz-2].Val.data2 + m_vRPN[sz-1].Val.data2;
-                m_vRPN[sz-2].Val.data2  = 0;
+                m_vRPN[sz-2].u.Val.ptr    = (value_type*)((long long)(m_vRPN[sz-2].u.Val.ptr) | (long long)(m_vRPN[sz-1].u.Val.ptr));
+                m_vRPN[sz-2].u.Val.data   = m_vRPN[sz-2].u.Val.data2 + m_vRPN[sz-1].u.Val.data2;
+                m_vRPN[sz-2].u.Val.data2  = 0;
                 m_vRPN.pop_back();
                 bOptimized = true;
               } 
@@ -272,22 +272,22 @@ namespace mu
               {
                 // Optimization: 2*(3*b+1) or (3*b+1)*2 -> 6*b+2
                 m_vRPN[sz-2].Cmd     = cmVARMUL;
-                m_vRPN[sz-2].Val.ptr = (value_type*)((long long)(m_vRPN[sz-2].Val.ptr) | (long long)(m_vRPN[sz-1].Val.ptr));
+                m_vRPN[sz-2].u.Val.ptr = (value_type*)((long long)(m_vRPN[sz-2].u.Val.ptr) | (long long)(m_vRPN[sz-1].u.Val.ptr));
                 if (m_vRPN[sz-1].Cmd == cmVAL)
                 {
-                  m_vRPN[sz-2].Val.data  *= m_vRPN[sz-1].Val.data2;
-                  m_vRPN[sz-2].Val.data2 *= m_vRPN[sz-1].Val.data2;
+                  m_vRPN[sz-2].u.Val.data  *= m_vRPN[sz-1].u.Val.data2;
+                  m_vRPN[sz-2].u.Val.data2 *= m_vRPN[sz-1].u.Val.data2;
                 }
                 else
                 {
-                  m_vRPN[sz-2].Val.data  = m_vRPN[sz-1].Val.data  * m_vRPN[sz-2].Val.data2;
-                  m_vRPN[sz-2].Val.data2 = m_vRPN[sz-1].Val.data2 * m_vRPN[sz-2].Val.data2;
+                  m_vRPN[sz-2].u.Val.data  = m_vRPN[sz-1].u.Val.data  * m_vRPN[sz-2].u.Val.data2;
+                  m_vRPN[sz-2].u.Val.data2 = m_vRPN[sz-1].u.Val.data2 * m_vRPN[sz-2].u.Val.data2;
                 }
                 m_vRPN.pop_back();
                 bOptimized = true;
               }
               else if (m_vRPN[sz-1].Cmd == cmVAR && m_vRPN[sz-2].Cmd == cmVAR &&
-                       m_vRPN[sz-1].Val.ptr == m_vRPN[sz-2].Val.ptr)
+                       m_vRPN[sz-1].u.Val.ptr == m_vRPN[sz-2].u.Val.ptr)
               {
                 // Optimization: a*a -> a^2
                 m_vRPN[sz-2].Cmd = cmVARPOW2;
@@ -297,11 +297,11 @@ namespace mu
               break;
 
         case cmDIV:
-              if (m_vRPN[sz-1].Cmd == cmVAL && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-1].Val.data2!=0)
+              if (m_vRPN[sz-1].Cmd == cmVAL && m_vRPN[sz-2].Cmd == cmVARMUL && m_vRPN[sz-1].u.Val.data2!=0)
               {
                 // Optimization: 4*a/2 -> 2*a
-                m_vRPN[sz-2].Val.data  /= m_vRPN[sz-1].Val.data2;
-                m_vRPN[sz-2].Val.data2 /= m_vRPN[sz-1].Val.data2;
+                m_vRPN[sz-2].u.Val.data  /= m_vRPN[sz-1].u.Val.data2;
+                m_vRPN[sz-2].u.Val.data2 /= m_vRPN[sz-1].u.Val.data2;
                 m_vRPN.pop_back();
                 bOptimized = true;
               }
@@ -348,7 +348,7 @@ namespace mu
 
     SToken tok;
     tok.Cmd = cmASSIGN;
-    tok.Oprt.ptr = a_pVar;
+    tok.u.Oprt.ptr = a_pVar;
     m_vRPN.push_back(tok);
   }
 
@@ -373,8 +373,8 @@ namespace mu
 
     SToken tok;
     tok.Cmd = cmFUNC;
-    tok.Fun.argc = a_iArgc;
-    tok.Fun.ptr = a_pFun;
+    tok.u.Fun.argc = a_iArgc;
+    tok.u.Fun.ptr = a_pFun;
     m_vRPN.push_back(tok);
   }
 
@@ -391,8 +391,8 @@ namespace mu
 
     SToken tok;
     tok.Cmd = cmFUNC_BULK;
-    tok.Fun.argc = a_iArgc;
-    tok.Fun.ptr = a_pFun;
+    tok.u.Fun.argc = a_iArgc;
+    tok.u.Fun.ptr = a_pFun;
     m_vRPN.push_back(tok);
   }
 
@@ -410,9 +410,9 @@ namespace mu
 
     SToken tok;
     tok.Cmd = cmFUNC_STR;
-    tok.Fun.argc = a_iArgc;
-    tok.Fun.idx = a_iIdx;
-    tok.Fun.ptr = a_pFun;
+    tok.u.Fun.argc = a_iArgc;
+    tok.u.Fun.idx = a_iIdx;
+    tok.u.Fun.ptr = a_pFun;
     m_vRPN.push_back(tok);
 
     m_iMaxStackSize = std::max(m_iMaxStackSize, (size_t)m_iStackPos);
@@ -444,12 +444,12 @@ namespace mu
       case  cmELSE:
             stElse.push(i);
             idx = stIf.pop();
-            m_vRPN[idx].Oprt.offset = i - idx;
+            m_vRPN[idx].u.Oprt.offset = i - idx;
             break;
-      
+
       case cmENDIF:
             idx = stElse.pop();
-            m_vRPN[idx].Oprt.offset = i - idx;
+            m_vRPN[idx].u.Oprt.offset = i - idx;
             break;
 
       default:
@@ -513,42 +513,42 @@ namespace mu
       switch (m_vRPN[i].Cmd)
       {
       case cmVAL:   mu::console() << _T("VAL \t");
-                    mu::console() << _T("[") << m_vRPN[i].Val.data2 << _T("]\n");
+                    mu::console() << _T("[") << m_vRPN[i].u.Val.data2 << _T("]\n");
                     break;
 
       case cmVAR:   mu::console() << _T("VAR \t");
-	                  mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Val.ptr << _T("]\n"); 
+	                  mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Val.ptr << _T("]\n");
                     break;
 
       case cmVARPOW2: mu::console() << _T("VARPOW2 \t");
-	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Val.ptr << _T("]\n"); 
+	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Val.ptr << _T("]\n");
                       break;
 
       case cmVARPOW3: mu::console() << _T("VARPOW3 \t");
-	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Val.ptr << _T("]\n"); 
+	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Val.ptr << _T("]\n");
                       break;
 
       case cmVARPOW4: mu::console() << _T("VARPOW4 \t");
-	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Val.ptr << _T("]\n"); 
+	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Val.ptr << _T("]\n");
                       break;
 
       case cmVARMUL:  mu::console() << _T("VARMUL \t");
-	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Val.ptr << _T("]"); 
-                      mu::console() << _T(" * [") << m_vRPN[i].Val.data << _T("]");
-                      mu::console() << _T(" + [") << m_vRPN[i].Val.data2 << _T("]\n");
+	                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Val.ptr << _T("]");
+                      mu::console() << _T(" * [") << m_vRPN[i].u.Val.data << _T("]");
+                      mu::console() << _T(" + [") << m_vRPN[i].u.Val.data2 << _T("]\n");
                       break;
 
       case cmFUNC:  mu::console() << _T("CALL\t");
-                    mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].Fun.argc << _T("]"); 
-                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].Fun.ptr << _T("]"); 
+                    mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].u.Fun.argc << _T("]");
+                    mu::console() << _T("[ADDR: 0x") << std::hex << m_vRPN[i].u.Fun.ptr << _T("]");
                     mu::console() << _T("\n");
                     break;
 
       case cmFUNC_STR:
                     mu::console() << _T("CALL STRFUNC\t");
-                    mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].Fun.argc << _T("]");
-                    mu::console() << _T("[IDX:") << std::dec << m_vRPN[i].Fun.idx << _T("]");
-                    mu::console() << _T("[ADDR: 0x") << m_vRPN[i].Fun.ptr << _T("]\n"); 
+                    mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].u.Fun.argc << _T("]");
+                    mu::console() << _T("[IDX:") << std::dec << m_vRPN[i].u.Fun.idx << _T("]");
+                    mu::console() << _T("[ADDR: 0x") << m_vRPN[i].u.Fun.ptr << _T("]\n");
                     break;
 
       case cmLT:    mu::console() << _T("LT\n");  break;
@@ -566,21 +566,21 @@ namespace mu
       case cmPOW:   mu::console() << _T("POW\n"); break;
 
       case cmIF:    mu::console() << _T("IF\t");
-                    mu::console() << _T("[OFFSET:") << std::dec << m_vRPN[i].Oprt.offset << _T("]\n");
+                    mu::console() << _T("[OFFSET:") << std::dec << m_vRPN[i].u.Oprt.offset << _T("]\n");
                     break;
 
       case cmELSE:  mu::console() << _T("ELSE\t");
-                    mu::console() << _T("[OFFSET:") << std::dec << m_vRPN[i].Oprt.offset << _T("]\n");
+                    mu::console() << _T("[OFFSET:") << std::dec << m_vRPN[i].u.Oprt.offset << _T("]\n");
                     break;
 
       case cmENDIF: mu::console() << _T("ENDIF\n"); break;
 
-      case cmASSIGN: 
+      case cmASSIGN:
                     mu::console() << _T("ASSIGN\t");
-                    mu::console() << _T("[ADDR: 0x") << m_vRPN[i].Oprt.ptr << _T("]\n"); 
-                    break; 
+                    mu::console() << _T("[ADDR: 0x") << m_vRPN[i].u.Oprt.ptr << _T("]\n");
+                    break;
 
-      default:      mu::console() << _T("(unknown code: ") << m_vRPN[i].Cmd << _T(")\n"); 
+      default:      mu::console() << _T("(unknown code: ") << m_vRPN[i].Cmd << _T(")\n");
                     break;
       } // switch cmdCode
     } // while bytecode


### PR DESCRIPTION
Clang rightfully complains that anonymous types declared in an anonymous union is an extension, so name the union.

Fixes #676.