### PR TITLE
reuse SAMRAIDataCache objects between FEDataManager instances

### DIFF
--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -421,6 +421,7 @@ public:
                const SpreadSpec& default_spread_spec,
                const WorkloadSpec& default_workload_spec,
                const SAMRAI::hier::IntVector<NDIM>& min_ghost_width = SAMRAI::hier::IntVector<NDIM>(0),
+               std::shared_ptr<SAMRAIDataCache> eulerian_data_cache = nullptr,
                bool register_for_restart = true);
 
     /*!
@@ -441,6 +442,7 @@ public:
                const SpreadSpec& default_spread_spec,
                const WorkloadSpec& default_workload_spec,
                const SAMRAI::hier::IntVector<NDIM>& min_ghost_width = SAMRAI::hier::IntVector<NDIM>(0),
+               std::shared_ptr<SAMRAIDataCache> eulerian_data_cache = nullptr,
                bool register_for_restart = true);
 
     /*!
@@ -961,6 +963,7 @@ protected:
                   SpreadSpec default_spread_spec,
                   WorkloadSpec default_workload_spec,
                   SAMRAI::hier::IntVector<NDIM> ghost_width,
+                  std::shared_ptr<SAMRAIDataCache> eulerian_data_cache,
                   bool register_for_restart = true);
 
     /*!
@@ -973,6 +976,7 @@ protected:
                   SpreadSpec default_spread_spec,
                   WorkloadSpec default_workload_spec,
                   SAMRAI::hier::IntVector<NDIM> ghost_width,
+                  std::shared_ptr<SAMRAIDataCache> eulerian_data_cache,
                   bool register_for_restart = true);
 
     /*!
@@ -1109,7 +1113,7 @@ private:
     /*
      * Cached Eulerian data to reduce the number of allocations/deallocations.
      */
-    SAMRAIDataCache d_cached_eulerian_data;
+    std::shared_ptr<SAMRAIDataCache> d_eulerian_data_cache;
 
     /*
      * SAMRAI::hier::VariableContext object used for data management.

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -40,6 +40,7 @@
 #include "ibamr/ibamr_enums.h"
 
 #include "ibtk/FEDataManager.h"
+#include "ibtk/SAMRAIDataCache.h"
 #include "ibtk/libmesh_utilities.h"
 
 #include "GriddingAlgorithm.h"
@@ -780,6 +781,17 @@ protected:
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > d_hierarchy;
     SAMRAI::tbox::Pointer<SAMRAI::mesh::GriddingAlgorithm<NDIM> > d_gridding_alg;
     bool d_is_initialized = false;
+
+    /*
+     * Scratch data caching objects.
+     *
+     * These are shared by all of the FEDataManagers associated with this class.
+     *
+     * Note that SAMRAIDataCache objects are associated with only a single
+     * PatchHierarchy object, and so different scratch data caching objects are
+     * needed for the regular and scratch patch hierarchies.
+     */
+    std::shared_ptr<IBTK::SAMRAIDataCache> d_eulerian_data_cache, d_scratch_eulerian_data_cache;
 
     /*
      * The current time step interval.

--- a/include/ibamr/IBFESurfaceMethod.h
+++ b/include/ibamr/IBFESurfaceMethod.h
@@ -513,6 +513,11 @@ protected:
     bool d_is_initialized = false;
 
     /*
+     * Scratch data caching objects.
+     */
+    std::shared_ptr<IBTK::SAMRAIDataCache> d_eulerian_data_cache;
+
+    /*
      * The current time step interval.
      */
     double d_current_time = std::numeric_limits<double>::quiet_NaN(),
@@ -545,6 +550,7 @@ protected:
      */
     IBTK::FEDataManager::InterpSpec d_default_interp_spec;
     IBTK::FEDataManager::SpreadSpec d_default_spread_spec;
+    IBTK::FEDataManager::WorkloadSpec d_default_workload_spec;
     std::vector<IBTK::FEDataManager::InterpSpec> d_interp_spec;
     std::vector<IBTK::FEDataManager::SpreadSpec> d_spread_spec;
     bool d_use_jump_conditions = false;

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1143,19 +1143,28 @@ IBFEMethod::initializeFEEquationSystems()
     d_primary_fe_data_managers.resize(d_num_parts, nullptr);
     d_scratch_fe_data_managers.resize(d_num_parts, nullptr);
     d_active_fe_data_managers.resize(d_num_parts, nullptr);
+    IntVector<NDIM> min_ghost_width(0);
+    if (!d_eulerian_data_cache) d_eulerian_data_cache.reset(new SAMRAIDataCache());
     for (unsigned int part = 0; part < d_num_parts; ++part)
     {
         // Create FE data managers.
         const std::string manager_name = "IBFEMethod FEDataManager::" + std::to_string(part);
-        d_primary_fe_data_managers[part] =
-            FEDataManager::getManager(manager_name, d_interp_spec[part], d_spread_spec[part], d_workload_spec[part]);
+        d_primary_fe_data_managers[part] = FEDataManager::getManager(manager_name,
+                                                                     d_interp_spec[part],
+                                                                     d_spread_spec[part],
+                                                                     d_workload_spec[part],
+                                                                     min_ghost_width,
+                                                                     d_eulerian_data_cache);
         if (d_use_scratch_hierarchy)
         {
+            if (!d_scratch_eulerian_data_cache) d_scratch_eulerian_data_cache.reset(new SAMRAIDataCache());
             d_scratch_fe_data_managers[part] = FEDataManager::getManager(d_primary_fe_data_managers[part]->getFEData(),
                                                                          manager_name + "::scratch",
                                                                          d_interp_spec[part],
                                                                          d_spread_spec[part],
-                                                                         d_workload_spec[part]);
+                                                                         d_workload_spec[part],
+                                                                         min_ghost_width,
+                                                                         d_scratch_eulerian_data_cache);
             d_active_fe_data_managers[part] = d_scratch_fe_data_managers[part];
         }
         else

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -44,6 +44,7 @@
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LEInteractor.h"
 #include "ibtk/RobinPhysBdryPatchStrategy.h"
+#include "ibtk/SAMRAIDataCache.h"
 #include "ibtk/ibtk_macros.h"
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/libmesh_utilities.h"
@@ -1169,11 +1170,18 @@ IBFESurfaceMethod::initializeFEEquationSystems()
     // parts and the Cartesian grid.
     d_equation_systems.resize(d_num_parts, nullptr);
     d_fe_data_managers.resize(d_num_parts, nullptr);
+    IntVector<NDIM> min_ghost_width(0);
+    if (!d_eulerian_data_cache) d_eulerian_data_cache.reset(new SAMRAIDataCache());
     for (unsigned int part = 0; part < d_num_parts; ++part)
     {
         // Create FE data managers.
         const std::string manager_name = "IBFESurfaceMethod FEDataManager::" + std::to_string(part);
-        d_fe_data_managers[part] = FEDataManager::getManager(manager_name, d_interp_spec[part], d_spread_spec[part]);
+        d_fe_data_managers[part] = FEDataManager::getManager(manager_name,
+                                                             d_interp_spec[part],
+                                                             d_spread_spec[part],
+                                                             d_default_workload_spec,
+                                                             min_ghost_width,
+                                                             d_eulerian_data_cache);
         d_ghosts = IntVector<NDIM>::max(d_ghosts, d_fe_data_managers[part]->getGhostCellWidth());
 
         // Create FE equation systems objects and corresponding variables.


### PR DESCRIPTION
Allow callers to share one (or more) `SAMRAIDataCache` objects between multiple `FEDataManager`s.