### PR TITLE
Get rid of some warnings from hypre headers.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -70,6 +70,9 @@ IncludeCategories:
 # PETSc:
   - Regex: "[<\"]petsc[a-z]*\\.h[>\"]$"
     Priority: 300
+# HYPRE:
+  - Regex: "[<\"]HYPRE[a-z_]*\\.h[>\"]$"
+    Priority: 350
 # other standardized headers:
   - Regex: "<[A-Za-z_]*\\.h>"
     Priority: 1000

--- a/ibtk/include/ibtk/CCPoissonHypreLevelSolver.h
+++ b/ibtk/include/ibtk/CCPoissonHypreLevelSolver.h
@@ -18,17 +18,21 @@
 
 #include "ibtk/LinearSolver.h"
 #include "ibtk/PoissonSolver.h"
+#include "ibtk/ibtk_macros.h"
 #include "ibtk/ibtk_utilities.h"
 
 #include "Box.h"
 #include "CoarseFineBoundary.h"
-#include "HYPRE_struct_ls.h"
-#include "HYPRE_struct_mv.h"
 #include "Index.h"
 #include "IntVector.h"
 #include "PatchHierarchy.h"
 #include "tbox/Database.h"
 #include "tbox/Pointer.h"
+
+IBTK_DISABLE_EXTRA_WARNINGS
+#include "HYPRE_struct_ls.h"
+#include "HYPRE_struct_mv.h"
+IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <string>
 #include <vector>

--- a/ibtk/include/ibtk/SCPoissonHypreLevelSolver.h
+++ b/ibtk/include/ibtk/SCPoissonHypreLevelSolver.h
@@ -18,17 +18,21 @@
 
 #include "ibtk/LinearSolver.h"
 #include "ibtk/PoissonSolver.h"
+#include "ibtk/ibtk_macros.h"
 #include "ibtk/ibtk_utilities.h"
 
 #include "Box.h"
 #include "CoarseFineBoundary.h"
-#include "HYPRE_sstruct_ls.h"
-#include "HYPRE_sstruct_mv.h"
 #include "Index.h"
 #include "IntVector.h"
 #include "PatchHierarchy.h"
 #include "tbox/Database.h"
 #include "tbox/Pointer.h"
+
+IBTK_DISABLE_EXTRA_WARNINGS
+#include "HYPRE_sstruct_ls.h"
+#include "HYPRE_sstruct_mv.h"
+IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <string>
 #include <vector>

--- a/ibtk/include/ibtk/ibtk_macros.h
+++ b/ibtk/include/ibtk/ibtk_macros.h
@@ -36,6 +36,7 @@ _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")     \
 _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")     \
 _Pragma("GCC diagnostic ignored \"-Wunused-local-typedefs\"")   \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-copy\"")         \
+_Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")        \
 _Pragma("GCC diagnostic ignored \"-Wunneeded-internal-declaration\"")
 
 #define IBTK_ENABLE_EXTRA_WARNINGS _Pragma("GCC diagnostic pop")

--- a/ibtk/src/solvers/impls/CCPoissonHypreLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonHypreLevelSolver.cpp
@@ -16,6 +16,7 @@
 #include "ibtk/CCPoissonHypreLevelSolver.h"
 #include "ibtk/GeneralSolver.h"
 #include "ibtk/PoissonUtilities.h"
+#include "ibtk/ibtk_macros.h"
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
 
@@ -25,8 +26,6 @@
 #include "CellData.h"
 #include "CellDataFactory.h"
 #include "CellIndex.h"
-#include "HYPRE_struct_ls.h"
-#include "HYPRE_struct_mv.h"
 #include "Index.h"
 #include "IntVector.h"
 #include "MultiblockDataTranslator.h"
@@ -48,6 +47,11 @@
 #include "tbox/Timer.h"
 #include "tbox/TimerManager.h"
 #include "tbox/Utilities.h"
+
+IBTK_DISABLE_EXTRA_WARNINGS
+#include "HYPRE_struct_ls.h"
+#include "HYPRE_struct_mv.h"
+IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <mpi.h>
 

--- a/ibtk/src/solvers/impls/SCPoissonHypreLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonHypreLevelSolver.cpp
@@ -16,14 +16,13 @@
 #include "ibtk/GeneralSolver.h"
 #include "ibtk/PoissonUtilities.h"
 #include "ibtk/SCPoissonHypreLevelSolver.h"
+#include "ibtk/ibtk_macros.h"
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
 
 #include "Box.h"
 #include "CartesianGridGeometry.h"
 #include "CartesianPatchGeometry.h"
-#include "HYPRE_sstruct_ls.h"
-#include "HYPRE_sstruct_mv.h"
 #include "Index.h"
 #include "IntVector.h"
 #include "Patch.h"
@@ -40,6 +39,11 @@
 #include "tbox/Timer.h"
 #include "tbox/TimerManager.h"
 #include "tbox/Utilities.h"
+
+IBTK_DISABLE_EXTRA_WARNINGS
+#include "HYPRE_sstruct_ls.h"
+#include "HYPRE_sstruct_mv.h"
+IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <mpi.h>
 


### PR DESCRIPTION
These are new in hypre 2.18 (or some other recent release) that added some CUDA functions that we don't use.