### PR TITLE
Multiple body force functions can be registered with INS integrators.

### DIFF
--- a/doc/news/changes/minor/20191112AaronBarrett
+++ b/doc/news/changes/minor/20191112AaronBarrett
@@ -1,0 +1,6 @@
+Fixed: Multiple body force functions can be registered with INS integrators.
+Previously, the integrator would overwrite the previous forcing function,
+despite claiming that functions would be evaluted in the order they are
+registered.
+<br>
+(Aaron Barrett, 2019/11/12)

--- a/src/navier_stokes/INSHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSHierarchyIntegrator.cpp
@@ -210,6 +210,7 @@ INSHierarchyIntegrator::registerBodyForceFunction(Pointer<CartGridFunction> F_fc
             p_F_fcn->addFunction(d_F_fcn);
         }
         p_F_fcn->addFunction(F_fcn);
+        d_F_fcn = p_F_fcn;
     }
     else
     {


### PR DESCRIPTION
Previously, `INSHierarchyIntegrator` would overwrite previously registered forcing functions despite claiming to evaluate them in registered order. This fixes that issue. This also addresses the problems raised in #747.