### PR TITLE
Fix a libMesh version check and clean up the rest.

### DIFF
--- a/doc/release-tasks.md
+++ b/doc/release-tasks.md
@@ -14,18 +14,18 @@ GitHub.
   `--disable-deprecated`) to verify that we do not use any deprecated
   functionality (this will cause compilation errors if we do use them). Add
   version checks: for example, here is one (lightly edited) in
-  `IBFEInstrumentPannel.cpp`:
+  `IBFEInstrumentPannel.cpp` that uses a macro defined in `libmesh_version.h`:
 ```cpp
     // new API in 1.4.0
-#if 1 <= LIBMESH_MAJOR_VERSION && 4 <= LIBMESH_MINOR_VERSION
+#if LIBMESH_VERSION_LESS_THAN(1, 4, 0)
+    boundary_info.build_node_list(nodes, bcs);
+#else
     const auto node_list = boundary_info.build_node_list();
     for (const auto& pair : node_list)
     {
         nodes.push_back(std::get<0>(pair));
         bcs.push_back(std::get<1>(pair));
     }
-#else
-    boundary_info.build_node_list(nodes, bcs);
 #endif
 ```
   around APIs to keep backwards compatibility with older versions of libMesh.

--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -22,11 +22,12 @@
 #include "tbox/Utilities.h"
 
 #include "libmesh/libmesh_config.h"
+#include "libmesh/libmesh_version.h"
 
-#if 1 <= LIBMESH_MAJOR_VERSION && 2 <= LIBMESH_MINOR_VERSION
-#include "libmesh/bounding_box.h"
-#else
+#if LIBMESH_VERSION_LESS_THAN(1, 2, 0)
 #include "libmesh/mesh_tools.h"
+#else
+#include "libmesh/bounding_box.h"
 #endif
 #include "libmesh/dof_map.h"
 #include "libmesh/dof_object.h"
@@ -56,10 +57,10 @@ namespace libMeshWrappers
 /**
  * Compatibility type alias for supporting older versions of libMesh.
  */
-#if 1 <= LIBMESH_MAJOR_VERSION && 2 <= LIBMESH_MINOR_VERSION
-using BoundingBox = libMesh::BoundingBox;
-#else
+#if LIBMESH_VERSION_LESS_THAN(1, 2, 0)
 using BoundingBox = libMesh::MeshTools::BoundingBox;
+#else
+using BoundingBox = libMesh::BoundingBox;
 #endif
 } // namespace libMeshWrappers
 
@@ -1241,7 +1242,7 @@ get_nodal_dof_indices(const libMesh::DofMap& dof_map,
                       const unsigned int variable_n,
                       std::vector<libMesh::dof_id_type>& nodal_indices)
 {
-#if LIBMESH_MINOR_VERSION < 2
+#if LIBMESH_VERSION_LESS_THAN(1, 2, 0)
     // See dof_map.C, circa line 2208
 
     // We only call this function with variable numbers 0, 1, or 2, so skip

--- a/ibtk/src/lagrangian/JacobianCalculator.cpp
+++ b/ibtk/src/lagrangian/JacobianCalculator.cpp
@@ -18,6 +18,7 @@
 #include "tbox/Utilities.h"
 
 #include <libmesh/fe.h>
+#include <libmesh/libmesh_version.h>
 #include <libmesh/point.h>
 #include <libmesh/quadrature.h>
 
@@ -53,10 +54,10 @@ LagrangeJacobianCalculator<dim, spacedim>::LagrangeJacobianCalculator(
     const typename LagrangeJacobianCalculator<dim, spacedim>::key_type quad_key)
     : JacobianCalculator(quad_key), d_n_nodes(get_n_nodes(std::get<0>(this->d_quad_key)))
 {
-#if 1 <= LIBMESH_MAJOR_VERSION && 4 <= LIBMESH_MINOR_VERSION
-    TBOX_ASSERT(d_n_nodes <= libMesh::Elem::max_n_nodes);
-#else
+#if LIBMESH_VERSION_LESS_THAN(1, 4, 0)
     TBOX_ASSERT(d_n_nodes <= 27);
+#else
+    TBOX_ASSERT(d_n_nodes <= libMesh::Elem::max_n_nodes);
 #endif
     const libMesh::ElemType elem_type = std::get<0>(this->d_quad_key);
 
@@ -117,10 +118,10 @@ LagrangeJacobianCalculator<dim, spacedim>::get_JxW(const libMesh::Elem* elem)
     std::copy(this->d_quad_weights.begin(), this->d_quad_weights.end(), this->d_JxW.begin());
 
     // max_n_nodes is a constant defined by libMesh - currently 27
-#if 1 <= LIBMESH_MAJOR_VERSION && 4 <= LIBMESH_MINOR_VERSION
-    double xs[libMesh::Elem::max_n_nodes][spacedim];
-#else
+#if LIBMESH_VERSION_LESS_THAN(1, 4, 0)
     double xs[27][spacedim];
+#else
+    double xs[libMesh::Elem::max_n_nodes][spacedim];
 #endif
 
     for (unsigned int i = 0; i < d_n_nodes; ++i)

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -57,6 +57,7 @@
 #include "libmesh/enum_quadrature_type.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/face_tri3.h"
+#include "libmesh/libmesh_version.h"
 #include "libmesh/linear_implicit_system.h"
 #include "libmesh/mesh.h"
 #include "libmesh/mesh_function.h"
@@ -322,15 +323,15 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
     std::vector<std::vector<libMesh::Point> > temp_nodes;
     std::vector<libMesh::Point> meter_centroids;
     // new API in 1.4.0
-#if 1 <= LIBMESH_MAJOR_VERSION && 4 <= LIBMESH_MINOR_VERSION
+#if LIBMESH_VERSION_LESS_THAN(1, 4, 0)
+    boundary_info.build_node_list(nodes, bcs);
+#else
     const std::vector<std::tuple<dof_id_type, boundary_id_type> > node_list = boundary_info.build_node_list();
     for (const std::tuple<dof_id_type, boundary_id_type>& pair : node_list)
     {
         nodes.push_back(std::get<0>(pair));
         bcs.push_back(std::get<1>(pair));
     }
-#else
-    boundary_info.build_node_list(nodes, bcs);
 #endif
 
     // check to make sure there are node sets to work with

--- a/tests/IBTK/bounding_boxes_01.cpp
+++ b/tests/IBTK/bounding_boxes_01.cpp
@@ -20,6 +20,7 @@
 #include <libmesh/enum_quadrature_type.h>
 #include <libmesh/equation_systems.h>
 #include <libmesh/explicit_system.h>
+#include <libmesh/libmesh_version.h>
 #include <libmesh/mesh.h>
 #include <libmesh/mesh_generation.h>
 
@@ -126,7 +127,7 @@ test(LibMeshInit& init,
         else
         {
             // the non-nodal box should be a subset of the nodal one
-#if 1 <= LIBMESH_MAJOR_VERSION && 2 <= LIBMESH_MINOR_VERSION
+#if !LIBMESH_VERSION_LESS_THAN(1, 2, 0)
             libMeshWrappers::BoundingBox box_union(box_2);
             box_union.union_with(box_1);
             TBOX_ASSERT(box_union.min() == box_2.min());
@@ -135,7 +136,7 @@ test(LibMeshInit& init,
 
             // box 2 should be a superset of box 1: i.e., the corners of box 1
             // should be in box 2
-#if 1 <= LIBMESH_MAJOR_VERSION && 4 <= LIBMESH_MINOR_VERSION
+#if !LIBMESH_VERSION_LESS_THAN(1, 4, 0)
             TBOX_ASSERT(box_2.signed_distance(box_1.min()) <= 0.0);
             TBOX_ASSERT(box_2.signed_distance(box_1.max()) <= 0.0);
 #endif
@@ -145,7 +146,7 @@ test(LibMeshInit& init,
         // Since X is just the initial coordinates of the mesh, we should
         // match the bounding box which is computed directly from the
         // element too.
-#if 1 <= LIBMESH_MAJOR_VERSION && 2 <= LIBMESH_MINOR_VERSION
+#if !LIBMESH_VERSION_LESS_THAN(1, 2, 0)
         libMeshWrappers::BoundingBox box_3 = (*el_it)->loose_bounding_box();
         if (order == FIRST)
         {
@@ -163,7 +164,7 @@ test(LibMeshInit& init,
 
         // box 3 should be a superset of box 2: i.e., the corners of box 2
         // should be in box 3
-#if 1 <= LIBMESH_MAJOR_VERSION && 4 <= LIBMESH_MINOR_VERSION
+#if !LIBMESH_VERSION_LESS_THAN(1, 4, 0)
         TBOX_ASSERT(box_2.signed_distance(box_1.min()) <= 0.0);
         TBOX_ASSERT(box_2.signed_distance(box_1.max()) <= 0.0);
 #endif


### PR DESCRIPTION
The version checks in FEDataManager are wrong - they use `LIBMESH_MAJOR_VERSION` twice. Ooops :)

Fix the problem more permanently by using the convenience macro provided by libMesh for doing version checks.