### PR TITLE
Combine some translation units to improve inlining.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -186,8 +186,8 @@ am__DIST_COMMON = $(srcdir)/Makefile.in \
 	$(top_srcdir)/config/install-sh $(top_srcdir)/config/ltmain.sh \
 	$(top_srcdir)/config/make.inc.in $(top_srcdir)/config/missing \
 	config/compile config/config.guess config/config.rpath \
-	config/config.sub config/install-sh config/ltmain.sh \
-	config/missing
+	config/config.sub config/depcomp config/install-sh \
+	config/ltmain.sh config/missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)

--- a/doc/news/changes/minor/2020121DavidWells
+++ b/doc/news/changes/minor/2020121DavidWells
@@ -1,0 +1,7 @@
+Improved: The build system has been modified slightly to permit inlining of the
+IB kernels in <code>lagrangian_interaction_2d.f</code> and
+<code>lagrangian_interaction_3d.f</code>. Inlining these kernels makes the
+force spreading and velocity interpolation about 15% faster in 3D.
+
+<br>
+(David Wells, 2020/01/21)

--- a/ibtk/Makefile.in
+++ b/ibtk/Makefile.in
@@ -188,7 +188,8 @@ am__DIST_COMMON = $(srcdir)/Makefile.in \
 	$(top_srcdir)/config/install-sh $(top_srcdir)/config/ltmain.sh \
 	$(top_srcdir)/config/missing config/compile \
 	config/config.guess config/config.rpath config/config.sub \
-	config/install-sh config/ltmain.sh config/missing
+	config/depcomp config/install-sh config/ltmain.sh \
+	config/missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)

--- a/ibtk/lib/Makefile.am
+++ b/ibtk/lib/Makefile.am
@@ -34,7 +34,6 @@ clean-local:
 
 ## Dimension-independent library
 libIBTK_a_SOURCES = \
-$(top_builddir)/src/lagrangian/fortran/lagrangian_delta.f \
 $(top_builddir)/src/utilities/ParallelEdgeMap.cpp \
 $(top_builddir)/src/utilities/FixedSizedStream.cpp \
 $(top_builddir)/src/utilities/IBTK_MPI.cpp

--- a/ibtk/lib/Makefile.in
+++ b/ibtk/lib/Makefile.in
@@ -184,7 +184,6 @@ am__v_AR_1 =
 libIBTK_a_AR = $(AR) $(ARFLAGS)
 libIBTK_a_LIBADD =
 am__libIBTK_a_SOURCES_DIST =  \
-	$(top_builddir)/src/lagrangian/fortran/lagrangian_delta.f \
 	$(top_builddir)/src/utilities/ParallelEdgeMap.cpp \
 	$(top_builddir)/src/utilities/FixedSizedStream.cpp \
 	$(top_builddir)/src/utilities/IBTK_MPI.cpp \
@@ -207,7 +206,7 @@ am__dirstamp = $(am__leading_dot)dirstamp
 @USING_BUNDLED_MUPARSER_TRUE@	../contrib/muparser/src/muParserInt.$(OBJEXT) \
 @USING_BUNDLED_MUPARSER_TRUE@	../contrib/muparser/src/muParserTest.$(OBJEXT) \
 @USING_BUNDLED_MUPARSER_TRUE@	../contrib/muparser/src/muParser.$(OBJEXT)
-am_libIBTK_a_OBJECTS = $(top_builddir)/src/lagrangian/fortran/lagrangian_delta.$(OBJEXT) \
+am_libIBTK_a_OBJECTS =  \
 	$(top_builddir)/src/utilities/ParallelEdgeMap.$(OBJEXT) \
 	$(top_builddir)/src/utilities/FixedSizedStream.$(OBJEXT) \
 	$(top_builddir)/src/utilities/IBTK_MPI.$(OBJEXT) \
@@ -1426,9 +1425,7 @@ IBTK3d_LIBS = ${top_builddir}/lib/libIBTK3d.a
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
 lib_LIBRARIES = libIBTK.a $(am__append_1) $(am__append_2)
-libIBTK_a_SOURCES =  \
-	$(top_builddir)/src/lagrangian/fortran/lagrangian_delta.f \
-	$(top_builddir)/src/utilities/ParallelEdgeMap.cpp \
+libIBTK_a_SOURCES = $(top_builddir)/src/utilities/ParallelEdgeMap.cpp \
 	$(top_builddir)/src/utilities/FixedSizedStream.cpp \
 	$(top_builddir)/src/utilities/IBTK_MPI.cpp $(am__append_3)
 pkg_include_HEADERS = ../include/ibtk/IBTK_CHKERRQ.h \
@@ -1803,15 +1800,6 @@ uninstall-libLIBRARIES:
 
 clean-libLIBRARIES:
 	-test -z "$(lib_LIBRARIES)" || rm -f $(lib_LIBRARIES)
-$(top_builddir)/src/lagrangian/fortran/$(am__dirstamp):
-	@$(MKDIR_P) $(top_builddir)/src/lagrangian/fortran
-	@: > $(top_builddir)/src/lagrangian/fortran/$(am__dirstamp)
-$(top_builddir)/src/lagrangian/fortran/$(DEPDIR)/$(am__dirstamp):
-	@$(MKDIR_P) $(top_builddir)/src/lagrangian/fortran/$(DEPDIR)
-	@: > $(top_builddir)/src/lagrangian/fortran/$(DEPDIR)/$(am__dirstamp)
-$(top_builddir)/src/lagrangian/fortran/lagrangian_delta.$(OBJEXT):  \
-	$(top_builddir)/src/lagrangian/fortran/$(am__dirstamp) \
-	$(top_builddir)/src/lagrangian/fortran/$(DEPDIR)/$(am__dirstamp)
 $(top_builddir)/src/utilities/$(am__dirstamp):
 	@$(MKDIR_P) $(top_builddir)/src/utilities
 	@: > $(top_builddir)/src/utilities/$(am__dirstamp)
@@ -2330,6 +2318,12 @@ $(top_builddir)/src/coarsen_ops/fortran/cubiccoarsen2d.$(OBJEXT):  \
 $(top_builddir)/src/coarsen_ops/fortran/rt0coarsen2d.$(OBJEXT):  \
 	$(top_builddir)/src/coarsen_ops/fortran/$(am__dirstamp) \
 	$(top_builddir)/src/coarsen_ops/fortran/$(DEPDIR)/$(am__dirstamp)
+$(top_builddir)/src/lagrangian/fortran/$(am__dirstamp):
+	@$(MKDIR_P) $(top_builddir)/src/lagrangian/fortran
+	@: > $(top_builddir)/src/lagrangian/fortran/$(am__dirstamp)
+$(top_builddir)/src/lagrangian/fortran/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) $(top_builddir)/src/lagrangian/fortran/$(DEPDIR)
+	@: > $(top_builddir)/src/lagrangian/fortran/$(DEPDIR)/$(am__dirstamp)
 $(top_builddir)/src/lagrangian/fortran/lagrangian_interaction2d.$(OBJEXT):  \
 	$(top_builddir)/src/lagrangian/fortran/$(am__dirstamp) \
 	$(top_builddir)/src/lagrangian/fortran/$(DEPDIR)/$(am__dirstamp)

--- a/ibtk/src/lagrangian/fortran/Makefile.am
+++ b/ibtk/src/lagrangian/fortran/Makefile.am
@@ -11,9 +11,19 @@
 ##
 ## ---------------------------------------------------------------------
 
-## Process this file with automake to produce Makefile.in
-include $(top_srcdir)/config/Make-rules
-
 EXTRA_DIST = lagrangian_delta.f.m4 lagrangian_interaction2d.f.m4 lagrangian_interaction3d.f.m4
 BUILT_SOURCES = lagrangian_delta.f lagrangian_interaction2d.f lagrangian_interaction3d.f
 CLEANFILES = ${BUILT_SOURCES}
+
+# we have to use some custom Make logic here since, long story short, autotools
+# does not correctly generate Fortran file dependency information and, to get
+# function inlining, we have to include lagrangian_delta.f in the other two
+# files.
+lagrangian_delta.f: lagrangian_delta.f.m4 Makefile
+	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+
+lagrangian_interaction2d.f: lagrangian_interaction2d.f.m4 lagrangian_delta.f Makefile
+	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+
+lagrangian_interaction3d.f: lagrangian_interaction3d.f.m4 lagrangian_delta.f Makefile
+	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@

--- a/ibtk/src/lagrangian/fortran/Makefile.in
+++ b/ibtk/src/lagrangian/fortran/Makefile.in
@@ -140,8 +140,7 @@ am__can_run_installinfo = \
     *) (install-info --version) >/dev/null 2>&1;; \
   esac
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
-am__DIST_COMMON = $(srcdir)/Makefile.in \
-	$(top_srcdir)/config/Make-rules
+am__DIST_COMMON = $(srcdir)/Makefile.in
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@
@@ -402,14 +401,6 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-MAINTAINERCLEANFILES = Makefile.in
-AM_CPPFLAGS = -I${top_srcdir}/include -I${top_builddir}/config
-AM_LDFLAGS = -L${top_builddir}/lib
-IBTK_LIBS = ${top_builddir}/lib/libIBTK.a
-IBTK2d_LIBS = ${top_builddir}/lib/libIBTK2d.a
-IBTK3d_LIBS = ${top_builddir}/lib/libIBTK3d.a
-pkg_includedir = $(includedir)/@PACKAGE@
-SUFFIXES = .f.m4
 EXTRA_DIST = lagrangian_delta.f.m4 lagrangian_interaction2d.f.m4 lagrangian_interaction3d.f.m4
 BUILT_SOURCES = lagrangian_delta.f lagrangian_interaction2d.f lagrangian_interaction3d.f
 CLEANFILES = ${BUILT_SOURCES}
@@ -417,8 +408,7 @@ all: $(BUILT_SOURCES)
 	$(MAKE) $(AM_MAKEFLAGS) all-am
 
 .SUFFIXES:
-.SUFFIXES: .f.m4 .f
-$(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am $(top_srcdir)/config/Make-rules $(am__configure_deps)
+$(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__configure_deps)
 	@for dep in $?; do \
 	  case '$(am__configure_deps)' in \
 	    *$$dep*) \
@@ -438,7 +428,6 @@ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	    echo ' cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__maybe_remake_depfiles)'; \
 	    cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__maybe_remake_depfiles);; \
 	esac;
-$(top_srcdir)/config/Make-rules $(am__empty):
 
 $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENCIES)
 	cd $(top_builddir) && $(MAKE) $(AM_MAKEFLAGS) am--refresh
@@ -532,7 +521,6 @@ maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
 	-test -z "$(BUILT_SOURCES)" || rm -f $(BUILT_SOURCES)
-	-test -z "$(MAINTAINERCLEANFILES)" || rm -f $(MAINTAINERCLEANFILES)
 clean: clean-am
 
 clean-am: clean-generic clean-libtool mostlyclean-am
@@ -615,7 +603,18 @@ uninstall-am:
 
 .PRECIOUS: Makefile
 
-.f.m4.f:
+
+# we have to use some custom Make logic here since, long story short, autotools
+# does not correctly generate Fortran file dependency information and, to get
+# function inlining, we have to include lagrangian_delta.f in the other two
+# files.
+lagrangian_delta.f: lagrangian_delta.f.m4 Makefile
+	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+
+lagrangian_interaction2d.f: lagrangian_interaction2d.f.m4 lagrangian_delta.f Makefile
+	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
+
+lagrangian_interaction3d.f: lagrangian_interaction3d.f.m4 lagrangian_delta.f Makefile
 	$(M4) $(FM4FLAGS) $(AM_FM4FLAGS) -DTOP_SRCDIR=$(top_srcdir) -DSAMRAI_FORTDIR=@SAMRAI_FORTDIR@ $< > $@
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.

--- a/ibtk/src/lagrangian/fortran/lagrangian_delta.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_delta.f.m4
@@ -13,6 +13,13 @@ c ---------------------------------------------------------------------
 
 define(REAL,`double precision')dnl
 define(INTEGER,`integer')dnl
+dnl This file only exists to be included into
+dnl lagrangian_interaction2d.f and lagrangian_interaction3d.f: i.e., it is
+dnl never explicitly compiled on its own so that the delta function kernels
+dnl can be inlined. This is necessary since Fortran compilers will (unless
+dnl we use something fancy like LTO) only do inlining of functions and
+dnl subroutines defined in the same translation unit.
+
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -48,6 +48,10 @@ define(INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH,
                                 $3, $4)
          endif')dnl
 include(SAMRAI_FORTDIR/pdat_m4arrdim2d.i)dnl
+
+c     this is a Fortran include, not an m4 include
+      include 'lagrangian_delta.f'
+
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
@@ -54,6 +54,10 @@ define(INTERPOLATE_3D_SPECIALIZE_FIXED_WIDTH,
                                 $5, $6)
          endif')dnl
 include(SAMRAI_FORTDIR/pdat_m4arrdim3d.i)dnl
+
+c     this is a Fortran include, not an m4 include
+      include 'lagrangian_delta.f'
+
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c


### PR DESCRIPTION
This makes the 3D BSPLINE_3 kernels for both interpolation and spreading take about 15% less time since the delta functions are inlined.

autotools doesn't generate dependency information for Fortran - AFAICT it cannot correctly track the file dependency created by the `include` statement. Hence we have to manually specify this dependency in the Makefile.