### PR TITLE
Fixed compilation error in IBFE ex4: missing replicated_mesh header

### DIFF
--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -30,9 +30,9 @@
 #include <libmesh/boundary_info.h>
 #include <libmesh/equation_systems.h>
 #include <libmesh/exodusII_io.h>
-#include <libmesh/mesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_triangle_interface.h>
+#include <libmesh/replicated_mesh.h>
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibamr/IBExplicitHierarchyIntegrator.h>


### PR DESCRIPTION
### IBAMR Pull Request Checklist
- [x] Does the test suite pass?  
- [x] Was clang-format run? 
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.     
      Bugfix in one of the examples.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
      ...