### PR TITLE
Zero some stored hypre residuals.

### DIFF
--- a/doc/news/changes/minor/20200318DavidWells
+++ b/doc/news/changes/minor/20200318DavidWells
@@ -1,0 +1,6 @@
+Improved: IBTK::CCPoissonHypreLevelSolver::solveSystem() and
+IBTK::SCPoissonHypreLevelSolver::solveSystem() now both return <code>true</code> in
+the case where the right-hand side vector is zero (which causes the relative
+error to be <code>NaN</code> and the number of iterations to be zero).
+<br>
+(David Wells, 2020/03/18)

--- a/ibtk/src/solvers/impls/SCPoissonHypreLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonHypreLevelSolver.cpp
@@ -704,6 +704,9 @@ SCPoissonHypreLevelSolver::solveSystem(const int x_idx, const int b_idx)
     // Solve the system.
     IBTK_TIMER_START(t_solve_system_hypre);
 
+    d_current_iterations = 0;
+    d_current_residual_norm = 0.0;
+
     if (d_solver_type == "SysPFMG")
     {
         HYPRE_SStructSysPFMGSetMaxIter(d_solver, d_max_iterations);
@@ -793,6 +796,12 @@ SCPoissonHypreLevelSolver::solveSystem(const int x_idx, const int b_idx)
         Pointer<SideData<NDIM, double> > x_data = patch->getPatchData(x_idx);
         copyFromHypre(*x_data, d_sol_vec, patch_box);
     }
+
+    // During initialization we may call this function with zero vectors for
+    // the RHS and solution - in that case we converge with zero iterations
+    // and the relative error is NaN. If this is the case then return true.
+    if (std::isnan(d_current_residual_norm) && d_current_iterations == 0) return true;
+
     return (d_current_residual_norm <= d_rel_residual_tol || d_current_residual_norm <= d_abs_residual_tol);
 } // solveSystem
 


### PR DESCRIPTION
Additionally, exit successfully if there were no iterations and the residual norm is nan - this can happen when the right-hand side is the zero vector (which occurs durring initialization, like in regridProjection).

Part of #778 - we need this change to get most of the tests passing with floating point exceptions enabled.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?