### PR TITLE
Use array sizes for reductions.

### DIFF
--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -947,7 +947,7 @@ LDataManager::computeLagrangianStructureCenterOfMass(const int structure_id, con
     }
     d_lag_mesh_data[level_number][POSN_DATA_NAME]->restoreArrays();
 
-    SAMRAI_MPI::sumReduction(&X_com[0], NDIM);
+    SAMRAI_MPI::sumReduction(X_com.data(), X_com.size());
     node_counter = SAMRAI_MPI::sumReduction(node_counter);
     for (unsigned int d = 0; d < NDIM; ++d)
     {

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -1766,7 +1766,7 @@ CIBMethod::computeCOMOfStructures(IBTK::EigenAlignedVector<Eigen::Vector3d>& cen
 
         for (unsigned struct_no = 0; struct_no < structs_on_this_ln; ++struct_no)
         {
-            SAMRAI_MPI::sumReduction(&center_of_mass[struct_no][0], NDIM);
+            SAMRAI_MPI::sumReduction(center_of_mass[struct_no].data(), center_of_mass[struct_no].size());
             const int total_nodes = getNumberOfNodes(struct_no);
             center_of_mass[struct_no] /= total_nodes;
         }

--- a/src/IB/ConstraintIBMethod.cpp
+++ b/src/IB/ConstraintIBMethod.cpp
@@ -940,8 +940,9 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
         const StructureParameters& struct_param = d_ib_kinematics[struct_no]->getStructureParameters();
         const int total_nodes = struct_param.getTotalNodes();
 
-        SAMRAI_MPI::sumReduction(&d_center_of_mass_current[struct_no][0], NDIM);
-        SAMRAI_MPI::sumReduction(&d_center_of_mass_new[struct_no][0], NDIM);
+        SAMRAI_MPI::sumReduction(d_center_of_mass_current[struct_no].data(),
+                                 d_center_of_mass_current[struct_no].size());
+        SAMRAI_MPI::sumReduction(d_center_of_mass_new[struct_no].data(), d_center_of_mass_new[struct_no].size());
 
         for (int i = 0; i < 3; ++i)
         {
@@ -1184,7 +1185,7 @@ ConstraintIBMethod::calculateMomentumOfKinematicsVelocity(const int position_han
             d_vel_com_def_new[position_handle][d] += U_com_def[d];
         }
     }
-    SAMRAI_MPI::sumReduction(&d_vel_com_def_new[position_handle][0], NDIM);
+    SAMRAI_MPI::sumReduction(d_vel_com_def_new[position_handle].data(), d_vel_com_def_new[position_handle].size());
 
     for (int d = 0; d < 3; ++d)
     {
@@ -1483,7 +1484,7 @@ ConstraintIBMethod::calculateRigidTranslationalMomentum()
         const StructureParameters& struct_param = d_ib_kinematics[struct_no]->getStructureParameters();
         if (struct_param.getStructureIsSelfTranslating())
         {
-            SAMRAI_MPI::sumReduction(&d_rigid_trans_vel_new[struct_no][0], NDIM);
+            SAMRAI_MPI::sumReduction(d_rigid_trans_vel_new[struct_no].data(), d_rigid_trans_vel_new[struct_no].size());
             Array<int> calculate_trans_mom = struct_param.getCalculateTranslationalMomentum();
             for (int d = 0; d < NDIM; ++d)
             {

--- a/src/IB/IBFEDirectForcingKinematics.cpp
+++ b/src/IB/IBFEDirectForcingKinematics.cpp
@@ -576,7 +576,7 @@ IBFEDirectForcingKinematics::computeCOMOfStructure(Eigen::Vector3d& X0)
             vol_part += JxW[qp];
         }
     }
-    SAMRAI_MPI::sumReduction(&X0[0], NDIM);
+    SAMRAI_MPI::sumReduction(X0.data(), X0.size());
     vol_part = SAMRAI_MPI::sumReduction(vol_part);
     X0 /= vol_part;
 

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -1083,7 +1083,7 @@ IBFESurfaceMethod::computeLagrangianForce(const double data_time)
             }
         }
 
-        SAMRAI_MPI::sumReduction(&F_integral(0), NDIM);
+        SAMRAI_MPI::sumReduction(&F_integral(0), LIBMESH_DIM);
 
         // Solve for F.
         d_fe_data_managers[part]->computeL2Projection(

--- a/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
@@ -340,10 +340,10 @@ IBHydrodynamicSurfaceForceEvaluator::computeHydrodynamicForceTorque(IBTK::Vector
         }
     }
     // Sum the net force and torque across processors.
-    SAMRAI_MPI::sumReduction(pressure_force.data(), NDIM);
-    SAMRAI_MPI::sumReduction(viscous_force.data(), NDIM);
-    SAMRAI_MPI::sumReduction(pressure_torque.data(), NDIM);
-    SAMRAI_MPI::sumReduction(viscous_torque.data(), NDIM);
+    SAMRAI_MPI::sumReduction(pressure_force.data(), pressure_force.size());
+    SAMRAI_MPI::sumReduction(viscous_force.data(), viscous_force.size());
+    SAMRAI_MPI::sumReduction(pressure_torque.data(), pressure_torque.size());
+    SAMRAI_MPI::sumReduction(viscous_torque.data(), viscous_force.size());
 
     // Deallocate patch data
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)


### PR DESCRIPTION
This avoids some confusion where we are using 3D arrays in 2D; i.e., `NDIM` is wrong. I made this mistake back in #607.