### PR TITLE
Complex fluid boundary conditions and projection updates

### DIFF
--- a/doc/news/changes/minor/20200221AaronBarrett
+++ b/doc/news/changes/minor/20200221AaronBarrett
@@ -1,0 +1,3 @@
+Bug fix: The option to evolve the square root or logarithm of the conformation tensor now works as expected. Boundary conditions should be specified to whatever quantity is being evolved.
+<br>
+(Aaron Barrett, 2020/02/21)

--- a/examples/complex_fluids/ex0/input2d
+++ b/examples/complex_fluids/ex0/input2d
@@ -11,10 +11,8 @@ NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on f
 
 // Complex Fluid parameters
 FLUID_MODEL = "OLDROYDB"
-CONFORMATION_TENSOR = TRUE
-SQUARE_ROOT_EVOLVE  = FALSE
+EVOLVE_TYPE = "STANDARD"
 LOG_DETERMINANT     = TRUE
-LOG_CONFORM_EVOLVE  = FALSE
 CONVECTIVE_OPERATOR_TYPE     = "WAVE_PROP"
 OUTPUT_CONFORMATION_TENSOR = TRUE
 OUTPUT_STRESS_TENSOR = FALSE
@@ -151,10 +149,8 @@ ExtraStressBoundaryConditions_2 {
 relaxation_time = RELAXATION_TIME
 viscosity = VISCOSITY
 fluid_model         = FLUID_MODEL
-conformation_tensor = CONFORMATION_TENSOR
-square_root_evolve  = SQUARE_ROOT_EVOLVE
+evolution_type = EVOLVE_TYPE
 log_determinant     = LOG_DETERMINANT
-log_conform_evolve  = LOG_CONFORM_EVOLVE
 convective_operator_type     = CONVECTIVE_OPERATOR_TYPE
 output_stress_tensor = OUTPUT_STRESS_TENSOR
 output_conformation_tensor = OUTPUT_CONFORMATION_TENSOR

--- a/examples/complex_fluids/ex1/input2d
+++ b/examples/complex_fluids/ex1/input2d
@@ -14,10 +14,8 @@ Start_L = 0.0
 
 // Complex Fluid parameters
 FLUID_MODEL = "OLDROYDB"
-CONFORMATION_TENSOR = TRUE
-SQUARE_ROOT_EVOLVE  = TRUE
+EVOLVE_TYPE = "SQUARE_ROOT"
 LOG_DETERMINANT     = TRUE
-LOG_CONFORM_EVOLVE  = FALSE
 CONVECTIVE_OPERATOR_TYPE     = "WAVE_PROP"
 OUTPUT_CONFORMATION_TENSOR = TRUE
 OUTPUT_STRESS_TENSOR = FALSE
@@ -86,10 +84,8 @@ InitialConditions{
 relaxation_time = RELAXATION_TIME
 viscosity = VISCOSITY
 fluid_model         = FLUID_MODEL
-conformation_tensor = CONFORMATION_TENSOR
-square_root_evolve  = SQUARE_ROOT_EVOLVE
+evolve_type = EVOLVE_TYPE
 log_determinant     = LOG_DETERMINANT
-log_conform_evolve  = LOG_CONFORM_EVOLVE
 convective_operator_type     = CONVECTIVE_OPERATOR_TYPE
 output_stress_tensor = OUTPUT_STRESS_TENSOR
 output_conformation_tensor = OUTPUT_CONFORMATION_TENSOR

--- a/examples/complex_fluids/ex2/input2d
+++ b/examples/complex_fluids/ex2/input2d
@@ -21,11 +21,9 @@ ELEM_TYPE = "TRI3"                             // type of element to use for str
 
 // Complex Fluid parameters
 FLUID_MODEL = "OLDROYDB"
-CONFORMATION_TENSOR = TRUE
-SQUARE_ROOT_EVOLVE  = FALSE
+EVOLVE_TYPE = "STANDARD"
 LOG_DETERMINANT     = TRUE
 LOG_DIVERGENCE = TRUE
-LOG_CONFORM_EVOLVE  = FALSE
 CONVECTIVE_OPERATOR_TYPE     = "WAVE_PROP"
 OUTPUT_CONFORMATION_TENSOR = TRUE
 OUTPUT_STRESS_TENSOR = TRUE
@@ -165,11 +163,9 @@ relaxation_time = RELAXATION_TIME
 viscosity = VISCOSITY
 alpha = ALPHA
 fluid_model         = FLUID_MODEL
-conformation_tensor = CONFORMATION_TENSOR
-square_root_evolve  = SQUARE_ROOT_EVOLVE
+evolve_type         = EVOLVE_TYPE
 log_determinant     = LOG_DETERMINANT
 log_divergence      = LOG_DIVERGENCE
-log_conform_evolve  = LOG_CONFORM_EVOLVE
 convective_operator_type     = CONVECTIVE_OPERATOR_TYPE
 output_stress_tensor = OUTPUT_STRESS_TENSOR
 output_conformation_tensor = OUTPUT_CONFORMATION_TENSOR

--- a/examples/complex_fluids/ex3/input2d
+++ b/examples/complex_fluids/ex3/input2d
@@ -14,11 +14,9 @@ Start_L = 0.0
 
 // Complex Fluid parameters
 FLUID_MODEL = "OLDROYDB"
-CONFORMATION_TENSOR = TRUE
-SQUARE_ROOT_EVOLVE  = TRUE
+EVOLVE_TYPE = "SQUARE_ROOT"
 LOG_DETERMINANT     = TRUE
 LOG_DIVERGENCE = TRUE
-LOG_CONFORM_EVOLVE  = FALSE
 CONVECTIVE_OPERATOR_TYPE     = "WAVE_PROP"
 OUTPUT_CONFORMATION_TENSOR = TRUE
 OUTPUT_STRESS_TENSOR = TRUE
@@ -132,10 +130,8 @@ ExtraStressBoundaryConditions_2 {
 relaxation_time = RELAXATION_TIME
 viscosity = VISCOSITY
 fluid_model         = FLUID_MODEL
-conformation_tensor = CONFORMATION_TENSOR
-square_root_evolve  = SQUARE_ROOT_EVOLVE
+evolve_type         = EVOLVE_TYPE
 log_determinant     = LOG_DETERMINANT
-log_conform_evolve  = LOG_CONFORM_EVOLVE
 convective_operator_type     = CONVECTIVE_OPERATOR_TYPE
 output_stress_tensor = OUTPUT_STRESS_TENSOR
 output_conformation_tensor = OUTPUT_CONFORMATION_TENSOR

--- a/examples/complex_fluids/ex4/input2d
+++ b/examples/complex_fluids/ex4/input2d
@@ -23,11 +23,9 @@ B = 1.25
 
 // Complex Fluid parameters
 FLUID_MODEL = "OLDROYDB"
-CONFORMATION_TENSOR = TRUE
-SQUARE_ROOT_EVOLVE  = FALSE
+EVOLVE_TYPE = "STANDARD"
 LOG_DETERMINANT     = TRUE
 LOG_DIVERGENCE = TRUE
-LOG_CONFORM_EVOLVE  = FALSE
 CONVECTIVE_OPERATOR_TYPE     = "WAVE_PROP"
 OUTPUT_CONFORMATION_TENSOR = TRUE
 OUTPUT_STRESS_TENSOR = TRUE
@@ -167,12 +165,10 @@ ExtraStressBoundaryConditions_2 {
 relaxation_time = RELAXATION_TIME
 viscosity = VISCOSITY
 alpha = ALPHA
+evolve_type         = EVOLVE_TYPE
 fluid_model         = FLUID_MODEL
-conformation_tensor = CONFORMATION_TENSOR
-square_root_evolve  = SQUARE_ROOT_EVOLVE
 log_determinant     = LOG_DETERMINANT
 log_divergence      = LOG_DIVERGENCE
-log_conform_evolve  = LOG_CONFORM_EVOLVE
 convective_operator_type     = CONVECTIVE_OPERATOR_TYPE
 output_stress_tensor = OUTPUT_STRESS_TENSOR
 output_conformation_tensor = OUTPUT_CONFORMATION_TENSOR

--- a/ibtk/include/ibtk/ibtk_utilities.h
+++ b/ibtk/include/ibtk/ibtk_utilities.h
@@ -28,6 +28,7 @@ IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <algorithm>
 #include <array>
+#include <utility>
 
 /////////////////////////////// MACRO DEFINITIONS ////////////////////////////
 
@@ -143,6 +144,36 @@ level_can_be_refined(int level_number, int max_levels)
 {
     const int finest_level_number = max_levels - 1;
     return level_number < finest_level_number;
+}
+
+/*!
+ * Convert a Voigt notation index to the corresponding symmetric tensor index. This function only returns the upper
+ * triangular index.
+ */
+inline std::pair<int, int>
+voigt_to_tensor_idx(const int k)
+{
+    if (k < NDIM)
+        return std::make_pair(k, k);
+    else
+#if (NDIM == 2)
+        return std::make_pair(0, 1);
+#endif
+#if (NDIM == 3)
+    return std::make_pair(k > 3 ? 0 : 1, k > 4 ? 1 : 2);
+#endif
+}
+
+/*!
+ * Convert a symmetric tensor index to the corresponding Voigt notation index.
+ */
+inline int
+tensor_idx_to_voigt(const std::pair<int, int>& idx)
+{
+    if (idx.first == idx.second)
+        return idx.first;
+    else
+        return 3 * NDIM - 3 - idx.first - idx.second;
 }
 
 /*!

--- a/include/ibamr/ibamr_enums.h
+++ b/include/ibamr/ibamr_enums.h
@@ -473,7 +473,7 @@ inline TensorEvolutionType
 string_to_enum<TensorEvolutionType>(const std::string& val)
 {
     if (strcasecmp(val.c_str(), "STANDARD") == 0) return STANDARD;
-    if (strcasecmp(val.c_str(), "SQUARE_ROOT") == 0) return STANDARD;
+    if (strcasecmp(val.c_str(), "SQUARE_ROOT") == 0) return SQUARE_ROOT;
     if (strcasecmp(val.c_str(), "LOGARITHM") == 0) return LOGARITHM;
     return UNKNOWN_TENSOR_EVOLUTION_TYPE;
 }

--- a/src/complex_fluids/CFINSForcing.cpp
+++ b/src/complex_fluids/CFINSForcing.cpp
@@ -150,7 +150,10 @@ CFINSForcing::commonConstructor(const Pointer<Database> input_db,
     // Read parameters from input file
     d_lambda = input_db->getDouble("relaxation_time");
     d_eta = input_db->getDouble("viscosity");
-    d_evolve_type = string_to_enum<TensorEvolutionType>(input_db->getStringWithDefault("evolution_type", "STANDARD"));
+    if (input_db->keyExists("evolution_type"))
+        d_evolve_type = string_to_enum<TensorEvolutionType>(input_db->getString("evolution_type"));
+    if (input_db->keyExists("evolve_type"))
+        d_evolve_type = string_to_enum<TensorEvolutionType>(input_db->getString("evolve_type"));
     if (input_db->keyExists("D")) d_adv_diff_integrator->setDiffusionCoefficient(d_W_cc_var, input_db->getDouble("D"));
     d_log_det = input_db->getBoolWithDefault("log_determinant", d_log_det);
     d_convec_oper_type = input_db->getStringWithDefault("convective_operator_type", "CENTERED");

--- a/src/complex_fluids/CFINSForcing.cpp
+++ b/src/complex_fluids/CFINSForcing.cpp
@@ -146,7 +146,6 @@ CFINSForcing::commonConstructor(const Pointer<Database> input_db,
     d_adv_diff_integrator->registerTransportedQuantity(d_W_cc_var);
     d_adv_diff_integrator->setInitialConditions(d_W_cc_var, d_init_conds);
     d_W_scratch_idx = var_db->registerVariableAndContext(d_W_cc_var, d_context, ghosts_cc);
-    d_W_cc_idx = var_db->registerClonedPatchDataIndex(d_W_cc_var, d_W_scratch_idx);
 
     // Read parameters from input file
     d_lambda = input_db->getDouble("relaxation_time");
@@ -160,6 +159,10 @@ CFINSForcing::commonConstructor(const Pointer<Database> input_db,
     d_error_on_spd = input_db->getBoolWithDefault("error_on_spd", d_error_on_spd);
     d_log_divW = input_db->getBoolWithDefault("log_divergence", d_log_divW);
     d_project_conform = input_db->getBoolWithDefault("project_conformation_tensor", d_project_conform);
+    // Have advection diffusion integrator project conformation tensor if necessary.
+    if (d_project_conform)
+        d_adv_diff_integrator->registerIntegrateHierarchyCallback(&apply_project_tensor_callback,
+                                                                  static_cast<void*>(this));
 
     // Set up drawing variables if necessary
     d_conform_draw = input_db->getBoolWithDefault("output_conformation_tensor", d_conform_draw);
@@ -262,11 +265,11 @@ CFINSForcing::setDataOnPatchHierarchy(const int data_idx,
         if (d_conform_draw && !level->checkAllocated(d_conform_idx_draw)) level->allocatePatchData(d_conform_idx_draw);
         if ((d_divW_idx_draw > -1) && !level->checkAllocated(d_divW_idx_draw))
             level->allocatePatchData(d_divW_idx_draw);
-        if (!level->checkAllocated(d_W_cc_idx)) level->allocatePatchData(d_W_cc_idx);
     }
     if (initial_time)
     {
-        d_init_conds->setDataOnPatchHierarchy(d_W_cc_idx, d_W_cc_var, hierarchy, data_time, coarsest_ln, finest_ln);
+        d_init_conds->setDataOnPatchHierarchy(
+            d_W_scratch_idx, d_W_cc_var, hierarchy, data_time, coarsest_ln, finest_ln);
     }
     else
     {
@@ -279,42 +282,16 @@ CFINSForcing::setDataOnPatchHierarchy(const int data_idx,
             hier_data_ops_manager->getOperationsDouble(d_W_cc_var, hierarchy, true);
         if (d_adv_diff_integrator->getCurrentCycleNumber() == 0 || !W_new_is_allocated)
         {
-            hier_cc_data_ops->copyData(d_W_cc_idx, W_current_idx);
+            hier_cc_data_ops->copyData(d_W_scratch_idx, W_current_idx);
         }
         else
         {
-            hier_cc_data_ops->linearSum(d_W_cc_idx, 0.5, W_current_idx, 0.5, W_new_idx);
+            hier_cc_data_ops->linearSum(d_W_scratch_idx, 0.5, W_current_idx, 0.5, W_new_idx);
         }
     }
 
-    HierarchyDataOpsManager<NDIM>* hier_data_ops_manager = HierarchyDataOpsManager<NDIM>::getManager();
-    Pointer<HierarchyDataOpsReal<NDIM, double> > hier_cc_data_ops =
-        hier_data_ops_manager->getOperationsDouble(d_W_cc_var, hierarchy);
-    switch (d_evolve_type)
-    {
-    case SQUARE_ROOT:
-        squareMatrix(d_W_scratch_idx, d_W_cc_var, hierarchy, data_time, initial_time, coarsest_ln, finest_ln);
-        break;
-    case LOGARITHM:
-        exponentiateMatrix(d_W_scratch_idx, d_W_cc_var, hierarchy, data_time, initial_time, coarsest_ln, finest_ln);
-        break;
-    case STANDARD:
-        if (d_project_conform)
-        {
-            // TODO: This only projects the conformation tensor data owned by
-            // this class. Really, we need to project the conformation tensor
-            // owned by the advection diffusion integrator.
-            projectTensor(d_W_cc_idx, d_W_cc_var, hierarchy, data_time, initial_time, coarsest_ln, finest_ln);
-        }
-        hier_cc_data_ops->copyData(d_W_scratch_idx, d_W_cc_idx);
-        break;
-    case UNKNOWN_TENSOR_EVOLUTION_TYPE:
-        TBOX_ERROR(d_object_name << "\n:"
-                                 << "  Unknown tensor evolution type");
-        break;
-    }
-
-    typedef HierarchyGhostCellInterpolation::InterpolationTransactionComponent InterpolationTransactionComponent;
+    // Fill in boundary conditions for evolved quantity.
+    using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
     std::vector<InterpolationTransactionComponent> ghost_cell_components(1);
     ghost_cell_components[0] = InterpolationTransactionComponent(d_W_scratch_idx,
                                                                  "CONSERVATIVE_LINEAR_REFINE",
@@ -328,6 +305,42 @@ CFINSForcing::setDataOnPatchHierarchy(const int data_idx,
     HierarchyGhostCellInterpolation ghost_fill_op;
     ghost_fill_op.initializeOperatorState(ghost_cell_components, hierarchy);
     ghost_fill_op.fillData(data_time);
+
+    HierarchyDataOpsManager<NDIM>* hier_data_ops_manager = HierarchyDataOpsManager<NDIM>::getManager();
+    Pointer<HierarchyDataOpsReal<NDIM, double> > hier_cc_data_ops =
+        hier_data_ops_manager->getOperationsDouble(d_W_cc_var, hierarchy);
+    // Convert evolved quantity including ghost cells to conformation tensor.
+    switch (d_evolve_type)
+    {
+    case SQUARE_ROOT:
+        squareMatrix(d_W_scratch_idx,
+                     d_W_cc_var,
+                     hierarchy,
+                     data_time,
+                     initial_time,
+                     coarsest_ln,
+                     finest_ln,
+                     true /*extended_box*/);
+        break;
+    case LOGARITHM:
+        exponentiateMatrix(d_W_scratch_idx,
+                           d_W_cc_var,
+                           hierarchy,
+                           data_time,
+                           initial_time,
+                           coarsest_ln,
+                           finest_ln,
+                           true /*extended_box*/);
+        break;
+    case STANDARD:
+        if (d_project_conform)
+            projectTensor(d_W_scratch_idx, d_W_cc_var, data_time, initial_time, true /*extended_box*/);
+        break;
+    case UNKNOWN_TENSOR_EVOLUTION_TYPE:
+        TBOX_ERROR(d_object_name << "\n:"
+                                 << "  Unknown tensor evolution type");
+        break;
+    }
 
     // Check to ensure conformation tensor is positive definite
     d_positive_def = true;
@@ -674,7 +687,8 @@ CFINSForcing::squareMatrix(const int data_idx,
                            const double /*data_time*/,
                            const bool initial_time,
                            const int coarsest_ln,
-                           const int finest_ln)
+                           const int finest_ln,
+                           const bool extended_box)
 {
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
     {
@@ -682,32 +696,40 @@ CFINSForcing::squareMatrix(const int data_idx,
         for (PatchLevel<NDIM>::Iterator p(level); p; p++)
         {
             Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& box = patch->getBox();
-            const Pointer<PatchGeometry<NDIM> > p_geom = patch->getPatchGeometry();
             if (initial_time) return;
-            Pointer<CellData<NDIM, double> > half_data = patch->getPatchData(d_W_cc_idx);
-            Pointer<CellData<NDIM, double> > tens_data = patch->getPatchData(data_idx);
+            Pointer<CellData<NDIM, double> > data = patch->getPatchData(data_idx);
+            const Box<NDIM>& box = extended_box ? data->getGhostBox() : patch->getBox();
+            const Pointer<PatchGeometry<NDIM> > p_geom = patch->getPatchGeometry();
+
             for (CellIterator<NDIM> it(box); it; it++)
             {
                 CellIndex<NDIM> i = *it;
 #if (NDIM == 2)
-                (*tens_data)(i, 0) = (*half_data)(i, 0) * (*half_data)(i, 0) + (*half_data)(i, 2) * (*half_data)(i, 2);
-                (*tens_data)(i, 1) = (*half_data)(i, 2) * (*half_data)(i, 2) + (*half_data)(i, 1) * (*half_data)(i, 1);
-                (*tens_data)(i, 2) = (*half_data)(i, 0) * (*half_data)(i, 2) + (*half_data)(i, 1) * (*half_data)(i, 2);
+                Eigen::Matrix2d mat;
+                mat(0, 0) = (*data)(i, 0);
+                mat(1, 0) = (*data)(i, 2);
+                mat(0, 1) = (*data)(i, 2);
+                mat(1, 1) = (*data)(i, 1);
+                mat = mat * mat;
+                (*data)(i, 0) = mat(0, 0);
+                (*data)(i, 1) = mat(1, 1);
+                (*data)(i, 2) = mat(0, 1);
 #endif
 #if (NDIM == 3)
-                (*tens_data)(i, 0) = (*half_data)(i, 0) * (*half_data)(i, 0) + (*half_data)(i, 4) * (*half_data)(i, 4) +
-                                     (*half_data)(i, 5) * (*half_data)(i, 5);
-                (*tens_data)(i, 1) = (*half_data)(i, 1) * (*half_data)(i, 1) + (*half_data)(i, 3) * (*half_data)(i, 3) +
-                                     (*half_data)(i, 5) * (*half_data)(i, 5);
-                (*tens_data)(i, 2) = (*half_data)(i, 2) * (*half_data)(i, 2) + (*half_data)(i, 3) * (*half_data)(i, 3) +
-                                     (*half_data)(i, 4) * (*half_data)(i, 4);
-                (*tens_data)(i, 3) = (*half_data)(i, 1) * (*half_data)(i, 3) + (*half_data)(i, 2) * (*half_data)(i, 3) +
-                                     (*half_data)(i, 4) * (*half_data)(i, 5);
-                (*tens_data)(i, 4) = (*half_data)(i, 0) * (*half_data)(i, 4) + (*half_data)(i, 2) * (*half_data)(i, 4) +
-                                     (*half_data)(i, 3) * (*half_data)(i, 5);
-                (*tens_data)(i, 5) = (*half_data)(i, 3) * (*half_data)(i, 4) + (*half_data)(i, 0) * (*half_data)(i, 5) +
-                                     (*half_data)(i, 1) * (*half_data)(i, 5);
+                Eigen::Matrix3d mat;
+                mat(0, 0) = (*data)(i, 0);
+                mat(1, 1) = (*data)(i, 1);
+                mat(2, 2) = (*data)(i, 2);
+                mat(1, 2) = mat(2, 1) = (*data)(i, 3);
+                mat(0, 2) = mat(2, 0) = (*data)(i, 4);
+                mat(0, 1) = mat(1, 0) = (*data)(i, 5);
+                mat = mat * mat;
+                (*data)(i, 0) = mat(0, 0);
+                (*data)(i, 1) = mat(1, 1);
+                (*data)(i, 2) = mat(2, 2);
+                (*data)(i, 3) = mat(1, 2);
+                (*data)(i, 4) = mat(0, 2);
+                (*data)(i, 5) = mat(0, 1);
 #endif
             }
         }
@@ -757,7 +779,8 @@ CFINSForcing::exponentiateMatrix(const int data_idx,
                                  const double /*data_time*/,
                                  const bool /*initial_time*/,
                                  const int coarsest_ln,
-                                 const int finest_ln)
+                                 const int finest_ln,
+                                 const bool extended_box)
 {
     for (int ln = coarsest_ln; ln <= finest_ln; ln++)
     {
@@ -765,18 +788,17 @@ CFINSForcing::exponentiateMatrix(const int data_idx,
         for (PatchLevel<NDIM>::Iterator p(level); p; p++)
         {
             Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& box = patch->getBox();
             Pointer<CellData<NDIM, double> > data = patch->getPatchData(data_idx);
-            Pointer<CellData<NDIM, double> > log_data = patch->getPatchData(d_W_cc_idx);
+            const Box<NDIM>& box = extended_box ? data->getGhostBox() : patch->getBox();
             for (CellIterator<NDIM> it(box); it; it++)
             {
                 CellIndex<NDIM> i = *it;
 #if (NDIM == 2)
                 Eigen::Matrix2d mat;
-                mat(0, 0) = (*log_data)(i, 0);
-                mat(1, 0) = (*log_data)(i, 2);
-                mat(0, 1) = (*log_data)(i, 2);
-                mat(1, 1) = (*log_data)(i, 1);
+                mat(0, 0) = (*data)(i, 0);
+                mat(1, 0) = (*data)(i, 2);
+                mat(0, 1) = (*data)(i, 2);
+                mat(1, 1) = (*data)(i, 1);
                 mat = mat.exp();
                 (*data)(i, 0) = mat(0, 0);
                 (*data)(i, 1) = mat(1, 1);
@@ -784,12 +806,12 @@ CFINSForcing::exponentiateMatrix(const int data_idx,
 #endif
 #if (NDIM == 3)
                 Eigen::Matrix3d mat;
-                mat(0, 0) = (*log_data)(i, 0);
-                mat(1, 1) = (*log_data)(i, 1);
-                mat(2, 2) = (*log_data)(i, 2);
-                mat(1, 2) = mat(2, 1) = (*log_data)(i, 3);
-                mat(0, 2) = mat(2, 0) = (*log_data)(i, 4);
-                mat(0, 1) = mat(1, 0) = (*log_data)(i, 5);
+                mat(0, 0) = (*data)(i, 0);
+                mat(1, 1) = (*data)(i, 1);
+                mat(2, 2) = (*data)(i, 2);
+                mat(1, 2) = mat(2, 1) = (*data)(i, 3);
+                mat(0, 2) = mat(2, 0) = (*data)(i, 4);
+                mat(0, 1) = mat(1, 0) = (*data)(i, 5);
                 mat = mat.exp();
                 (*data)(i, 0) = mat(0, 0);
                 (*data)(i, 1) = mat(1, 1);
@@ -807,21 +829,20 @@ CFINSForcing::exponentiateMatrix(const int data_idx,
 void
 CFINSForcing::projectTensor(const int data_idx,
                             const Pointer<Variable<NDIM> > /*var*/,
-                            const Pointer<PatchHierarchy<NDIM> > hierarchy,
                             const double /*data_time*/,
                             const bool initial_time,
-                            const int coarsest_ln,
-                            const int finest_ln)
+                            const bool extended_box)
 {
-    for (int ln = coarsest_ln; ln <= finest_ln; ln++)
+    Pointer<PatchHierarchy<NDIM> > hierarchy = d_adv_diff_integrator->getPatchHierarchy();
+    for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++)
     {
         Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(ln);
         for (PatchLevel<NDIM>::Iterator p(level); p; p++)
         {
             Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& box = patch->getBox();
             if (initial_time) return;
             Pointer<CellData<NDIM, double> > data = patch->getPatchData(data_idx);
+            const Box<NDIM>& box = extended_box ? data->getGhostBox() : patch->getBox();
             for (CellIterator<NDIM> it(box); it; it++)
             {
                 CellIndex<NDIM> i = *it;
@@ -934,4 +955,18 @@ CFINSForcing::apply_gradient_detector_callback(Pointer<BasePatchHierarchy<NDIM> 
         hierarchy, level_number, error_data_time, tag_index, initial_time, richardson_extrapolation_too);
     return;
 } // apply_gradient_detector_callback
+
+void
+CFINSForcing::apply_project_tensor_callback(const double current_time,
+                                            const double /*new_time*/,
+                                            const int /*cycle_num*/,
+                                            void* ctx)
+{
+    auto object = static_cast<CFINSForcing*>(ctx);
+    auto var_db = VariableDatabase<NDIM>::getDatabase();
+    const int Q_idx = var_db->mapVariableAndContextToIndex(object->getVariable(),
+                                                           object->getAdvDiffHierarchyIntegrator()->getNewContext());
+    object->projectTensor(Q_idx, object->getVariable(), current_time, false /*initial_time*/, false /*extended_box*/);
+    return;
+} // apply_project_tensor_callback
 } // namespace IBAMR

--- a/src/complex_fluids/CFRelaxationOperator.cpp
+++ b/src/complex_fluids/CFRelaxationOperator.cpp
@@ -22,7 +22,10 @@ CFRelaxationOperator::CFRelaxationOperator(const std::string& object_name, Point
 {
     if (input_db)
     {
-        d_evolve_type = string_to_enum<TensorEvolutionType>(input_db->getStringWithDefault("evolve_type", "STANDARD"));
+        if (input_db->keyExists("evolution_type"))
+            d_evolve_type = string_to_enum<TensorEvolutionType>(input_db->getString("evolution_type"));
+        if (input_db->keyExists("evolve_type"))
+            d_evolve_type = string_to_enum<TensorEvolutionType>(input_db->getString("evolve_type"));
     }
     return;
 } // Constructor

--- a/src/complex_fluids/CFUpperConvectiveOperator.cpp
+++ b/src/complex_fluids/CFUpperConvectiveOperator.cpp
@@ -145,8 +145,10 @@ CFUpperConvectiveOperator::CFUpperConvectiveOperator(const std::string& object_n
     if (input_db)
     {
         d_interp_type = input_db->getStringWithDefault("interp_type", d_interp_type);
-        d_evolve_type =
-            string_to_enum<TensorEvolutionType>(input_db->getStringWithDefault("evolution_type", "STANDARD"));
+        if (input_db->keyExists("evolution_type"))
+            d_evolve_type = string_to_enum<TensorEvolutionType>(input_db->getString("evolution_type"));
+        if (input_db->keyExists("evolve_type"))
+            d_evolve_type = string_to_enum<TensorEvolutionType>(input_db->getString("evolve_type"));
     }
     // Register some scratch variables
     auto var_db = VariableDatabase<NDIM>::getDatabase();

--- a/tests/complex_fluids/cf_forcing_op_01_2d.cell.logarithm.input
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.cell.logarithm.input
@@ -1,0 +1,145 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// Complex Fluid parameters
+RELAX_OP = "OLDROYDB"
+VAR_CENTERING = "CELL"
+RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "LOGARITHM"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QXY = "0.0"
+
+ComplexFluid {
+   relaxation_time = RELAXATION_TIME
+   viscosity = 1.0
+   output_conformation_tensor = FALSE
+   output_stress_tensor = FALSE
+   output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
+   InitialConditions {
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+   }
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+   }
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
+   }
+   FCN {
+       function_0 = "2.0*PI*cos(2*PI*X_0)*exp(2+sin(2*PI*X_0))"
+       function_1 = "-2.0*PI*sin(2*PI*X_1)*exp(2+cos(2*PI*X_1))"
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "visit"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+AdvDiffHierarchyIntegrator {
+}
+

--- a/tests/complex_fluids/cf_forcing_op_01_2d.cell.logarithm.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.cell.logarithm.output
@@ -1,0 +1,6 @@
+AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+Conformation tensor is SPD
+Error norms:
+  L1-norm:  0.97983536
+  L2-norm:  1.0673658
+  max-norm: 2.7850786

--- a/tests/complex_fluids/cf_forcing_op_01_2d.cell.square_root.input
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.cell.square_root.input
@@ -1,0 +1,145 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// Complex Fluid parameters
+RELAX_OP = "OLDROYDB"
+VAR_CENTERING = "CELL"
+RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "SQUARE_ROOT"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QXY = "0.0"
+
+ComplexFluid {
+   relaxation_time = RELAXATION_TIME
+   viscosity = 1.0
+   output_conformation_tensor = FALSE
+   output_stress_tensor = FALSE
+   output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
+   InitialConditions {
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+   }
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+   }
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
+   }
+   FCN {
+       function_0 = "4.0*PI*cos(2.0*PI*X_0)*(2.0+sin(2.0*PI*X_0))"
+       function_1 = "-4.0*PI*sin(2.0*PI*X_1)*(2.0+cos(2.0*PI*X_1))"
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "visit"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+AdvDiffHierarchyIntegrator {
+}
+

--- a/tests/complex_fluids/cf_forcing_op_01_2d.cell.square_root.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.cell.square_root.output
@@ -1,0 +1,6 @@
+AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+Conformation tensor is SPD
+Error norms:
+  L1-norm:  0.30806833
+  L2-norm:  0.3156627
+  max-norm: 0.87747078

--- a/tests/complex_fluids/cf_forcing_op_01_2d.cell.standard.input
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.cell.standard.input
@@ -8,6 +8,10 @@ NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on f
 RELAX_OP = "OLDROYDB"
 VAR_CENTERING = "CELL"
 RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "STANDARD"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QXY = "0.0"
 
 ComplexFluid {
    relaxation_time = RELAXATION_TIME
@@ -15,18 +19,65 @@ ComplexFluid {
    output_conformation_tensor = FALSE
    output_stress_tensor = FALSE
    output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
    InitialConditions {
-       function_0 = "sin(2*PI*X_0)+2"
-       function_1 = "cos(2*PI*X_1)+2"
-       function_2 = "sin(2*PI*X_2)+2"
-       function_3 = "0.0"
-       function_4 = "0.0"
-       function_5 = "0.0"
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+   }
+
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+   }
+
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
    }
    FCN {
        function_0 = "2*PI*cos(2*PI*X_0)"
        function_1 = "-2*PI*sin(2*PI*X_1)"
-       function_2 = "2*PI*cos(2*PI*X_2)"
    }
 }
 
@@ -50,24 +101,24 @@ Main {
 }
 
 CartesianGeometry {
-   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
-   x_lo = 0.0, 0.0, 0.0
-   x_up = 1.0, 1.0, 1.0
-   periodic_dimension = 1,1,1
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 0,0
 }
 
 GriddingAlgorithm {
    max_levels = MAX_LEVELS
    ratio_to_coarser {
-      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
-      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
-      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
    }
    largest_patch_size {
-      level_0 = 512,512,512  // all finer levels will use same values as level_0
+      level_0 = 512,512  // all finer levels will use same values as level_0
    }
    smallest_patch_size {
-      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+      level_0 =   4,  4  // all finer levels will use same values as level_0
    }
    efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
    combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
@@ -76,6 +127,7 @@ GriddingAlgorithm {
 StandardTagAndInitialize {
    tagging_method = "REFINE_BOXES"
    RefineBoxes {
+      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )]
    }
 }
 

--- a/tests/complex_fluids/cf_forcing_op_01_2d.cell.standard.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.cell.standard.output
@@ -1,6 +1,6 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 Conformation tensor is SPD
 Error norms:
-  L1-norm:  0.051387699
-  L2-norm:  0.040295003
-  max-norm: 0.040100971
+  L1-norm:  0.060524546
+  L2-norm:  0.055059717
+  max-norm: 0.15013915

--- a/tests/complex_fluids/cf_forcing_op_01_2d.side.logarithm.input
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.side.logarithm.input
@@ -8,6 +8,10 @@ NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on f
 RELAX_OP = "OLDROYDB"
 VAR_CENTERING = "SIDE"
 RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "LOGARITHM"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QXY = "0.0"
 
 ComplexFluid {
    relaxation_time = RELAXATION_TIME
@@ -15,14 +19,63 @@ ComplexFluid {
    output_conformation_tensor = FALSE
    output_stress_tensor = FALSE
    output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
    InitialConditions {
-       function_0 = "sin(2*PI*X_0)+2"
-       function_1 = "cos(2*PI*X_1)+2"
-       function_2 = "0.0"
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+   }
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+   }
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
    }
    FCN {
-       function_0 = "2*PI*cos(2*PI*X_0)"
-       function_1 = "-2*PI*sin(2*PI*X_1)"
+       function_0 = "2.0*PI*cos(2*PI*X_0)*exp(2+sin(2*PI*X_0))"
+       function_1 = "-2.0*PI*sin(2*PI*X_1)*exp(2+cos(2*PI*X_1))"
    }
 }
 
@@ -49,7 +102,7 @@ CartesianGeometry {
    domain_boxes = [ (0,0),(N - 1,N - 1) ]
    x_lo = 0.0, 0.0
    x_up = 1.0, 1.0
-   periodic_dimension = 1,1
+   periodic_dimension = 0,0
 }
 
 GriddingAlgorithm {

--- a/tests/complex_fluids/cf_forcing_op_01_2d.side.logarithm.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.side.logarithm.output
@@ -1,0 +1,6 @@
+AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+Conformation tensor is SPD
+Error norms:
+  L1-norm:  0.3969317
+  L2-norm:  1.1131887
+  max-norm: 6.1899343

--- a/tests/complex_fluids/cf_forcing_op_01_2d.side.square_root.input
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.side.square_root.input
@@ -6,8 +6,12 @@ NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on f
 
 // Complex Fluid parameters
 RELAX_OP = "OLDROYDB"
-VAR_CENTERING = "CELL"
+VAR_CENTERING = "SIDE"
 RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "SQUARE_ROOT"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QXY = "0.0"
 
 ComplexFluid {
    relaxation_time = RELAXATION_TIME
@@ -15,14 +19,65 @@ ComplexFluid {
    output_conformation_tensor = FALSE
    output_stress_tensor = FALSE
    output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
    InitialConditions {
-       function_0 = "sin(2*PI*X_0)+2"
-       function_1 = "cos(2*PI*X_1)+2"
-       function_2 = "0.0"
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+   }
+
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+   }
+
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
    }
    FCN {
-       function_0 = "2*PI*cos(2*PI*X_0)"
-       function_1 = "-2*PI*sin(2*PI*X_1)"
+       function_0 = "4.0*PI*cos(2.0*PI*X_0)*(2.0+sin(2.0*PI*X_0))"
+       function_1 = "-4.0*PI*sin(2.0*PI*X_1)*(2.0+cos(2.0*PI*X_1))"
    }
 }
 
@@ -49,7 +104,7 @@ CartesianGeometry {
    domain_boxes = [ (0,0),(N - 1,N - 1) ]
    x_lo = 0.0, 0.0
    x_up = 1.0, 1.0
-   periodic_dimension = 1,1
+   periodic_dimension = 0,0
 }
 
 GriddingAlgorithm {

--- a/tests/complex_fluids/cf_forcing_op_01_2d.side.square_root.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.side.square_root.output
@@ -1,6 +1,6 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 Conformation tensor is SPD
 Error norms:
-  L1-norm:  0.077081549
-  L2-norm:  0.049351098
-  max-norm: 0.040101043
+  L1-norm:  0.12170821
+  L2-norm:  0.33180885
+  max-norm: 1.849065

--- a/tests/complex_fluids/cf_forcing_op_01_2d.side.standard.input
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.side.standard.input
@@ -8,6 +8,10 @@ NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on f
 RELAX_OP = "OLDROYDB"
 VAR_CENTERING = "SIDE"
 RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "STANDARD"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QXY = "0.0"
 
 ComplexFluid {
    relaxation_time = RELAXATION_TIME
@@ -15,18 +19,65 @@ ComplexFluid {
    output_conformation_tensor = FALSE
    output_stress_tensor = FALSE
    output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
    InitialConditions {
-       function_0 = "sin(2*PI*X_0)+2"
-       function_1 = "cos(2*PI*X_1)+2"
-       function_2 = "sin(2*PI*X_2)+2"
-       function_3 = "0.0"
-       function_4 = "0.0"
-       function_5 = "0.0"
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+   }
+
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+   }
+
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
    }
    FCN {
        function_0 = "2*PI*cos(2*PI*X_0)"
        function_1 = "-2*PI*sin(2*PI*X_1)"
-       function_2 = "2*PI*cos(2*PI*X_2)"
    }
 }
 
@@ -50,24 +101,24 @@ Main {
 }
 
 CartesianGeometry {
-   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
-   x_lo = 0.0, 0.0, 0.0
-   x_up = 1.0, 1.0, 1.0
-   periodic_dimension = 1,1,1
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 0,0
 }
 
 GriddingAlgorithm {
    max_levels = MAX_LEVELS
    ratio_to_coarser {
-      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
-      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
-      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
    }
    largest_patch_size {
-      level_0 = 512,512,512  // all finer levels will use same values as level_0
+      level_0 = 512,512  // all finer levels will use same values as level_0
    }
    smallest_patch_size {
-      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+      level_0 =   4,  4  // all finer levels will use same values as level_0
    }
    efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
    combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
@@ -76,6 +127,7 @@ GriddingAlgorithm {
 StandardTagAndInitialize {
    tagging_method = "REFINE_BOXES"
    RefineBoxes {
+      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )]
    }
 }
 

--- a/tests/complex_fluids/cf_forcing_op_01_2d.side.standard.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.side.standard.output
@@ -1,6 +1,6 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 Conformation tensor is SPD
 Error norms:
-  L1-norm:  0.012803562
-  L2-norm:  0.010088326
-  max-norm: 0.010088326
+  L1-norm:  0.022434108
+  L2-norm:  0.055404802
+  max-norm: 0.30817749

--- a/tests/complex_fluids/cf_forcing_op_01_3d.cell.logarithm.input
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.cell.logarithm.input
@@ -1,0 +1,237 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// Complex Fluid parameters
+RELAX_OP = "OLDROYDB"
+VAR_CENTERING = "CELL"
+RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "LOGARITHM"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QZZ = "sin(2*PI*X_2)+2"
+QYZ = "0.0"
+QXZ = "0.0"
+QXY = "0.0"
+
+ComplexFluid {
+   relaxation_time = RELAXATION_TIME
+   viscosity = 1.0
+   output_conformation_tensor = FALSE
+   output_stress_tensor = FALSE
+   output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
+   InitialConditions {
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QZZ
+       function_3 = QYZ
+       function_4 = QXZ
+       function_5 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+      gcoef_function_4 = QXX
+      gcoef_function_5 = QXX
+   }
+
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+      gcoef_function_4 = QYY
+      gcoef_function_5 = QYY
+   }
+
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QZZ
+      gcoef_function_1 = QZZ
+      gcoef_function_2 = QZZ
+      gcoef_function_3 = QZZ
+      gcoef_function_4 = QZZ
+      gcoef_function_5 = QZZ
+   }
+   ExtraStressBoundaryConditions_3 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYZ
+      gcoef_function_1 = QYZ
+      gcoef_function_2 = QYZ
+      gcoef_function_3 = QYZ
+      gcoef_function_4 = QYZ
+      gcoef_function_5 = QYZ
+   }
+   ExtraStressBoundaryConditions_4 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXZ
+      gcoef_function_1 = QXZ
+      gcoef_function_2 = QXZ
+      gcoef_function_3 = QXZ
+      gcoef_function_4 = QXZ
+      gcoef_function_5 = QXZ
+   }
+   ExtraStressBoundaryConditions_5 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
+      gcoef_function_4 = QXY
+      gcoef_function_5 = QXY
+   }
+   FCN {
+       function_0 = "2*PI*cos(2*PI*X_0)*exp(2+sin(2*PI*X_0))"
+       function_1 = "-2*PI*sin(2*PI*X_1)*exp(2+cos(2*PI*X_1))"
+       function_2 = "2*PI*cos(2*PI*X_2)*exp(2+sin(2*PI*X_2))"
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "visit"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 0,0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+AdvDiffHierarchyIntegrator {
+}
+

--- a/tests/complex_fluids/cf_forcing_op_01_3d.cell.logarithm.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.cell.logarithm.output
@@ -1,6 +1,6 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 Conformation tensor is SPD
 Error norms:
-  L1-norm:  0.019205343
-  L2-norm:  0.012355626
-  max-norm: 0.010088468
+  L1-norm:  1.3924034
+  L2-norm:  1.2122335
+  max-norm: 2.7850786

--- a/tests/complex_fluids/cf_forcing_op_01_3d.cell.square_root.input
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.cell.square_root.input
@@ -1,0 +1,237 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// Complex Fluid parameters
+RELAX_OP = "OLDROYDB"
+VAR_CENTERING = "CELL"
+RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "SQUARE_ROOT"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QZZ = "sin(2*PI*X_2)+2"
+QYZ = "0.0"
+QXZ = "0.0"
+QXY = "0.0"
+
+ComplexFluid {
+   relaxation_time = RELAXATION_TIME
+   viscosity = 1.0
+   output_conformation_tensor = FALSE
+   output_stress_tensor = FALSE
+   output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
+   InitialConditions {
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QZZ
+       function_3 = QYZ
+       function_4 = QXZ
+       function_5 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+      gcoef_function_4 = QXX
+      gcoef_function_5 = QXX
+   }
+
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+      gcoef_function_4 = QYY
+      gcoef_function_5 = QYY
+   }
+
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QZZ
+      gcoef_function_1 = QZZ
+      gcoef_function_2 = QZZ
+      gcoef_function_3 = QZZ
+      gcoef_function_4 = QZZ
+      gcoef_function_5 = QZZ
+   }
+   ExtraStressBoundaryConditions_3 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYZ
+      gcoef_function_1 = QYZ
+      gcoef_function_2 = QYZ
+      gcoef_function_3 = QYZ
+      gcoef_function_4 = QYZ
+      gcoef_function_5 = QYZ
+   }
+   ExtraStressBoundaryConditions_4 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXZ
+      gcoef_function_1 = QXZ
+      gcoef_function_2 = QXZ
+      gcoef_function_3 = QXZ
+      gcoef_function_4 = QXZ
+      gcoef_function_5 = QXZ
+   }
+   ExtraStressBoundaryConditions_5 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
+      gcoef_function_4 = QXY
+      gcoef_function_5 = QXY
+   }
+   FCN {
+       function_0 = "4*PI*cos(2*PI*X_0)*(2+sin(2*PI*X_0))"
+       function_1 = "-4*PI*sin(2*PI*X_1)*(2+cos(2*PI*X_1))"
+       function_2 = "4*PI*cos(2*PI*X_2)*(2+sin(2*PI*X_2))"
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 1
+   viz_dump_dirname            = "visit"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 0,0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+AdvDiffHierarchyIntegrator {
+}
+

--- a/tests/complex_fluids/cf_forcing_op_01_3d.cell.square_root.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.cell.square_root.output
@@ -1,0 +1,6 @@
+AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+Conformation tensor is SPD
+Error norms:
+  L1-norm:  0.43615221
+  L2-norm:  0.35422102
+  max-norm: 0.87747078

--- a/tests/complex_fluids/cf_forcing_op_01_3d.cell.standard.input
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.cell.standard.input
@@ -1,0 +1,238 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// Complex Fluid parameters
+RELAX_OP = "OLDROYDB"
+VAR_CENTERING = "CELL"
+RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "STANDARD"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QZZ = "sin(2*PI*X_2)+2"
+QYZ = "0.0"
+QXZ = "0.0"
+QXY = "0.0"
+
+
+ComplexFluid {
+   relaxation_time = RELAXATION_TIME
+   viscosity = 1.0
+   output_conformation_tensor = FALSE
+   output_stress_tensor = FALSE
+   output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
+   InitialConditions {
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QZZ
+       function_3 = QYZ
+       function_4 = QXZ
+       function_5 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+      gcoef_function_4 = QXX
+      gcoef_function_5 = QXX
+   }
+
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+      gcoef_function_4 = QYY
+      gcoef_function_5 = QYY
+   }
+
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QZZ
+      gcoef_function_1 = QZZ
+      gcoef_function_2 = QZZ
+      gcoef_function_3 = QZZ
+      gcoef_function_4 = QZZ
+      gcoef_function_5 = QZZ
+   }
+   ExtraStressBoundaryConditions_3 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYZ
+      gcoef_function_1 = QYZ
+      gcoef_function_2 = QYZ
+      gcoef_function_3 = QYZ
+      gcoef_function_4 = QYZ
+      gcoef_function_5 = QYZ
+   }
+   ExtraStressBoundaryConditions_4 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXZ
+      gcoef_function_1 = QXZ
+      gcoef_function_2 = QXZ
+      gcoef_function_3 = QXZ
+      gcoef_function_4 = QXZ
+      gcoef_function_5 = QXZ
+   }
+   ExtraStressBoundaryConditions_5 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
+      gcoef_function_4 = QXY
+      gcoef_function_5 = QXY
+   }
+   FCN {
+       function_0 = "2*PI*cos(2*PI*X_0)"
+       function_1 = "-2*PI*sin(2*PI*X_1)"
+       function_2 = "2*PI*cos(2*PI*X_2)"
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "visit"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 0,0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+AdvDiffHierarchyIntegrator {
+}
+

--- a/tests/complex_fluids/cf_forcing_op_01_3d.cell.standard.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.cell.standard.output
@@ -1,0 +1,6 @@
+AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+Conformation tensor is SPD
+Error norms:
+  L1-norm:  0.086218396
+  L2-norm:  0.061995291
+  max-norm: 0.15013923

--- a/tests/complex_fluids/cf_forcing_op_01_3d.side.logarithm.input
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.side.logarithm.input
@@ -1,0 +1,238 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// Complex Fluid parameters
+RELAX_OP = "OLDROYDB"
+VAR_CENTERING = "SIDE"
+RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "LOGARITHM"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QZZ = "sin(2*PI*X_2)+2"
+QYZ = "0.0"
+QXZ = "0.0"
+QXY = "0.0"
+
+
+ComplexFluid {
+   relaxation_time = RELAXATION_TIME
+   viscosity = 1.0
+   output_conformation_tensor = FALSE
+   output_stress_tensor = FALSE
+   output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
+   InitialConditions {
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QZZ
+       function_3 = QYZ
+       function_4 = QXZ
+       function_5 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+      gcoef_function_4 = QXX
+      gcoef_function_5 = QXX
+   }
+
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+      gcoef_function_4 = QYY
+      gcoef_function_5 = QYY
+   }
+
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QZZ
+      gcoef_function_1 = QZZ
+      gcoef_function_2 = QZZ
+      gcoef_function_3 = QZZ
+      gcoef_function_4 = QZZ
+      gcoef_function_5 = QZZ
+   }
+   ExtraStressBoundaryConditions_3 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYZ
+      gcoef_function_1 = QYZ
+      gcoef_function_2 = QYZ
+      gcoef_function_3 = QYZ
+      gcoef_function_4 = QYZ
+      gcoef_function_5 = QYZ
+   }
+   ExtraStressBoundaryConditions_4 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXZ
+      gcoef_function_1 = QXZ
+      gcoef_function_2 = QXZ
+      gcoef_function_3 = QXZ
+      gcoef_function_4 = QXZ
+      gcoef_function_5 = QXZ
+   }
+   ExtraStressBoundaryConditions_5 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
+      gcoef_function_4 = QXY
+      gcoef_function_5 = QXY
+   }
+   FCN {
+       function_0 = "2*PI*cos(2*PI*X_0)*exp(2+sin(2*PI*X_0))"
+       function_1 = "-2*PI*sin(2*PI*X_1)*exp(2+cos(2*PI*X_1))"
+       function_2 = "2*PI*cos(2*PI*X_2)*exp(2+sin(2*PI*X_2))"
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "visit"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 0,0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+AdvDiffHierarchyIntegrator {
+}
+

--- a/tests/complex_fluids/cf_forcing_op_01_3d.side.logarithm.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.side.logarithm.output
@@ -1,0 +1,6 @@
+AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+Conformation tensor is SPD
+Error norms:
+  L1-norm:  0.49867983
+  L2-norm:  1.1225451
+  max-norm: 6.1899343

--- a/tests/complex_fluids/cf_forcing_op_01_3d.side.square_root.input
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.side.square_root.input
@@ -1,0 +1,237 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// Complex Fluid parameters
+RELAX_OP = "OLDROYDB"
+VAR_CENTERING = "SIDE"
+RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "SQUARE_ROOT"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QZZ = "sin(2*PI*X_2)+2"
+QYZ = "0.0"
+QXZ = "0.0"
+QXY = "0.0"
+
+ComplexFluid {
+   relaxation_time = RELAXATION_TIME
+   viscosity = 1.0
+   output_conformation_tensor = FALSE
+   output_stress_tensor = FALSE
+   output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
+   InitialConditions {
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QZZ
+       function_3 = QYZ
+       function_4 = QXZ
+       function_5 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+      gcoef_function_4 = QXX
+      gcoef_function_5 = QXX
+   }
+
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+      gcoef_function_4 = QYY
+      gcoef_function_5 = QYY
+   }
+
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QZZ
+      gcoef_function_1 = QZZ
+      gcoef_function_2 = QZZ
+      gcoef_function_3 = QZZ
+      gcoef_function_4 = QZZ
+      gcoef_function_5 = QZZ
+   }
+   ExtraStressBoundaryConditions_3 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYZ
+      gcoef_function_1 = QYZ
+      gcoef_function_2 = QYZ
+      gcoef_function_3 = QYZ
+      gcoef_function_4 = QYZ
+      gcoef_function_5 = QYZ
+   }
+   ExtraStressBoundaryConditions_4 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXZ
+      gcoef_function_1 = QXZ
+      gcoef_function_2 = QXZ
+      gcoef_function_3 = QXZ
+      gcoef_function_4 = QXZ
+      gcoef_function_5 = QXZ
+   }
+   ExtraStressBoundaryConditions_5 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
+      gcoef_function_4 = QXY
+      gcoef_function_5 = QXY
+   }
+   FCN {
+       function_0 = "4.0*PI*cos(2.0*PI*X_0)*(2.0+sin(2.0*PI*X_0))"
+       function_1 = "-4.0*PI*sin(2.0*PI*X_1)*(2.0+cos(2.0*PI*X_1))"
+       function_2 = "4.0*PI*cos(2.0*PI*X_2)*(2.0+sin(2.0*PI*X_2))"
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "visit"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 0,0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+AdvDiffHierarchyIntegrator {
+}
+

--- a/tests/complex_fluids/cf_forcing_op_01_3d.side.square_root.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.side.square_root.output
@@ -1,0 +1,6 @@
+AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+Conformation tensor is SPD
+Error norms:
+  L1-norm:  0.15367068
+  L2-norm:  0.33425013
+  max-norm: 1.849065

--- a/tests/complex_fluids/cf_forcing_op_01_3d.side.standard.input
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.side.standard.input
@@ -1,0 +1,238 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// Complex Fluid parameters
+RELAX_OP = "OLDROYDB"
+VAR_CENTERING = "SIDE"
+RELAXATION_TIME = 1.0
+EVOLVE_TYPE = "STANDARD"
+QXX = "sin(2*PI*X_0)+2"
+QYY = "cos(2*PI*X_1)+2"
+QZZ = "sin(2*PI*X_2)+2"
+QYZ = "0.0"
+QXZ = "0.0"
+QXY = "0.0"
+
+
+ComplexFluid {
+   relaxation_time = RELAXATION_TIME
+   viscosity = 1.0
+   output_conformation_tensor = FALSE
+   output_stress_tensor = FALSE
+   output_divergence = FALSE
+   evolution_type = EVOLVE_TYPE
+   InitialConditions {
+       function_0 = QXX
+       function_1 = QYY
+       function_2 = QZZ
+       function_3 = QYZ
+       function_4 = QXZ
+       function_5 = QXY
+   }
+   ExtraStressBoundaryConditions_0 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXX
+      gcoef_function_1 = QXX
+      gcoef_function_2 = QXX
+      gcoef_function_3 = QXX
+      gcoef_function_4 = QXX
+      gcoef_function_5 = QXX
+   }
+
+   ExtraStressBoundaryConditions_1 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYY
+      gcoef_function_1 = QYY
+      gcoef_function_2 = QYY
+      gcoef_function_3 = QYY
+      gcoef_function_4 = QYY
+      gcoef_function_5 = QYY
+   }
+
+   ExtraStressBoundaryConditions_2 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QZZ
+      gcoef_function_1 = QZZ
+      gcoef_function_2 = QZZ
+      gcoef_function_3 = QZZ
+      gcoef_function_4 = QZZ
+      gcoef_function_5 = QZZ
+   }
+   ExtraStressBoundaryConditions_3 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QYZ
+      gcoef_function_1 = QYZ
+      gcoef_function_2 = QYZ
+      gcoef_function_3 = QYZ
+      gcoef_function_4 = QYZ
+      gcoef_function_5 = QYZ
+   }
+   ExtraStressBoundaryConditions_4 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXZ
+      gcoef_function_1 = QXZ
+      gcoef_function_2 = QXZ
+      gcoef_function_3 = QXZ
+      gcoef_function_4 = QXZ
+      gcoef_function_5 = QXZ
+   }
+   ExtraStressBoundaryConditions_5 {
+      acoef_function_0 = "1.0"
+      acoef_function_1 = "1.0"
+      acoef_function_2 = "1.0"
+      acoef_function_3 = "1.0"
+      acoef_function_4 = "1.0"
+      acoef_function_5 = "1.0"
+
+      bcoef_function_0 = "0.0"
+      bcoef_function_1 = "0.0"
+      bcoef_function_2 = "0.0"
+      bcoef_function_3 = "0.0"
+      bcoef_function_4 = "0.0"
+      bcoef_function_5 = "0.0"
+
+      gcoef_function_0 = QXY
+      gcoef_function_1 = QXY
+      gcoef_function_2 = QXY
+      gcoef_function_3 = QXY
+      gcoef_function_4 = QXY
+      gcoef_function_5 = QXY
+   }
+   FCN {
+       function_0 = "2*PI*cos(2*PI*X_0)"
+       function_1 = "-2*PI*sin(2*PI*X_1)"
+       function_2 = "2*PI*cos(2*PI*X_2)"
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "visit"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 0,0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+AdvDiffHierarchyIntegrator {
+}
+

--- a/tests/complex_fluids/cf_forcing_op_01_3d.side.standard.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.side.standard.output
@@ -1,0 +1,6 @@
+AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+Conformation tensor is SPD
+Error norms:
+  L1-norm:  0.028835889
+  L2-norm:  0.055862145
+  max-norm: 0.30817762

--- a/tests/complex_fluids/cf_four_roll_mill.logarithm.input
+++ b/tests/complex_fluids/cf_four_roll_mill.logarithm.input
@@ -14,10 +14,8 @@ Start_L = 0.0
 
 // Complex Fluid parameters
 FLUID_MODEL = "OLDROYDB"
-CONFORMATION_TENSOR = TRUE
-SQUARE_ROOT_EVOLVE  = FALSE
+EVOLVE_TYPE = "LOGARITHM"
 LOG_DETERMINANT     = TRUE
-LOG_CONFORM_EVOLVE  = TRUE
 CONVECTIVE_OPERATOR_TYPE     = "WAVE_PROP"
 OUTPUT_CONFORMATION_TENSOR = TRUE
 OUTPUT_STRESS_TENSOR = FALSE
@@ -85,11 +83,9 @@ InitialConditions{
 relaxation_time = RELAXATION_TIME
 viscosity = VISCOSITY
 fluid_model         = FLUID_MODEL
-conformation_tensor = CONFORMATION_TENSOR
-square_root_evolve  = SQUARE_ROOT_EVOLVE
 log_determinant     = LOG_DETERMINANT
-log_conform_evolve  = LOG_CONFORM_EVOLVE
 convective_operator_type     = CONVECTIVE_OPERATOR_TYPE
+evolution_type = EVOLVE_TYPE
 output_stress_tensor = OUTPUT_STRESS_TENSOR
 output_conformation_tensor = OUTPUT_CONFORMATION_TENSOR
 }

--- a/tests/complex_fluids/cf_four_roll_mill.logarithm.output
+++ b/tests/complex_fluids/cf_four_roll_mill.logarithm.output
@@ -1,318 +1,318 @@
 INSStaggeredHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
-Conformation tensor is NOT SPD
-Largest det:  0
-Smallest det: 0
 Conformation tensor is SPD
-Largest det:  5.02941e-05
-Smallest det: 5.02891e-05
+Largest det:  1
+Smallest det: 1
 Conformation tensor is SPD
-Largest det:  0.000201177
-Smallest det: 0.000201156
+Largest det:  1.005
+Smallest det: 1.00001
 Conformation tensor is SPD
-Largest det:  0.000793334
-Smallest det: 0.000793333
+Largest det:  1.01003
+Smallest det: 1.00002
 Conformation tensor is SPD
-Largest det:  0.00176013
-Smallest det: 0.00175983
+Largest det:  1.03008
+Smallest det: 1.00007
 Conformation tensor is SPD
-Largest det:  0.00308583
-Smallest det: 0.00308458
+Largest det:  1.05019
+Smallest det: 1.00012
 Conformation tensor is SPD
-Largest det:  0.00475538
-Smallest det: 0.00475203
+Largest det:  1.07034
+Smallest det: 1.00016
 Conformation tensor is SPD
-Largest det:  0.00675437
-Smallest det: 0.00674712
+Largest det:  1.09052
+Smallest det: 1.00021
 Conformation tensor is SPD
-Largest det:  0.00906898
-Smallest det: 0.00905533
+Largest det:  1.11074
+Smallest det: 1.00025
 Conformation tensor is SPD
-Largest det:  0.011686
-Smallest det: 0.0116626
+Largest det:  1.13098
+Smallest det: 1.00029
 Conformation tensor is SPD
-Largest det:  0.0145928
-Smallest det: 0.0145553
+Largest det:  1.15126
+Smallest det: 1.00034
 Conformation tensor is SPD
-Largest det:  0.0177771
-Smallest det: 0.0177204
+Largest det:  1.17155
+Smallest det: 1.00038
 Conformation tensor is SPD
-Largest det:  0.0212275
-Smallest det: 0.0211451
+Largest det:  1.19187
+Smallest det: 1.00042
 Conformation tensor is SPD
-Largest det:  0.0249329
-Smallest det: 0.0248171
+Largest det:  1.21221
+Smallest det: 1.00046
 Conformation tensor is SPD
-Largest det:  0.0288825
-Smallest det: 0.0287248
+Largest det:  1.23256
+Smallest det: 1.0005
 Conformation tensor is SPD
-Largest det:  0.0330662
-Smallest det: 0.0328565
+Largest det:  1.25293
+Smallest det: 1.00053
 Conformation tensor is SPD
-Largest det:  0.0374743
-Smallest det: 0.0372013
+Largest det:  1.27331
+Smallest det: 1.00057
 Conformation tensor is SPD
-Largest det:  0.0420974
-Smallest det: 0.0417484
+Largest det:  1.29369
+Smallest det: 1.00061
 Conformation tensor is SPD
-Largest det:  0.0469267
-Smallest det: 0.0464876
+Largest det:  1.31409
+Smallest det: 1.00064
 Conformation tensor is SPD
-Largest det:  0.0519536
-Smallest det: 0.051409
+Largest det:  1.33449
+Smallest det: 1.00068
 Conformation tensor is SPD
-Largest det:  0.0571699
-Smallest det: 0.0565028
+Largest det:  1.35489
+Smallest det: 1.00071
 Conformation tensor is SPD
-Largest det:  0.0625679
-Smallest det: 0.0617599
+Largest det:  1.37529
+Smallest det: 1.00074
 Conformation tensor is SPD
-Largest det:  0.06814
-Smallest det: 0.0671712
+Largest det:  1.39568
+Smallest det: 1.00077
 Conformation tensor is SPD
-Largest det:  0.073879
-Smallest det: 0.0727283
+Largest det:  1.41607
+Smallest det: 1.0008
 Conformation tensor is SPD
-Largest det:  0.0797783
-Smallest det: 0.0784226
+Largest det:  1.43645
+Smallest det: 1.00083
 Conformation tensor is SPD
-Largest det:  0.0858311
-Smallest det: 0.0842463
+Largest det:  1.45683
+Smallest det: 1.00086
 Conformation tensor is SPD
-Largest det:  0.0920313
-Smallest det: 0.0901914
+Largest det:  1.47719
+Smallest det: 1.00089
 Conformation tensor is SPD
-Largest det:  0.0983728
-Smallest det: 0.0962507
+Largest det:  1.49753
+Smallest det: 1.00092
 Conformation tensor is SPD
-Largest det:  0.10485
-Smallest det: 0.102417
+Largest det:  1.51786
+Smallest det: 1.00095
 Conformation tensor is SPD
-Largest det:  0.111457
-Smallest det: 0.108683
+Largest det:  1.53817
+Smallest det: 1.00098
 Conformation tensor is SPD
-Largest det:  0.118189
-Smallest det: 0.115042
+Largest det:  1.55846
+Smallest det: 1.001
 Conformation tensor is SPD
-Largest det:  0.125041
-Smallest det: 0.121488
+Largest det:  1.57872
+Smallest det: 1.00103
 Conformation tensor is SPD
-Largest det:  0.132008
-Smallest det: 0.128015
+Largest det:  1.59896
+Smallest det: 1.00105
 Conformation tensor is SPD
-Largest det:  0.139085
-Smallest det: 0.134616
+Largest det:  1.61917
+Smallest det: 1.00108
 Conformation tensor is SPD
-Largest det:  0.146268
-Smallest det: 0.141286
+Largest det:  1.63935
+Smallest det: 1.0011
 Conformation tensor is SPD
-Largest det:  0.153552
-Smallest det: 0.148019
+Largest det:  1.6595
+Smallest det: 1.00112
 Conformation tensor is SPD
-Largest det:  0.160935
-Smallest det: 0.15481
+Largest det:  1.67962
+Smallest det: 1.00115
 Conformation tensor is SPD
-Largest det:  0.168411
-Smallest det: 0.161654
+Largest det:  1.6997
+Smallest det: 1.00117
 Conformation tensor is SPD
-Largest det:  0.175977
-Smallest det: 0.168545
+Largest det:  1.71974
+Smallest det: 1.00119
 Conformation tensor is SPD
-Largest det:  0.183629
-Smallest det: 0.17548
+Largest det:  1.73975
+Smallest det: 1.00121
 Conformation tensor is SPD
-Largest det:  0.191365
-Smallest det: 0.182453
+Largest det:  1.75971
+Smallest det: 1.00123
 Conformation tensor is SPD
-Largest det:  0.19918
-Smallest det: 0.189461
+Largest det:  1.77963
+Smallest det: 1.00125
 Conformation tensor is SPD
-Largest det:  0.207072
-Smallest det: 0.196498
+Largest det:  1.79951
+Smallest det: 1.00127
 Conformation tensor is SPD
-Largest det:  0.215037
-Smallest det: 0.203561
+Largest det:  1.81934
+Smallest det: 1.00129
 Conformation tensor is SPD
-Largest det:  0.223073
-Smallest det: 0.210646
+Largest det:  1.83912
+Smallest det: 1.00131
 Conformation tensor is SPD
-Largest det:  0.231177
-Smallest det: 0.217749
+Largest det:  1.85885
+Smallest det: 1.00132
 Conformation tensor is SPD
-Largest det:  0.239346
-Smallest det: 0.224866
+Largest det:  1.87853
+Smallest det: 1.00134
 Conformation tensor is SPD
-Largest det:  0.247578
-Smallest det: 0.231995
+Largest det:  1.89816
+Smallest det: 1.00136
 Conformation tensor is SPD
-Largest det:  0.255869
-Smallest det: 0.239131
+Largest det:  1.91774
+Smallest det: 1.00138
 Conformation tensor is SPD
-Largest det:  0.264219
-Smallest det: 0.246272
+Largest det:  1.93725
+Smallest det: 1.00139
 Conformation tensor is SPD
-Largest det:  0.272623
-Smallest det: 0.253414
+Largest det:  1.95671
+Smallest det: 1.00141
 Conformation tensor is SPD
-Largest det:  0.281081
-Smallest det: 0.260556
+Largest det:  1.97612
+Smallest det: 1.00142
 Conformation tensor is SPD
-Largest det:  0.28959
-Smallest det: 0.267692
+Largest det:  1.99546
+Smallest det: 1.00144
 Conformation tensor is SPD
-Largest det:  0.298148
-Smallest det: 0.274823
+Largest det:  2.01474
+Smallest det: 1.00145
 Conformation tensor is SPD
-Largest det:  0.306753
-Smallest det: 0.281943
+Largest det:  2.03396
+Smallest det: 1.00147
 Conformation tensor is SPD
-Largest det:  0.315403
-Smallest det: 0.289052
+Largest det:  2.05311
+Smallest det: 1.00148
 Conformation tensor is SPD
-Largest det:  0.324097
-Smallest det: 0.296147
+Largest det:  2.0722
+Smallest det: 1.00149
 Conformation tensor is SPD
-Largest det:  0.332832
-Smallest det: 0.303225
+Largest det:  2.09122
+Smallest det: 1.00151
 Conformation tensor is SPD
-Largest det:  0.341606
-Smallest det: 0.310285
+Largest det:  2.11018
+Smallest det: 1.00152
 Conformation tensor is SPD
-Largest det:  0.350419
-Smallest det: 0.317324
+Largest det:  2.12907
+Smallest det: 1.00153
 Conformation tensor is SPD
-Largest det:  0.359268
-Smallest det: 0.32434
+Largest det:  2.14788
+Smallest det: 1.00155
 Conformation tensor is SPD
-Largest det:  0.368152
-Smallest det: 0.331332
+Largest det:  2.16663
+Smallest det: 1.00156
 Conformation tensor is SPD
-Largest det:  0.37707
-Smallest det: 0.338298
+Largest det:  2.1853
+Smallest det: 1.00157
 Conformation tensor is SPD
-Largest det:  0.386019
-Smallest det: 0.345236
+Largest det:  2.20391
+Smallest det: 1.00158
 Conformation tensor is SPD
-Largest det:  0.394999
-Smallest det: 0.352145
+Largest det:  2.22243
+Smallest det: 1.00159
 Conformation tensor is SPD
-Largest det:  0.404008
-Smallest det: 0.359022
+Largest det:  2.24089
+Smallest det: 1.00161
 Conformation tensor is SPD
-Largest det:  0.413045
-Smallest det: 0.365867
+Largest det:  2.25927
+Smallest det: 1.00162
 Conformation tensor is SPD
-Largest det:  0.422109
-Smallest det: 0.372679
+Largest det:  2.27757
+Smallest det: 1.00163
 Conformation tensor is SPD
-Largest det:  0.431198
-Smallest det: 0.379455
+Largest det:  2.2958
+Smallest det: 1.00164
 Conformation tensor is SPD
-Largest det:  0.44031
-Smallest det: 0.386195
+Largest det:  2.31395
+Smallest det: 1.00165
 Conformation tensor is SPD
-Largest det:  0.449446
-Smallest det: 0.392897
+Largest det:  2.33202
+Smallest det: 1.00166
 Conformation tensor is SPD
-Largest det:  0.458603
-Smallest det: 0.399561
+Largest det:  2.35001
+Smallest det: 1.00167
 Conformation tensor is SPD
-Largest det:  0.46778
-Smallest det: 0.406185
+Largest det:  2.36792
+Smallest det: 1.00168
 Conformation tensor is SPD
-Largest det:  0.476977
-Smallest det: 0.412768
+Largest det:  2.38575
+Smallest det: 1.00169
 Conformation tensor is SPD
-Largest det:  0.486193
-Smallest det: 0.41931
+Largest det:  2.4035
+Smallest det: 1.0017
 Conformation tensor is SPD
-Largest det:  0.495425
-Smallest det: 0.425809
+Largest det:  2.42117
+Smallest det: 1.00171
 Conformation tensor is SPD
-Largest det:  0.504674
-Smallest det: 0.432265
+Largest det:  2.43875
+Smallest det: 1.00172
 Conformation tensor is SPD
-Largest det:  0.513937
-Smallest det: 0.438677
+Largest det:  2.45626
+Smallest det: 1.00173
 Conformation tensor is SPD
-Largest det:  0.523215
-Smallest det: 0.445044
+Largest det:  2.47368
+Smallest det: 1.00174
 Conformation tensor is SPD
-Largest det:  0.532506
-Smallest det: 0.451366
+Largest det:  2.49102
+Smallest det: 1.00175
 Conformation tensor is SPD
-Largest det:  0.54181
-Smallest det: 0.457642
+Largest det:  2.50827
+Smallest det: 1.00176
 Conformation tensor is SPD
-Largest det:  0.551124
-Smallest det: 0.463871
+Largest det:  2.52544
+Smallest det: 1.00177
 Conformation tensor is SPD
-Largest det:  0.560449
-Smallest det: 0.470054
+Largest det:  2.54252
+Smallest det: 1.00177
 Conformation tensor is SPD
-Largest det:  0.569784
-Smallest det: 0.476188
+Largest det:  2.55952
+Smallest det: 1.00178
 Conformation tensor is SPD
-Largest det:  0.579127
-Smallest det: 0.482274
+Largest det:  2.57644
+Smallest det: 1.00179
 Conformation tensor is SPD
-Largest det:  0.588478
-Smallest det: 0.488312
+Largest det:  2.59327
+Smallest det: 1.0018
 Conformation tensor is SPD
-Largest det:  0.597836
-Smallest det: 0.494301
+Largest det:  2.61001
+Smallest det: 1.00181
 Conformation tensor is SPD
-Largest det:  0.607199
-Smallest det: 0.500241
+Largest det:  2.62667
+Smallest det: 1.00182
 Conformation tensor is SPD
-Largest det:  0.616568
-Smallest det: 0.506132
+Largest det:  2.64324
+Smallest det: 1.00182
 Conformation tensor is SPD
-Largest det:  0.625942
-Smallest det: 0.511972
+Largest det:  2.65973
+Smallest det: 1.00183
 Conformation tensor is SPD
-Largest det:  0.635319
-Smallest det: 0.517763
+Largest det:  2.67612
+Smallest det: 1.00184
 Conformation tensor is SPD
-Largest det:  0.644698
-Smallest det: 0.523503
+Largest det:  2.69243
+Smallest det: 1.00185
 Conformation tensor is SPD
-Largest det:  0.65408
-Smallest det: 0.529193
+Largest det:  2.70866
+Smallest det: 1.00186
 Conformation tensor is SPD
-Largest det:  0.663463
-Smallest det: 0.534832
+Largest det:  2.7248
+Smallest det: 1.00186
 Conformation tensor is SPD
-Largest det:  0.672847
-Smallest det: 0.54042
+Largest det:  2.74085
+Smallest det: 1.00187
 Conformation tensor is SPD
-Largest det:  0.68223
-Smallest det: 0.545958
+Largest det:  2.75681
+Smallest det: 1.00188
 Conformation tensor is SPD
-Largest det:  0.691613
-Smallest det: 0.551444
+Largest det:  2.77269
+Smallest det: 1.00189
 Conformation tensor is SPD
-Largest det:  0.700993
-Smallest det: 0.55688
+Largest det:  2.78848
+Smallest det: 1.00189
 Conformation tensor is SPD
-Largest det:  0.710372
-Smallest det: 0.562265
+Largest det:  2.80418
+Smallest det: 1.0019
 Conformation tensor is SPD
-Largest det:  0.719747
-Smallest det: 0.567599
+Largest det:  2.81979
+Smallest det: 1.00191
 Conformation tensor is SPD
-Largest det:  0.729119
-Smallest det: 0.572881
+Largest det:  2.83532
+Smallest det: 1.00192
+Conformation tensor is SPD
+Largest det:  2.85076
+Smallest det: 1.00192
 Soln norms in sxx at time 1:
-  L1-norm:  32.75739925
-  L2-norm:  5.527761345
-  max-norm: 1.698773474
+  L1-norm:  7.826606441
+  L2-norm:  2.193154019
+  max-norm: 1.052956707
 Soln norms in syy at time 1:
-  L1-norm:  32.75739925
-  L2-norm:  5.527761345
-  max-norm: 1.698773474
+  L1-norm:  7.826606441
+  L2-norm:  2.193154019
+  max-norm: 1.052956707
 Soln norms in sxy at time 1:
-  L1-norm:  1.029026247
-  L2-norm:  0.2017946666
-  max-norm: 0.06399773938
+  L1-norm:  0.7985592197
+  L2-norm:  0.1588130878
+  max-norm: 0.05059146564

--- a/tests/complex_fluids/cf_four_roll_mill.square_root.input
+++ b/tests/complex_fluids/cf_four_roll_mill.square_root.input
@@ -14,10 +14,8 @@ Start_L = 0.0
 
 // Complex Fluid parameters
 FLUID_MODEL = "OLDROYDB"
-CONFORMATION_TENSOR = TRUE
-SQUARE_ROOT_EVOLVE  = TRUE
+EVOLVE_TYPE = "SQUARE_ROOT"
 LOG_DETERMINANT     = TRUE
-LOG_CONFORM_EVOLVE  = FALSE
 CONVECTIVE_OPERATOR_TYPE     = "WAVE_PROP"
 OUTPUT_CONFORMATION_TENSOR = TRUE
 OUTPUT_STRESS_TENSOR = FALSE
@@ -85,11 +83,9 @@ InitialConditions{
 relaxation_time = RELAXATION_TIME
 viscosity = VISCOSITY
 fluid_model         = FLUID_MODEL
-conformation_tensor = CONFORMATION_TENSOR
-square_root_evolve  = SQUARE_ROOT_EVOLVE
 log_determinant     = LOG_DETERMINANT
-log_conform_evolve  = LOG_CONFORM_EVOLVE
 convective_operator_type     = CONVECTIVE_OPERATOR_TYPE
+evolution_type = EVOLVE_TYPE
 output_stress_tensor = OUTPUT_STRESS_TENSOR
 output_conformation_tensor = OUTPUT_CONFORMATION_TENSOR
 }

--- a/tests/complex_fluids/cf_four_roll_mill.square_root.output
+++ b/tests/complex_fluids/cf_four_roll_mill.square_root.output
@@ -6,313 +6,313 @@ Largest det:  1
 Smallest det: 1
 Conformation tensor is SPD
 Largest det:  1
-Smallest det: 0.999975
+Smallest det: 0.999988
 Conformation tensor is SPD
 Largest det:  1
-Smallest det: 0.9999
+Smallest det: 0.99995
 Conformation tensor is SPD
 Largest det:  1
-Smallest det: 0.999912
+Smallest det: 0.999959
 Conformation tensor is SPD
 Largest det:  1
-Smallest det: 0.999939
+Smallest det: 0.999985
 Conformation tensor is SPD
-Largest det:  1
-Smallest det: 0.999991
+Largest det:  1.00004
+Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00008
-Smallest det: 0.999999
+Largest det:  1.00012
+Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00021
-Smallest det: 0.999999
+Largest det:  1.00025
+Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00039
+Largest det:  1.00043
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00063
+Largest det:  1.00067
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00094
-Smallest det: 0.999999
+Largest det:  1.00097
+Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00131
-Smallest det: 0.999999
+Largest det:  1.00135
+Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00176
-Smallest det: 0.999999
+Largest det:  1.00179
+Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00229
-Smallest det: 0.999999
+Largest det:  1.00232
+Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00291
-Smallest det: 0.999999
+Largest det:  1.00294
+Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00361
+Largest det:  1.00364
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.0044
+Largest det:  1.00443
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00529
+Largest det:  1.00531
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00627
+Largest det:  1.0063
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00736
+Largest det:  1.00738
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00854
+Largest det:  1.00857
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.00983
+Largest det:  1.00985
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.01122
+Largest det:  1.01124
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.01272
+Largest det:  1.01274
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.01432
+Largest det:  1.01434
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.01603
+Largest det:  1.01605
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.01785
+Largest det:  1.01787
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.01977
+Largest det:  1.01979
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.02181
+Largest det:  1.02182
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.02394
+Largest det:  1.02396
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.02619
+Largest det:  1.02621
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.02854
+Largest det:  1.02856
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.031
+Largest det:  1.03102
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.03356
+Largest det:  1.03358
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.03623
+Largest det:  1.03625
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.039
+Largest det:  1.03902
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.04187
+Largest det:  1.04189
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.04484
+Largest det:  1.04486
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.04792
+Largest det:  1.04793
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.05109
+Largest det:  1.0511
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.05435
+Largest det:  1.05437
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.05772
+Largest det:  1.05773
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.06117
+Largest det:  1.06119
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.06472
+Largest det:  1.06474
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.06836
+Largest det:  1.06838
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.07209
+Largest det:  1.07211
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.07591
+Largest det:  1.07592
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.07981
+Largest det:  1.07982
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.0838
+Largest det:  1.08381
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.08786
+Largest det:  1.08788
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.09201
+Largest det:  1.09202
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.09624
+Largest det:  1.09625
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.10054
+Largest det:  1.10055
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.10492
+Largest det:  1.10493
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.10937
+Largest det:  1.10938
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.11389
+Largest det:  1.11391
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.11848
+Largest det:  1.1185
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.12314
+Largest det:  1.12316
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.12787
+Largest det:  1.12788
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.13266
+Largest det:  1.13267
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.13751
+Largest det:  1.13752
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.14242
+Largest det:  1.14243
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.14739
+Largest det:  1.1474
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.15241
+Largest det:  1.15242
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.15749
+Largest det:  1.15751
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.16263
+Largest det:  1.16264
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.16781
+Largest det:  1.16782
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.17304
+Largest det:  1.17306
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.17833
+Largest det:  1.17834
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.18365
+Largest det:  1.18367
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.18903
+Largest det:  1.18904
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.19444
+Largest det:  1.19445
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.1999
+Largest det:  1.19991
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.20539
+Largest det:  1.20541
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.21093
+Largest det:  1.21094
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.2165
+Largest det:  1.21651
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.2221
+Largest det:  1.22212
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.22774
+Largest det:  1.22775
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.23341
+Largest det:  1.23343
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.23911
+Largest det:  1.23913
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.24484
+Largest det:  1.24485
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.2506
+Largest det:  1.25061
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.25638
+Largest det:  1.25639
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.26219
+Largest det:  1.2622
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.26802
+Largest det:  1.26803
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.27387
+Largest det:  1.27389
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.27975
+Largest det:  1.27976
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.28564
+Largest det:  1.28565
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.29155
+Largest det:  1.29156
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.29748
+Largest det:  1.29749
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.30342
+Largest det:  1.30344
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.30938
+Largest det:  1.30939
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.31535
+Largest det:  1.31537
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.32134
+Largest det:  1.32135
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.32733
+Largest det:  1.32735
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.33334
+Largest det:  1.33335
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.33935
+Largest det:  1.33937
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.34537
+Largest det:  1.34539
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.3514
+Largest det:  1.35142
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.35744
+Largest det:  1.35745
 Smallest det: 1
 Conformation tensor is SPD
-Largest det:  1.36348
+Largest det:  1.36349
 Smallest det: 1
 Soln norms in sxx at time 1:
-  L1-norm:  44.60778085
-  L2-norm:  7.728263339
-  max-norm: 2.64690267
+  L1-norm:  41.08564205
+  L2-norm:  6.676467325
+  max-norm: 1.626939129
 Soln norms in syy at time 1:
-  L1-norm:  44.60778085
-  L2-norm:  7.728263339
-  max-norm: 2.64690267
+  L1-norm:  41.08564205
+  L2-norm:  6.676467325
+  max-norm: 1.626939129
 Soln norms in sxy at time 1:
-  L1-norm:  1.915578886
-  L2-norm:  0.3759901117
-  max-norm: 0.1200481671
+  L1-norm:  0.9203447252
+  L2-norm:  0.1805837413
+  max-norm: 0.05740399672

--- a/tests/complex_fluids/cf_four_roll_mill.standard.input
+++ b/tests/complex_fluids/cf_four_roll_mill.standard.input
@@ -14,10 +14,8 @@ Start_L = 0.0
 
 // Complex Fluid parameters
 FLUID_MODEL = "OLDROYDB"
-CONFORMATION_TENSOR = TRUE
-SQUARE_ROOT_EVOLVE  = FALSE
+EVOLVE_TYPE = "STANDARD"
 LOG_DETERMINANT     = TRUE
-LOG_CONFORM_EVOLVE  = FALSE
 CONVECTIVE_OPERATOR_TYPE     = "WAVE_PROP"
 OUTPUT_CONFORMATION_TENSOR = TRUE
 OUTPUT_STRESS_TENSOR = FALSE
@@ -85,11 +83,9 @@ InitialConditions{
 relaxation_time = RELAXATION_TIME
 viscosity = VISCOSITY
 fluid_model         = FLUID_MODEL
-conformation_tensor = CONFORMATION_TENSOR
-square_root_evolve  = SQUARE_ROOT_EVOLVE
 log_determinant     = LOG_DETERMINANT
-log_conform_evolve  = LOG_CONFORM_EVOLVE
 convective_operator_type     = CONVECTIVE_OPERATOR_TYPE
+evolution_type = EVOLVE_TYPE
 output_stress_tensor = OUTPUT_STRESS_TENSOR
 output_conformation_tensor = OUTPUT_CONFORMATION_TENSOR
 }


### PR DESCRIPTION
The boundary conditions were not consistently applied to the correct form of the conformation tensor. The boundary conditions for the tensor are now consistently applied to the quantity which is being solved for (e.g. square root or logarithm). In doing so, an extra scratch index has been eliminated since we do decompositions in place now.

We are also now applying the projection of the conformation to the index that is owned by the advection diffusion integrator. Previously, we only projected the scratch index used to compute the divergence of the stress.

@fuhuifang I'm not sure if you were using them, but this should make simulating higher Weissenberg numbers easier and more accurate.