### PR TITLE
Remove some unused variables.

### DIFF
--- a/ibtk/src/solvers/impls/CCPoissonLevelRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonLevelRelaxationFACOperator.cpp
@@ -378,7 +378,6 @@ CCPoissonLevelRelaxationFACOperator::computeResidual(SAMRAIVectorReal<NDIM, doub
 
     const Pointer<CellVariable<NDIM, double> > res_var = residual.getComponentVariable(0);
     const Pointer<CellVariable<NDIM, double> > sol_var = solution.getComponentVariable(0);
-    const Pointer<CellVariable<NDIM, double> > rhs_var = rhs.getComponentVariable(0);
 
     // Fill ghost-cell values.
     using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;

--- a/ibtk/src/solvers/impls/CCPoissonPointRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonPointRelaxationFACOperator.cpp
@@ -678,7 +678,6 @@ CCPoissonPointRelaxationFACOperator::computeResidual(SAMRAIVectorReal<NDIM, doub
 
     const Pointer<CellVariable<NDIM, double> > res_var = residual.getComponentVariable(0);
     const Pointer<CellVariable<NDIM, double> > sol_var = solution.getComponentVariable(0);
-    const Pointer<CellVariable<NDIM, double> > rhs_var = rhs.getComponentVariable(0);
 
     // Fill ghost-cell values.
     using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;

--- a/ibtk/src/solvers/impls/SCPoissonPointRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonPointRelaxationFACOperator.cpp
@@ -667,7 +667,6 @@ SCPoissonPointRelaxationFACOperator::computeResidual(SAMRAIVectorReal<NDIM, doub
 
     const Pointer<SideVariable<NDIM, double> > res_var = residual.getComponentVariable(0);
     const Pointer<SideVariable<NDIM, double> > sol_var = solution.getComponentVariable(0);
-    const Pointer<SideVariable<NDIM, double> > rhs_var = rhs.getComponentVariable(0);
 
     // Fill ghost-cell values.
     using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;

--- a/ibtk/src/solvers/impls/VCSCViscousOpPointRelaxationFACOperator.cpp
+++ b/ibtk/src/solvers/impls/VCSCViscousOpPointRelaxationFACOperator.cpp
@@ -817,7 +817,6 @@ VCSCViscousOpPointRelaxationFACOperator::computeResidual(SAMRAIVectorReal<NDIM, 
 
     const Pointer<SideVariable<NDIM, double> > res_var = residual.getComponentVariable(0);
     const Pointer<SideVariable<NDIM, double> > sol_var = solution.getComponentVariable(0);
-    const Pointer<SideVariable<NDIM, double> > rhs_var = rhs.getComponentVariable(0);
 
     // Fill ghost-cell values.
     using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -319,7 +319,6 @@ CIBMethod::postprocessIntegrateData(double current_time, double new_time, int nu
     // Dump Lagrange multiplier data.
     if (d_lambda_dump_interval && ((d_ib_solver->getIntegratorStep() + 1) % d_lambda_dump_interval == 0))
     {
-        Pointer<LData> ptr_lagmultpr = d_l_data_manager->getLData("lambda", finest_ln);
         Vec lambda_petsc_vec_parallel = ptr_lagmultpr->getVec();
         Vec lambda_lag_vec_parallel = nullptr;
         Vec lambda_lag_vec_seq = nullptr;

--- a/src/IB/ConstraintIBMethod.cpp
+++ b/src/IB/ConstraintIBMethod.cpp
@@ -513,7 +513,6 @@ ConstraintIBMethod::registerEulerianVariables()
         d_Div_u_var = new CellVariable<NDIM, double>(d_object_name + "::Div_u");
         d_phi_var = new CellVariable<NDIM, double>(d_object_name + "::phi");
         const IntVector<NDIM> cell_ghosts = CELLG;
-        const IntVector<NDIM> side_ghosts = SIDEG;
         d_phi_idx = var_db->registerVariableAndContext(d_phi_var, d_scratch_context, cell_ghosts);
         d_Div_u_scratch_idx = var_db->registerVariableAndContext(d_Div_u_var, d_scratch_context, cell_ghosts);
     }

--- a/src/IB/GeneralizedIBMethod.cpp
+++ b/src/IB/GeneralizedIBMethod.cpp
@@ -113,7 +113,6 @@ GeneralizedIBMethod::registerEulerianVariables()
     IBMethod::registerEulerianVariables();
 
     const IntVector<NDIM> ib_ghosts = getMinimumGhostCellWidth();
-    const IntVector<NDIM> ghosts = 1;
     const IntVector<NDIM> no_ghosts = 0;
 
     Pointer<Variable<NDIM> > u_var = d_ib_solver->getVelocityVariable();
@@ -147,7 +146,6 @@ GeneralizedIBMethod::registerEulerianCommunicationAlgorithms()
 {
     IBMethod::registerEulerianCommunicationAlgorithms();
 
-    Pointer<Geometry<NDIM> > grid_geom = d_ib_solver->getPatchHierarchy()->getGridGeometry();
     Pointer<RefineAlgorithm<NDIM> > refine_alg;
     Pointer<RefineOperator<NDIM> > refine_op;
 

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -392,7 +392,6 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
         double max_dist = std::numeric_limits<double>::max();
         d_nodes[jj].push_back(temp_nodes[jj][0]);
         d_node_dof_IDs[jj].push_back(temp_node_dof_IDs[jj][0]);
-        max_dist = std::numeric_limits<double>::max();
         for (unsigned int kk = 1; kk < temp_nodes[jj].size(); ++kk)
         {
             for (unsigned int ll = 0; ll < temp_nodes[jj].size(); ++ll)
@@ -1046,8 +1045,6 @@ IBFEInstrumentPanel::initializeSystemDependentData(IBFEMethod* ib_method_ops, co
     {
         // get node on meter mesh
         const Node* node = &d_meter_meshes[meter_mesh_number]->node_ref(ii);
-        // get the centroid
-        const Node* centroid_node = &d_meter_meshes[meter_mesh_number]->node_ref(d_num_nodes[meter_mesh_number]);
 
         std::vector<double> node_disp(NDIM, 0.0);
         std::vector<double> centroid_disp(NDIM, 0.0);

--- a/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
@@ -475,8 +475,6 @@ IBHydrodynamicSurfaceForceEvaluator::fillPatchData(Pointer<PatchHierarchy<NDIM> 
                          use_new_ctx ?
                          var_db->mapVariableAndContextToIndex(mu_ins_var, d_fluid_solver->getNewContext()) :
                          IBTK::invalid_index;
-            auto p_vc_ins_hier_integrator =
-                dynamic_cast<INSVCStaggeredHierarchyIntegrator*>(d_fluid_solver.getPointer());
             mu_bc_coef = p_vc_ins_hier_integrator->getViscosityBoundaryConditions();
         }
         else

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -435,9 +435,7 @@ IBImplicitStaggeredHierarchyIntegrator::integrateHierarchy_position(const double
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    Pointer<VariableContext> current_ctx = ins_hier_integrator->getCurrentContext();
     Pointer<VariableContext> scratch_ctx = ins_hier_integrator->getScratchContext();
-    Pointer<VariableContext> new_ctx = ins_hier_integrator->getNewContext();
 
     const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
     const int wgt_sc_idx = d_hier_math_ops->getSideWeightPatchDescriptorIndex();
@@ -621,7 +619,6 @@ IBImplicitStaggeredHierarchyIntegrator::integrateHierarchy_velocity(const double
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     Pointer<VariableContext> current_ctx = ins_hier_integrator->getCurrentContext();
     Pointer<VariableContext> scratch_ctx = ins_hier_integrator->getScratchContext();
-    Pointer<VariableContext> new_ctx = ins_hier_integrator->getNewContext();
 
     const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
     const int wgt_sc_idx = d_hier_math_ops->getSideWeightPatchDescriptorIndex();

--- a/src/IB/IBInterpolantMethod.cpp
+++ b/src/IB/IBInterpolantMethod.cpp
@@ -650,7 +650,6 @@ IBInterpolantMethod::initializePatchHierarchy(
 
     // Initialize initial center of mass of structures.
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    EigenAlignedVector<Eigen::Vector3d> X0_com(d_num_rigid_parts, Eigen::Vector3d::Zero());
     std::vector<Pointer<LData> > X0_data_vec(finest_ln + 1, Pointer<LData>(NULL));
     X0_data_vec[finest_ln] = d_l_data_manager->getLData("X0", finest_ln);
     computeCenterOfMass(d_center_of_mass_initial, X0_data_vec);
@@ -738,7 +737,6 @@ IBInterpolantMethod::applyGradientDetector(Pointer<BasePatchHierarchy<NDIM> > ba
     TBOX_ASSERT((level_number >= 0) && (level_number <= hierarchy->getFinestLevelNumber()));
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
 #endif
-    Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
 
     // Tag cells that contain Lagrangian nodes.
     d_l_data_manager->applyGradientDetector(

--- a/src/IB/IBRedundantInitializer.cpp
+++ b/src/IB/IBRedundantInitializer.cpp
@@ -177,8 +177,6 @@ IBRedundantInitializer::computeLocalNodeCountOnPatchLevel(const Pointer<PatchHie
 #if !defined(NDEBUG)
     TBOX_ASSERT(d_data_processed);
 #endif
-    // Determine the extents of the physical domain.
-    Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
 
     // Loop over all patches in the specified level of the patch level and count
     // the number of local vertices.
@@ -1078,9 +1076,6 @@ IBRedundantInitializer::initializeMassDataOnPatchLevel(const unsigned int /*glob
     TBOX_ASSERT(d_data_processed);
 #endif
 
-    // Determine the extents of the physical domain.
-    Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
-
     // Loop over all patches in the specified level of the patch level and
     // initialize the local vertices.
     boost::multi_array_ref<double, 1>& M_array = *M_data->getLocalFormArray();
@@ -1140,9 +1135,6 @@ IBRedundantInitializer::initializeDirectorDataOnPatchLevel(const unsigned int /*
     TBOX_ASSERT(d_data_processed);
 #endif
 
-    // Determine the extents of the physical domain.
-    Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
-
     // Loop over all patches in the specified level of the patch level and
     // initialize the local vertices.
     boost::multi_array_ref<double, 2>& D_array = *D_data->getLocalFormVecArray();
@@ -1198,7 +1190,6 @@ IBRedundantInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarch
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
-        const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
         const Box<NDIM>& patch_box = patch->getBox();
 
         Pointer<CellData<NDIM, int> > tag_data = patch->getPatchData(tag_index);
@@ -1374,7 +1365,6 @@ IBRedundantInitializer::getPatchVerticesAtLevel(std::vector<std::pair<int, int> 
     // NOTE: This is clearly not the best way to do this, but it will work for
     // now.
     const Box<NDIM>& patch_box = patch->getBox();
-    const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
     for (unsigned int j = 0; j < d_num_vertex[vertex_level_number].size(); ++j)
     {
         for (int k = 0; k < d_num_vertex[vertex_level_number][j]; ++k)

--- a/src/IB/IBStandardForceGen.cpp
+++ b/src/IB/IBStandardForceGen.cpp
@@ -148,8 +148,6 @@ IBStandardForceGen::initializeLevelData(const Pointer<PatchHierarchy<NDIM> > hie
 #if !defined(NDEBUG)
     TBOX_ASSERT(hierarchy);
 #endif
-    Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-
     // Resize the vectors corresponding to data individually maintained for
     // separate levels of the patch hierarchy.
     const int new_size = std::max(level_number + 1, static_cast<int>(d_is_initialized.size()));

--- a/src/IB/IMPInitializer.cpp
+++ b/src/IB/IMPInitializer.cpp
@@ -420,7 +420,6 @@ IMPInitializer::tagCellsForInitialRefinement(const Pointer<PatchHierarchy<NDIM> 
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
-        const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
         const Box<NDIM>& patch_box = patch->getBox();
 
         Pointer<CellData<NDIM, int> > tag_data = patch->getPatchData(tag_index);

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -1069,8 +1069,6 @@ IMPMethod::applyGradientDetector(Pointer<BasePatchHierarchy<NDIM> > base_hierarc
     TBOX_ASSERT((level_number >= 0) && (level_number <= hierarchy->getFinestLevelNumber()));
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
 #endif
-    Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-
     // Tag cells that contain Lagrangian nodes.
     d_l_data_manager->applyGradientDetector(
         hierarchy, level_number, error_data_time, tag_index, initial_time, uses_richardson_extrapolation_too);

--- a/src/complex_fluids/CFGiesekusRelaxation.cpp
+++ b/src/complex_fluids/CFGiesekusRelaxation.cpp
@@ -53,7 +53,6 @@ CFGiesekusRelaxation::setDataOnPatch(const int data_idx,
                                      Pointer<PatchLevel<NDIM> > /*patch_level*/)
 {
     const Box<NDIM>& patch_box = patch->getBox();
-    const Pointer<CartesianPatchGeometry<NDIM> > p_geom = patch->getPatchGeometry();
     Pointer<CellData<NDIM, double> > ret_data = patch->getPatchData(data_idx);
     Pointer<CellData<NDIM, double> > in_data = patch->getPatchData(d_W_cc_idx);
     ret_data->fillAll(0.0);

--- a/src/complex_fluids/CFINSForcing.cpp
+++ b/src/complex_fluids/CFINSForcing.cpp
@@ -217,7 +217,6 @@ CFINSForcing::commonConstructor(const Pointer<Database> input_db,
     const IntVector<NDIM>& periodic_shift = grid_geom->getPeriodicShift();
     if (periodic_shift.min() <= 0)
     {
-        std::vector<RobinBcCoefStrategy<NDIM>*> conc_bc_coefs(NDIM * (NDIM + 1) / 2);
         d_conc_bc_coefs.resize(NDIM * (NDIM + 1) / 2);
         for (int d = 0; d < NDIM * (NDIM + 1) / 2; ++d)
         {

--- a/src/complex_fluids/CFOldroydBRelaxation.cpp
+++ b/src/complex_fluids/CFOldroydBRelaxation.cpp
@@ -52,7 +52,6 @@ CFOldroydBRelaxation::setDataOnPatch(const int data_idx,
                                      Pointer<PatchLevel<NDIM> > /*patch_level*/)
 {
     const Box<NDIM>& patch_box = patch->getBox();
-    const Pointer<CartesianPatchGeometry<NDIM> > p_geom = patch->getPatchGeometry();
     Pointer<CellData<NDIM, double> > ret_data = patch->getPatchData(data_idx);
     Pointer<CellData<NDIM, double> > in_data = patch->getPatchData(d_W_cc_idx);
     ret_data->fillAll(0.0);

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1589,8 +1589,6 @@ INSCollocatedHierarchyIntegrator::initializeLevelDataSpecialized(
     }
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
 #endif
-    Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
-
     // Initialize level data at the initial time.
     if (initial_time)
     {

--- a/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
@@ -212,7 +212,6 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::initializeHierarchyIntegrator(
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     const IntVector<NDIM> cell_ghosts = CELLG;
-    const IntVector<NDIM> side_ghosts = SIDEG;
     const IntVector<NDIM> no_ghosts = 0;
 
     // Get the density variable, which can either be an advected field maintained by

--- a/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
@@ -449,11 +449,9 @@ StaggeredStokesBlockFactorizationPreconditioner::solvePressureSubsystem(SAMRAIVe
     // Get the vector components.
     const int P_idx = P_vec.getComponentDescriptorIndex(0);
     const Pointer<Variable<NDIM> >& P_var = P_vec.getComponentVariable(0);
-    Pointer<CellVariable<NDIM, double> > P_cc_var = P_var;
 
     const int F_P_idx = F_P_vec.getComponentDescriptorIndex(0);
     const Pointer<Variable<NDIM> >& F_P_var = F_P_vec.getComponentVariable(0);
-    Pointer<CellVariable<NDIM, double> > F_P_cc_var = F_P_var;
 
     Pointer<SAMRAIVectorReal<NDIM, double> > P_scratch_vec;
     P_scratch_vec =

--- a/src/navier_stokes/StaggeredStokesFACPreconditionerStrategy.cpp
+++ b/src/navier_stokes/StaggeredStokesFACPreconditionerStrategy.cpp
@@ -518,7 +518,6 @@ StaggeredStokesFACPreconditionerStrategy::computeResidual(SAMRAIVectorReal<NDIM,
 
     const Pointer<SideVariable<NDIM, double> > U_res_sc_var = residual.getComponentVariable(0);
     const Pointer<SideVariable<NDIM, double> > U_sol_sc_var = solution.getComponentVariable(0);
-    const Pointer<SideVariable<NDIM, double> > U_rhs_sc_var = rhs.getComponentVariable(0);
 
     const int P_res_idx = residual.getComponentDescriptorIndex(1);
     const int P_sol_idx = solution.getComponentDescriptorIndex(1);
@@ -526,7 +525,6 @@ StaggeredStokesFACPreconditionerStrategy::computeResidual(SAMRAIVectorReal<NDIM,
 
     const Pointer<CellVariable<NDIM, double> > P_res_cc_var = residual.getComponentVariable(1);
     const Pointer<CellVariable<NDIM, double> > P_sol_cc_var = solution.getComponentVariable(1);
-    const Pointer<CellVariable<NDIM, double> > P_rhs_cc_var = rhs.getComponentVariable(1);
 
     // Fill ghost-cell values.
     using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;

--- a/src/wave_generation/IrregularWaveBcCoef.cpp
+++ b/src/wave_generation/IrregularWaveBcCoef.cpp
@@ -162,9 +162,6 @@ IrregularWaveBcCoef::setBcCoefs(Pointer<ArrayData<NDIM, double> >& acoef_data,
     for (int d = 0; d < NDIM; ++d) vol_cell *= dx[d];
     auto alpha = d_num_interface_cells * std::pow(vol_cell, 1.0 / static_cast<double>(NDIM));
 
-    // Get physical domain box extents on patch box level.
-    const SAMRAI::hier::Box<NDIM> domain_box =
-        SAMRAI::hier::Box<NDIM>::refine(d_grid_geom->getPhysicalDomain()[0], pgeom->getRatio());
     const int dir = (NDIM == 2) ? 1 : (NDIM == 3) ? 2 : -1;
 
     // We take location index = 0, i.e., x_lower to be the wave inlet.

--- a/src/wave_generation/StokesFirstOrderWaveBcCoef.cpp
+++ b/src/wave_generation/StokesFirstOrderWaveBcCoef.cpp
@@ -84,9 +84,6 @@ StokesFirstOrderWaveBcCoef::setBcCoefs(Pointer<ArrayData<NDIM, double> >& acoef_
     for (int d = 0; d < NDIM; ++d) vol_cell *= dx[d];
     auto alpha = d_num_interface_cells * std::pow(vol_cell, 1.0 / static_cast<double>(NDIM));
 
-    // Get physical domain box extents on patch box level.
-    const SAMRAI::hier::Box<NDIM> domain_box =
-        SAMRAI::hier::Box<NDIM>::refine(d_grid_geom->getPhysicalDomain()[0], pgeom->getRatio());
     const int dir = (NDIM == 2) ? 1 : (NDIM == 3) ? 2 : -1;
 
     // We take location index = 0, i.e., x_lower to be the wave inlet.

--- a/src/wave_generation/StokesSecondOrderWaveBcCoef.cpp
+++ b/src/wave_generation/StokesSecondOrderWaveBcCoef.cpp
@@ -84,9 +84,6 @@ StokesSecondOrderWaveBcCoef::setBcCoefs(Pointer<ArrayData<NDIM, double> >& acoef
     for (int d = 0; d < NDIM; ++d) vol_cell *= dx[d];
     auto alpha = d_num_interface_cells * std::pow(vol_cell, 1.0 / static_cast<double>(NDIM));
 
-    // Get physical domain box extents on patch box level.
-    const SAMRAI::hier::Box<NDIM> domain_box =
-        SAMRAI::hier::Box<NDIM>::refine(d_grid_geom->getPhysicalDomain()[0], pgeom->getRatio());
     const int dir = (NDIM == 2) ? 1 : (NDIM == 3) ? 2 : -1;
 
     // We take location index = 0, i.e., x_lower to be the wave inlet.


### PR DESCRIPTION
Found by cppcheck. Part of #749 

I am not going to fix everything cppcheck found: some of the issues, e.g., use of virtual functions in ctors and dtors, require care. I am going to put up patches with some of the really obvious fixes (like this).