### PR TITLE
Improve fe coupling

### DIFF
--- a/doc/news/changes/minor/20200316DavidWells
+++ b/doc/news/changes/minor/20200316DavidWells
@@ -1,0 +1,5 @@
+Improved: Systems created inside IBFEMethod no longer couple all variables to
+each-other since these systems are only used to solve projection problems. This
+lowers memory usage in IBFE applications by about 10-15%.
+<br>
+(David Wells, 2020/03/16)

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -1075,10 +1075,22 @@ protected:
            d_half_time = std::numeric_limits<double>::quiet_NaN();
 
     /*!
-     * FE data associated with this object.
+     * Meshes provided to this object. These are set up and managed outside
+     * this class. These meshes are modified by IBFEMethod since this class
+     * creates several libMesh Systems (and hence stores DoF information in
+     * these meshes).
      */
     std::vector<libMesh::MeshBase*> d_meshes;
-    int d_max_level_number;
+
+    /*!
+     * Maximum level number in the patch hierarchy.
+     */
+    int d_max_level_number = -1;
+
+    /*!
+     * EquationSystems objects, one per part. These contain the actual
+     * matrices and solution vectors for each relevant libMesh system.
+     */
     std::vector<std::unique_ptr<libMesh::EquationSystems> > d_equation_systems;
 
     /// Number of parts owned by the present object.

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -30,6 +30,7 @@
 #include "PatchHierarchy.h"
 #include "tbox/Pointer.h"
 
+#include "libmesh/coupling_matrix.h"
 #include "libmesh/enum_fe_family.h"
 #include "libmesh/enum_order.h"
 #include "libmesh/enum_quadrature_type.h"
@@ -1086,6 +1087,17 @@ protected:
      * Maximum level number in the patch hierarchy.
      */
     int d_max_level_number = -1;
+
+    /*!
+     * The libMesh Systems set up by this system (for example, for velocity
+     * projection) consist of one variable per spatial component. By default,
+     * libMesh assumes that all variables in a given System couple to
+     * eachother which, since we only ever solve projection problems in this
+     * class, is not the case. Hence we can save some memory by explicitly
+     * informing libMesh that the variables in a system only couple to
+     * themselves by providing a diagonal coupling matrix to each System.
+     */
+    libMesh::CouplingMatrix d_diagonal_system_coupling;
 
     /*!
      * EquationSystems objects, one per part. These contain the actual

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1240,8 +1240,7 @@ IBFEMethod::initializeFEEquationSystems()
     // Set up the coupling matrix which will be used by each system.
     d_diagonal_system_coupling.resize(NDIM);
     for (unsigned int i = 0; i < NDIM; ++i)
-        for (unsigned int j = 0; j < NDIM; ++j)
-            d_diagonal_system_coupling(i, j) = i == j ? 1 : 0;
+        for (unsigned int j = 0; j < NDIM; ++j) d_diagonal_system_coupling(i, j) = i == j ? 1 : 0;
 
     // Create the FE data managers that manage mappings between the FE mesh
     // parts and the Cartesian grid.
@@ -1836,8 +1835,7 @@ void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarch
 
         // We only need to reinitialize FE data when AMR is enabled (which is
         // not yet implemented)
-        if (d_libmesh_use_amr)
-            reinitializeFEData();
+        if (d_libmesh_use_amr) reinitializeFEData();
 
         for (unsigned int part = 0; part < d_num_parts; ++part)
         {


### PR DESCRIPTION
I took a look at our mass matrix solves and I noticed (via `-ksp_log`) that our matrices allocated three times as many entries as they actually used in 3D. This is because, by default, libMesh assumes all variables couple to each-other.

We can get around this by providing an extra argument to libMesh. This saves us some memory (about 10% for the heart model). Fortunately PETSc is already smart enough to ignore the zero entries so it does not really change the performance.