### PR TITLE
Change the default settings for libMesh remeshing.

### DIFF
--- a/doc/news/changes/incompatibilities/20200311DavidWells
+++ b/doc/news/changes/incompatibilities/20200311DavidWells
@@ -1,0 +1,7 @@
+Changed: Repartitioning of Lagrangian data now must be explicitly requested
+inside IBFEMethod. The new default value is to never repartition the meshes
+(instead of the old logic which used SAMRAI's partitioning whenever a load
+balancer was attached). As a result the enum value
+<tt>LibmeshPartitionerType::AUTOMATIC</tt> has been removed.
+<br>
+(David Wells, 2020/03/11)

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -150,6 +150,8 @@ namespace IBAMR
  * </ul>
  *
  * <h2>Options Controlling libMesh Partitioning</h2>
+ * <em>This feature is experimental: at the present time the default settings
+ * have the best performance and are the correct choice.</em>
  *
  * This class can repartition libMesh data in a way that matches SAMRAI's
  * distribution of patches; put another way, if a certain region of space on
@@ -160,19 +162,8 @@ namespace IBAMR
  * descriptions on how this partitioning is performed.
  *
  * The choice of libMesh partitioner depends on the libmesh_partitioner_type
- * parameter in the input database and whether or not workload estimates are
- * available (it is assumed that if workload estimates are available then a
- * load balancer is being used). More exactly:
+ * parameter in the input database:
  * <ul>
- *  <li>If <code>libmesh_partitioner_type</code> is <code>AUTOMATIC</code>
- *      and workload estimates are available then this class will use the
- *      IBTK::BoxPartitioner class to repartition libMesh data after the SAMRAI
- *      data is regridded.</li>
- *
- *  <li>If <code>libmesh_partitioner_type</code> is <code>AUTOMATIC</code> and
- *      workload estimates are not available then this class will never
- *      repartition libMesh data.</li>
- *
  *  <li>If <code>libmesh_partitioner_type</code> is
  *      <code>LIBMESH_DEFAULT</code> then this class will never repartition
  *      libMesh data, since the default libMesh partitioner is already used at
@@ -185,9 +176,9 @@ namespace IBAMR
  *      IBTK::BoxPartitioner every time the Eulerian data is regridded.</li>
  * </ul>
  * The default value for <code>libmesh_partitioner_type</code> is
- * <code>AUTOMATIC</code>. The intent of these choices is to automatically use
- * the fairest (that is, partitioning based on workload estimation)
- * partitioner.
+ * <code>LIBMESH_DEFAULT</code>. The intent of these choices is to
+ * automatically use the fairest (that is, partitioning based on equal work
+ * when computing force densities and L2 projections) partitioner.
  *
  * <h2>Options Controlling IB Data Partitioning</h2>
  *
@@ -1188,7 +1179,7 @@ protected:
      * Type of partitioner to use. See the main documentation of this class
      * for more information.
      */
-    LibmeshPartitionerType d_libmesh_partitioner_type = AUTOMATIC;
+    LibmeshPartitionerType d_libmesh_partitioner_type = LIBMESH_DEFAULT;
 
     /*!
      * Method parameters.

--- a/include/ibamr/ibamr_enums.h
+++ b/include/ibamr/ibamr_enums.h
@@ -431,7 +431,6 @@ enum_to_string<MobilityMatrixInverseType>(MobilityMatrixInverseType val)
  */
 enum LibmeshPartitionerType
 {
-    AUTOMATIC,
     LIBMESH_DEFAULT,
     SAMRAI_BOX,
     UNKNOWN_LIBMESH_PARTITIONER_TYPE = -1
@@ -441,7 +440,6 @@ template <>
 inline LibmeshPartitionerType
 string_to_enum<LibmeshPartitionerType>(const std::string& val)
 {
-    if (strcasecmp(val.c_str(), "AUTOMATIC") == 0) return AUTOMATIC;
     if (strcasecmp(val.c_str(), "LIBMESH_DEFAULT") == 0) return LIBMESH_DEFAULT;
     if (strcasecmp(val.c_str(), "SAMRAI_BOX") == 0) return SAMRAI_BOX;
     return UNKNOWN_LIBMESH_PARTITIONER_TYPE;
@@ -451,7 +449,6 @@ template <>
 inline std::string
 enum_to_string<LibmeshPartitionerType>(LibmeshPartitionerType val)
 {
-    if (val == AUTOMATIC) return "AUTOMATIC";
     if (val == LIBMESH_DEFAULT) return "LIBMESH_DEFAULT";
     if (val == SAMRAI_BOX) return "SAMRAI_BOX";
     return "UNKNOWN_LIBMESH_PARTITIONER_TYPE";

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1789,15 +1789,12 @@ void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarch
             if (d_do_log) plog << "IBFEMethod: finished scratch hierarchy regrid" << std::endl;
         }
 
-        // Checking the workload index like this breaks encapsulation, but
-        // since this is inside the library and not user code its not so bad
-        const bool workload_is_setup = d_ib_solver ? d_ib_solver->getWorkloadDataIndex() != IBTK::invalid_index : false;
         // At this point in the code SAMRAI has already redistributed the
         // patches (usually by taking into account the number of IB points on
-        // each patch). Here is the other half: we inform libMesh of the
-        // updated partitioning so that libMesh Elems and Nodes are on the
-        // same processor as the relevant SAMRAI patch.
-        if (d_libmesh_partitioner_type == SAMRAI_BOX || (d_libmesh_partitioner_type == AUTOMATIC && workload_is_setup))
+        // each patch). Here is the other half: if requested, we inform
+        // libMesh of the updated partitioning so that libMesh Elems and Nodes
+        // are on the same processor as the relevant SAMRAI patch.
+        if (d_libmesh_partitioner_type == SAMRAI_BOX)
         {
             for (unsigned int part = 0; part < d_num_parts; ++part)
             {
@@ -3757,10 +3754,8 @@ IBFEMethod::getFromInput(Pointer<Database> db, bool /*is_from_restart*/)
 
     if (db->isDouble("epsilon")) d_epsilon = db->getDouble("epsilon");
 
-    if (db->keyExists("libmesh_partitioner_type"))
-    {
-        d_libmesh_partitioner_type = string_to_enum<LibmeshPartitionerType>(db->getString("libmesh_partitioner_type"));
-    }
+    d_libmesh_partitioner_type =
+        string_to_enum<LibmeshPartitionerType>(db->getStringWithDefault("libmesh_partitioner_type", "LIBMESH_DEFAULT"));
     if (db->keyExists("workload_quad_point_weight"))
     {
         d_default_workload_spec.q_point_weight = db->getDouble("workload_quad_point_weight");


### PR DESCRIPTION
The old version was based on an incorrect assumption that the nonlocality of libMesh data was the cause of performance problems - in fact, the problem was/is the number of IB points per processor. We should not repartition the Lagrangian data unless the user explicitly asks for it since this will actually degrade performance in the calculation of forces on the Lagrangian mesh.