### PR TITLE
Fix interpolate velocity 01

### DIFF
--- a/tests/IBFE/interpolate_velocity_01.cpp
+++ b/tests/IBFE/interpolate_velocity_01.cpp
@@ -141,8 +141,12 @@ main(int argc, char** argv)
     SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
     SAMRAIManager::startup();
 
-    PetscOptionsSetValue(nullptr, "-ksp_rtol", "1e-16");
-    PetscOptionsSetValue(nullptr, "-ksp_atol", "1e-16");
+    // set up options for the linear solver to not depend on the parallel partitioning
+    PetscOptionsSetValue(nullptr, "-ksp_rtol", "1e-14");
+    PetscOptionsSetValue(nullptr, "-ksp_atol", "1e-12");
+    PetscOptionsSetValue(nullptr, "-ksp_type", "cg");
+    PetscOptionsSetValue(nullptr, "-pc_type", "jacobi");
+    PetscOptionsSetValue(nullptr, "-pc_jacobi_type", "diagonal");
 
     // prevent a warning about timer initializations
     TimerManager::createManager(nullptr);
@@ -378,7 +382,7 @@ main(int argc, char** argv)
             {
                 plog << std::setprecision(20) << max_norm_errors[i] << "   ";
             }
-            plog << max_norm_errors[n_vars - 1] << std::endl;
+            plog << SAMRAI_MPI::maxReduction(max_norm_errors[n_vars - 1]) << std::endl;
         }
     } // cleanup dynamically allocated objects prior to shutdown
 

--- a/tests/IBFE/interpolate_velocity_01_2d.a.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.a.mpirun=4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0236627
-max norm errors: 0.0001756721356397372702   0.00021896759573336588289
+max norm errors: 0.00017567213561375805142   0.00026357631227047484401

--- a/tests/IBFE/interpolate_velocity_01_2d.a.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.a.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0236627
-max norm errors: 0.00017567228360637621165   0.00026357631227225120085
+max norm errors: 0.00017567228361037301454   0.00026357631227047484401

--- a/tests/IBFE/interpolate_velocity_01_2d.b.bspline-3.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.bspline-3.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 3.9707998142901601568e-05   5.9561997213686268537e-05
+max norm errors: 3.9707998144455913803e-05   5.9561997216572848401e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.bspline-4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.bspline-4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 4.2251129654280461523e-05   6.3376694479533313142e-05
+max norm errors: 4.2251129654058416918e-05   6.3376694482419893006e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.bspline-5.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.bspline-5.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 2 4
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 4.4794261165437276873e-05   6.7191391746268536167e-05
+max norm errors: 4.479426116443807615e-05   6.7191391749155116031e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.bspline-6.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.bspline-6.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 2 4
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 4.7337392695911972851e-05   7.1006089054970189522e-05
+max norm errors: 4.7337392733659555688e-05   7.1006089028546881536e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.ib-3.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.ib-3.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 4.1181397054446122752e-05   6.1789747127560801232e-05
+max norm errors: 4.1181397052669765912e-05   6.1789747130558403398e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.ib-4-w8.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.ib-4-w8.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 2 5
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 9.603882649567019314e-05   0.00014406281293921630038
+max norm errors: 9.6038826497002460769e-05   0.00014406281294254696945

--- a/tests/IBFE/interpolate_velocity_01_2d.b.ib-4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.ib-4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 4.8066888366005144917e-05   7.2113280273677915488e-05
+max norm errors: 4.8066888367448434849e-05   7.2113280277008584562e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.ib-5.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.ib-5.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 2 4
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 4.7181435712362329582e-05   7.0772153567988382861e-05
+max norm errors: 4.7181435714138686421e-05   7.077215357109700733e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.ib-6.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.ib-6.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 2 4
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 5.3870446048431830377e-05   8.0805669072092634053e-05
+max norm errors: 5.3870446049875120309e-05   8.0805669075423303127e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.mpirun=4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 4.8066888366338211824e-05   5.4930730361668622663e-05
+max norm errors: 4.8066888367670479454e-05   7.211328027689756226e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 4.8066888366227189522e-05   7.2113280273677915488e-05
+max norm errors: 4.8066888367781501756e-05   7.2113280277008584562e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.piecewise-cubic.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.piecewise-cubic.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 3.2078603611651601568e-05   4.8117905417033313142e-05
+max norm errors: 3.2078603613427958408e-05   4.8117905419919893006e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.b.piecewise-linear.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.piecewise-linear.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 2
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0127652
-max norm errors: 3.7149205570852217306e-05   5.5877684509431091442e-05
+max norm errors: 3.7149205572406529541e-05   5.5877684512539715911e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.c.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.c.mpirun=4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.00668694
-max norm errors: 1.2820255439027761213e-05   1.3889043202819362222e-05
+max norm errors: 1.2820255440804118052e-05   1.9232317827855283099e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.c.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.c.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.00668694
-max norm errors: 1.2820255439471850423e-05   1.923231781031375931e-05
+max norm errors: 1.2820255440804118052e-05   1.9232317827855283099e-05

--- a/tests/IBFE/interpolate_velocity_01_2d.d.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.d.mpirun=4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.00348279
-max norm errors: 3.2305877768479263068e-06   3.6510271375078673373e-06
+max norm errors: 3.2305877791793946585e-06   4.8473241573976366681e-06

--- a/tests/IBFE/interpolate_velocity_01_2d.d.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.d.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.00348279
-max norm errors: 3.2305877775140601216e-06   4.8473241542890121991e-06
+max norm errors: 3.2305877790683723561e-06   4.8473241571755920631e-06

--- a/tests/IBFE/interpolate_velocity_01_3d.a.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.a.mpirun=4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.112856
-max norm errors: 0.00093667747957248970181   0.0016901433827078427008   0.0013516244805421573361
+max norm errors: 0.00093667747957404401404   0.001690143382711950526   0.0013516244805636956627

--- a/tests/IBFE/interpolate_velocity_01_3d.a.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.a.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.112856
-max norm errors: 0.0010161360760612137   0.0021560874070296609517   0.0013516244805428234699
+max norm errors: 0.0010161360760618798338   0.00215608740703343571   0.0013516244805620303282

--- a/tests/IBFE/interpolate_velocity_01_3d.b.bspline-3.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.bspline-3.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461611362389078   0.00042962996997708557956   0.00031586477070333351946
+max norm errors: 0.0002198546161007453037   0.00042962996991247059952   0.00031586477069978080578

--- a/tests/IBFE/interpolate_velocity_01_3d.b.bspline-4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.bspline-4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461611340184618   0.00042962996998197056087   0.00031586477070244534104
+max norm errors: 0.0002198546161007453037   0.00042962996991091628729   0.00031586477069889262737

--- a/tests/IBFE/interpolate_velocity_01_3d.b.bspline-5.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.bspline-5.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 4
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461611262469006   0.00042962997001194658253   0.00031586477070466578709
+max norm errors: 0.00021985461609441703246   0.0004296299699519945392   0.0003158647707048878317

--- a/tests/IBFE/interpolate_velocity_01_3d.b.bspline-6.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.bspline-6.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 4
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461615148249592   0.00042962996993445301541   0.00031586477069867058276
+max norm errors: 0.0002198546161414904887   0.00042962996988249457786   0.00031586477066802842728

--- a/tests/IBFE/interpolate_velocity_01_3d.b.ib-3.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.ib-3.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461609730361232   0.00042962996993778368449   0.00031586477073064500587
+max norm errors: 0.00021985461608464706984   0.0004296299698753891505   0.0003158647707273143368

--- a/tests/IBFE/interpolate_velocity_01_3d.b.ib-4-w8.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.ib-4-w8.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 5
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461611362389078   0.0004296299699744210443   0.00031586477070333351946
+max norm errors: 0.0002198546161007453037   0.00042962996991202651031   0.00031586477070000285039

--- a/tests/IBFE/interpolate_velocity_01_3d.b.ib-4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.ib-4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461611373491309   0.00042962996997641944574   0.00031586477070399965328
+max norm errors: 0.00021985461610052325909   0.00042962996991269264413   0.00031586477070022489499

--- a/tests/IBFE/interpolate_velocity_01_3d.b.ib-5.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.ib-5.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 4
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461611384593539   0.00042962996997597535653   0.00031586477070333351946
+max norm errors: 0.00021985461610052325909   0.00042962996991025015348   0.0003158647707004469396

--- a/tests/IBFE/interpolate_velocity_01_3d.b.ib-6.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.ib-6.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 4
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461611362389078   0.0004296299699746430889   0.00031586477070355556407
+max norm errors: 0.00021985461610052325909   0.00042962996991025015348   0.00031586477070000285039

--- a/tests/IBFE/interpolate_velocity_01_3d.b.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.mpirun=4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00020177932299292322682   0.00031747846973390059233   0.00030694718823986999467
+max norm errors: 0.00020177932298992562465   0.00031747846973084747901   0.0003158647707004469396

--- a/tests/IBFE/interpolate_velocity_01_3d.b.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461611351286848   0.00042962996997664149035   0.00031586477070399965328
+max norm errors: 0.00021985461610052325909   0.00042962996991269264413   0.00031586477070022489499

--- a/tests/IBFE/interpolate_velocity_01_3d.b.piecewise-cubic.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.piecewise-cubic.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461611306877927   0.00042962996997286673206   0.00031586477070444374249
+max norm errors: 0.00021985461609941303607   0.00042962996990758561822   0.00031586477070133511802

--- a/tests/IBFE/interpolate_velocity_01_3d.b.piecewise-linear.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.piecewise-linear.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 2
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00021985461611362389078   0.00042962996997619740114   0.00031586477070333351946
+max norm errors: 0.00021985461610041223679   0.0004296299699115824211   0.0003158647707004469396

--- a/tests/IBFE/interpolate_velocity_01_3d.c.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.c.mpirun=4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0328818
-max norm errors: 4.6699731008126299514e-05   9.2891170307640713588e-05   7.6211749438059861461e-05
+max norm errors: 4.6699731032995295266e-05   9.2891170293485370024e-05   8.3217136437885308453e-05

--- a/tests/IBFE/interpolate_velocity_01_3d.c.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.c.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0328818
-max norm errors: 6.3268666428584197092e-05   0.00013722456560683049531   8.3217136472968356031e-05
+max norm errors: 6.3268666459670441782e-05   0.00013722456563280971409   8.3217136438273886512e-05


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?



This PR fixes two problems:
1. We now use a consistent preconditioner over different processor counts (block jacobi, the default, is dependent on the number of processes; plain old jacobi is not)
2. Do a max reduction of the error to get the true error max.

In addition, I adjusted the solver tolerances to be a bit more sane.