### PR TITLE
Clean up most of the IB kernels.

### DIFF
--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -47,6 +47,31 @@ define(INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH,
            INTERPOLATE_INNER_2D($1, $2,
                                 $3, $4)
          endif')dnl
+define(SPREAD_INNER_2D,
+          ` do d = 0,depth-1
+               do ic1 = $1,$2
+                  do ic0 = $3,$4
+                     u(ic0,ic1,d) = u(ic0,ic1,d) + (
+     &                    +w(0,ic0-$3)
+     &                    *w(1,ic1-$1)
+     &                    *V(d,s)/(dx(0)*dx(1)))
+                  enddo
+               enddo
+            enddo')
+dnl Same arguments as before, but the seventh argument is the width of the
+dnl stencil (e.g., 3 for bspline 3). The first branch is a hotter code path
+dnl since when we are not at a boundary the number of inner loop iterations
+dnl is known. Exposing this to the compiler helps generate code which speeds
+dnl up the subroutine by about 25%.
+define(SPREAD_2D_SPECIALIZE_FIXED_WIDTH,
+`   if ($2 - $1 == ($5 - 1) .and.
+     &       $4 - $3 == ($5 - 1)) then
+           SPREAD_INNER_2D($1, ($1 + $5 - 1),
+                           $3, ($3 + $5 - 1))
+         else
+           SPREAD_INNER_2D($1, $2,
+                           $3, $4)
+         endif')dnl
 include(SAMRAI_FORTDIR/pdat_m4arrdim2d.i)dnl
 
 c     this is a Fortran include, not an m4 include
@@ -710,9 +735,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
@@ -720,27 +746,34 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use the piecewise cubic delta function to interpolate u onto V.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d=0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the interpolation stencil corresponding to the position
 c     of X(s) within the cell.
 c
-         do d = 0,NDIM-1
             if ( X(d,s).lt.X_cell(d) ) then
                ic_lower(d) = ic_center(d)-2
                ic_upper(d) = ic_center(d)+1
@@ -748,34 +781,25 @@ c
                ic_lower(d) = ic_center(d)-1
                ic_upper(d) = ic_center(d)+2
             endif
-         enddo
 
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the interpolation weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_piecewise_cubic_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_piecewise_cubic_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_piecewise_cubic_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Interpolate u onto V.
 c
          INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
-                                               ic_lower(0), ic_upper(0), 4)
+                                               ic_lower(0), ic_upper(0),
+                                               4)
 c
 c     End loop over points.
 c
@@ -827,9 +851,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
@@ -837,27 +862,34 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use the piecewise cubic delta function to spread V onto u.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d = 0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the spreading stencil corresponding to the position of
 c     X(s) within the cell.
 c
-         do d = 0,NDIM-1
             if ( X(d,s).lt.X_cell(d) ) then
                ic_lower(d) = ic_center(d)-2
                ic_upper(d) = ic_center(d)+1
@@ -865,42 +897,24 @@ c
                ic_lower(d) = ic_center(d)-1
                ic_upper(d) = ic_center(d)+2
             endif
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the spreading weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_piecewise_cubic_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_piecewise_cubic_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_piecewise_cubic_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Spread V onto u.
 c
-         do d = 0,depth-1
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w(0,ic0-ic_lower(0))*
-     &                 w(1,ic1-ic_lower(1))*
-     &                 V(d,s)/(dx(0)*dx(1)))
-               enddo
-            enddo
-         enddo
+         SPREAD_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                          ic_lower(0), ic_upper(0),
+                                          4)
 c
 c     End loop over points.
 c
@@ -951,9 +965,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
@@ -961,57 +976,54 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use the IB 3-point delta function to interpolate u onto V.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d = 0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the interpolation stencil corresponding to the position
 c     of X(s) within the cell.
 c
-         do d = 0,NDIM-1
             ic_lower(d) = ic_center(d)-1
             ic_upper(d) = ic_center(d)+1
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the interpolation weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_ib_3_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_ib_3_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_ib_3_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Interpolate u onto V.
 c
          INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
-                                               ic_lower(0), ic_upper(0), 3)
+                                               ic_lower(0), ic_upper(0),
+                                               3)
 c
 c     End loop over points.
 c
@@ -1063,9 +1075,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
@@ -1073,65 +1086,54 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use the IB 3-point delta function to spread V onto u.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d = 0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the spreading stencil corresponding to the position of
 c     X(s) within the cell.
 c
-         do d = 0,NDIM-1
             ic_lower(d) = ic_center(d)-1
             ic_upper(d) = ic_center(d)+1
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the spreading weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_ib_3_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_ib_3_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d, ic-ic_lower(d)) =
+     &              lagrangian_ib_3_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Spread V onto u.
 c
-         do d = 0,depth-1
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w(0,ic0-ic_lower(0))*
-     &                 w(1,ic1-ic_lower(1))*
-     &                 V(d,s)/(dx(0)*dx(1)))
-               enddo
-            enddo
-         enddo
+         SPREAD_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                          ic_lower(0), ic_upper(0),
+                                          3)
 c
 c     End loop over points.
 c
@@ -2330,9 +2332,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
@@ -2340,57 +2343,54 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use a 3-point B-spline function to interpolate u onto V.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d=0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the interpolation stencil corresponding to the position
 c     of X(s) within the cell.
 c
-         do d = 0,NDIM-1
             ic_lower(d) = ic_center(d)-1
             ic_upper(d) = ic_center(d)+1
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the interpolation weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_bspline_3_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_bspline_3_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_bspline_3_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Interpolate u onto V.
 c
          INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
-                                               ic_lower(0), ic_upper(0), 3)
+                                               ic_lower(0), ic_upper(0),
+                                               3)
 c
 c     End loop over points.
 c
@@ -2442,9 +2442,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:2)
 c
@@ -2452,65 +2453,54 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use a 3-point B-spline function to spread V onto u.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d=0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the spreading stencil corresponding to the position of
 c     X(s) within the cell.
 c
-         do d = 0,NDIM-1
             ic_lower(d) = ic_center(d)-1
             ic_upper(d) = ic_center(d)+1
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the spreading weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_bspline_3_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_bspline_3_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_bspline_3_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Spread V onto u.
 c
-         do d = 0,depth-1
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w(0,ic0-ic_lower(0))*
-     &                 w(1,ic1-ic_lower(1))*
-     &                 V(d,s)/(dx(0)*dx(1)))
-               enddo
-            enddo
-         enddo
+         SPREAD_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                          ic_lower(0), ic_upper(0),
+                                          3)
 c
 c     End loop over points.
 c
@@ -2561,9 +2551,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
@@ -2571,27 +2562,34 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use a 4-point B-spline function to interpolate u onto V.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d=0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the interpolation stencil corresponding to the position
 c     of X(s) within the cell.
 c
-         do d = 0,NDIM-1
             if ( X(d,s).lt.X_cell(d) ) then
                ic_lower(d) = ic_center(d)-2
                ic_upper(d) = ic_center(d)+1
@@ -2599,34 +2597,24 @@ c
                ic_lower(d) = ic_center(d)-1
                ic_upper(d) = ic_center(d)+2
             endif
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the interpolation weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_bspline_4_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_bspline_4_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_bspline_4_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Interpolate u onto V.
 c
          INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
-                                               ic_lower(0), ic_upper(0), 4)
+                                               ic_lower(0), ic_upper(0),
+                                               4)
 c
 c     End loop over points.
 c
@@ -2678,9 +2666,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:3)
 c
@@ -2688,27 +2677,34 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use a 4-point B-spline function to spread V onto u.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d=0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the spreading stencil corresponding to the position of
 c     X(s) within the cell.
 c
-         do d = 0,NDIM-1
             if ( X(d,s).lt.X_cell(d) ) then
                ic_lower(d) = ic_center(d)-2
                ic_upper(d) = ic_center(d)+1
@@ -2716,42 +2712,24 @@ c
                ic_lower(d) = ic_center(d)-1
                ic_upper(d) = ic_center(d)+2
             endif
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the spreading weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_bspline_4_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_bspline_4_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_bspline_4_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Spread V onto u.
 c
-         do d = 0,depth-1
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w(0,ic0-ic_lower(0))*
-     &                 w(1,ic1-ic_lower(1))*
-     &                 V(d,s)/(dx(0)*dx(1)))
-               enddo
-            enddo
-         enddo
+         SPREAD_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                          ic_lower(0), ic_upper(0),
+                                          4)
 c
 c     End loop over points.
 c
@@ -2802,9 +2780,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:4)
 c
@@ -2812,57 +2791,54 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use a 5-point B-spline function to interpolate u onto V.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d=0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the interpolation stencil corresponding to the position
 c     of X(s) within the cell.
 c
-         do d = 0,NDIM-1
             ic_lower(d) = ic_center(d)-2
             ic_upper(d) = ic_center(d)+2
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the interpolation weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_bspline_5_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_bspline_5_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_bspline_5_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Interpolate u onto V.
 c
          INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
-                                               ic_lower(0), ic_upper(0), 5)
+                                               ic_lower(0), ic_upper(0),
+                                               5)
 c
 c     End loop over points.
 c
@@ -2914,9 +2890,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:4)
 c
@@ -2924,65 +2901,54 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use a 5-point B-spline function to spread V onto u.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d = 0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the spreading stencil corresponding to the position of
 c     X(s) within the cell.
 c
-         do d = 0,NDIM-1
             ic_lower(d) = ic_center(d)-2
             ic_upper(d) = ic_center(d)+2
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the spreading weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_bspline_5_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_bspline_5_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_bspline_5_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Spread V onto u.
 c
-         do d = 0,depth-1
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w(0,ic0-ic_lower(0))*
-     &                 w(1,ic1-ic_lower(1))*
-     &                 V(d,s)/(dx(0)*dx(1)))
-               enddo
-            enddo
-         enddo
+         SPREAD_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                          ic_lower(0), ic_upper(0),
+                                          5)
 c
 c     End loop over points.
 c
@@ -3033,9 +2999,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:5)
 c
@@ -3043,27 +3010,34 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use a 6-point B-spline function to interpolate u onto V.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d=0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the interpolation stencil corresponding to the position
 c     of X(s) within the cell.
 c
-         do d = 0,NDIM-1
             if ( X(d,s).lt.X_cell(d) ) then
                ic_lower(d) = ic_center(d)-3
                ic_upper(d) = ic_center(d)+2
@@ -3071,34 +3045,24 @@ c
                ic_lower(d) = ic_center(d)-2
                ic_upper(d) = ic_center(d)+3
             endif
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the interpolation weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_bspline_6_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_bspline_6_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_bspline_6_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Interpolate u onto V.
 c
          INTERPOLATE_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
-                                               ic_lower(0), ic_upper(0), 6)
+                                               ic_lower(0), ic_upper(0),
+                                               6)
 c
 c     End loop over points.
 c
@@ -3150,9 +3114,10 @@ c
 c
 c     Local variables.
 c
-      INTEGER ic0,ic1
+      INTEGER ilower(0:NDIM-1),iupper(0:NDIM-1)
+      INTEGER ic,ic0,ic1
       INTEGER ic_center(0:NDIM-1),ic_lower(0:NDIM-1),ic_upper(0:NDIM-1)
-      INTEGER d,l,s
+      INTEGER d,l,s,nugc(0:NDIM-1)
 
       REAL X_cell(0:NDIM-1),w(0:NDIM-1,0:5)
 c
@@ -3160,27 +3125,34 @@ c     Prevent compiler warning about unused variables.
 c
       x_upper(0) = x_upper(0)
 c
+c     Setup convenience arrays.
+c
+      ilower(0) = ilower0
+      ilower(1) = ilower1
+
+      iupper(0) = iupper0
+      iupper(1) = iupper1
+
+      nugc(0) = nugc0
+      nugc(1) = nugc1
+c
 c     Use a 6-point B-spline function to spread V onto u.
 c
       do l = 0,nindices-1
          s = indices(l)
+         do d=0,NDIM-1
 c
 c     Determine the Cartesian cell in which X(s) is located.
 c
-         ic_center(0) =
-     &        floor((X(0,s)+Xshift(0,l)-x_lower(0))/dx(0))
-     &        + ilower0
-         ic_center(1) =
-     &        floor((X(1,s)+Xshift(1,l)-x_lower(1))/dx(1))
-     &        + ilower1
-
-         X_cell(0) = x_lower(0)+(dble(ic_center(0)-ilower0)+0.5d0)*dx(0)
-         X_cell(1) = x_lower(1)+(dble(ic_center(1)-ilower1)+0.5d0)*dx(1)
+            ic_center(d) =
+     &           floor((X(d,s)+Xshift(d,l)-x_lower(d))/dx(d))
+     &           + ilower(d)
+            X_cell(d) = x_lower(d)
+     &           +(dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
 c
 c     Determine the spreading stencil corresponding to the position of
 c     X(s) within the cell.
 c
-         do d = 0,NDIM-1
             if ( X(d,s).lt.X_cell(d) ) then
                ic_lower(d) = ic_center(d)-3
                ic_upper(d) = ic_center(d)+2
@@ -3188,42 +3160,24 @@ c
                ic_lower(d) = ic_center(d)-2
                ic_upper(d) = ic_center(d)+3
             endif
-         enddo
-
-         ic_lower(0) = max(ic_lower(0),ilower0-nugc0)
-         ic_upper(0) = min(ic_upper(0),iupper0+nugc0)
-
-         ic_lower(1) = max(ic_lower(1),ilower1-nugc1)
-         ic_upper(1) = min(ic_upper(1),iupper1+nugc1)
+            ic_lower(d) = max(ic_lower(d),ilower(d)-nugc(d))
+            ic_upper(d) = min(ic_upper(d),iupper(d)+nugc(d))
 c
 c     Compute the spreading weights.
 c
-         do ic0 = ic_lower(0),ic_upper(0)
-            X_cell(0) = x_lower(0)+(dble(ic0-ilower0)+0.5d0)*dx(0)
-            w(0,ic0-ic_lower(0)) =
-     &           lagrangian_bspline_6_delta(
-     &           (X(0,s)+Xshift(0,l)-X_cell(0))/dx(0))
-         enddo
-
-         do ic1 = ic_lower(1),ic_upper(1)
-            X_cell(1) = x_lower(1)+(dble(ic1-ilower1)+0.5d0)*dx(1)
-            w(1,ic1-ic_lower(1)) =
-     &           lagrangian_bspline_6_delta(
-     &           (X(1,s)+Xshift(1,l)-X_cell(1))/dx(1))
+            do ic = ic_lower(d),ic_upper(d)
+               X_cell(d) = x_lower(d)+(dble(ic-ilower(d))+0.5d0)*dx(d)
+               w(d,ic-ic_lower(d)) =
+     &              lagrangian_bspline_6_delta(
+     &              (X(d,s)+Xshift(d,l)-X_cell(d))/dx(d))
+            enddo
          enddo
 c
 c     Spread V onto u.
 c
-         do d = 0,depth-1
-            do ic1 = ic_lower(1),ic_upper(1)
-               do ic0 = ic_lower(0),ic_upper(0)
-                  u(ic0,ic1,d) = u(ic0,ic1,d)+(
-     &                 w(0,ic0-ic_lower(0))*
-     &                 w(1,ic1-ic_lower(1))*
-     &                 V(d,s)/(dx(0)*dx(1)))
-               enddo
-            enddo
-         enddo
+         SPREAD_2D_SPECIALIZE_FIXED_WIDTH(ic_lower(1), ic_upper(1),
+                                          ic_lower(0), ic_upper(0),
+                                          6)
 c
 c     End loop over points.
 c


### PR DESCRIPTION
I have been working on this patch off-and-on for the last two months - its now done ~except for the high-order IB kernels (those are unlike the rest of the kernels in that they compute the complete stencil regardless of the position of the point in the box: i.e., they compute stencil values that are never used if we are at a patch boundary).~ Clarification: once #615 is done we will always need the complete stencil for every point so converting the kernels that already unconditionally compute the stencil (constant, RT0, and high order IB) is not worth doing quite yet.

This mostly addresses the goals of #615 - once we change things to sum values spread into ghost regions into other patch interiors then we can fix the remaining issues (we can avoid the awkward partial stencil calculations).

For all but the constant, linear, and high-order IB kernels:
1. use the same convenience arrays
2. loop over the dimension when assembling stencils
3. implement macros for unrolling spreading loops
4. consistently use the interpolation and spreading macros for unrolling

The excluded kernels are unusual in that they unconditionally compute the stencil at all points and use a different indexing scheme.