### PR TITLE
Add some missing header inclusions.

### DIFF
--- a/ibtk/include/ibtk/BoxPartitioner.h
+++ b/ibtk/include/ibtk/BoxPartitioner.h
@@ -21,6 +21,8 @@
 #include <libmesh/partitioner.h>
 #include <libmesh/system.h>
 
+#include <memory>
+
 /////////////////////////////// CLASS DEFINITION /////////////////////////////
 namespace IBTK
 {

--- a/ibtk/include/ibtk/FEDataInterpolation.h
+++ b/ibtk/include/ibtk/FEDataInterpolation.h
@@ -26,6 +26,10 @@ IBTK_DISABLE_EXTRA_WARNINGS
 #include "boost/multi_array.hpp"
 IBTK_ENABLE_EXTRA_WARNINGS
 
+#include <limits>
+#include <memory>
+#include <vector>
+
 /////////////////////////////// CLASS DEFINITION /////////////////////////////
 
 namespace IBTK

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -50,6 +50,7 @@ IBTK_DISABLE_EXTRA_WARNINGS
 IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <map>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -44,6 +44,7 @@
 #include <limits>
 #include <list>
 #include <map>
+#include <memory>
 #include <ostream>
 #include <set>
 #include <string>

--- a/ibtk/include/ibtk/LaplaceOperator.h
+++ b/ibtk/include/ibtk/LaplaceOperator.h
@@ -20,6 +20,7 @@
 
 #include "PoissonSpecifications.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/ibtk/include/ibtk/PoissonFACPreconditionerStrategy.h
+++ b/ibtk/include/ibtk/PoissonFACPreconditionerStrategy.h
@@ -34,6 +34,7 @@
 #include "VariableFillPattern.h"
 #include "tbox/Pointer.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/ibtk/include/ibtk/PoissonSolver.h
+++ b/ibtk/include/ibtk/PoissonSolver.h
@@ -20,6 +20,7 @@
 
 #include "PoissonSpecifications.h"
 
+#include <memory>
 #include <vector>
 
 namespace SAMRAI

--- a/include/ibamr/ConstraintIBMethod.h
+++ b/include/ibamr/ConstraintIBMethod.h
@@ -38,6 +38,7 @@ IBTK_DISABLE_EXTRA_WARNINGS
 IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <fstream>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -36,6 +36,7 @@
 #include "libmesh/explicit_system.h"
 
 #include <array>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>

--- a/include/ibamr/IBStrategy.h
+++ b/include/ibamr/IBStrategy.h
@@ -26,6 +26,7 @@
 #include "tbox/Pointer.h"
 #include "tbox/Serializable.h"
 
+#include <memory>
 #include <ostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
We cannot compile on some systems without explicitly including the memory header in IBStrategy.h - add it everywhere else we might need it while we are at it.