### PR TITLE
Add a pointer check to FEDataManager.

### DIFF
--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -2574,6 +2574,7 @@ FEDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> > hi
     TBOX_ASSERT(hierarchy);
     TBOX_ASSERT((level_number >= 0) && (level_number <= hierarchy->getFinestLevelNumber()));
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
+    TBOX_ASSERT(hierarchy == d_hierarchy);
 
     if (initial_time)
     {


### PR DESCRIPTION
Peeled off from #654.

These pointers have to point to the same patch hierarchy so explicitly assert it.