### PR TITLE
Allow IBAMR to be built with bundled boost when libMesh is enabled with no boost support.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -187,8 +187,8 @@ am__DIST_COMMON = $(srcdir)/Makefile.in \
 	$(top_srcdir)/config/install-sh $(top_srcdir)/config/ltmain.sh \
 	$(top_srcdir)/config/make.inc.in $(top_srcdir)/config/missing \
 	config/compile config/config.guess config/config.rpath \
-	config/config.sub config/depcomp config/install-sh \
-	config/ltmain.sh config/missing
+	config/config.sub config/install-sh config/ltmain.sh \
+	config/missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)

--- a/config/IBAMR_config.h.tmp.in
+++ b/config/IBAMR_config.h.tmp.in
@@ -166,6 +166,9 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
+/* Define if libmesh was built with boost */
+#undef LIBMESH_HAS_BOOST
+
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
 

--- a/configure
+++ b/configure
@@ -24074,6 +24074,9 @@ $as_echo "$as_me: using Eigen library bundled with libMesh" >&6;}
 
   if test -e "$LIBMESH_DIR/include/boost" ; then
     as_fn_error $? "libMesh appears to be configured to use a bundled Boost library, but when IBAMR is also configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library" "$LINENO" 5
+
+$as_echo "#define LIBMESH_HAS_BOOST 1" >>confdefs.h
+
   fi
 
   CPPFLAGS="$LIBMESH_CPPFLAGS $CPPFLAGS"
@@ -27061,8 +27064,8 @@ CONTRIB_SRCDIR="$ABSOLUTE_SRCDIR/ibtk/contrib/boost"
 #$as_unset boost_cv_version
 #BOOST_REQUIRE([1.57.0],[AC_MSG_WARN([could not find system Boost library, using bundled Boost library])])
 if test x"$USING_BUNDLED_BOOST" = xyes ; then
-  if test "$LIBMESH_ENABLED" = yes ; then
-    as_fn_error $? "IBAMR is configured to use a bundled Boost library, but when IBAMR is also configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library" "$LINENO" 5
+  if test "$LIBMESH_HAS_BOOST" = yes ; then
+    as_fn_error $? "IBAMR is configured to use a bundled Boost library, but libMesh is configured with Boost support. When IBAMR is configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library" "$LINENO" 5
   fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: configuring bundled Boost library" >&5
 $as_echo "$as_me: configuring bundled Boost library" >&6;}

--- a/doc/news/changes/minor/20191119AaronBarrett
+++ b/doc/news/changes/minor/20191119AaronBarrett
@@ -1,0 +1,3 @@
+Fixed: Allows IBAMR to be built with the bundled boost when libMesh is configured without boost support.
+<br>
+(Aaron Barrett, 2019/11/19)

--- a/ibtk/Makefile.in
+++ b/ibtk/Makefile.in
@@ -189,8 +189,7 @@ am__DIST_COMMON = $(srcdir)/Makefile.in \
 	$(top_srcdir)/config/install-sh $(top_srcdir)/config/ltmain.sh \
 	$(top_srcdir)/config/missing config/compile \
 	config/config.guess config/config.rpath config/config.sub \
-	config/depcomp config/install-sh config/ltmain.sh \
-	config/missing
+	config/install-sh config/ltmain.sh config/missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)

--- a/ibtk/config/IBTK_config.h.tmp.in
+++ b/ibtk/config/IBTK_config.h.tmp.in
@@ -170,6 +170,9 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
+/* Define if libmesh was built with boost */
+#undef LIBMESH_HAS_BOOST
+
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
 

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -24238,6 +24238,9 @@ $as_echo "$as_me: using Eigen library bundled with libMesh" >&6;}
 
   if test -e "$LIBMESH_DIR/include/boost" ; then
     as_fn_error $? "libMesh appears to be configured to use a bundled Boost library, but when IBAMR is also configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library" "$LINENO" 5
+
+$as_echo "#define LIBMESH_HAS_BOOST 1" >>confdefs.h
+
   fi
 
   CPPFLAGS="$LIBMESH_CPPFLAGS $CPPFLAGS"
@@ -27225,8 +27228,8 @@ CONTRIB_SRCDIR="$ABSOLUTE_SRCDIR/contrib/boost"
 #$as_unset boost_cv_version
 #BOOST_REQUIRE([1.57.0],[AC_MSG_WARN([could not find system Boost library, using bundled Boost library])])
 if test x"$USING_BUNDLED_BOOST" = xyes ; then
-  if test "$LIBMESH_ENABLED" = yes ; then
-    as_fn_error $? "IBAMR is configured to use a bundled Boost library, but when IBAMR is also configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library" "$LINENO" 5
+  if test "$LIBMESH_HAS_BOOST" = yes ; then
+    as_fn_error $? "IBAMR is configured to use a bundled Boost library, but libMesh is configured with Boost support. When IBAMR is configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library" "$LINENO" 5
   fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: configuring bundled Boost library" >&5
 $as_echo "$as_me: configuring bundled Boost library" >&6;}

--- a/ibtk/m4/configure_boost.m4
+++ b/ibtk/m4/configure_boost.m4
@@ -25,8 +25,8 @@ AC_ARG_VAR(BOOST_ROOT,[the location of the Boost installation that is to be used
 #$as_unset boost_cv_version
 #BOOST_REQUIRE([1.57.0],[AC_MSG_WARN([could not find system Boost library, using bundled Boost library])])
 if test x"$USING_BUNDLED_BOOST" = xyes ; then
-  if test "$LIBMESH_ENABLED" = yes ; then
-    AC_MSG_ERROR([IBAMR is configured to use a bundled Boost library, but when IBAMR is also configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library])
+  if test "$LIBMESH_HAS_BOOST" = yes ; then
+    AC_MSG_ERROR([IBAMR is configured to use a bundled Boost library, but libMesh is configured with Boost support. When IBAMR is configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library])
   fi
   AC_MSG_NOTICE([configuring bundled Boost library])
   BOOST_CPPFLAGS="-I$CONTRIB_SRCDIR"

--- a/m4/configure_boost.m4
+++ b/m4/configure_boost.m4
@@ -25,8 +25,8 @@ AC_ARG_VAR(BOOST_ROOT,[the location of the Boost installation that is to be used
 #$as_unset boost_cv_version
 #BOOST_REQUIRE([1.57.0],[AC_MSG_WARN([could not find system Boost library, using bundled Boost library])])
 if test x"$USING_BUNDLED_BOOST" = xyes ; then
-  if test "$LIBMESH_ENABLED" = yes ; then
-    AC_MSG_ERROR([IBAMR is configured to use a bundled Boost library, but when IBAMR is also configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library])
+  if test "$LIBMESH_HAS_BOOST" = yes ; then
+    AC_MSG_ERROR([IBAMR is configured to use a bundled Boost library, but libMesh is configured with Boost support. When IBAMR is configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library])
   fi
   AC_MSG_NOTICE([configuring bundled Boost library])
   BOOST_CPPFLAGS="-I$CONTRIB_SRCDIR"

--- a/m4/configure_libmesh.m4
+++ b/m4/configure_libmesh.m4
@@ -183,6 +183,7 @@ dnl
 
   if test -e "$LIBMESH_DIR/include/boost" ; then
     AC_MSG_ERROR([libMesh appears to be configured to use a bundled Boost library, but when IBAMR is also configured to use libMesh, IBAMR and libMesh both must use the same (external) Boost library])
+    AC_DEFINE([LIBMESH_HAS_BOOST],1,[Define if libmesh was built with boost])
   fi
 
   CPPFLAGS_PREPEND($LIBMESH_CPPFLAGS)


### PR DESCRIPTION
Currently, IBAMR _must_ be compiled with an external boost if libMesh is present. This allows IBAMR to use the bundled boost if libMesh is configured without boost support.

@drwells, I'm not very familiar with the buildsystem. Can you double check this?