### PR TITLE
Print IBAMR version and git commit hash in config.log.

### DIFF
--- a/configure
+++ b/configure
@@ -41148,6 +41148,29 @@ ac_config_files="$ac_config_files Makefile config/make.inc examples/Makefile exa
 
 subdirs="$subdirs ibtk"
 
+
+ibamr_version_string=$(cat "$srcdir/VERSION")
+{ $as_echo "$as_me:${as_lineno-$LINENO}: Configured version of IBAMR is $ibamr_version_string" >&5
+$as_echo "$as_me: Configured version of IBAMR is $ibamr_version_string" >&6;}
+# check if git is available:
+which git>/dev/null
+FOUND_GIT=$?
+if test "$FOUND_GIT" -eq 0 # 0 indicates 'which git' succeeded
+then
+# and we have a git repository:
+    if test -f $srcdir/.git/HEAD
+    then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: IBAMR configured with git commit $(git rev-parse HEAD)" >&5
+$as_echo "$as_me: IBAMR configured with git commit $(git rev-parse HEAD)" >&6;}
+    else
+        { $as_echo "$as_me:${as_lineno-$LINENO}: Current source directory is not a git repository. Skipping git version info." >&5
+$as_echo "$as_me: Current source directory is not a git repository. Skipping git version info." >&6;}
+    fi
+else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: Current source directory is not a git repository. Skipping git version info." >&5
+$as_echo "$as_me: Current source directory is not a git repository. Skipping git version info." >&6;}
+fi
+
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
 # tests run on this system so they can be shared between configure

--- a/configure.ac
+++ b/configure.ac
@@ -269,6 +269,25 @@ AC_CONFIG_FILES([
   tests/wave_tank/Makefile
 ])
 AC_CONFIG_SUBDIRS([ibtk])
+
+ibamr_version_string=$(cat "$srcdir/VERSION")
+AC_MSG_NOTICE([Configured version of IBAMR is $ibamr_version_string])
+# check if git is available:
+which git>/dev/null
+FOUND_GIT=$?
+if test "$FOUND_GIT" -eq 0 # 0 indicates 'which git' succeeded
+then
+# and we have a git repository:
+    if test -f $srcdir/.git/HEAD
+    then
+        AC_MSG_NOTICE([IBAMR configured with git commit $(git rev-parse HEAD)])
+    else
+        AC_MSG_NOTICE([Current source directory is not a git repository. Skipping git version info.])
+    fi
+else
+    AC_MSG_NOTICE([Current source directory is not a git repository. Skipping git version info.])
+fi
+
 AC_OUTPUT
 echo
 echo "===================================================================="


### PR DESCRIPTION
This is sometimes useful when comparing builds. Fixes #881. 

It would be nice to also make this information available in something like
```cpp
print_ibamr_hash(std::ostream &out);
```
but this would require rerunning `configure` after every commit to make sure we always have the correct hash in the source code. Its not clear to me how to do this with autotools and I don't think its worthwhile at this time since running configure takes a long time.