### PR TITLE
Remove call to IBFEMethod::reinitializeFEData().

### DIFF
--- a/doc/news/changes/minor/20200311DavidWells
+++ b/doc/news/changes/minor/20200311DavidWells
@@ -1,0 +1,4 @@
+Fixed: IBFEMethod::reinitializeFEData() is no longer called after every time
+regrid since it does the same thing every time.
+<br>
+(David Wells, 2020/03/11)

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -1191,6 +1191,12 @@ protected:
     LibmeshPartitionerType d_libmesh_partitioner_type = AUTOMATIC;
 
     /*!
+     * Whether or not to use AMR in the finite element discretization. This
+     * feature is not yet implemented and currently defaults to false.
+     */
+    bool d_libmesh_use_amr = false;
+
+    /*!
      * Method parameters.
      */
     IBTK::FEDataManager::InterpSpec d_default_interp_spec;

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1831,7 +1831,11 @@ void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarch
             }
         }
 
-        reinitializeFEData();
+        // We only need to reinitialize FE data when AMR is enabled (which is
+        // not yet implemented)
+        if (d_libmesh_use_amr)
+            reinitializeFEData();
+
         for (unsigned int part = 0; part < d_num_parts; ++part)
         {
             d_primary_fe_data_managers[part]->reinitElementMappings();


### PR DESCRIPTION
This doesn't change anything after the first time we call it. This function accounts for about 15% of the total time spent setting things up after regridding so its worth removing for performance reasons.

We regrid about every other timestep when we start the TAVR code so this is actually noticeable in some regimes of some applications.