### PR TITLE
Fix a bug in FEDataManager::spread().

### DIFF
--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -1126,7 +1126,7 @@ FEDataManager::spread(const int f_data_idx,
 
     // Accumulate data.
     f_data_ops->swapData(f_copy_data_idx, f_data_idx);
-    f_data_ops->add(f_data_idx, f_data_idx, f_copy_data_idx);
+    f_data_ops->add(f_data_idx, f_data_idx, f_copy_data_idx, /*interior_only*/ false);
 
     return;
 } // spread

--- a/tests/spread/spread_01.cpp
+++ b/tests/spread/spread_01.cpp
@@ -348,8 +348,35 @@ main(int argc, char** argv)
 
         // Test the accumulation code when we have meshes that are against the
         // boundary (i.e., the cube and composite cube geometries)
+        const double data_time = time_integrator->getIntegratorTime() + dt / 2;
         RobinPhysBdryPatchStrategy* bdry_op = geometry == "sphere" ? nullptr : time_integrator->getVelocityPhysBdryOp();
-        ib_method_ops->spreadForce(f_ghost_idx, bdry_op, {}, time_integrator->getIntegratorTime() + dt / 2);
+        if (input_db->getBoolWithDefault("spread_with_ibfemethod", true))
+            ib_method_ops->spreadForce(f_ghost_idx, bdry_op, {}, data_time);
+        else
+        {
+            TBOX_ASSERT(meshes.size() == 1); // not implemented for multiple parts
+            auto& fe_data_manager = *ib_method_ops->getFEDataManager(0);
+            auto& equation_systems = *fe_data_manager.getEquationSystems();
+            auto& force_system = equation_systems.get_system(IBFEMethod::FORCE_SYSTEM_NAME);
+            auto& F_vec = dynamic_cast<libMesh::PetscVector<double>&>(*force_system.current_local_solution);
+            auto& position_system = equation_systems.get_system(IBFEMethod::COORDS_SYSTEM_NAME);
+            auto& X_vec = dynamic_cast<libMesh::PetscVector<double>&>(*position_system.current_local_solution);
+            fe_data_manager.spread(
+                f_ghost_idx, F_vec, X_vec, IBFEMethod::FORCE_SYSTEM_NAME, nullptr, data_time, false, false);
+
+            // here's the real test for the bug in this case: FEDataManager::spread()
+            // previously did not copy values spread into ghost regions, so the values
+            // computed by these two combined calls would be wrong.
+            bdry_op->setPatchDataIndex(f_ghost_idx);
+            const int ln = patch_hierarchy->getFinestLevelNumber();
+            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+            {
+                const Pointer<Patch<NDIM> > patch = level->getPatch(p());
+                Pointer<PatchData<NDIM> > f_data = patch->getPatchData(f_ghost_idx);
+                bdry_op->accumulateFromPhysicalBoundaryData(*patch, data_time, f_data->getGhostCellWidth());
+            }
+        }
         const double cutoff = input_db->getDoubleWithDefault("output_cutoff_value", 0.0);
         {
             const int ln = patch_hierarchy->getFinestLevelNumber();

--- a/tests/spread/spread_01_2d.square.b.bspline_3.input
+++ b/tests/spread/spread_01_2d.square.b.bspline_3.input
@@ -1,0 +1,71 @@
+// Check force accumulation from ghost cells - here the "cube" geometry gives
+// us a structure comprised of one cube the size of the fluid domain, so all
+// boundaries will have forces spread outside them.
+
+// This test checks that we can correctly accumulate forces spread outside the
+// domain by using FEDataManager directly - in particular, we call one of the
+// old spread() overloads that is no longer used by IBFEMethod.
+
+geometry = "cube"
+spread_with_ibfemethod = FALSE
+
+L   = 1.0
+MAX_LEVELS = 1
+REF_RATIO  = 4
+N = 8
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N
+DX  = L/NFINEST
+MFAC = 2.0
+ELEM_TYPE = "TRI6"
+
+IB_DELTA_FUNCTION = "BSPLINE_3"
+
+VelocityInitialConditions {
+function_0 = "X_0 + 2*X_1*X_1"
+function_1 = "2*X_0 + 3*X_0*X_0 - 2*X_1"
+}
+
+PressureInitialConditions {function = "42.0"}
+
+IBHierarchyIntegrator {}
+
+IBFEMethod {
+   IB_delta_fcn               = IB_DELTA_FUNCTION
+   enable_logging = FALSE
+}
+
+INSStaggeredHierarchyIntegrator {
+   mu             = 1
+   rho            = 1
+}
+
+Main {
+   solver_type   = "STAGGERED"
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {tagging_method = "GRADIENT_DETECTOR"}
+LoadBalancer {}

--- a/tests/spread/spread_01_2d.square.b.bspline_3.output
+++ b/tests/spread/spread_01_2d.square.b.bspline_3.output
@@ -1,0 +1,1 @@
+spread_01_2d.square.bspline_3.output


### PR DESCRIPTION
Found while working on #857 - it looks like this function hasn't ever worked correctly when one did not provide the boundary ops object since we spread values into ghost regions and then do not add those values back to the provided force index.