### PR TITLE
Initialize a variable.

### DIFF
--- a/tests/IBFE/ib_partitioning_01.cpp
+++ b/tests/IBFE/ib_partitioning_01.cpp
@@ -234,7 +234,7 @@ main(int argc, char** argv)
                     int ierr = MPI_Recv(bounds, 2, MPIU_INT, r, range_tag, SAMRAI_MPI::commWorld, MPI_STATUS_IGNORE);
                     TBOX_ASSERT(ierr == 0);
 
-                    PetscInt n;
+                    PetscInt n = std::numeric_limits<PetscInt>::max();
                     ierr = MPI_Recv(&n, 1, MPIU_INT, r, length_tag, SAMRAI_MPI::commWorld, MPI_STATUS_IGNORE);
                     TBOX_ASSERT(ierr == 0);
                     indices.resize(n);


### PR DESCRIPTION
GCC's address sanitizer complains about this - its quick so lets just fix it.