### PR TITLE
Implement contravariants

### DIFF
--- a/ibtk/include/ibtk/JacobianCalculatorCache.h
+++ b/ibtk/include/ibtk/JacobianCalculatorCache.h
@@ -122,7 +122,7 @@ inline JacobianCalculatorCache::value_type&
         switch (d_spatial_dimension)
         {
         case 1:
-            jac_calc.reset(new LagrangeJacobianCalculator<1>(quad_key));
+            jac_calc.reset(new LagrangeMapping<1>(quad_key));
             break;
         case 2:
             switch (elem_type)
@@ -130,20 +130,20 @@ inline JacobianCalculatorCache::value_type&
             case libMesh::EDGE2:
             case libMesh::EDGE3:
             case libMesh::EDGE4:
-                jac_calc.reset(new LagrangeJacobianCalculator<1, 2>(quad_key));
+                jac_calc.reset(new LagrangeMapping<1, 2>(quad_key));
                 break;
             case libMesh::TRI3:
-                jac_calc.reset(new Tri3JacobianCalculator(quad_key));
+                jac_calc.reset(new Tri3Mapping(quad_key));
                 break;
             case libMesh::QUAD4:
-                jac_calc.reset(new Quad4JacobianCalculator(quad_key));
+                jac_calc.reset(new Quad4Mapping(quad_key));
                 break;
             case libMesh::TRI6:
             case libMesh::QUAD8:
-                jac_calc.reset(new LagrangeJacobianCalculator<2, 2>(quad_key));
+                jac_calc.reset(new LagrangeMapping<2, 2>(quad_key));
                 break;
             case libMesh::QUAD9:
-                jac_calc.reset(new Quad9JacobianCalculator(quad_key));
+                jac_calc.reset(new Quad9Mapping(quad_key));
                 break;
             default:
                 TBOX_ERROR("unimplemented element type");
@@ -151,13 +151,13 @@ inline JacobianCalculatorCache::value_type&
             break;
         case 3:
             if (dim == 1)
-                jac_calc.reset(new LagrangeJacobianCalculator<1, 3>(quad_key));
+                jac_calc.reset(new LagrangeMapping<1, 3>(quad_key));
             else if (dim == 2)
-                jac_calc.reset(new LagrangeJacobianCalculator<2, 3>(quad_key));
+                jac_calc.reset(new LagrangeMapping<2, 3>(quad_key));
             else if (elem_type == libMesh::TET4)
-                jac_calc.reset(new Tet4JacobianCalculator(quad_key));
+                jac_calc.reset(new Tet4Mapping(quad_key));
             else
-                jac_calc.reset(new LagrangeJacobianCalculator<3, 3>(quad_key));
+                jac_calc.reset(new LagrangeMapping<3, 3>(quad_key));
             break;
         default:
             TBOX_ERROR("unimplemented spatial dimension");

--- a/tests/IBTK/jacobian_calc_01.cpp
+++ b/tests/IBTK/jacobian_calc_01.cpp
@@ -232,10 +232,10 @@ main(int argc, char** argv)
         {
             plog << "Test " << test_n << ": TRI3 square" << std::endl;
             const key_type key(TRI3, QGAUSS, THIRD);
-            Tri3JacobianCalculator jac_calc_1(key);
-            LagrangeJacobianCalculator<2> jac_calc_2(key);
+            Tri3Mapping jac_calc_1(key);
+            LagrangeMapping<2> jac_calc_2(key);
             const key_type boundary_key(EDGE2, QGAUSS, THIRD);
-            LagrangeJacobianCalculator<1, 2> jac_calc_b(boundary_key);
+            LagrangeMapping<1, 2> jac_calc_b(boundary_key);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, 2, key);
             ++test_n;
         }
@@ -243,10 +243,10 @@ main(int argc, char** argv)
         {
             plog << "Test " << test_n << ": TRI3 square" << std::endl;
             const key_type key(TRI3, QGAUSS, THIRD);
-            Tri3JacobianCalculator jac_calc_1(key);
-            LagrangeJacobianCalculator<2> jac_calc_2(key);
+            Tri3Mapping jac_calc_1(key);
+            LagrangeMapping<2> jac_calc_2(key);
             const key_type boundary_key(EDGE2, QGAUSS, THIRD);
-            LagrangeJacobianCalculator<1, 2> jac_calc_b(boundary_key);
+            LagrangeMapping<1, 2> jac_calc_b(boundary_key);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, 2, key);
             ++test_n;
         }
@@ -254,10 +254,10 @@ main(int argc, char** argv)
         {
             plog << "Test " << test_n << ": Quad4 square" << std::endl;
             const key_type key(QUAD4, QGAUSS, THIRD);
-            Quad4JacobianCalculator jac_calc_1(key);
-            LagrangeJacobianCalculator<2> jac_calc_2(key);
+            Quad4Mapping jac_calc_1(key);
+            LagrangeMapping<2> jac_calc_2(key);
             const key_type boundary_key(EDGE2, QGAUSS, THIRD);
-            LagrangeJacobianCalculator<1, 2> jac_calc_b(boundary_key);
+            LagrangeMapping<1, 2> jac_calc_b(boundary_key);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, 2, key);
             ++test_n;
         }
@@ -265,10 +265,10 @@ main(int argc, char** argv)
         {
             plog << "Test " << test_n << ": Quad4 circle" << std::endl;
             const key_type key(QUAD4, QGAUSS, THIRD);
-            Quad4JacobianCalculator jac_calc_1(key);
-            LagrangeJacobianCalculator<2> jac_calc_2(key);
+            Quad4Mapping jac_calc_1(key);
+            LagrangeMapping<2> jac_calc_2(key);
             const key_type boundary_key(EDGE2, QGAUSS, THIRD);
-            LagrangeJacobianCalculator<1, 2> jac_calc_b(boundary_key);
+            LagrangeMapping<1, 2> jac_calc_b(boundary_key);
             test_circle(init, jac_calc_1, jac_calc_2, jac_calc_b, 5, 2, key);
             ++test_n;
         }
@@ -276,10 +276,10 @@ main(int argc, char** argv)
         {
             plog << "Test " << test_n << ": Quad9 square" << std::endl;
             const key_type key(QUAD9, QGAUSS, FOURTH);
-            Quad9JacobianCalculator jac_calc_1(key);
-            LagrangeJacobianCalculator<2> jac_calc_2(key);
+            Quad9Mapping jac_calc_1(key);
+            LagrangeMapping<2> jac_calc_2(key);
             const key_type boundary_key(EDGE3, QGAUSS, FOURTH);
-            LagrangeJacobianCalculator<1, 2> jac_calc_b(boundary_key);
+            LagrangeMapping<1, 2> jac_calc_b(boundary_key);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, 2, key);
             ++test_n;
         }
@@ -287,10 +287,10 @@ main(int argc, char** argv)
         {
             plog << "Test " << test_n << ": Quad9 circle" << std::endl;
             const key_type key(QUAD9, QGAUSS, FOURTH);
-            Quad9JacobianCalculator jac_calc_1(key);
-            LagrangeJacobianCalculator<2> jac_calc_2(key);
+            Quad9Mapping jac_calc_1(key);
+            LagrangeMapping<2> jac_calc_2(key);
             const key_type boundary_key(EDGE3, QGAUSS, FOURTH);
-            LagrangeJacobianCalculator<1, 2> jac_calc_b(boundary_key);
+            LagrangeMapping<1, 2> jac_calc_b(boundary_key);
             test_circle(init, jac_calc_1, jac_calc_2, jac_calc_b, 4, 2, key);
             ++test_n;
         }
@@ -298,10 +298,10 @@ main(int argc, char** argv)
         {
             plog << "Test " << test_n << ": TET4 cube" << std::endl;
             const key_type key(TET4, QGAUSS, THIRD);
-            Tet4JacobianCalculator jac_calc_1(key);
-            LagrangeJacobianCalculator<3> jac_calc_2(key);
+            Tet4Mapping jac_calc_1(key);
+            LagrangeMapping<3> jac_calc_2(key);
             const key_type boundary_key(TRI3, QGAUSS, THIRD);
-            LagrangeJacobianCalculator<2, 3> jac_calc_b(boundary_key);
+            LagrangeMapping<2, 3> jac_calc_b(boundary_key);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, 3, key);
             ++test_n;
         }
@@ -310,10 +310,10 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": HEX8 square" << std::endl;
             const key_type key(HEX8, QGAUSS, THIRD);
             // HEX8 doesn't have a custom calculator yet
-            LagrangeJacobianCalculator<3> jac_calc_1(key);
-            LagrangeJacobianCalculator<3> jac_calc_2(key);
+            LagrangeMapping<3> jac_calc_1(key);
+            LagrangeMapping<3> jac_calc_2(key);
             const key_type boundary_key(QUAD4, QGAUSS, THIRD);
-            LagrangeJacobianCalculator<2, 3> jac_calc_b(boundary_key);
+            LagrangeMapping<2, 3> jac_calc_b(boundary_key);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, 3, key);
             ++test_n;
         }
@@ -322,10 +322,10 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": HEX8 circle" << std::endl;
             const key_type key(HEX8, QGAUSS, THIRD);
             // HEX8 doesn't have a custom calculator yet
-            LagrangeJacobianCalculator<3> jac_calc_1(key);
-            LagrangeJacobianCalculator<3> jac_calc_2(key);
+            LagrangeMapping<3> jac_calc_1(key);
+            LagrangeMapping<3> jac_calc_2(key);
             const key_type boundary_key(QUAD4, QGAUSS, THIRD);
-            LagrangeJacobianCalculator<2, 3> jac_calc_b(boundary_key);
+            LagrangeMapping<2, 3> jac_calc_b(boundary_key);
             test_circle(init, jac_calc_1, jac_calc_2, jac_calc_b, 4, 3, key);
             ++test_n;
         }
@@ -334,10 +334,10 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": HEX27 square" << std::endl;
             const key_type key(HEX27, QGAUSS, FOURTH);
             // HEX27 doesn't have a custom calculator yet
-            LagrangeJacobianCalculator<3> jac_calc_1(key);
-            LagrangeJacobianCalculator<3> jac_calc_2(key);
+            LagrangeMapping<3> jac_calc_1(key);
+            LagrangeMapping<3> jac_calc_2(key);
             const key_type boundary_key(QUAD9, QGAUSS, FOURTH);
-            LagrangeJacobianCalculator<2, 3> jac_calc_b(boundary_key);
+            LagrangeMapping<2, 3> jac_calc_b(boundary_key);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, 3, key);
             ++test_n;
         }
@@ -346,10 +346,10 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": HEX27 circle" << std::endl;
             const key_type key(HEX27, QGAUSS, FOURTH);
             // HEX27 doesn't have a custom calculator yet
-            LagrangeJacobianCalculator<3> jac_calc_1(key);
-            LagrangeJacobianCalculator<3> jac_calc_2(key);
+            LagrangeMapping<3> jac_calc_1(key);
+            LagrangeMapping<3> jac_calc_2(key);
             const key_type boundary_key(QUAD9, QGAUSS, FOURTH);
-            LagrangeJacobianCalculator<2, 3> jac_calc_b(boundary_key);
+            LagrangeMapping<2, 3> jac_calc_b(boundary_key);
             test_circle(init, jac_calc_1, jac_calc_2, jac_calc_b, 2, 3, key);
             ++test_n;
         }


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

First part of #482: we need to efficiently sidestep libMesh's computations of the contravariant so that we can compute both JxW values and gradients.

This first PR doesn't do much - it just explicitly stores the computed contravariant in a renamed class. The new few PRs will add other useful mapping features (array of jacobians, mapped quadrature points). Once we have all the features of the mapping we can move on to replace `libMesh::FEBase` for a subset of elements.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?