### PR TITLE
Fix compilation with clang.

### DIFF
--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -23,6 +23,7 @@
 #include "BasePatchHierarchy.h"
 #include "BasePatchLevel.h"
 #include "CoarsenAlgorithm.h"
+#include "CoarsenPatchStrategy.h"
 #include "CoarsenSchedule.h"
 #include "ComponentSelector.h"
 #include "GriddingAlgorithm.h"
@@ -30,6 +31,7 @@
 #include "LoadBalancer.h"
 #include "PatchHierarchy.h"
 #include "RefineAlgorithm.h"
+#include "RefinePatchStrategy.h"
 #include "RefineSchedule.h"
 #include "StandardTagAndInitStrategy.h"
 #include "VariableContext.h"
@@ -58,13 +60,6 @@ namespace tbox
 {
 class Database;
 } // namespace tbox
-namespace xfer
-{
-template <int DIM>
-class CoarsenPatchStrategy;
-template <int DIM>
-class RefinePatchStrategy;
-} // namespace xfer
 } // namespace SAMRAI
 
 /////////////////////////////// CLASS DEFINITION /////////////////////////////

--- a/include/ibamr/IBStrategy.h
+++ b/include/ibamr/IBStrategy.h
@@ -18,7 +18,9 @@
 
 #include "ibtk/CartGridFunction.h"
 
+#include "CoarsenPatchStrategy.h"
 #include "IntVector.h"
+#include "RefinePatchStrategy.h"
 #include "StandardTagAndInitStrategy.h"
 #include "VariableContext.h"
 #include "tbox/Pointer.h"
@@ -73,13 +75,9 @@ namespace xfer
 template <int DIM>
 class CoarsenAlgorithm;
 template <int DIM>
-class CoarsenPatchStrategy;
-template <int DIM>
 class CoarsenSchedule;
 template <int DIM>
 class RefineAlgorithm;
-template <int DIM>
-class RefinePatchStrategy;
 template <int DIM>
 class RefineSchedule;
 } // namespace xfer


### PR DESCRIPTION
I merged #849 without actually running the CI - the result was that we broke something with clang. Fortunately this is straightforward to fix - we just need some real definitions for `std::unique_ptr` instead of forward declarations.