### PR TITLE
Use std::expm1 where appropriate.

### DIFF
--- a/src/wave_generation/WaveDampingFunctions.cpp
+++ b/src/wave_generation/WaveDampingFunctions.cpp
@@ -245,8 +245,8 @@ callRelaxationZoneCallbackFunction(double /*current_time*/,
 
                     if (x_posn >= x_zone_start && x_posn <= x_zone_end)
                     {
-                        double xtilde = (x_posn - x_zone_start) / (x_zone_end - x_zone_start);
-                        double gamma = 1.0 - (exp(std::pow(xtilde, alpha)) - 1.0) / (exp(1.0) - 1.0);
+                        const double xtilde = (x_posn - x_zone_start) / (x_zone_end - x_zone_start);
+                        const double gamma = 1.0 - std::expm1(std::pow(xtilde, alpha)) / std::expm1(1.0);
                         const double target = 0.0;
 
                         if (axis == 0 || axis == dir)
@@ -286,9 +286,9 @@ callRelaxationZoneCallbackFunction(double /*current_time*/,
 
                 if (x_posn >= x_zone_start && x_posn <= x_zone_end)
                 {
-                    double xtilde = (x_posn - x_zone_start) / (x_zone_end - x_zone_start);
-                    double gamma = 1.0 - (exp(std::pow(xtilde, alpha)) - 1.0) / (exp(1.0) - 1.0);
-                    double target = dir_surface;
+                    const double xtilde = (x_posn - x_zone_start) / (x_zone_end - x_zone_start);
+                    const double gamma = 1.0 - std::expm1(std::pow(xtilde, alpha)) / std::expm1(1.0);
+                    const double target = dir_surface;
 
                     (*phi_data)(i, 0) = gamma * (*phi_data)(i, 0) + (1.0 - gamma) * target;
                 }

--- a/src/wave_generation/WaveGenerationFunctions.cpp
+++ b/src/wave_generation/WaveGenerationFunctions.cpp
@@ -112,7 +112,7 @@ callStokesWaveRelaxationCallbackFunction(double /*current_time*/,
                     if (x_posn >= x_zone_start && x_posn <= x_zone_end)
                     {
                         const double xtilde = (x_posn - x_zone_start) / (x_zone_end - x_zone_start);
-                        const double gamma = 1.0 - (exp(std::pow(xtilde, alpha)) - 1.0) / (exp(1.0) - 1.0);
+                        const double gamma = 1.0 - std::expm1(std::pow(xtilde, alpha)) / std::expm1(1.0);
 
                         if (axis == 0 || axis == (NDIM - 1))
                         {
@@ -154,7 +154,7 @@ callStokesWaveRelaxationCallbackFunction(double /*current_time*/,
                 {
                     const double eta = stokes_wave_generator->getSurfaceElevation(x_posn, new_time);
                     const double xtilde = (x_posn - x_zone_start) / (x_zone_end - x_zone_start);
-                    const double gamma = 1.0 - (exp(std::pow(xtilde, alpha)) - 1.0) / (exp(1.0) - 1.0);
+                    const double gamma = 1.0 - std::expm1(std::pow(xtilde, alpha)) / std::expm1(1.0);
 
                     const double target = sign_gas * (-eta + dir_posn - depth);
 


### PR DESCRIPTION
Part of #749. Also found by cppcheck.

@amneetb this should make the wave calculations ever so slightly better :)