### PR TITLE
Change the default q point weight to 1.0.

### DIFF
--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -359,7 +359,7 @@ public:
     struct WorkloadSpec
     {
         /// The multiplier applied to each quadrature point.
-        double q_point_weight = 2.0;
+        double q_point_weight = 1.0;
     };
 
     /*!


### PR DESCRIPTION
Also taken from #654.

This will make more sense later when we also include nodal weights.