### PR TITLE
Redo fe cache

### DIFF
--- a/doc/news/changes/incompatibilities/20190916DavidWells
+++ b/doc/news/changes/incompatibilities/20190916DavidWells
@@ -1,0 +1,16 @@
+Changed: IBTK::FECache has been changed in several incompatible ways to enable
+compatibility with elements that are not translation invariant (e.g., libMesh's
+subdivision elements). In particular, IBTK::FECache will now reinitialize
+libMesh::FEBase objects based on a provided set of flags and known properties of
+the finite element space before returning the object to the caller. The interface
+changes are
+<ol>
+  <li>IBTK::FECache objects must be set up with an enum (IBTK::FEUpdateFlags)
+  describing which values should be computed on each element.</li>
+  <li>IBTK::FECache::operator[]() has been replaced by
+  IBTK::FECache::operator()(), which takes a libMesh::Elem pointer as an
+  argument which is used to reinitialize values and gradients when
+  appropriate.</li>
+</ol>
+<br>
+(David Wells, 2019/09/16)

--- a/ibtk/include/ibtk/FECache.h
+++ b/ibtk/include/ibtk/FECache.h
@@ -115,43 +115,43 @@ protected:
     /**
      * Dimension of the FE mesh.
      */
-    const unsigned int dim;
+    const unsigned int d_dim;
 
     /**
      * Object describing the finite element type.
      */
-    const libMesh::FEType fe_type;
+    const libMesh::FEType d_fe_type;
 
     /**
      * Managed libMesh::Quadrature objects. These are attached to the FE
      * objects.
      */
-    QuadratureCache quadrature_cache;
+    QuadratureCache d_quadrature_cache;
 
     /**
      * Managed libMesh::FE objects of specified dimension and family.
      */
-    std::map<key_type, std::unique_ptr<libMesh::FEBase> > fes;
+    std::map<key_type, std::unique_ptr<libMesh::FEBase> > d_fes;
 };
 
 inline FECache::FECache(const unsigned int dim, const libMesh::FEType& fe_type)
-    : dim(dim), fe_type(fe_type), quadrature_cache(dim)
+    : d_dim(dim), d_fe_type(fe_type), d_quadrature_cache(d_dim)
 {
 }
 
 inline libMesh::FEType
 FECache::getFEType() const
 {
-    return fe_type;
+    return d_fe_type;
 }
 
 inline FECache::value_type& FECache::operator[](const FECache::key_type& quad_key)
 {
-    auto it = fes.find(quad_key);
-    if (it == fes.end())
+    auto it = d_fes.find(quad_key);
+    if (it == d_fes.end())
     {
-        libMesh::QBase& quad = quadrature_cache[quad_key];
-        libMesh::FEBase& fe = *(*fes.emplace(quad_key, libMesh::FEBase::build(dim, fe_type)).first).second;
+        libMesh::QBase& quad = d_quadrature_cache[quad_key];
+        libMesh::FEBase& fe = *(*d_fes.emplace(quad_key, libMesh::FEBase::build(d_dim, d_fe_type)).first).second;
 
         fe.attach_quadrature_rule(&quad);
         return fe;

--- a/ibtk/include/ibtk/FECache.h
+++ b/ibtk/include/ibtk/FECache.h
@@ -37,6 +37,9 @@
 
 #include <ibtk/QuadratureCache.h>
 
+#include <tbox/Utilities.h>
+
+#include <libmesh/elem.h>
 #include <libmesh/enum_elem_type.h>
 #include <libmesh/enum_order.h>
 #include <libmesh/enum_quadrature_type.h>
@@ -53,6 +56,35 @@ namespace IBTK
 /////////////////////////////// STATIC ///////////////////////////////////////
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
+
+/**
+ * Enumeration describing the various update options available for
+ * libMesh::FEBase objects stored by FECache. Multiple flags can be enabled
+ * with bitwise or operations, e.g.,
+ *
+ * @code
+ * const IBTK::FEUpdateFlags update_flags = IBTK::update_phi | IBTK::update_dphi;
+ * @endcode
+ *
+ * See IBTK::FECache for more information.
+ */
+enum FEUpdateFlags
+{
+    /**
+     * Do not update anything.
+     */
+    update_default = 0,
+
+    /**
+     * Update phi (shape function values).
+     */
+    update_phi = 1,
+
+    /**
+     * Update dphi (shape function gradients).
+     */
+    update_dphi = 2
+};
 
 /**
  * \brief Class storing multiple libMesh::FE objects, each corresponding to a
@@ -94,17 +126,28 @@ public:
      *
      * @param fe_type The libMesh FEType object describing the relevant finite
      * element.
+     *
+     * @param flags FEUpdateFlags indicating which values should be calculated
+     * by each libMesh::FEBase object.
      */
-    FECache(const unsigned int dim, const libMesh::FEType& fe_type);
+    FECache(const unsigned int dim, const libMesh::FEType& fe_type, const FEUpdateFlags flags);
 
     /**
      * Return a reference to an FE object that matches the specified
-     * quadrature rule type and order.
+     * quadrature rule type and order on the given element.
      *
      * @param quad_key a tuple of enums that completely describes
      * a libMesh quadrature rule.
+     *
+     * @param elem Pointer to an element. This will be used to, if necessary,
+     * reinitialize the returned FE object.
      */
-    value_type& operator[](const key_type& quad_key);
+    value_type& operator()(const key_type& quad_key, const libMesh::Elem* elem);
+
+    /**
+     * Return the FEUpdateFlags stored by the current FECache.
+     */
+    FEUpdateFlags getFEUpdateFlags() const;
 
     /**
      * Return the FEType stored by the current FECache.
@@ -123,6 +166,11 @@ protected:
     const libMesh::FEType d_fe_type;
 
     /**
+     * Update flags for the current object.
+     */
+    const FEUpdateFlags d_update_flags;
+
+    /**
      * Managed libMesh::Quadrature objects. These are attached to the FE
      * objects.
      */
@@ -134,9 +182,15 @@ protected:
     std::map<key_type, std::unique_ptr<libMesh::FEBase> > d_fes;
 };
 
-inline FECache::FECache(const unsigned int dim, const libMesh::FEType& fe_type)
-    : d_dim(dim), d_fe_type(fe_type), d_quadrature_cache(d_dim)
+inline FECache::FECache(const unsigned int dim, const libMesh::FEType& fe_type, const FEUpdateFlags flags)
+    : d_dim(dim), d_fe_type(fe_type), d_update_flags(flags), d_quadrature_cache(d_dim)
 {
+}
+
+inline FEUpdateFlags
+FECache::getFEUpdateFlags() const
+{
+    return d_update_flags;
 }
 
 inline libMesh::FEType
@@ -145,20 +199,39 @@ FECache::getFEType() const
     return d_fe_type;
 }
 
-inline FECache::value_type& FECache::operator[](const FECache::key_type& quad_key)
+inline FECache::value_type&
+FECache::operator()(const FECache::key_type& quad_key, const libMesh::Elem* elem)
 {
+#ifndef NDEBUG
+    TBOX_ASSERT(elem->type() == std::get<0>(quad_key));
+#endif
     auto it = d_fes.find(quad_key);
     if (it == d_fes.end())
     {
         libMesh::QBase& quad = d_quadrature_cache[quad_key];
         libMesh::FEBase& fe = *(*d_fes.emplace(quad_key, libMesh::FEBase::build(d_dim, d_fe_type)).first).second;
-
         fe.attach_quadrature_rule(&quad);
+
+        if (d_update_flags & FEUpdateFlags::update_phi) fe.get_phi();
+        if (d_update_flags & FEUpdateFlags::update_dphi) fe.get_dphi();
+
+        fe.reinit(elem);
+
         return fe;
     }
     else
     {
-        return *(it->second);
+        libMesh::FEBase& fe = *(it->second);
+        // TODO: we need better reinitialization logic than hardcoding in
+        // libMesh element types.
+        //
+        // Subdivision elements have a variable number of degrees of freedom
+        // per cell (and the values at quadrature points depend on both the
+        // current and neighbor element geometries) so these values must
+        // always be recomputed.
+        if (d_update_flags & FEUpdateFlags::update_dphi || d_fe_type.family == libMesh::FEFamily::SUBDIVISION)
+            fe.reinit(elem);
+        return fe;
     }
 }
 


### PR DESCRIPTION
Most of the fix for #675: we should now reinitialize the FE objects correctly with subdivision elements inside FEDataManager.

@xxjaehoxx I don't actually have any test code for subdivision elements but we should add some to this PR. Do you have the L2 projection code done? If so, send it to me and I will modify it to use `FECache` to check that our implementation actually works.