### PR TITLE
Fix a path fed to rpath.

### DIFF
--- a/configure
+++ b/configure
@@ -26955,7 +26955,9 @@ fi
 
 PETSC_LDFLAGS=""
 if test -d "${PETSC_DIR}/${PETSC_ARCH}/lib" ; then
-    PETSC_LDFLAGS="-L${PETSC_DIR}/${PETSC_ARCH}/lib"
+  PETSC_LDFLAGS="-L${PETSC_DIR}/${PETSC_ARCH}/lib"
+else
+  as_fn_error $? "Unable to find lib directory for PETSc: ${PETSC_DIR}/${PETSC_ARCH}/lib does not exist." "$LINENO" 5
 fi
 
 LDFLAGS="$PETSC_LDFLAGS $LDFLAGS"
@@ -27020,8 +27022,15 @@ fi
 
 
   if test "$enable_rpath" = yes; then
-    libdir=$PETSC_LDFLAGS
+    libdir=${PETSC_DIR}/${PETSC_ARCH}/lib
+    # acl_cv_hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:wl is $wl" >&5
+$as_echo "$as_me: XXXX:wl is $wl" >&6;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:libdir is $libdir" >&5
+$as_echo "$as_me: XXXX:libdir is $libdir" >&6;}
     rpath_path=$(eval echo "$acl_cv_hardcode_libdir_flag_spec")
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:rpath_path is $rpath_path" >&5
+$as_echo "$as_me: XXXX:rpath_path is $rpath_path" >&6;}
     LDFLAGS=""$rpath_path" $LDFLAGS"
 
   fi
@@ -29311,6 +29320,8 @@ fi
     fi
     if test -d "${HDF5_DIR}/lib" ; then
       HDF5_LDFLAGS="-L${HDF5_DIR}/lib"
+    else
+      as_fn_error $? "Unable to find lib directory for HDF5: ${HDF5_DIR}/lib does not exist." "$LINENO" 5
     fi
   fi
 
@@ -29441,8 +29452,15 @@ fi
 
 
   if test "$enable_rpath" = yes; then
-    libdir=$HDF5_LDFLAGS
+    libdir=${HDF5_DIR}/lib
+    # acl_cv_hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:wl is $wl" >&5
+$as_echo "$as_me: XXXX:wl is $wl" >&6;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:libdir is $libdir" >&5
+$as_echo "$as_me: XXXX:libdir is $libdir" >&6;}
     rpath_path=$(eval echo "$acl_cv_hardcode_libdir_flag_spec")
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:rpath_path is $rpath_path" >&5
+$as_echo "$as_me: XXXX:rpath_path is $rpath_path" >&6;}
     LDFLAGS=""$rpath_path" $LDFLAGS"
 
   fi
@@ -29594,8 +29612,15 @@ fi
 
 
   if test "$enable_rpath" = yes; then
-    libdir=$HYPRE_LDFLAGS
+    libdir=${HYPRE_DIR}/lib
+    # acl_cv_hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:wl is $wl" >&5
+$as_echo "$as_me: XXXX:wl is $wl" >&6;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:libdir is $libdir" >&5
+$as_echo "$as_me: XXXX:libdir is $libdir" >&6;}
     rpath_path=$(eval echo "$acl_cv_hardcode_libdir_flag_spec")
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:rpath_path is $rpath_path" >&5
+$as_echo "$as_me: XXXX:rpath_path is $rpath_path" >&6;}
     LDFLAGS=""$rpath_path" $LDFLAGS"
 
   fi
@@ -30917,6 +30942,8 @@ if test "$SILO_ENABLED" = yes; then
     fi
     if test -d "${SILO_DIR}/lib" ; then
       SILO_LDFLAGS="-L${SILO_DIR}/lib"
+    else
+      as_fn_error $? "Unable to find lib directory for silo: ${SILO_DIR}/lib does not exist." "$LINENO" 5
     fi
   fi
 
@@ -31107,8 +31134,15 @@ fi
 
 
   if test "$enable_rpath" = yes; then
-    libdir=$SILO_LDFLAGS
+    libdir=${SILO_DIR}/lib
+    # acl_cv_hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:wl is $wl" >&5
+$as_echo "$as_me: XXXX:wl is $wl" >&6;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:libdir is $libdir" >&5
+$as_echo "$as_me: XXXX:libdir is $libdir" >&6;}
     rpath_path=$(eval echo "$acl_cv_hardcode_libdir_flag_spec")
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:rpath_path is $rpath_path" >&5
+$as_echo "$as_me: XXXX:rpath_path is $rpath_path" >&6;}
     LDFLAGS=""$rpath_path" $LDFLAGS"
 
   fi

--- a/doc/news/changes/minor/20190920DavidWells
+++ b/doc/news/changes/minor/20190920DavidWells
@@ -1,0 +1,4 @@
+Fixed: Fixed a problem where <code>rpath</code> arguments to the linker were
+incorrectly formatted, resulting in missing libraries at run time.
+<br>
+(David Wells, 2019/09/19)

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -27119,7 +27119,9 @@ fi
 
 PETSC_LDFLAGS=""
 if test -d "${PETSC_DIR}/${PETSC_ARCH}/lib" ; then
-    PETSC_LDFLAGS="-L${PETSC_DIR}/${PETSC_ARCH}/lib"
+  PETSC_LDFLAGS="-L${PETSC_DIR}/${PETSC_ARCH}/lib"
+else
+  as_fn_error $? "Unable to find lib directory for PETSc: ${PETSC_DIR}/${PETSC_ARCH}/lib does not exist." "$LINENO" 5
 fi
 
 LDFLAGS="$PETSC_LDFLAGS $LDFLAGS"
@@ -27184,8 +27186,15 @@ fi
 
 
   if test "$enable_rpath" = yes; then
-    libdir=$PETSC_LDFLAGS
+    libdir=${PETSC_DIR}/${PETSC_ARCH}/lib
+    # acl_cv_hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:wl is $wl" >&5
+$as_echo "$as_me: XXXX:wl is $wl" >&6;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:libdir is $libdir" >&5
+$as_echo "$as_me: XXXX:libdir is $libdir" >&6;}
     rpath_path=$(eval echo "$acl_cv_hardcode_libdir_flag_spec")
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:rpath_path is $rpath_path" >&5
+$as_echo "$as_me: XXXX:rpath_path is $rpath_path" >&6;}
     LDFLAGS=""$rpath_path" $LDFLAGS"
 
   fi
@@ -27495,6 +27504,8 @@ fi
     fi
     if test -d "${HDF5_DIR}/lib" ; then
       HDF5_LDFLAGS="-L${HDF5_DIR}/lib"
+    else
+      as_fn_error $? "Unable to find lib directory for HDF5: ${HDF5_DIR}/lib does not exist." "$LINENO" 5
     fi
   fi
 
@@ -27625,8 +27636,15 @@ fi
 
 
   if test "$enable_rpath" = yes; then
-    libdir=$HDF5_LDFLAGS
+    libdir=${HDF5_DIR}/lib
+    # acl_cv_hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:wl is $wl" >&5
+$as_echo "$as_me: XXXX:wl is $wl" >&6;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:libdir is $libdir" >&5
+$as_echo "$as_me: XXXX:libdir is $libdir" >&6;}
     rpath_path=$(eval echo "$acl_cv_hardcode_libdir_flag_spec")
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:rpath_path is $rpath_path" >&5
+$as_echo "$as_me: XXXX:rpath_path is $rpath_path" >&6;}
     LDFLAGS=""$rpath_path" $LDFLAGS"
 
   fi
@@ -27778,8 +27796,15 @@ fi
 
 
   if test "$enable_rpath" = yes; then
-    libdir=$HYPRE_LDFLAGS
+    libdir=${HYPRE_DIR}/lib
+    # acl_cv_hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:wl is $wl" >&5
+$as_echo "$as_me: XXXX:wl is $wl" >&6;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:libdir is $libdir" >&5
+$as_echo "$as_me: XXXX:libdir is $libdir" >&6;}
     rpath_path=$(eval echo "$acl_cv_hardcode_libdir_flag_spec")
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:rpath_path is $rpath_path" >&5
+$as_echo "$as_me: XXXX:rpath_path is $rpath_path" >&6;}
     LDFLAGS=""$rpath_path" $LDFLAGS"
 
   fi
@@ -31081,6 +31106,8 @@ if test "$SILO_ENABLED" = yes; then
     fi
     if test -d "${SILO_DIR}/lib" ; then
       SILO_LDFLAGS="-L${SILO_DIR}/lib"
+    else
+      as_fn_error $? "Unable to find lib directory for silo: ${SILO_DIR}/lib does not exist." "$LINENO" 5
     fi
   fi
 
@@ -31271,8 +31298,15 @@ fi
 
 
   if test "$enable_rpath" = yes; then
-    libdir=$SILO_LDFLAGS
+    libdir=${SILO_DIR}/lib
+    # acl_cv_hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:wl is $wl" >&5
+$as_echo "$as_me: XXXX:wl is $wl" >&6;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:libdir is $libdir" >&5
+$as_echo "$as_me: XXXX:libdir is $libdir" >&6;}
     rpath_path=$(eval echo "$acl_cv_hardcode_libdir_flag_spec")
+    { $as_echo "$as_me:${as_lineno-$LINENO}: XXXX:rpath_path is $rpath_path" >&5
+$as_echo "$as_me: XXXX:rpath_path is $rpath_path" >&6;}
     LDFLAGS=""$rpath_path" $LDFLAGS"
 
   fi

--- a/m4/configure_hdf5.m4
+++ b/m4/configure_hdf5.m4
@@ -25,6 +25,8 @@ else
     fi
     if test -d "${HDF5_DIR}/lib" ; then
       HDF5_LDFLAGS="-L${HDF5_DIR}/lib"
+    else
+      AC_MSG_ERROR([Unable to find lib directory for HDF5: ${HDF5_DIR}/lib does not exist.])
     fi
   fi
 
@@ -37,7 +39,7 @@ else
   AC_CHECK_LIB([hdf5_hl], H5LTfind_dataset, [],
                [AC_MSG_ERROR([could not find working libhdf5_hl])])
   # set up rpath
-  ADD_RPATH_LDFLAG($HDF5_LDFLAGS)
+  ADD_RPATH_LDFLAG(${HDF5_DIR}/lib)
 fi
 
 AC_MSG_CHECKING([for HDF5 version >= 1.8.7])

--- a/m4/configure_hypre.m4
+++ b/m4/configure_hypre.m4
@@ -34,7 +34,7 @@ else
   LDFLAGS_PREPEND($HYPRE_LDFLAGS)
   AC_CHECK_LIB([HYPRE], BoomerAMGCreate, [],
                [AC_MSG_ERROR([could not find working libHYPRE])])
-  ADD_RPATH_LDFLAG($HYPRE_LDFLAGS)
+  ADD_RPATH_LDFLAG(${HYPRE_DIR}/lib)
 fi
 
 ])

--- a/m4/configure_petsc.m4
+++ b/m4/configure_petsc.m4
@@ -42,12 +42,14 @@ fi
 
 PETSC_LDFLAGS=""
 if test -d "${PETSC_DIR}/${PETSC_ARCH}/lib" ; then
-    PETSC_LDFLAGS="-L${PETSC_DIR}/${PETSC_ARCH}/lib"
+  PETSC_LDFLAGS="-L${PETSC_DIR}/${PETSC_ARCH}/lib"
+else
+  AC_MSG_ERROR([Unable to find lib directory for PETSc: ${PETSC_DIR}/${PETSC_ARCH}/lib does not exist.])
 fi
 
 LDFLAGS_PREPEND($PETSC_LDFLAGS)
 LIBS_PREPEND($PETSC_EXTERNAL_LIB_BASIC)
 AC_CHECK_LIB([petsc], VecAssemblyBegin, [],
              [AC_MSG_ERROR([could not find working libpetsc])])
-ADD_RPATH_LDFLAG($PETSC_LDFLAGS)
+ADD_RPATH_LDFLAG(${PETSC_DIR}/${PETSC_ARCH}/lib)
 ])

--- a/m4/configure_silo.m4
+++ b/m4/configure_silo.m4
@@ -48,6 +48,8 @@ if test "$SILO_ENABLED" = yes; then
     fi
     if test -d "${SILO_DIR}/lib" ; then
       SILO_LDFLAGS="-L${SILO_DIR}/lib"
+    else
+      AC_MSG_ERROR([Unable to find lib directory for silo: ${SILO_DIR}/lib does not exist.])
     fi
   fi
 
@@ -79,7 +81,7 @@ asdf
   AC_SEARCH_LIBS([DBSetDir], [silo siloh5], [],
                  [AC_MSG_ERROR([Silo enabled but could not find working libsilo or libsiloh5])])
   # set up rpath
-  ADD_RPATH_LDFLAG($SILO_LDFLAGS)
+  ADD_RPATH_LDFLAG(${SILO_DIR}/lib)
 
   AC_DEFINE([HAVE_SILO],1,[Define if you have the silo library.])
 else


### PR DESCRIPTION
Fixes #686. I need to do some more tests before we merge but this appears to add the correct linker flags. @jabrown893 if you have some time it would help a lot if you could run this on longleaf.

We should not have the -L prefix here, so we should pass the directory instead.