### PR TITLE
Add another release task

### DIFF
--- a/doc/release-tasks.md
+++ b/doc/release-tasks.md
@@ -7,6 +7,8 @@ GitHub.
 
 ## static analysis
 
+- [ ] verify that neither `namespaces.h` nor `app_namespaces.h` are in IBTK or
+  IBAMR headers
 - [ ] clear basic compilation warnings with GCC and clang on linux
 - [ ] compile with the latest libMesh release (which should be configured with
   `--disable-deprecated`) to verify that we do not use any deprecated


### PR DESCRIPTION
At some point we should add this task to a linter CI job, but for now it suffices to spend a few minutes before each release checking.