### PR TITLE
Refactor computeActiveElementBoundingBoxes.

### DIFF
--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -1020,6 +1020,9 @@ private:
      *
      * \note For inactive elements, the lower and upper bound values will be
      * identically zero.
+     *
+     * @deprecated Use the non member function
+     * IBTK::get_global_active_element_bounding_boxes instead.
      */
     std::vector<std::pair<Point, Point> >* computeActiveElementBoundingBoxes();
 

--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -40,6 +40,7 @@
 
 #include "tbox/Utilities.h"
 
+#include "libmesh/bounding_box.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/dof_object.h"
 #include "libmesh/edge.h"
@@ -1325,6 +1326,20 @@ void write_elem_partitioning(const std::string& file_name, const libMesh::System
  * function.
  */
 void write_node_partitioning(const std::string& file_name, const libMesh::System& position_system);
+
+/*
+ * Compute bounding boxes for each local active (i.e., active on the current
+ * processor) element in @p mesh with coordinates given by @p X_system.
+ */
+std::vector<libMesh::BoundingBox> get_local_active_element_bounding_boxes(const libMesh::MeshBase& mesh,
+                                                                          const libMesh::System& X_system);
+
+/*
+ * Compute bounding boxes for each active (i.e., active on any processor)
+ * element in @p mesh with coordinates given by @p X_system.
+ */
+std::vector<libMesh::BoundingBox> get_global_active_element_bounding_boxes(const libMesh::MeshBase& mesh,
+                                                                           const libMesh::System& X_system);
 } // namespace IBTK
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -2942,74 +2942,17 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
 std::vector<std::pair<Point, Point> >*
 FEDataManager::computeActiveElementBoundingBoxes()
 {
-    // Get the necessary FE data.
     const MeshBase& mesh = d_fe_data->d_es->get_mesh();
-    const unsigned int n_elem = mesh.max_elem_id() + 1;
-    System& X_system = d_fe_data->d_es->get_system(COORDINATES_SYSTEM_NAME);
-    const unsigned int X_sys_num = X_system.number();
-    NumericVector<double>& X_vec = *X_system.solution;
-    NumericVector<double>& X_ghost_vec = *X_system.current_local_solution;
-    copy_and_synch(X_vec, X_ghost_vec, /*close_v_in*/ false);
+    const System& X_system = d_fe_data->d_es->get_system(COORDINATES_SYSTEM_NAME);
 
-    // Compute the lower and upper bounds of all active local elements in the
-    // mesh.  Assumes nodal basis functions.
-    d_active_elem_bboxes.resize(n_elem);
-    std::fill(d_active_elem_bboxes.begin(), d_active_elem_bboxes.end(), std::make_pair(Point::Zero(), Point::Zero()));
-    std::vector<unsigned int> dof_indices;
-    MeshBase::const_element_iterator el_it = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (; el_it != el_end; ++el_it)
+    const std::vector<libMesh::BoundingBox> bboxes = get_global_active_element_bounding_boxes(mesh, X_system);
+    d_active_elem_bboxes.resize(bboxes.size());
+    for (std::size_t i = 0; i < bboxes.size(); ++i)
     {
-        const Elem* const elem = *el_it;
-        const unsigned int elem_id = elem->id();
-        Point& elem_lower_bound = d_active_elem_bboxes[elem_id].first;
-        Point& elem_upper_bound = d_active_elem_bboxes[elem_id].second;
-        elem_lower_bound = Point::Constant(std::numeric_limits<double>::max());
-        elem_upper_bound = Point::Constant(-std::numeric_limits<double>::max());
-
-        const unsigned int n_nodes = elem->n_nodes();
-        dof_indices.clear();
-        for (unsigned int k = 0; k < n_nodes; ++k)
+        for (int d = 0; d < NDIM; ++d)
         {
-            const Node* const node = elem->node_ptr(k);
-            for (unsigned int d = 0; d < NDIM; ++d)
-            {
-                TBOX_ASSERT(node->n_dofs(X_sys_num, d) == 1);
-                dof_indices.push_back(node->dof_number(X_sys_num, d, 0));
-            }
-        }
-        std::vector<double> X_node;
-        X_ghost_vec.get(dof_indices, X_node);
-        for (unsigned int k = 0; k < n_nodes; ++k)
-        {
-            for (unsigned int d = 0; d < NDIM; ++d)
-            {
-                const double& X = X_node[k * NDIM + d];
-                elem_lower_bound[d] = std::min(elem_lower_bound[d], X);
-                elem_upper_bound[d] = std::max(elem_upper_bound[d], X);
-            }
-        }
-    }
-
-    // Parallel sum elem_lower_bound and elem_upper_bound so that each process
-    // has access to the bounding box data for each active element in the mesh.
-    std::vector<double> d_active_elem_bboxes_flattened(2 * NDIM * n_elem);
-    for (unsigned int e = 0; e < n_elem; ++e)
-    {
-        for (unsigned int d = 0; d < NDIM; ++d)
-        {
-            d_active_elem_bboxes_flattened[2 * e * NDIM + d] = d_active_elem_bboxes[e].first[d];
-            d_active_elem_bboxes_flattened[(2 * e + 1) * NDIM + d] = d_active_elem_bboxes[e].second[d];
-        }
-    }
-    SAMRAI_MPI::sumReduction(&d_active_elem_bboxes_flattened[0],
-                             static_cast<int>(d_active_elem_bboxes_flattened.size()));
-    for (unsigned int e = 0; e < n_elem; ++e)
-    {
-        for (unsigned int d = 0; d < NDIM; ++d)
-        {
-            d_active_elem_bboxes[e].first[d] = d_active_elem_bboxes_flattened[2 * e * NDIM + d];
-            d_active_elem_bboxes[e].second[d] = d_active_elem_bboxes_flattened[(2 * e + 1) * NDIM + d];
+            d_active_elem_bboxes[i].first[d] = bboxes[i].first(d);
+            d_active_elem_bboxes[i].second[d] = bboxes[i].second(d);
         }
     }
     return &d_active_elem_bboxes;

--- a/ibtk/src/utilities/libmesh_utilities.cpp
+++ b/ibtk/src/utilities/libmesh_utilities.cpp
@@ -40,6 +40,7 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/parallel.h"
+#include "libmesh/petsc_vector.h"
 #include "libmesh/point.h"
 #include "libmesh/system.h"
 
@@ -224,6 +225,101 @@ write_node_partitioning(const std::string& file_name, const libMesh::System& pos
     }
 }
 
+std::vector<libMesh::BoundingBox>
+get_local_active_element_bounding_boxes(const libMesh::MeshBase& mesh, const libMesh::System& X_system)
+{
+    static_assert(NDIM <= LIBMESH_DIM,
+                  "NDIM should be no more than LIBMESH_DIM for this function to "
+                  "work correctly.");
+    const unsigned int X_sys_num = X_system.number();
+    auto X_ghost_vec_ptr = X_system.current_local_solution->zero_clone();
+    auto& X_ghost_vec = dynamic_cast<libMesh::PetscVector<double>&>(*X_ghost_vec_ptr);
+    X_ghost_vec = *X_system.solution;
+
+    std::vector<libMesh::BoundingBox> bboxes;
+    bboxes.reserve(mesh.n_local_elem());
+
+    std::vector<libMesh::dof_id_type> dof_indices;
+    std::vector<double> X_node;
+    for (auto it = mesh.active_local_elements_begin(); it != mesh.active_local_elements_end(); ++it)
+    {
+        const libMesh::Elem* const elem = *it;
+        const unsigned int n_nodes = elem->n_nodes();
+        bboxes.emplace_back();
+        libMesh::BoundingBox& box = bboxes.back();
+        libMesh::Point& lower_bound = box.first;
+        libMesh::Point& upper_bound = box.second;
+        for (unsigned int d = 0; d < LIBMESH_DIM; ++d)
+        {
+            lower_bound(d) = std::numeric_limits<double>::max();
+            upper_bound(d) = -std::numeric_limits<double>::max();
+        }
+
+        dof_indices.clear();
+        for (unsigned int k = 0; k < n_nodes; ++k)
+        {
+            const libMesh::Node* const node = elem->node_ptr(k);
+            for (unsigned int d = 0; d < NDIM; ++d)
+            {
+                TBOX_ASSERT(node->n_dofs(X_sys_num, d) == 1);
+                dof_indices.push_back(node->dof_number(X_sys_num, d, 0));
+            }
+        }
+
+        X_node.resize(dof_indices.size());
+        X_ghost_vec.get(dof_indices, X_node.data());
+        for (unsigned int k = 0; k < n_nodes; ++k)
+        {
+            for (unsigned int d = 0; d < NDIM; ++d)
+            {
+                const double& X = X_node[k * NDIM + d];
+                lower_bound(d) = std::min(lower_bound(d), X);
+                upper_bound(d) = std::max(upper_bound(d), X);
+            }
+        }
+    }
+
+    return bboxes;
+} // get_local_active_element_bounding_boxes
+
+std::vector<libMesh::BoundingBox>
+get_global_active_element_bounding_boxes(const libMesh::MeshBase& mesh, const libMesh::System& X_system)
+{
+    static_assert(NDIM <= LIBMESH_DIM,
+                  "NDIM should be no more than LIBMESH_DIM for this function to "
+                  "work correctly.");
+    const std::vector<libMesh::BoundingBox> bboxes = get_local_active_element_bounding_boxes(mesh, X_system);
+
+    // Parallel sum bounds so that each process has access to the bounding box
+    // data for each active element in the mesh.
+    const std::size_t n_elem = mesh.n_active_elem();
+    std::vector<double> flattened_bboxes(2 * LIBMESH_DIM * n_elem);
+    std::size_t elem_n = 0;
+    for (auto it = mesh.active_local_elements_begin(); it != mesh.active_local_elements_end(); ++it)
+    {
+        const auto id = (*it)->id();
+        for (unsigned int d = 0; d < NDIM; ++d)
+        {
+            flattened_bboxes[2 * id * NDIM + d] = bboxes[elem_n].first(d);
+            flattened_bboxes[(2 * id + 1) * NDIM + d] = bboxes[elem_n].second(d);
+        }
+        ++elem_n;
+    }
+    const int ierr = MPI_Allreduce(
+        MPI_IN_PLACE, flattened_bboxes.data(), flattened_bboxes.size(), MPI_DOUBLE, MPI_SUM, mesh.comm().get());
+    TBOX_ASSERT(ierr == 0);
+
+    std::vector<libMesh::BoundingBox> global_bboxes(n_elem);
+    for (unsigned int e = 0; e < n_elem; ++e)
+    {
+        for (unsigned int d = 0; d < NDIM; ++d)
+        {
+            global_bboxes[e].first(d) = flattened_bboxes[2 * e * NDIM + d];
+            global_bboxes[e].second(d) = flattened_bboxes[(2 * e + 1) * NDIM + d];
+        }
+    }
+    return global_bboxes;
+} // get_global_active_element_bounding_boxes
 //////////////////////////////////////////////////////////////////////////////
 
 } // namespace IBTK


### PR DESCRIPTION
Part of #715: the relationship between IBFEMethod and FEDataManager is overly complicated. Fortunately, a lot of the stuff FEDataManager does that is required by IBFEMethod doesn't really depend on FEDataManager at all - just on the Lagrangian data.

This function, and several functions that call it, do not need to be member functions.