### PR TITLE
Fix test again

### DIFF
--- a/tests/IBFE/interpolate_velocity_01.cpp
+++ b/tests/IBFE/interpolate_velocity_01.cpp
@@ -378,11 +378,13 @@ main(int argc, char** argv)
 
             plog << "max vertex distance: " << SAMRAI_MPI::maxReduction(max_vertex_distance) << std::endl;
             plog << "max norm errors: ";
+            for (double& max_error : max_norm_errors) max_error = SAMRAI_MPI::maxReduction(max_error);
+            plog << std::setprecision(20);
             for (unsigned int i = 0; i < n_vars - 1; ++i)
             {
-                plog << std::setprecision(20) << max_norm_errors[i] << "   ";
+                plog << max_norm_errors[i] << "   ";
             }
-            plog << SAMRAI_MPI::maxReduction(max_norm_errors[n_vars - 1]) << std::endl;
+            plog << max_norm_errors[n_vars - 1] << std::endl;
         }
     } // cleanup dynamically allocated objects prior to shutdown
 

--- a/tests/IBFE/interpolate_velocity_01_2d.a.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.a.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 2560
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.0236627
-max norm errors: 0.00017567213561375805142   0.00026357631227047484401
+interpolate_velocity_01_2d.a.output

--- a/tests/IBFE/interpolate_velocity_01_2d.b.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.b.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 10240
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.0127652
-max norm errors: 4.8066888367670479454e-05   7.211328027689756226e-05
+interpolate_velocity_01_2d.b.output

--- a/tests/IBFE/interpolate_velocity_01_2d.c.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.c.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 40960
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.00668694
-max norm errors: 1.2820255440804118052e-05   1.9232317827855283099e-05
+interpolate_velocity_01_2d.c.output

--- a/tests/IBFE/interpolate_velocity_01_2d.d.ghosted.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.d.ghosted.mpirun=4.output
@@ -1,1 +1,1 @@
-interpolate_velocity_01_2d.d.mpirun=4.output
+interpolate_velocity_01_2d.d.output

--- a/tests/IBFE/interpolate_velocity_01_2d.d.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.d.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 163840
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.00348279
-max norm errors: 3.2305877791793946585e-06   4.8473241573976366681e-06
+interpolate_velocity_01_2d.d.output

--- a/tests/IBFE/interpolate_velocity_01_2d.nodal_quadrature.a.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.nodal_quadrature.a.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 2560
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.0236627
-max norm errors: 0.00031255785760297971621   0.00076958757943312861016
+interpolate_velocity_01_2d.nodal_quadrature.a.output

--- a/tests/IBFE/interpolate_velocity_01_2d.nodal_quadrature.b.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.nodal_quadrature.b.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 10240
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.0127652
-max norm errors: 8.7554918579035856396e-05   0.00021638268562762519309
+interpolate_velocity_01_2d.nodal_quadrature.b.output

--- a/tests/IBFE/interpolate_velocity_01_2d.nodal_quadrature.c.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_2d.nodal_quadrature.c.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 40960
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.00668694
-max norm errors: 2.286942704166072815e-05   5.7866810271089974549e-05
+interpolate_velocity_01_2d.nodal_quadrature.c.output

--- a/tests/IBFE/interpolate_velocity_01_3d.a.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.a.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 448
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.112856
-max norm errors: 0.0010161360760618798338   0.0021560874070347679776   0.0013516244805632515735
+interpolate_velocity_01_3d.a.output

--- a/tests/IBFE/interpolate_velocity_01_3d.a.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.a.mpirun=4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.112856
-max norm errors: 0.00093667747957404401404   0.001690143382711950526   0.0013516244805636956627
+max norm errors: 0.0010161360760618798338   0.0021560874070347679776   0.0013516244805632515735

--- a/tests/IBFE/interpolate_velocity_01_3d.b.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.mpirun=4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0632458
-max norm errors: 0.00020177932298992562465   0.00031747846973084747901   0.0003158647707004469396
+max norm errors: 0.00021985461610052325909   0.00042962996991291468873   0.0003158647707006689842

--- a/tests/IBFE/interpolate_velocity_01_3d.b.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.b.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 3584
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.0632458
-max norm errors: 0.00021985461610052325909   0.00042962996991291468873   0.0003158647707006689842
+interpolate_velocity_01_3d.b.output

--- a/tests/IBFE/interpolate_velocity_01_3d.c.cached.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.c.cached.mpirun=4.output
@@ -1,1 +1,1 @@
-interpolate_velocity_01_3d.c.mpirun=4.output
+interpolate_velocity_01_3d.c.output

--- a/tests/IBFE/interpolate_velocity_01_3d.c.ghosted.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.c.ghosted.mpirun=4.output
@@ -1,1 +1,1 @@
-interpolate_velocity_01_3d.c.mpirun=4.output
+interpolate_velocity_01_3d.c.output

--- a/tests/IBFE/interpolate_velocity_01_3d.c.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.c.mpirun=4.output
@@ -6,4 +6,4 @@ IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 max vertex distance: 0.0328818
-max norm errors: 4.6699731032995295266e-05   9.2891170293485370024e-05   8.3217136437885308453e-05
+max norm errors: 6.3268666460558620201e-05   0.00013722456563169949106   8.3217136437885308453e-05

--- a/tests/IBFE/interpolate_velocity_01_3d.c.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.c.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 28672
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.0328818
-max norm errors: 6.3268666460558620201e-05   0.00013722456563169949106   8.3217136437885308453e-05
+interpolate_velocity_01_3d.c.output

--- a/tests/IBFE/interpolate_velocity_01_3d.nodal_quadrature.a.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.nodal_quadrature.a.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 448
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.112856
-max norm errors: 0.00086495665495034401715   0.0012974349824257380703   0.0012974349824259601149
+interpolate_velocity_01_3d.nodal_quadrature.a.output

--- a/tests/IBFE/interpolate_velocity_01_3d.nodal_quadrature.b.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.nodal_quadrature.b.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 3584
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.0632458
-max norm errors: 0.00025498435220439041871   0.00038247652830736278418   0.00038247652830669665036
+interpolate_velocity_01_3d.nodal_quadrature.b.output

--- a/tests/IBFE/interpolate_velocity_01_3d.nodal_quadrature.c.mpirun=4.output
+++ b/tests/IBFE/interpolate_velocity_01_3d.nodal_quadrature.c.mpirun=4.output
@@ -1,9 +1,1 @@
-Number of elements: 28672
-
-IBFEMethod: mesh part 0 is using FIRST order LAGRANGE finite elements.
-
-IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
-INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
-  projecting the interpolated velocity field
-max vertex distance: 0.0328818
-max norm errors: 7.1870498125736759221e-05   0.00010780574718838309423   0.00010780574718838309423
+interpolate_velocity_01_3d.nodal_quadrature.c.output


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

Quick followup to #957 - I forgot to do a max reduction everywhere.

Additionally, to make sure that we really do get the same results independent of the number of processors, I replaced all parallel output files with symbolic links to serial output files.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?