### PR TITLE
IBTK Initialization class

### DIFF
--- a/doc/news/changes/minor/20200306AaronBarrett
+++ b/doc/news/changes/minor/20200306AaronBarrett
@@ -1,0 +1,4 @@
+New: Added an initialization class to aid in the transition to SAMRAI 3.
+<br>
+(Aaron Barrett, 2020/03/06)
+

--- a/ibtk/include/ibtk/IBTKInit.h
+++ b/ibtk/include/ibtk/IBTKInit.h
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2014 - 2019 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#ifndef included_IBTKInit
+#define included_IBTKInit
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include <IBTK_config.h>
+
+#include "SAMRAI_config.h"
+#include "tbox/SAMRAIManager.h"
+#include "tbox/SAMRAI_MPI.h"
+
+#include <petscsys.h>
+#ifdef IBTK_HAVE_LIBMESH
+#include "libmesh/libmesh.h"
+#include "libmesh/reference_counter.h"
+#endif
+
+namespace IBTK
+{
+/**
+ * @brief Initialization for IBAMR programs.
+ *
+ * The singleton IBTKInit class handles the initializations for PETSc, LibMesh, and SAMRAI. This object should be
+ * created using the initialize() function at the start of the main() function. The destruction of the object correctly
+ * closes the libraries.
+ *
+ */
+
+class IBTKInit
+{
+public:
+    /**
+     * Constructor for IBTKInit. Initializes libraries and sets the SAMRAI world communicator. Attempts to create a
+     * second IBTKInit object will result in a run time error.
+     */
+    IBTKInit(int argc,
+             char** argv,
+             MPI_Comm communicator = MPI_COMM_WORLD,
+             char* petsc_file = nullptr,
+             char* petsc_help = nullptr);
+    /*!
+     * \brief Default constructor. This function is not implemented and should not be used.
+     */
+    IBTKInit() = delete;
+
+    /*!
+     * \brief Copy constructor. This function is not implemented and should not be used.
+     */
+    IBTKInit(const IBTKInit& from) = delete;
+
+    /*!
+     * \brief Assignment operator. This function is not implemented and should not be used.
+     */
+    IBTKInit& operator=(const IBTKInit& that) = delete;
+
+    /**
+     * Destructor. Closes libraries appropriately.
+     */
+    ~IBTKInit();
+
+#ifdef IBTK_HAVE_LIBMESH
+    /**
+     * Get libMesh initialization object.
+     */
+    libMesh::LibMeshInit& getLibMeshInit()
+    {
+        return d_libmesh_init;
+    }
+#endif
+
+    /*!
+     * \brief Check if the library has been initialized. Throw an error if it has not been initialized.
+     */
+    inline static bool check_initialized()
+    {
+        if (!s_initialized)
+        {
+            TBOX_ERROR(
+                "IBAMR is not initialized! IBAMR must be initialized by an appropriate call to IBTKInit::initialize() "
+                "prior to using any of the library.");
+        }
+        return s_initialized;
+    }
+
+private:
+
+#ifdef IBTK_HAVE_LIBMESH
+    libMesh::LibMeshInit d_libmesh_init;
+#endif
+    static bool s_initialized;
+};
+
+} // namespace IBTK
+
+#endif

--- a/ibtk/include/ibtk/IBTK_MPI.h
+++ b/ibtk/include/ibtk/IBTK_MPI.h
@@ -69,6 +69,12 @@ mpi_type_id(const char)
     return MPI_CHAR;
 }
 
+inline MPI_Datatype
+mpi_type_id(const unsigned int)
+{
+    return MPI_UNSIGNED;
+}
+
 template <typename T>
 inline MPI_Datatype
 mpi_type_id(const T&)
@@ -312,5 +318,9 @@ private:
 };
 
 } // namespace IBTK
+
+/////////////////////////////// INLINE ///////////////////////////////////////
+
+#include "ibtk/private/IBTK_MPI-inl.h" // IWYU pragma: keep
 
 #endif

--- a/ibtk/include/ibtk/private/IBTK_MPI-inl.h
+++ b/ibtk/include/ibtk/private/IBTK_MPI-inl.h
@@ -1,0 +1,178 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2019 - 2019 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#ifndef included_IBTK_MPI_inc
+#define included_IBTK_MPI_inc
+
+#include "ibtk/IBTK_MPI.h"
+
+namespace IBTK
+{
+template <typename T>
+inline T
+IBTK_MPI::minReduction(T x, int* rank_of_min, IBTK_MPI::comm communicator)
+{
+    minReduction(&x, 1, rank_of_min, communicator);
+    return x;
+} // minReduction
+
+template <typename T>
+inline void
+IBTK_MPI::minReduction(T* x, const int n, int* rank_of_min, IBTK_MPI::comm communicator)
+{
+    if (n == 0) return;
+    if (rank_of_min == nullptr)
+    {
+        MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_MIN, communicator);
+    }
+    else
+    {
+        minMaxReduction(x, n, rank_of_min, MPI_MINLOC, communicator);
+    }
+} // minReduction
+
+template <typename T>
+inline T
+IBTK_MPI::maxReduction(T x, int* rank_of_max, IBTK_MPI::comm communicator)
+{
+    maxReduction(&x, 1, rank_of_max, communicator);
+    return x;
+} // maxReduction
+
+template <typename T>
+inline void
+IBTK_MPI::maxReduction(T* x, const int n, int* rank_of_max, IBTK_MPI::comm communicator)
+{
+    if (n == 0) return;
+    if (rank_of_max == nullptr)
+    {
+        MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_MAX, communicator);
+    }
+    else
+    {
+        minMaxReduction(x, n, rank_of_max, MPI_MAXLOC, communicator);
+    }
+} // maxReduction
+
+template <typename T>
+inline T
+IBTK_MPI::sumReduction(T x, IBTK_MPI::comm communicator)
+{
+    sumReduction(&x, 1, communicator);
+    return x;
+} // sumReduction
+
+template <typename T>
+inline void
+IBTK_MPI::sumReduction(T* x, const int n, IBTK_MPI::comm communicator)
+{
+    if (n == 0 || getNodes(communicator) < 2) return;
+    MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_SUM, communicator);
+} // sumReduction
+
+template <typename T>
+inline T
+IBTK_MPI::bcast(const T x, const int root, IBTK_MPI::comm communicator)
+{
+    int size = 1;
+    T temp_copy = x;
+    bcast(&temp_copy, size, root, communicator);
+    return x;
+}
+
+template <typename T>
+inline void
+IBTK_MPI::bcast(T* x, int& length, const int root, IBTK_MPI::comm communicator)
+{
+    if (getNodes(communicator) > 1)
+    {
+        MPI_Bcast(x, length, mpi_type_id(x[0]), root, communicator);
+    }
+} // bcast
+
+template <typename T>
+inline void
+IBTK_MPI::send(const T* buf,
+               const int length,
+               const int receiving_proc_number,
+               const bool send_length,
+               int tag,
+               IBTK_MPI::comm communicator)
+{
+    tag = (tag >= 0) ? tag : 0;
+    int size = length;
+    if (send_length)
+    {
+        MPI_Send(&size, 1, MPI_INT, receiving_proc_number, tag, communicator);
+    }
+    MPI_Send(buf, length, mpi_type_id(buf[0]), receiving_proc_number, tag, communicator);
+} // send
+
+template <typename T>
+inline void
+IBTK_MPI::recv(T* buf,
+               int& length,
+               const int sending_proc_number,
+               const bool get_length,
+               int tag,
+               IBTK_MPI::comm communicator)
+{
+    MPI_Status status;
+    tag = (tag >= 0) ? tag : 0;
+    if (get_length)
+    {
+        MPI_Recv(&length, 1, MPI_INT, sending_proc_number, tag, communicator, &status);
+    }
+    MPI_Recv(buf, length, mpi_type_id(buf[0]), sending_proc_number, tag, communicator, &status);
+} // recv
+
+template <typename T>
+inline void
+IBTK_MPI::allGather(const T* x_in, int size_in, T* x_out, int size_out, IBTK_MPI::comm communicator)
+{
+    std::vector<int> rcounts, disps;
+    allGatherSetup(size_in, size_out, rcounts, disps, communicator);
+
+    MPI_Allgatherv(
+        x_in, size_in, mpi_type_id(x_in[0]), x_out, rcounts.data(), disps.data(), mpi_type_id(x_in[0]), communicator);
+} // allGather
+
+template <typename T>
+inline void
+IBTK_MPI::allGather(T x_in, T* x_out, IBTK_MPI::comm communicator)
+{
+    MPI_Allgather(&x_in, 1, mpi_type_id(x_in), x_out, 1, mpi_type_id(x_in), communicator);
+} // allGather
+
+//////////////////////////////////////  PRIVATE  ///////////////////////////////////////////////////
+template <typename T>
+inline void
+IBTK_MPI::minMaxReduction(T* x, const int n, int* rank, MPI_Op op, IBTK_MPI::comm communicator)
+{
+    std::vector<std::pair<T, int> > recv(n);
+    std::vector<std::pair<T, int> > send(n);
+    for (int i = 0; i < n; ++i)
+    {
+        send[i].first = x[i];
+        send[i].second = getRank(communicator);
+    }
+    MPI_Allreduce(send.data(), recv.data(), n, mpi_type_id(recv[0]), op, communicator);
+    for (int i = 0; i < n; ++i)
+    {
+        x[i] = recv[i].first;
+        rank[i] = send[i].second;
+    }
+} // minMaxReduction
+} // namespace IBTK
+
+#endif

--- a/ibtk/lib/Makefile.am
+++ b/ibtk/lib/Makefile.am
@@ -36,7 +36,8 @@ clean-local:
 libIBTK_a_SOURCES = \
 ../src/utilities/ParallelEdgeMap.cpp \
 ../src/utilities/FixedSizedStream.cpp \
-../src/utilities/IBTK_MPI.cpp
+../src/utilities/IBTK_MPI.cpp \
+../src/utilities/IBTKInit.cpp
 
 if USING_BUNDLED_MUPARSER
 libIBTK_a_SOURCES += \
@@ -239,6 +240,7 @@ pkg_include_HEADERS += \
 ../include/ibtk/HierarchyIntegrator.h \
 ../include/ibtk/HierarchyMathOps.h \
 ../include/ibtk/IBTK_MPI.h \
+../include/ibtk/IBTKInit.h \
 ../include/ibtk/IndexUtilities.h \
 ../include/ibtk/JacobianOperator.h \
 ../include/ibtk/KrylovLinearSolver.h \

--- a/ibtk/lib/Makefile.in
+++ b/ibtk/lib/Makefile.in
@@ -185,7 +185,7 @@ libIBTK_a_AR = $(AR) $(ARFLAGS)
 libIBTK_a_LIBADD =
 am__libIBTK_a_SOURCES_DIST = ../src/utilities/ParallelEdgeMap.cpp \
 	../src/utilities/FixedSizedStream.cpp \
-	../src/utilities/IBTK_MPI.cpp \
+	../src/utilities/IBTK_MPI.cpp ../src/utilities/IBTKInit.cpp \
 	../contrib/muparser/src/muParserDLL.cpp \
 	../contrib/muparser/src/muParserTokenReader.cpp \
 	../contrib/muparser/src/muParserError.cpp \
@@ -207,7 +207,8 @@ am__dirstamp = $(am__leading_dot)dirstamp
 @USING_BUNDLED_MUPARSER_TRUE@	../contrib/muparser/src/muParser.$(OBJEXT)
 am_libIBTK_a_OBJECTS = ../src/utilities/ParallelEdgeMap.$(OBJEXT) \
 	../src/utilities/FixedSizedStream.$(OBJEXT) \
-	../src/utilities/IBTK_MPI.$(OBJEXT) $(am__objects_1)
+	../src/utilities/IBTK_MPI.$(OBJEXT) \
+	../src/utilities/IBTKInit.$(OBJEXT) $(am__objects_1)
 libIBTK_a_OBJECTS = $(am_libIBTK_a_OBJECTS)
 libIBTK2d_a_AR = $(AR) $(ARFLAGS)
 libIBTK2d_a_LIBADD =
@@ -1014,6 +1015,7 @@ am__depfiles_remade = ../contrib/muparser/src/$(DEPDIR)/muParser.Po \
 	../src/solvers/wrappers/$(DEPDIR)/libIBTK3d_a-PETScSNESFunctionGOWrapper.Po \
 	../src/solvers/wrappers/$(DEPDIR)/libIBTK3d_a-PETScSNESJacobianJOWrapper.Po \
 	../src/utilities/$(DEPDIR)/FixedSizedStream.Po \
+	../src/utilities/$(DEPDIR)/IBTKInit.Po \
 	../src/utilities/$(DEPDIR)/IBTK_MPI.Po \
 	../src/utilities/$(DEPDIR)/ParallelEdgeMap.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-AppInitializer.Po \
@@ -1441,7 +1443,8 @@ SUFFIXES = .f.m4
 lib_LIBRARIES = libIBTK.a $(am__append_1) $(am__append_2)
 libIBTK_a_SOURCES = ../src/utilities/ParallelEdgeMap.cpp \
 	../src/utilities/FixedSizedStream.cpp \
-	../src/utilities/IBTK_MPI.cpp $(am__append_3)
+	../src/utilities/IBTK_MPI.cpp ../src/utilities/IBTKInit.cpp \
+	$(am__append_3)
 pkg_include_HEADERS = ../include/ibtk/IBTK_CHKERRQ.h \
 	../include/ibtk/app_namespaces.h \
 	../include/ibtk/compiler_hints.h ../include/ibtk/ibtk_enums.h \
@@ -1491,7 +1494,7 @@ pkg_include_HEADERS = ../include/ibtk/IBTK_CHKERRQ.h \
 	../include/ibtk/HierarchyGhostCellInterpolation.h \
 	../include/ibtk/HierarchyIntegrator.h \
 	../include/ibtk/HierarchyMathOps.h ../include/ibtk/IBTK_MPI.h \
-	../include/ibtk/IndexUtilities.h \
+	../include/ibtk/IBTKInit.h ../include/ibtk/IndexUtilities.h \
 	../include/ibtk/JacobianOperator.h \
 	../include/ibtk/KrylovLinearSolver.h \
 	../include/ibtk/KrylovLinearSolverManager.h \
@@ -1832,6 +1835,8 @@ clean-libLIBRARIES:
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 ../src/utilities/IBTK_MPI.$(OBJEXT): ../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/IBTKInit.$(OBJEXT): ../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 ../contrib/muparser/src/$(am__dirstamp):
 	@$(MKDIR_P) ../contrib/muparser/src
@@ -3075,6 +3080,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/solvers/wrappers/$(DEPDIR)/libIBTK3d_a-PETScSNESFunctionGOWrapper.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/solvers/wrappers/$(DEPDIR)/libIBTK3d_a-PETScSNESJacobianJOWrapper.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/FixedSizedStream.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/IBTKInit.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/IBTK_MPI.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/ParallelEdgeMap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-AppInitializer.Po@am__quote@ # am--include-marker
@@ -7101,6 +7107,7 @@ distclean: distclean-am
 	-rm -f ../src/solvers/wrappers/$(DEPDIR)/libIBTK3d_a-PETScSNESFunctionGOWrapper.Po
 	-rm -f ../src/solvers/wrappers/$(DEPDIR)/libIBTK3d_a-PETScSNESJacobianJOWrapper.Po
 	-rm -f ../src/utilities/$(DEPDIR)/FixedSizedStream.Po
+	-rm -f ../src/utilities/$(DEPDIR)/IBTKInit.Po
 	-rm -f ../src/utilities/$(DEPDIR)/IBTK_MPI.Po
 	-rm -f ../src/utilities/$(DEPDIR)/ParallelEdgeMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-AppInitializer.Po
@@ -7410,6 +7417,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/solvers/wrappers/$(DEPDIR)/libIBTK3d_a-PETScSNESFunctionGOWrapper.Po
 	-rm -f ../src/solvers/wrappers/$(DEPDIR)/libIBTK3d_a-PETScSNESJacobianJOWrapper.Po
 	-rm -f ../src/utilities/$(DEPDIR)/FixedSizedStream.Po
+	-rm -f ../src/utilities/$(DEPDIR)/IBTKInit.Po
 	-rm -f ../src/utilities/$(DEPDIR)/IBTK_MPI.Po
 	-rm -f ../src/utilities/$(DEPDIR)/ParallelEdgeMap.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-AppInitializer.Po

--- a/ibtk/src/utilities/IBTKInit.cpp
+++ b/ibtk/src/utilities/IBTKInit.cpp
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2014 - 2019 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include "ibtk/IBTKInit.h"
+#include "ibtk/IBTK_MPI.h"
+#include "ibtk/app_namespaces.h"
+
+namespace IBTK
+{
+/////////////////////////////// STATIC //////////////////////////////////////
+bool IBTKInit::s_initialized = false;
+
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+IBTKInit::IBTKInit(int argc, char** argv, MPI_Comm communicator, char* petsc_file, char* petsc_help)
+#ifdef IBTK_HAVE_LIBMESH
+    : d_libmesh_init(argc, argv, communicator)
+#endif
+{
+    if (s_initialized) TBOX_ERROR("IBAMR has already been initialized.\n");
+#ifdef IBTK_HAVE_LIBMESH
+    libMesh::ReferenceCounter::disable_print_counter_info();
+    NULL_USE(petsc_file);
+    NULL_USE(petsc_help);
+#else
+    // We need to initialize PETSc.
+    PetscInitialize(&argc, &argv, petsc_file, petsc_help);
+#endif
+#if SAMRAI_VERSION_MAJOR > 2
+    SAMRAIManager::initialize();
+    SAMRAI_MPI::init(comm);
+    SAMRAIManager::setMaxNumberPatchDataEntries(std::max(2048, SAMRAIManager::getMaxNumberPatchDataEntries()));
+#else
+    SAMRAIManager::setMaxNumberPatchDataEntries(2048);
+#endif
+    SAMRAI_MPI::setCommunicator(communicator);
+    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
+    SAMRAIManager::startup();
+    IBTK_MPI::setCommunicator(communicator);
+    s_initialized = true;
+}
+
+IBTKInit::~IBTKInit()
+{
+    pout << "IBTKInit destructor called. Shutting down libraries.\n";
+    SAMRAIManager::shutdown();
+#if SAMRAI_VERSION_MAJOR > 2
+    SAMRAIManager::finalize();
+#endif
+#ifndef IBTK_HAVE_LIBMESH
+    PetscFinalize();
+#endif
+    s_initialized = false;
+}
+} // namespace IBTK

--- a/ibtk/src/utilities/IBTK_MPI.cpp
+++ b/ibtk/src/utilities/IBTK_MPI.cpp
@@ -16,6 +16,7 @@
 #include "ibtk/IBTK_MPI.h"
 #include "ibtk/app_namespaces.h"
 
+#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <string>
@@ -23,7 +24,7 @@
 
 namespace IBTK
 {
-IBTK_MPI::comm IBTK_MPI::s_communicator = MPI_COMM_WORLD;
+IBTK_MPI::comm IBTK_MPI::s_communicator = MPI_COMM_NULL;
 
 void
 IBTK_MPI::setCommunicator(IBTK_MPI::comm communicator)
@@ -41,9 +42,9 @@ IBTK_MPI::comm
 IBTK_MPI::getSAMRAIWorld()
 {
 #if SAMRAI_VERSION_MAJOR == 2
-    return IBTK_MPI::getCommunicator();
+    return SAMRAI_MPI::commWorld;
 #else
-    return IBTK_MPI::getSAMRAIWorld()
+    return SAMRAI_MPI::getSAMRAIWorld()
 #endif
 }
 

--- a/ibtk/src/utilities/IBTK_MPI.cpp
+++ b/ibtk/src/utilities/IBTK_MPI.cpp
@@ -16,7 +16,6 @@
 #include "ibtk/IBTK_MPI.h"
 #include "ibtk/app_namespaces.h"
 
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <string>
@@ -42,9 +41,9 @@ IBTK_MPI::comm
 IBTK_MPI::getSAMRAIWorld()
 {
 #if SAMRAI_VERSION_MAJOR == 2
-    return SAMRAI_MPI::commWorld;
+    return IBTK_MPI::getCommunicator();
 #else
-    return SAMRAI_MPI::getSAMRAIWorld()
+    return IBTK_MPI::getSAMRAIWorld()
 #endif
 }
 
@@ -70,68 +69,6 @@ IBTK_MPI::barrier(IBTK_MPI::comm communicator)
     (void)MPI_Barrier(communicator);
 } // barrier
 
-template <typename T>
-T
-IBTK_MPI::minReduction(T x, int* rank_of_min, IBTK_MPI::comm communicator)
-{
-    minReduction(&x, 1, rank_of_min, communicator);
-    return x;
-} // minReduction
-
-template <typename T>
-void
-IBTK_MPI::minReduction(T* x, const int n, int* rank_of_min, IBTK_MPI::comm communicator)
-{
-    if (n == 0) return;
-    if (rank_of_min == nullptr)
-    {
-        MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_MIN, communicator);
-    }
-    else
-    {
-        minMaxReduction(x, n, rank_of_min, MPI_MINLOC, communicator);
-    }
-} // minReduction
-
-template <typename T>
-T
-IBTK_MPI::maxReduction(T x, int* rank_of_max, IBTK_MPI::comm communicator)
-{
-    maxReduction(&x, 1, rank_of_max, communicator);
-    return x;
-} // maxReduction
-
-template <typename T>
-void
-IBTK_MPI::maxReduction(T* x, const int n, int* rank_of_max, IBTK_MPI::comm communicator)
-{
-    if (n == 0) return;
-    if (rank_of_max == nullptr)
-    {
-        MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_MAX, communicator);
-    }
-    else
-    {
-        minMaxReduction(x, n, rank_of_max, MPI_MAXLOC, communicator);
-    }
-} // maxReduction
-
-template <typename T>
-T
-IBTK_MPI::sumReduction(T x, IBTK_MPI::comm communicator)
-{
-    sumReduction(&x, 1, communicator);
-    return x;
-} // sumReduction
-
-template <typename T>
-void
-IBTK_MPI::sumReduction(T* x, const int n, IBTK_MPI::comm communicator)
-{
-    if (n == 0 || getNodes(communicator) < 2) return;
-    MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_SUM, communicator);
-} // sumReduction
-
 void
 IBTK_MPI::allToOneSumReduction(int* x, const int n, const int root, IBTK_MPI::comm communicator)
 {
@@ -140,59 +77,6 @@ IBTK_MPI::allToOneSumReduction(int* x, const int n, const int root, IBTK_MPI::co
         MPI_Reduce(MPI_IN_PLACE, x, n, MPI_INT, MPI_SUM, root, communicator);
     }
 } // allToOneSumReduction
-
-template <typename T>
-T
-IBTK_MPI::bcast(const T x, const int root, IBTK_MPI::comm communicator)
-{
-    bcast(&x, 1, root, communicator);
-}
-
-template <typename T>
-void
-IBTK_MPI::bcast(T* x, int& length, const int root, IBTK_MPI::comm communicator)
-{
-    if (getNodes(communicator) > 1)
-    {
-        MPI_Bcast(x, length, mpi_type_id(x[0]), root, communicator);
-    }
-} // bcast
-
-template <typename T>
-void
-IBTK_MPI::send(const T* buf,
-               const int length,
-               const int receiving_proc_number,
-               const bool send_length,
-               int tag,
-               IBTK_MPI::comm communicator)
-{
-    tag = (tag >= 0) ? tag : 0;
-    int size = length;
-    if (send_length)
-    {
-        MPI_Send(&size, 1, MPI_INT, receiving_proc_number, tag, communicator);
-    }
-    MPI_Send(buf, length, mpi_type_id(buf[0]), receiving_proc_number, tag, communicator);
-} // send
-
-template <typename T>
-void
-IBTK_MPI::recv(T* buf,
-               int& length,
-               const int sending_proc_number,
-               const bool get_length,
-               int tag,
-               IBTK_MPI::comm communicator)
-{
-    MPI_Status status;
-    tag = (tag >= 0) ? tag : 0;
-    if (get_length)
-    {
-        MPI_Recv(&length, 1, MPI_INT, sending_proc_number, tag, communicator, &status);
-    }
-    MPI_Recv(buf, length, mpi_type_id(buf[0]), sending_proc_number, tag, communicator, &status);
-} // recv
 
 void
 IBTK_MPI::sendBytes(const void* buf,
@@ -214,23 +98,6 @@ IBTK_MPI::recvBytes(void* buf, int number_bytes, IBTK_MPI::comm communicator)
     return rval;
 } // recvBytes
 
-template <typename T>
-void
-IBTK_MPI::allGather(const T* x_in, int size_in, T* x_out, int size_out, IBTK_MPI::comm communicator)
-{
-    std::vector<int> rcounts, disps;
-    allGatherSetup(size_in, size_out, rcounts, disps, communicator);
-
-    MPI_Allgatherv(
-        x_in, size_in, mpi_type_id(x_in[0]), x_out, rcounts.data(), disps.data(), mpi_type_id(x_in[0]), communicator);
-} // allGather
-
-template <typename T>
-void
-IBTK_MPI::allGather(T x_in, T* x_out, IBTK_MPI::comm communicator)
-{
-    MPI_Allgather(&x_in, 1, mpi_type_id(x_in), x_out, 1, mpi_type_id(x_in), communicator);
-} // allGather
 //////////////////////////////////////  PRIVATE  ///////////////////////////////////////////////////
 
 void
@@ -266,23 +133,4 @@ IBTK_MPI::allGatherSetup(int size_in,
                    << "should be: " << c << std::endl);
     }
 } // allGatherSetup
-
-template <typename T>
-void
-IBTK_MPI::minMaxReduction(T* x, const int n, int* rank, MPI_Op op, IBTK_MPI::comm communicator)
-{
-    std::vector<std::pair<T, int> > recv(n);
-    std::vector<std::pair<T, int> > send(n);
-    for (int i = 0; i < n; ++i)
-    {
-        send[i].first = x[i];
-        send[i].second = getRank(communicator);
-    }
-    MPI_Allreduce(send.data(), recv.data(), n, mpi_type_id(recv[0]), op, communicator);
-    for (int i = 0; i < n; ++i)
-    {
-        x[i] = recv[i].first;
-        rank[i] = send[i].second;
-    }
-} // minMaxReduction
 } // namespace IBTK

--- a/tests/IBTK/Makefile.am
+++ b/tests/IBTK/Makefile.am
@@ -19,7 +19,7 @@ laplace_01_3d laplace_02_2d laplace_02_3d laplace_03_2d laplace_03_3d ldata_01 \
 prolongation_mat_2d prolongation_mat_3d phys_boundary_ops_2d phys_boundary_ops_3d \
 vc_viscous_solver_2d vc_viscous_solver_3d box_utilities_01_2d box_utilities_01_3d \
 ghost_accumulation_01_2d ghost_accumulation_01_3d ghost_indices_01_2d \
-ghost_indices_01_3d
+ghost_indices_01_3d ibtk_init
 
 if LIBMESH_ENABLED
 EXTRA_PROGRAMS += elem_hmax_01 elem_hmax_02 jacobian_calc_01 bounding_boxes_01_2d \
@@ -37,6 +37,10 @@ elem_hmax_02_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=3
 elem_hmax_02_LDADD = $(IBAMR_LDFLAGS) $(IBAMR3d_LIBS) $(IBAMR_LIBS)
 elem_hmax_02_SOURCES = elem_hmax_02.cpp
 endif
+
+ibtk_init_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
+ibtk_init_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+ibtk_init_SOURCES = ibtk_init.cpp
 
 mpi_type_wrappers_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 mpi_type_wrappers_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)

--- a/tests/IBTK/Makefile.in
+++ b/tests/IBTK/Makefile.in
@@ -99,7 +99,8 @@ EXTRA_PROGRAMS = mpi_type_wrappers$(EXEEXT) poisson_01_2d$(EXEEXT) \
 	box_utilities_01_2d$(EXEEXT) box_utilities_01_3d$(EXEEXT) \
 	ghost_accumulation_01_2d$(EXEEXT) \
 	ghost_accumulation_01_3d$(EXEEXT) ghost_indices_01_2d$(EXEEXT) \
-	ghost_indices_01_3d$(EXEEXT) $(am__EXEEXT_1)
+	ghost_indices_01_3d$(EXEEXT) ibtk_init$(EXEEXT) \
+	$(am__EXEEXT_1)
 @LIBMESH_ENABLED_TRUE@am__append_1 = elem_hmax_01 elem_hmax_02 jacobian_calc_01 bounding_boxes_01_2d \
 @LIBMESH_ENABLED_TRUE@bounding_boxes_01_3d
 
@@ -229,6 +230,12 @@ ghost_indices_01_3d_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(ghost_indices_01_3d_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
+am_ibtk_init_OBJECTS = ibtk_init-ibtk_init.$(OBJEXT)
+ibtk_init_OBJECTS = $(am_ibtk_init_OBJECTS)
+ibtk_init_DEPENDENCIES = $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+ibtk_init_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(ibtk_init_CXXFLAGS) \
+	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 am__jacobian_calc_01_SOURCES_DIST = jacobian_calc_01.cpp
 @LIBMESH_ENABLED_TRUE@am_jacobian_calc_01_OBJECTS = jacobian_calc_01-jacobian_calc_01.$(OBJEXT)
 jacobian_calc_01_OBJECTS = $(am_jacobian_calc_01_OBJECTS)
@@ -398,6 +405,7 @@ am__depfiles_remade =  \
 	./$(DEPDIR)/ghost_accumulation_01_3d-ghost_accumulation_01.Po \
 	./$(DEPDIR)/ghost_indices_01_2d-ghost_indices_01.Po \
 	./$(DEPDIR)/ghost_indices_01_3d-ghost_indices_01.Po \
+	./$(DEPDIR)/ibtk_init-ibtk_init.Po \
 	./$(DEPDIR)/jacobian_calc_01-jacobian_calc_01.Po \
 	./$(DEPDIR)/laplace_01_2d-laplace_01.Po \
 	./$(DEPDIR)/laplace_01_3d-laplace_01.Po \
@@ -442,11 +450,12 @@ SOURCES = $(bounding_boxes_01_2d_SOURCES) \
 	$(elem_hmax_02_SOURCES) $(ghost_accumulation_01_2d_SOURCES) \
 	$(ghost_accumulation_01_3d_SOURCES) \
 	$(ghost_indices_01_2d_SOURCES) $(ghost_indices_01_3d_SOURCES) \
-	$(jacobian_calc_01_SOURCES) $(laplace_01_2d_SOURCES) \
-	$(laplace_01_3d_SOURCES) $(laplace_02_2d_SOURCES) \
-	$(laplace_02_3d_SOURCES) $(laplace_03_2d_SOURCES) \
-	$(laplace_03_3d_SOURCES) $(ldata_01_SOURCES) \
-	$(mpi_type_wrappers_SOURCES) $(phys_boundary_ops_2d_SOURCES) \
+	$(ibtk_init_SOURCES) $(jacobian_calc_01_SOURCES) \
+	$(laplace_01_2d_SOURCES) $(laplace_01_3d_SOURCES) \
+	$(laplace_02_2d_SOURCES) $(laplace_02_3d_SOURCES) \
+	$(laplace_03_2d_SOURCES) $(laplace_03_3d_SOURCES) \
+	$(ldata_01_SOURCES) $(mpi_type_wrappers_SOURCES) \
+	$(phys_boundary_ops_2d_SOURCES) \
 	$(phys_boundary_ops_3d_SOURCES) $(poisson_01_2d_SOURCES) \
 	$(poisson_01_3d_SOURCES) $(prolongation_mat_2d_SOURCES) \
 	$(prolongation_mat_3d_SOURCES) \
@@ -462,11 +471,12 @@ DIST_SOURCES = $(am__bounding_boxes_01_2d_SOURCES_DIST) \
 	$(ghost_accumulation_01_2d_SOURCES) \
 	$(ghost_accumulation_01_3d_SOURCES) \
 	$(ghost_indices_01_2d_SOURCES) $(ghost_indices_01_3d_SOURCES) \
-	$(am__jacobian_calc_01_SOURCES_DIST) $(laplace_01_2d_SOURCES) \
-	$(laplace_01_3d_SOURCES) $(laplace_02_2d_SOURCES) \
-	$(laplace_02_3d_SOURCES) $(laplace_03_2d_SOURCES) \
-	$(laplace_03_3d_SOURCES) $(ldata_01_SOURCES) \
-	$(mpi_type_wrappers_SOURCES) $(phys_boundary_ops_2d_SOURCES) \
+	$(ibtk_init_SOURCES) $(am__jacobian_calc_01_SOURCES_DIST) \
+	$(laplace_01_2d_SOURCES) $(laplace_01_3d_SOURCES) \
+	$(laplace_02_2d_SOURCES) $(laplace_02_3d_SOURCES) \
+	$(laplace_03_2d_SOURCES) $(laplace_03_3d_SOURCES) \
+	$(ldata_01_SOURCES) $(mpi_type_wrappers_SOURCES) \
+	$(phys_boundary_ops_2d_SOURCES) \
 	$(phys_boundary_ops_3d_SOURCES) $(poisson_01_2d_SOURCES) \
 	$(poisson_01_3d_SOURCES) $(prolongation_mat_2d_SOURCES) \
 	$(prolongation_mat_3d_SOURCES) \
@@ -771,6 +781,9 @@ SUFFIXES = .f.m4
 @LIBMESH_ENABLED_TRUE@elem_hmax_02_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=3
 @LIBMESH_ENABLED_TRUE@elem_hmax_02_LDADD = $(IBAMR_LDFLAGS) $(IBAMR3d_LIBS) $(IBAMR_LIBS)
 @LIBMESH_ENABLED_TRUE@elem_hmax_02_SOURCES = elem_hmax_02.cpp
+ibtk_init_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
+ibtk_init_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+ibtk_init_SOURCES = ibtk_init.cpp
 mpi_type_wrappers_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 mpi_type_wrappers_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 mpi_type_wrappers_SOURCES = mpi_type_wrappers.cpp
@@ -927,6 +940,10 @@ ghost_indices_01_3d$(EXEEXT): $(ghost_indices_01_3d_OBJECTS) $(ghost_indices_01_
 	@rm -f ghost_indices_01_3d$(EXEEXT)
 	$(AM_V_CXXLD)$(ghost_indices_01_3d_LINK) $(ghost_indices_01_3d_OBJECTS) $(ghost_indices_01_3d_LDADD) $(LIBS)
 
+ibtk_init$(EXEEXT): $(ibtk_init_OBJECTS) $(ibtk_init_DEPENDENCIES) $(EXTRA_ibtk_init_DEPENDENCIES) 
+	@rm -f ibtk_init$(EXEEXT)
+	$(AM_V_CXXLD)$(ibtk_init_LINK) $(ibtk_init_OBJECTS) $(ibtk_init_LDADD) $(LIBS)
+
 jacobian_calc_01$(EXEEXT): $(jacobian_calc_01_OBJECTS) $(jacobian_calc_01_DEPENDENCIES) $(EXTRA_jacobian_calc_01_DEPENDENCIES) 
 	@rm -f jacobian_calc_01$(EXEEXT)
 	$(AM_V_CXXLD)$(jacobian_calc_01_LINK) $(jacobian_calc_01_OBJECTS) $(jacobian_calc_01_LDADD) $(LIBS)
@@ -1019,6 +1036,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ghost_accumulation_01_3d-ghost_accumulation_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ghost_indices_01_2d-ghost_indices_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ghost_indices_01_3d-ghost_indices_01.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ibtk_init-ibtk_init.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/jacobian_calc_01-jacobian_calc_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/laplace_01_2d-laplace_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/laplace_01_3d-laplace_01.Po@am__quote@ # am--include-marker
@@ -1208,6 +1226,20 @@ ghost_indices_01_3d-ghost_indices_01.obj: ghost_indices_01.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='ghost_indices_01.cpp' object='ghost_indices_01_3d-ghost_indices_01.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ghost_indices_01_3d_CXXFLAGS) $(CXXFLAGS) -c -o ghost_indices_01_3d-ghost_indices_01.obj `if test -f 'ghost_indices_01.cpp'; then $(CYGPATH_W) 'ghost_indices_01.cpp'; else $(CYGPATH_W) '$(srcdir)/ghost_indices_01.cpp'; fi`
+
+ibtk_init-ibtk_init.o: ibtk_init.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ibtk_init_CXXFLAGS) $(CXXFLAGS) -MT ibtk_init-ibtk_init.o -MD -MP -MF $(DEPDIR)/ibtk_init-ibtk_init.Tpo -c -o ibtk_init-ibtk_init.o `test -f 'ibtk_init.cpp' || echo '$(srcdir)/'`ibtk_init.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/ibtk_init-ibtk_init.Tpo $(DEPDIR)/ibtk_init-ibtk_init.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='ibtk_init.cpp' object='ibtk_init-ibtk_init.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ibtk_init_CXXFLAGS) $(CXXFLAGS) -c -o ibtk_init-ibtk_init.o `test -f 'ibtk_init.cpp' || echo '$(srcdir)/'`ibtk_init.cpp
+
+ibtk_init-ibtk_init.obj: ibtk_init.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ibtk_init_CXXFLAGS) $(CXXFLAGS) -MT ibtk_init-ibtk_init.obj -MD -MP -MF $(DEPDIR)/ibtk_init-ibtk_init.Tpo -c -o ibtk_init-ibtk_init.obj `if test -f 'ibtk_init.cpp'; then $(CYGPATH_W) 'ibtk_init.cpp'; else $(CYGPATH_W) '$(srcdir)/ibtk_init.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/ibtk_init-ibtk_init.Tpo $(DEPDIR)/ibtk_init-ibtk_init.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='ibtk_init.cpp' object='ibtk_init-ibtk_init.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ibtk_init_CXXFLAGS) $(CXXFLAGS) -c -o ibtk_init-ibtk_init.obj `if test -f 'ibtk_init.cpp'; then $(CYGPATH_W) 'ibtk_init.cpp'; else $(CYGPATH_W) '$(srcdir)/ibtk_init.cpp'; fi`
 
 jacobian_calc_01-jacobian_calc_01.o: jacobian_calc_01.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(jacobian_calc_01_CXXFLAGS) $(CXXFLAGS) -MT jacobian_calc_01-jacobian_calc_01.o -MD -MP -MF $(DEPDIR)/jacobian_calc_01-jacobian_calc_01.Tpo -c -o jacobian_calc_01-jacobian_calc_01.o `test -f 'jacobian_calc_01.cpp' || echo '$(srcdir)/'`jacobian_calc_01.cpp
@@ -1616,6 +1648,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/ghost_accumulation_01_3d-ghost_accumulation_01.Po
 	-rm -f ./$(DEPDIR)/ghost_indices_01_2d-ghost_indices_01.Po
 	-rm -f ./$(DEPDIR)/ghost_indices_01_3d-ghost_indices_01.Po
+	-rm -f ./$(DEPDIR)/ibtk_init-ibtk_init.Po
 	-rm -f ./$(DEPDIR)/jacobian_calc_01-jacobian_calc_01.Po
 	-rm -f ./$(DEPDIR)/laplace_01_2d-laplace_01.Po
 	-rm -f ./$(DEPDIR)/laplace_01_3d-laplace_01.Po
@@ -1690,6 +1723,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/ghost_accumulation_01_3d-ghost_accumulation_01.Po
 	-rm -f ./$(DEPDIR)/ghost_indices_01_2d-ghost_indices_01.Po
 	-rm -f ./$(DEPDIR)/ghost_indices_01_3d-ghost_indices_01.Po
+	-rm -f ./$(DEPDIR)/ibtk_init-ibtk_init.Po
 	-rm -f ./$(DEPDIR)/jacobian_calc_01-jacobian_calc_01.Po
 	-rm -f ./$(DEPDIR)/laplace_01_2d-laplace_01.Po
 	-rm -f ./$(DEPDIR)/laplace_01_3d-laplace_01.Po

--- a/tests/IBTK/ibtk_init.cpp
+++ b/tests/IBTK/ibtk_init.cpp
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2017 - 2019 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+// Config files
+#include <IBTK_config.h>
+
+#include <SAMRAI_config.h>
+
+// Headers for basic PETSc objects
+#include <petscsys.h>
+
+// Headers for application-specific algorithm/data structure objects
+#include <ibtk/AppInitializer.h>
+
+// Set up application namespace declarations
+#include <ibtk/IBTKInit.h>
+#include <ibtk/app_namespaces.h>
+
+/*******************************************************************************
+ * For each run, the input filename must be given on the command line.  In all *
+ * cases, the command line is:                                                 *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize IBTK
+    IBTKInit ibtkInit(argc, argv, PETSC_COMM_WORLD);
+
+#ifdef IBTK_HAVE_LIBMESH
+    const LibMeshInit& libmesh_init = ibtkInit.getLibMeshInit();
+    NULL_USE(libmesh_init);
+    // Check if libMesh is initialized.
+    TBOX_ASSERT(libMesh::initialized());
+#endif
+    Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "ibtk_init.output");
+    // Check whether MPI is initialized
+    int test;
+    MPI_Initialized(&test);
+    pout << "MPI " << (test ? "is " : "is not ") << "initialized.\n";
+} // main

--- a/tests/IBTK/ibtk_init.input
+++ b/tests/IBTK/ibtk_init.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}

--- a/tests/IBTK/ibtk_init.output
+++ b/tests/IBTK/ibtk_init.output
@@ -1,0 +1,2 @@
+MPI is initialized.
+IBTKInit destructor called. Shutting down libraries.


### PR DESCRIPTION
This is a follow up from #287. We need to add an initialization class to ensure that the default communicator in `IBTK_MPI` is set. This also initializes standard libraries to make a transition to SAMRAI 3 easier (SAMRAI 3 adds required initialization calls). I also went ahead and moved templated `IBTK_MPI` functions to a separate private file.

This PR just adds the class, but does change any of the examples. 