### PR TITLE
Rearrange things to permit the scratch hierarchy.

### DIFF
--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -768,6 +768,12 @@ protected:
     bool d_do_log = false;
 
     /*
+     * Boolean controlling whether or not the scratch hierarchy should be
+     * used.
+     */
+    bool d_use_scratch_hierarchy = false;
+
+    /*
      * Pointers to the patch hierarchy and gridding algorithm objects associated
      * with this object.
      */
@@ -792,8 +798,22 @@ protected:
     /// Number of parts owned by the present object.
     const unsigned int d_num_parts = 1;
 
-    /// Currently, each FEDataManager object is associated with exactly one part.
-    std::vector<IBTK::FEDataManager*> d_fe_data_managers;
+    /// FEDataManager objects associated with the primary hierarchy (i.e.,
+    /// d_hierarchy). These are used by some other objects (such as
+    /// IBFEPostProcessor); IBFEMethod keeps them up to date (i.e.,
+    /// reinitializing data after regrids).
+    std::vector<IBTK::FEDataManager*> d_primary_fe_data_managers;
+
+    /// FEDataManager objects that use the scratch hierarchy instead of
+    /// d_hierarchy. These are only used internally by IBFEMethod and are not
+    /// intended to be accessed by any other object.
+    std::vector<IBTK::FEDataManager*> d_scratch_fe_data_managers;
+
+    /// The FEDataManager objects that are actually used in computations. This
+    /// vector will be equal to either d_primary_fe_data_managers or
+    /// d_scratch_fe_data_managers, dependent on which is actually used in IB
+    /// calculations.
+    std::vector<IBTK::FEDataManager*> d_active_fe_data_managers;
 
     /// Minimum ghost cell width.
     SAMRAI::hier::IntVector<NDIM> d_ghosts = 0;

--- a/src/IB/CIBFEMethod.cpp
+++ b/src/IB/CIBFEMethod.cpp
@@ -353,12 +353,12 @@ CIBFEMethod::interpolateVelocity(const int u_data_idx,
             X_vec->localize(*X_ghost_vec);
             if (d_compute_L2_projection)
             {
-                d_fe_data_managers[part]->interp(
+                d_active_fe_data_managers[part]->interp(
                     u_data_idx, *U_vec, *X_ghost_vec, VELOCITY_SYSTEM_NAME, u_ghost_fill_scheds, data_time);
             }
             else if (!d_compute_L2_projection)
             {
-                d_fe_data_managers[part]->interpWeighted(
+                d_active_fe_data_managers[part]->interpWeighted(
                     u_data_idx, *U_vec, *X_ghost_vec, VELOCITY_SYSTEM_NAME, u_ghost_fill_scheds, data_time);
             }
         }
@@ -736,7 +736,7 @@ CIBFEMethod::computeMobilityRegularization(Vec D, Vec L, const double scale)
         for (unsigned part = 0; part < d_num_rigid_parts; ++part)
         {
             std::pair<LinearSolver<double>*, SparseMatrix<double>*> filter =
-                d_fe_data_managers[part]->buildL2ProjectionSolver(VELOCITY_SYSTEM_NAME);
+                d_active_fe_data_managers[part]->buildL2ProjectionSolver(VELOCITY_SYSTEM_NAME);
             Mat mat = static_cast<PetscMatrix<double>*>(filter.second)->mat();
             MatMult(mat, vL[part], vD[part]);
         }
@@ -1055,7 +1055,7 @@ CIBFEMethod::setRigidBodyVelocity(const unsigned int part, const RigidDOFVector&
     if (!d_compute_L2_projection)
     {
         std::pair<LinearSolver<double>*, SparseMatrix<double>*> filter =
-            d_fe_data_managers[part]->buildL2ProjectionSolver(VELOCITY_SYSTEM_NAME);
+            d_active_fe_data_managers[part]->buildL2ProjectionSolver(VELOCITY_SYSTEM_NAME);
         Mat mat = static_cast<PetscMatrix<double>*>(filter.second)->mat();
         MatMult(mat, U_k.vec(), vV[part]);
     }
@@ -1088,7 +1088,7 @@ CIBFEMethod::initializeFEData()
 
     for (unsigned part = 0; part < d_num_rigid_parts; ++part)
     {
-        EquationSystems& equation_systems = *d_fe_data_managers[part]->getEquationSystems();
+        EquationSystems& equation_systems = *d_active_fe_data_managers[part]->getEquationSystems();
         computeCOMOfStructure(d_center_of_mass_initial[part], &equation_systems);
     }
 


### PR DESCRIPTION
IBFEMethod will need to, in the future, handle multiple FEDataManagers which are associated with different patch hierarchies. This patch adds support for multiple FEDataManager sets: future work will actually turn the scratch hierarchy on.

This patch doesn't really do anything: the default and only choice is to use the 'primary' FEDataManager, which is associated with the main patch hierarchy.