### PR TITLE
Fix the discontinuous linear 3D spread kernel.

### DIFF
--- a/doc/news/changes/minor/20200215DavidWells
+++ b/doc/news/changes/minor/20200215DavidWells
@@ -1,0 +1,3 @@
+Fixed: The 3D discontinuous linear spread kernel now works correctly.
+<br>
+(David Wells, 2020/02/15)

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -268,7 +268,6 @@ c
      &           NINT((X_shifted(d)-x_lower(d))/dx(d)-0.5d0)
             X_cell(d) = x_lower(d) +
      &           (dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
-
             if ( d.eq.axis ) then
                if ( X_shifted(d).lt.X_cell(d) ) then
                   ic_lower(d) = ic_center(d)-1
@@ -393,7 +392,6 @@ c
      &           NINT((X_shifted(d)-x_lower(d))/dx(d)-0.5d0)
             X_cell(d) = x_lower(d) +
      &           (dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
-
             if ( d.eq.axis ) then
                if ( X_shifted(d).lt.X_cell(d) ) then
                   ic_lower(d) = ic_center(d)-1

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction3d.f.m4
@@ -280,7 +280,6 @@ c
      &           NINT((X_shifted(d)-x_lower(d))/dx(d)-0.5d0)
             X_cell(d) = x_lower(d) +
      &           (dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
-
             if ( d.eq.axis ) then
                if ( X_shifted(d).lt.X_cell(d) ) then
                   ic_lower(d) = ic_center(d)-1
@@ -406,12 +405,11 @@ c
 c     Determine the interpolation stencils and weights.
 c
          do d = 0,NDIM-1
+            ic_center(d) = ilower(d) +
+     &           NINT((X_shifted(d)-x_lower(d))/dx(d)-0.5d0)
+            X_cell(d) = x_lower(d) +
+     &           (dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
             if ( d.eq.axis ) then
-               ic_center(d) = ilower(d) +
-     &              NINT((X_shifted(d)-x_lower(d))/dx(d)-0.5d0)
-               X_cell(d) = x_lower(d) +
-     &              (dble(ic_center(d)-ilower(d))+0.5d0)*dx(d)
-
                if ( X_shifted(d).lt.X_cell(d) ) then
                   ic_lower(d) = ic_center(d)-1
                   ic_upper(d) = ic_center(d)


### PR DESCRIPTION
`ic_center` was read before initialized in the 3D version of this kernel. I fixed it and cleaned up the other kernel implementations to match.

The test output for this test is still unreliable but I have a more general fix for that in the pipeline.

Part of #784.