### PR TITLE
allow users to set outflow_bdry_extrap_type in AdvDiffWavePropConvectiveOperator

### DIFF
--- a/doc/news/changes/minor/20200408BoyceGriffith
+++ b/doc/news/changes/minor/20200408BoyceGriffith
@@ -1,0 +1,3 @@
+Fixed: Recognize outflow_bdry_extrap_type input setting in the WAVE_PROP convective operator.
+<br>
+(Boyce Griffith and Aaron Barrett, 2020/04/08)

--- a/src/adv_diff/AdvDiffWavePropConvectiveOperator.cpp
+++ b/src/adv_diff/AdvDiffWavePropConvectiveOperator.cpp
@@ -107,7 +107,7 @@ namespace IBAMR
 AdvDiffWavePropConvectiveOperator::AdvDiffWavePropConvectiveOperator(
     std::string object_name,
     Pointer<CellVariable<NDIM, double> > Q_var,
-    Pointer<Database> /*input_db*/,
+    Pointer<Database> input_db,
     const ConvectiveDifferencingType differencing_form,
     std::vector<RobinBcCoefStrategy<NDIM>*> conc_bc_coefs)
     : ConvectiveOperator(std::move(object_name), differencing_form),
@@ -123,6 +123,18 @@ AdvDiffWavePropConvectiveOperator::AdvDiffWavePropConvectiveOperator(
             << "  unsupported differencing form: " << enum_to_string<ConvectiveDifferencingType>(d_difference_form)
             << " \n"
             << "  valid choices are: ADVECTIVE\n");
+    }
+
+    if (input_db)
+    {
+        if (input_db->keyExists("outflow_bdry_extrap_type"))
+            d_outflow_bdry_extrap_type = input_db->getString("outflow_bdry_extrap_type");
+        if (input_db->keyExists("bdry_extrap_type"))
+        {
+            TBOX_ERROR("AdvDiffWavePropConvectiveOperator::AdvDiffWavePropConvectiveOperator():\n"
+                       << "  input database key ``bdry_extrap_type'' has been changed to "
+                          "``outflow_bdry_extrap_type''\n");
+        }
     }
 
     // Register some scratch variables

--- a/tests/adv_diff/Makefile.am
+++ b/tests/adv_diff/Makefile.am
@@ -14,7 +14,7 @@
 include $(top_srcdir)/config/Make-rules
 
 
-EXTRA_PROGRAMS = adv_diff_01_2d adv_diff_01_3d adv_diff_02_2d adv_diff_02_3d adv_diff_03_2d
+EXTRA_PROGRAMS = adv_diff_01_2d adv_diff_01_3d adv_diff_02_2d adv_diff_02_3d adv_diff_03_2d adv_diff_convec_opers_2d adv_diff_convec_opers_3d
 
 adv_diff_01_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 adv_diff_01_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
@@ -35,6 +35,14 @@ adv_diff_02_3d_SOURCES = adv_diff_02.cpp
 adv_diff_03_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 adv_diff_03_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 adv_diff_03_2d_SOURCES = adv_diff_03.cpp
+
+adv_diff_convec_opers_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
+adv_diff_convec_opers_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+adv_diff_convec_opers_2d_SOURCES = adv_diff_convec_opers.cpp
+
+adv_diff_convec_opers_3d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=3
+adv_diff_convec_opers_3d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR3d_LIBS) $(IBAMR_LIBS)
+adv_diff_convec_opers_3d_SOURCES = adv_diff_convec_opers.cpp
 
 tests: $(EXTRA_PROGRAMS)
 	if test "$(top_srcdir)" != "$(top_builddir)" ; then \

--- a/tests/adv_diff/Makefile.in
+++ b/tests/adv_diff/Makefile.in
@@ -89,7 +89,8 @@ build_triplet = @build@
 host_triplet = @host@
 EXTRA_PROGRAMS = adv_diff_01_2d$(EXEEXT) adv_diff_01_3d$(EXEEXT) \
 	adv_diff_02_2d$(EXEEXT) adv_diff_02_3d$(EXEEXT) \
-	adv_diff_03_2d$(EXEEXT)
+	adv_diff_03_2d$(EXEEXT) adv_diff_convec_opers_2d$(EXEEXT) \
+	adv_diff_convec_opers_3d$(EXEEXT)
 subdir = tests/adv_diff
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/add_rpath.m4 \
@@ -160,6 +161,24 @@ adv_diff_03_2d_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(adv_diff_03_2d_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
+am_adv_diff_convec_opers_2d_OBJECTS =  \
+	adv_diff_convec_opers_2d-adv_diff_convec_opers.$(OBJEXT)
+adv_diff_convec_opers_2d_OBJECTS =  \
+	$(am_adv_diff_convec_opers_2d_OBJECTS)
+adv_diff_convec_opers_2d_DEPENDENCIES = $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+adv_diff_convec_opers_2d_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
+	$(adv_diff_convec_opers_2d_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
+	$(LDFLAGS) -o $@
+am_adv_diff_convec_opers_3d_OBJECTS =  \
+	adv_diff_convec_opers_3d-adv_diff_convec_opers.$(OBJEXT)
+adv_diff_convec_opers_3d_OBJECTS =  \
+	$(am_adv_diff_convec_opers_3d_OBJECTS)
+adv_diff_convec_opers_3d_DEPENDENCIES = $(IBAMR3d_LIBS) $(IBAMR_LIBS)
+adv_diff_convec_opers_3d_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
+	$(adv_diff_convec_opers_3d_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
+	$(LDFLAGS) -o $@
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -179,7 +198,9 @@ am__depfiles_remade = ./$(DEPDIR)/adv_diff_01_2d-adv_diff_01.Po \
 	./$(DEPDIR)/adv_diff_01_3d-adv_diff_01.Po \
 	./$(DEPDIR)/adv_diff_02_2d-adv_diff_02.Po \
 	./$(DEPDIR)/adv_diff_02_3d-adv_diff_02.Po \
-	./$(DEPDIR)/adv_diff_03_2d-adv_diff_03.Po
+	./$(DEPDIR)/adv_diff_03_2d-adv_diff_03.Po \
+	./$(DEPDIR)/adv_diff_convec_opers_2d-adv_diff_convec_opers.Po \
+	./$(DEPDIR)/adv_diff_convec_opers_3d-adv_diff_convec_opers.Po
 am__mv = mv -f
 CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
@@ -201,10 +222,12 @@ am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
 SOURCES = $(adv_diff_01_2d_SOURCES) $(adv_diff_01_3d_SOURCES) \
 	$(adv_diff_02_2d_SOURCES) $(adv_diff_02_3d_SOURCES) \
-	$(adv_diff_03_2d_SOURCES)
+	$(adv_diff_03_2d_SOURCES) $(adv_diff_convec_opers_2d_SOURCES) \
+	$(adv_diff_convec_opers_3d_SOURCES)
 DIST_SOURCES = $(adv_diff_01_2d_SOURCES) $(adv_diff_01_3d_SOURCES) \
 	$(adv_diff_02_2d_SOURCES) $(adv_diff_02_3d_SOURCES) \
-	$(adv_diff_03_2d_SOURCES)
+	$(adv_diff_03_2d_SOURCES) $(adv_diff_convec_opers_2d_SOURCES) \
+	$(adv_diff_convec_opers_3d_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -511,6 +534,12 @@ adv_diff_02_3d_SOURCES = adv_diff_02.cpp
 adv_diff_03_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 adv_diff_03_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 adv_diff_03_2d_SOURCES = adv_diff_03.cpp
+adv_diff_convec_opers_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
+adv_diff_convec_opers_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+adv_diff_convec_opers_2d_SOURCES = adv_diff_convec_opers.cpp
+adv_diff_convec_opers_3d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=3
+adv_diff_convec_opers_3d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR3d_LIBS) $(IBAMR_LIBS)
+adv_diff_convec_opers_3d_SOURCES = adv_diff_convec_opers.cpp
 all: all-am
 
 .SUFFIXES:
@@ -566,6 +595,14 @@ adv_diff_03_2d$(EXEEXT): $(adv_diff_03_2d_OBJECTS) $(adv_diff_03_2d_DEPENDENCIES
 	@rm -f adv_diff_03_2d$(EXEEXT)
 	$(AM_V_CXXLD)$(adv_diff_03_2d_LINK) $(adv_diff_03_2d_OBJECTS) $(adv_diff_03_2d_LDADD) $(LIBS)
 
+adv_diff_convec_opers_2d$(EXEEXT): $(adv_diff_convec_opers_2d_OBJECTS) $(adv_diff_convec_opers_2d_DEPENDENCIES) $(EXTRA_adv_diff_convec_opers_2d_DEPENDENCIES) 
+	@rm -f adv_diff_convec_opers_2d$(EXEEXT)
+	$(AM_V_CXXLD)$(adv_diff_convec_opers_2d_LINK) $(adv_diff_convec_opers_2d_OBJECTS) $(adv_diff_convec_opers_2d_LDADD) $(LIBS)
+
+adv_diff_convec_opers_3d$(EXEEXT): $(adv_diff_convec_opers_3d_OBJECTS) $(adv_diff_convec_opers_3d_DEPENDENCIES) $(EXTRA_adv_diff_convec_opers_3d_DEPENDENCIES) 
+	@rm -f adv_diff_convec_opers_3d$(EXEEXT)
+	$(AM_V_CXXLD)$(adv_diff_convec_opers_3d_LINK) $(adv_diff_convec_opers_3d_OBJECTS) $(adv_diff_convec_opers_3d_LDADD) $(LIBS)
+
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
 
@@ -577,6 +614,8 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/adv_diff_02_2d-adv_diff_02.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/adv_diff_02_3d-adv_diff_02.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/adv_diff_03_2d-adv_diff_03.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/adv_diff_convec_opers_2d-adv_diff_convec_opers.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/adv_diff_convec_opers_3d-adv_diff_convec_opers.Po@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
 	@$(MKDIR_P) $(@D)
@@ -677,6 +716,34 @@ adv_diff_03_2d-adv_diff_03.obj: adv_diff_03.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='adv_diff_03.cpp' object='adv_diff_03_2d-adv_diff_03.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(adv_diff_03_2d_CXXFLAGS) $(CXXFLAGS) -c -o adv_diff_03_2d-adv_diff_03.obj `if test -f 'adv_diff_03.cpp'; then $(CYGPATH_W) 'adv_diff_03.cpp'; else $(CYGPATH_W) '$(srcdir)/adv_diff_03.cpp'; fi`
+
+adv_diff_convec_opers_2d-adv_diff_convec_opers.o: adv_diff_convec_opers.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(adv_diff_convec_opers_2d_CXXFLAGS) $(CXXFLAGS) -MT adv_diff_convec_opers_2d-adv_diff_convec_opers.o -MD -MP -MF $(DEPDIR)/adv_diff_convec_opers_2d-adv_diff_convec_opers.Tpo -c -o adv_diff_convec_opers_2d-adv_diff_convec_opers.o `test -f 'adv_diff_convec_opers.cpp' || echo '$(srcdir)/'`adv_diff_convec_opers.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/adv_diff_convec_opers_2d-adv_diff_convec_opers.Tpo $(DEPDIR)/adv_diff_convec_opers_2d-adv_diff_convec_opers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='adv_diff_convec_opers.cpp' object='adv_diff_convec_opers_2d-adv_diff_convec_opers.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(adv_diff_convec_opers_2d_CXXFLAGS) $(CXXFLAGS) -c -o adv_diff_convec_opers_2d-adv_diff_convec_opers.o `test -f 'adv_diff_convec_opers.cpp' || echo '$(srcdir)/'`adv_diff_convec_opers.cpp
+
+adv_diff_convec_opers_2d-adv_diff_convec_opers.obj: adv_diff_convec_opers.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(adv_diff_convec_opers_2d_CXXFLAGS) $(CXXFLAGS) -MT adv_diff_convec_opers_2d-adv_diff_convec_opers.obj -MD -MP -MF $(DEPDIR)/adv_diff_convec_opers_2d-adv_diff_convec_opers.Tpo -c -o adv_diff_convec_opers_2d-adv_diff_convec_opers.obj `if test -f 'adv_diff_convec_opers.cpp'; then $(CYGPATH_W) 'adv_diff_convec_opers.cpp'; else $(CYGPATH_W) '$(srcdir)/adv_diff_convec_opers.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/adv_diff_convec_opers_2d-adv_diff_convec_opers.Tpo $(DEPDIR)/adv_diff_convec_opers_2d-adv_diff_convec_opers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='adv_diff_convec_opers.cpp' object='adv_diff_convec_opers_2d-adv_diff_convec_opers.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(adv_diff_convec_opers_2d_CXXFLAGS) $(CXXFLAGS) -c -o adv_diff_convec_opers_2d-adv_diff_convec_opers.obj `if test -f 'adv_diff_convec_opers.cpp'; then $(CYGPATH_W) 'adv_diff_convec_opers.cpp'; else $(CYGPATH_W) '$(srcdir)/adv_diff_convec_opers.cpp'; fi`
+
+adv_diff_convec_opers_3d-adv_diff_convec_opers.o: adv_diff_convec_opers.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(adv_diff_convec_opers_3d_CXXFLAGS) $(CXXFLAGS) -MT adv_diff_convec_opers_3d-adv_diff_convec_opers.o -MD -MP -MF $(DEPDIR)/adv_diff_convec_opers_3d-adv_diff_convec_opers.Tpo -c -o adv_diff_convec_opers_3d-adv_diff_convec_opers.o `test -f 'adv_diff_convec_opers.cpp' || echo '$(srcdir)/'`adv_diff_convec_opers.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/adv_diff_convec_opers_3d-adv_diff_convec_opers.Tpo $(DEPDIR)/adv_diff_convec_opers_3d-adv_diff_convec_opers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='adv_diff_convec_opers.cpp' object='adv_diff_convec_opers_3d-adv_diff_convec_opers.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(adv_diff_convec_opers_3d_CXXFLAGS) $(CXXFLAGS) -c -o adv_diff_convec_opers_3d-adv_diff_convec_opers.o `test -f 'adv_diff_convec_opers.cpp' || echo '$(srcdir)/'`adv_diff_convec_opers.cpp
+
+adv_diff_convec_opers_3d-adv_diff_convec_opers.obj: adv_diff_convec_opers.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(adv_diff_convec_opers_3d_CXXFLAGS) $(CXXFLAGS) -MT adv_diff_convec_opers_3d-adv_diff_convec_opers.obj -MD -MP -MF $(DEPDIR)/adv_diff_convec_opers_3d-adv_diff_convec_opers.Tpo -c -o adv_diff_convec_opers_3d-adv_diff_convec_opers.obj `if test -f 'adv_diff_convec_opers.cpp'; then $(CYGPATH_W) 'adv_diff_convec_opers.cpp'; else $(CYGPATH_W) '$(srcdir)/adv_diff_convec_opers.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/adv_diff_convec_opers_3d-adv_diff_convec_opers.Tpo $(DEPDIR)/adv_diff_convec_opers_3d-adv_diff_convec_opers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='adv_diff_convec_opers.cpp' object='adv_diff_convec_opers_3d-adv_diff_convec_opers.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(adv_diff_convec_opers_3d_CXXFLAGS) $(CXXFLAGS) -c -o adv_diff_convec_opers_3d-adv_diff_convec_opers.obj `if test -f 'adv_diff_convec_opers.cpp'; then $(CYGPATH_W) 'adv_diff_convec_opers.cpp'; else $(CYGPATH_W) '$(srcdir)/adv_diff_convec_opers.cpp'; fi`
 
 mostlyclean-libtool:
 	-rm -f *.lo
@@ -814,6 +881,8 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/adv_diff_02_2d-adv_diff_02.Po
 	-rm -f ./$(DEPDIR)/adv_diff_02_3d-adv_diff_02.Po
 	-rm -f ./$(DEPDIR)/adv_diff_03_2d-adv_diff_03.Po
+	-rm -f ./$(DEPDIR)/adv_diff_convec_opers_2d-adv_diff_convec_opers.Po
+	-rm -f ./$(DEPDIR)/adv_diff_convec_opers_3d-adv_diff_convec_opers.Po
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -864,6 +933,8 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/adv_diff_02_2d-adv_diff_02.Po
 	-rm -f ./$(DEPDIR)/adv_diff_02_3d-adv_diff_02.Po
 	-rm -f ./$(DEPDIR)/adv_diff_03_2d-adv_diff_03.Po
+	-rm -f ./$(DEPDIR)/adv_diff_convec_opers_2d-adv_diff_convec_opers.Po
+	-rm -f ./$(DEPDIR)/adv_diff_convec_opers_3d-adv_diff_convec_opers.Po
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/tests/adv_diff/adv_diff_convec_opers.cpp
+++ b/tests/adv_diff/adv_diff_convec_opers.cpp
@@ -1,0 +1,210 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2019 - 2019 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+// Config files
+#include <IBAMR_config.h>
+#include <IBTK_config.h>
+
+#include <SAMRAI_config.h>
+
+// Headers for basic PETSc functions
+#include <petscsys.h>
+
+// Headers for basic SAMRAI objects
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <LoadBalancer.h>
+#include <StandardTagAndInitialize.h>
+
+// Headers for application-specific algorithm/data structure objects
+#include <ibamr/AdvDiffPredictorCorrectorHierarchyIntegrator.h>
+#include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
+
+#include <ibtk/AppInitializer.h>
+
+#include <LocationIndexRobinBcCoefs.h>
+
+// Set up application namespace declarations
+#include "ibamr/AdvDiffConvectiveOperatorManager.h"
+#include <ibamr/app_namespaces.h>
+
+#include "ibtk/muParserCartGridFunction.h"
+#include "ibtk/muParserRobinBcCoefs.h"
+
+#include <SAMRAIVectorReal.h>
+
+/*******************************************************************************
+ * For each run, the input filename and restart information (if needed) must   *
+ * be given on the command line.  For non-restarted case, command line is:     *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ * For restarted run, command line is:                                         *
+ *                                                                             *
+ *    executable <input file name> <restart directory> <restart number>        *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize PETSc, MPI, and SAMRAI.
+    PetscInitialize(&argc, &argv, NULL, NULL);
+    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
+    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
+    SAMRAIManager::startup();
+
+    { // cleanup dynamically allocated objects prior to shutdown
+
+        // prevent a warning about timer initialization
+        TimerManager::createManager(nullptr);
+
+        // Parse command line options, set some standard options from the input
+        // file, initialize the restart database (if this is a restarted run),
+        // and enable file logging.
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "adv_diff.log");
+        Pointer<Database> input_db = app_initializer->getInputDatabase();
+        Pointer<Database> main_db = app_initializer->getComponentDatabase("Main");
+
+        // Create major algorithm and data objects that comprise the
+        // application.
+        Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<StandardTagAndInitialize<NDIM> > error_detector = new StandardTagAndInitialize<NDIM>(
+            "StandardTagAndInitialize", nullptr, app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<BergerRigoutsos<NDIM> > box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM> > load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM> > gridding_algorithm =
+            new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                        app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                        error_detector,
+                                        box_generator,
+                                        load_balancer);
+
+        Pointer<VisItDataWriter<NDIM> > visit_writer = app_initializer->getVisItDataWriter();
+
+        auto var_db = VariableDatabase<NDIM>::getDatabase();
+        Pointer<VariableContext> var_ctx = var_db->getContext("Context");
+        Pointer<CellVariable<NDIM, double> > q_var = new CellVariable<NDIM, double>("CC_var");
+        Pointer<CellVariable<NDIM, double> > convec_var = new CellVariable<NDIM, double>("Convec var");
+        Pointer<CellVariable<NDIM, double> > exact_var = new CellVariable<NDIM, double>("Exact var");
+        Pointer<FaceVariable<NDIM, double> > u_var = new FaceVariable<NDIM, double>("U");
+
+        const int q_idx = var_db->registerVariableAndContext(q_var, var_ctx);
+        const int convec_idx = var_db->registerVariableAndContext(convec_var, var_ctx);
+        const int exact_idx = var_db->registerVariableAndContext(exact_var, var_ctx);
+        const int u_idx = var_db->registerVariableAndContext(u_var, var_ctx);
+//#define OUTPUT_VIZ_FILES // Comment out if you want to draw things
+#ifdef OUTPUT_VIZ_FILES
+        visit_writer->registerPlotQuantity("Q", "SCALAR", q_idx);
+        visit_writer->registerPlotQuantity("Convec", "SCALAR", convec_idx);
+        visit_writer->registerPlotQuantity("Error", "SCALAR", exact_idx);
+#endif
+
+        Pointer<muParserCartGridFunction> u_fcn =
+            new muParserCartGridFunction("U", app_initializer->getComponentDatabase("U"), grid_geometry);
+        Pointer<muParserCartGridFunction> q_fcn =
+            new muParserCartGridFunction("Q", app_initializer->getComponentDatabase("Q"), grid_geometry);
+        Pointer<muParserCartGridFunction> exact_fcn =
+            new muParserCartGridFunction("Exact", app_initializer->getComponentDatabase("Exact"), grid_geometry);
+
+        const IntVector<NDIM>& periodic_shift = grid_geometry->getPeriodicShift();
+        std::vector<RobinBcCoefStrategy<NDIM>*> q_bc_coefs(1);
+        if (periodic_shift.min() > 0)
+            q_bc_coefs[0] = nullptr;
+        else
+            q_bc_coefs[0] =
+                new muParserRobinBcCoefs("Q_bcs", app_initializer->getComponentDatabase("Q_bcs"), grid_geometry);
+
+        std::vector<std::string> convec_oper_types = { "CENTERED", "CUI", "PPM", "WAVE_PROP" };
+        std::vector<Pointer<ConvectiveOperator> > convec_opers(convec_oper_types.size());
+        auto oper_manager = AdvDiffConvectiveOperatorManager::getManager();
+        int i = 0;
+        for (const auto& convec_oper_type : convec_oper_types)
+        {
+            auto differencing_type =
+                IBAMR::string_to_enum<ConvectiveDifferencingType>(input_db->getString("CONVECTIVE_DIFFERENCING_TYPE"));
+            convec_opers[i++] = oper_manager->allocateOperator(convec_oper_type,
+                                                               convec_oper_type,
+                                                               q_var,
+                                                               app_initializer->getComponentDatabase("ConvecOper"),
+                                                               differencing_type,
+                                                               q_bc_coefs);
+        }
+
+        gridding_algorithm->makeCoarsestLevel(patch_hierarchy, 0.0);
+        const int tag_buffer = std::numeric_limits<int>::max();
+        int level_number = 0;
+        while (gridding_algorithm->levelCanBeRefined(level_number))
+        {
+            gridding_algorithm->makeFinerLevel(patch_hierarchy, 0.0, 0.0, tag_buffer);
+            ++level_number;
+        }
+
+        const int finest_level = patch_hierarchy->getFinestLevelNumber();
+        for (int ln = 0; ln <= finest_level; ++ln)
+        {
+            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+            level->allocatePatchData(q_idx, 0.0);
+            level->allocatePatchData(convec_idx, 0.0);
+            level->allocatePatchData(exact_idx, 0.0);
+            level->allocatePatchData(u_idx, 0.0);
+        }
+
+        solv::SAMRAIVectorReal<NDIM, double> q_vec("Q_vec", patch_hierarchy, 0, finest_level);
+        q_vec.addComponent(q_var, q_idx);
+
+        u_fcn->setDataOnPatchHierarchy(u_idx, u_var, patch_hierarchy, 0.0, false, 0, finest_level);
+        q_fcn->setDataOnPatchHierarchy(q_idx, q_var, patch_hierarchy, 0.0, false, 0, finest_level);
+
+#ifdef OUTPUT_VIZ_FILES
+        int step = 0;
+#endif
+        auto do_test = [&](Pointer<ConvectiveOperator> convec_oper) {
+            convec_oper->initializeOperatorState(q_vec, q_vec);
+            convec_oper->setAdvectionVelocity(u_idx);
+            convec_oper->applyConvectiveOperator(q_idx, convec_idx);
+            exact_fcn->setDataOnPatchHierarchy(exact_idx, exact_var, patch_hierarchy, 0.0, false, 0, finest_level);
+
+            HierarchyMathOps hier_math_ops("HierarchyMathOps", patch_hierarchy);
+            hier_math_ops.resetLevels(0, finest_level);
+            const int wgt_cc_idx = hier_math_ops.getCellWeightPatchDescriptorIndex();
+
+            HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(patch_hierarchy, 0, finest_level);
+            hier_cc_data_ops.subtract(exact_idx, convec_idx, exact_idx);
+
+            pout << "Error using: " << convec_oper->getName() << ":\n"
+                 << "  L1-norm :" << hier_cc_data_ops.L1Norm(exact_idx, wgt_cc_idx) << "\n"
+                 << "  L2-norm :" << hier_cc_data_ops.L2Norm(exact_idx, wgt_cc_idx) << "\n"
+                 << "  max-norm:" << hier_cc_data_ops.maxNorm(exact_idx, wgt_cc_idx) << "\n";
+#ifdef OUTPUT_VIZ_FILES
+            visit_writer->writePlotData(patch_hierarchy, step++, 0.0);
+#endif
+        };
+
+        for (const auto& convec_oper : convec_opers) do_test(convec_oper);
+
+        for (int ln = 0; ln <= finest_level; ++ln)
+        {
+            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+            level->deallocatePatchData(q_idx);
+            level->deallocatePatchData(convec_idx);
+            level->deallocatePatchData(exact_idx);
+            level->deallocatePatchData(u_idx);
+        }
+    } // cleanup dynamically allocated objects prior to shutdown
+
+    SAMRAIManager::shutdown();
+    PetscFinalize();
+} // main

--- a/tests/adv_diff/adv_diff_convec_opers_2d.constant.input
+++ b/tests/adv_diff/adv_diff_convec_opers_2d.constant.input
@@ -1,0 +1,102 @@
+// physical parameters
+L = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 2                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX  = L/NFINEST                                // mesh width on finest   grid level
+
+CONVECTIVE_DIFFERENCING_TYPE = "ADVECTIVE"
+OUTFLOW_EXTRAP_TYPE = "CONSTANT"
+
+QFCN = "cos(2*PI*X_0)*cos(2*PI*X_1)"
+
+ConvecOper {
+    outflow_bdry_extrap_type = OUTFLOW_EXTRAP_TYPE
+}
+
+Q {
+   function = QFCN
+}
+
+Q_bcs {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = QFCN
+   gcoef_function_1 = QFCN
+   gcoef_function_2 = QFCN
+   gcoef_function_3 = QFCN
+}
+
+U {
+   function_0 = "1.0"
+   function_1 = "1.0"
+}
+
+Exact {
+   function = "-2*PI*sin(2*PI*(X_0+X_1))"
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+   
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 2
+   viz_dump_dirname            = "viz_advect2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/adv_diff/adv_diff_convec_opers_2d.constant.output
+++ b/tests/adv_diff/adv_diff_convec_opers_2d.constant.output
@@ -1,0 +1,16 @@
+Error using: CENTERED:
+  L1-norm :0.0069359
+  L2-norm :0.0120674
+  max-norm:0.153007
+Error using: CUI:
+  L1-norm :0.012229
+  L2-norm :0.0399823
+  max-norm:0.385051
+Error using: PPM:
+  L1-norm :0.00481185
+  L2-norm :0.0174782
+  max-norm:0.217064
+Error using: WAVE_PROP:
+  L1-norm :0.00434733
+  L2-norm :0.0166877
+  max-norm:0.20535

--- a/tests/adv_diff/adv_diff_convec_opers_2d.linear.input
+++ b/tests/adv_diff/adv_diff_convec_opers_2d.linear.input
@@ -1,0 +1,102 @@
+// physical parameters
+L = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 2                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX  = L/NFINEST                                // mesh width on finest   grid level
+
+CONVECTIVE_DIFFERENCING_TYPE = "ADVECTIVE"
+OUTFLOW_EXTRAP_TYPE = "LINEAR"
+
+QFCN = "cos(2*PI*X_0)*cos(2*PI*X_1)"
+
+ConvecOper {
+    outflow_bdry_extrap_type = OUTFLOW_EXTRAP_TYPE
+}
+
+Q {
+   function = QFCN
+}
+
+Q_bcs {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = QFCN
+   gcoef_function_1 = QFCN
+   gcoef_function_2 = QFCN
+   gcoef_function_3 = QFCN
+}
+
+U {
+   function_0 = "1.0"
+   function_1 = "1.0"
+}
+
+Exact {
+   function = "-2*PI*sin(2*PI*(X_0+X_1))"
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+      
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 2
+   viz_dump_dirname            = "viz_advect2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/adv_diff/adv_diff_convec_opers_2d.linear.output
+++ b/tests/adv_diff/adv_diff_convec_opers_2d.linear.output
@@ -1,0 +1,16 @@
+Error using: CENTERED:
+  L1-norm :0.0127769
+  L2-norm :0.0405497
+  max-norm:0.613882
+Error using: CUI:
+  L1-norm :0.0142095
+  L2-norm :0.0463482
+  max-norm:0.513379
+Error using: PPM:
+  L1-norm :0.00785237
+  L2-norm :0.0304721
+  max-norm:0.439081
+Error using: WAVE_PROP:
+  L1-norm :0.0074412
+  L2-norm :0.0305214
+  max-norm:0.443602

--- a/tests/adv_diff/adv_diff_convec_opers_2d.none.input
+++ b/tests/adv_diff/adv_diff_convec_opers_2d.none.input
@@ -1,0 +1,102 @@
+// physical parameters
+L = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 2                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX  = L/NFINEST                                // mesh width on finest   grid level
+
+CONVECTIVE_DIFFERENCING_TYPE = "ADVECTIVE"
+OUTFLOW_EXTRAP_TYPE = "NONE"
+
+QFCN = "cos(2*PI*X_0)*cos(2*PI*X_1)"
+
+ConvecOper {
+    outflow_bdry_extrap_type = OUTFLOW_EXTRAP_TYPE
+}
+
+Q {
+   function = QFCN
+}
+
+Q_bcs {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "0.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "0.0"
+   
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "1.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "1.0"
+
+   gcoef_function_0 = QFCN
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = QFCN
+   gcoef_function_3 = "0.0"
+}
+
+U {
+   function_0 = "1.0"
+   function_1 = "1.0"
+}
+
+Exact {
+   function = "-2*PI*sin(2*PI*(X_0+X_1))"
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+      
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 2
+   viz_dump_dirname            = "viz_advect2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/adv_diff/adv_diff_convec_opers_2d.none.output
+++ b/tests/adv_diff/adv_diff_convec_opers_2d.none.output
@@ -1,0 +1,16 @@
+Error using: CENTERED:
+  L1-norm :0.0069359
+  L2-norm :0.0120674
+  max-norm:0.153007
+Error using: CUI:
+  L1-norm :0.012229
+  L2-norm :0.0399823
+  max-norm:0.385051
+Error using: PPM:
+  L1-norm :0.00260305
+  L2-norm :0.0109289
+  max-norm:0.149559
+Error using: WAVE_PROP:
+  L1-norm :0.00236394
+  L2-norm :0.0106455
+  max-norm:0.139673

--- a/tests/adv_diff/adv_diff_convec_opers_2d.quadratic.input
+++ b/tests/adv_diff/adv_diff_convec_opers_2d.quadratic.input
@@ -1,0 +1,102 @@
+// physical parameters
+L = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 2                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX  = L/NFINEST                                // mesh width on finest   grid level
+
+CONVECTIVE_DIFFERENCING_TYPE = "ADVECTIVE"
+OUTFLOW_EXTRAP_TYPE = "QUADRATIC"
+
+QFCN = "cos(2*PI*X_0)*cos(2*PI*X_1)"
+
+ConvecOper {
+    outflow_bdry_extrap_type = OUTFLOW_EXTRAP_TYPE
+}
+
+Q {
+   function = QFCN
+}
+
+Q_bcs {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = QFCN
+   gcoef_function_1 = QFCN
+   gcoef_function_2 = QFCN
+   gcoef_function_3 = QFCN
+}
+
+U {
+   function_0 = "1.0"
+   function_1 = "1.0"
+}
+
+Exact {
+   function = "-2*PI*sin(2*PI*(X_0+X_1))"
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+      
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 2
+   viz_dump_dirname            = "viz_advect2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/adv_diff/adv_diff_convec_opers_2d.quadratic.output
+++ b/tests/adv_diff/adv_diff_convec_opers_2d.quadratic.output
@@ -1,0 +1,16 @@
+Error using: CENTERED:
+  L1-norm :0.00693923
+  L2-norm :0.0120622
+  max-norm:0.153007
+Error using: CUI:
+  L1-norm :0.0121167
+  L2-norm :0.0397534
+  max-norm:0.385051
+Error using: PPM:
+  L1-norm :0.00264986
+  L2-norm :0.0109353
+  max-norm:0.149559
+Error using: WAVE_PROP:
+  L1-norm :0.00240652
+  L2-norm :0.010653
+  max-norm:0.139673

--- a/tests/adv_diff/adv_diff_convec_opers_3d.constant.input
+++ b/tests/adv_diff/adv_diff_convec_opers_3d.constant.input
@@ -1,0 +1,109 @@
+// physical parameters
+L = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 2                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX  = L/NFINEST                                // mesh width on finest   grid level
+
+CONVECTIVE_DIFFERENCING_TYPE = "ADVECTIVE"
+OUTFLOW_EXTRAP_TYPE = "CONSTANT"
+
+QFCN = "cos(2*PI*X_0)*cos(2*PI*X_1)*cos(2*PI*X_2)"
+
+ConvecOper {
+    outflow_bdry_extrap_type = OUTFLOW_EXTRAP_TYPE
+}
+
+Q {
+   function = QFCN
+}
+
+Q_bcs {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   acoef_function_4 = "1.0"
+   acoef_function_5 = "1.0"
+   
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+   bcoef_function_4 = "0.0"
+   bcoef_function_5 = "0.0"
+
+   gcoef_function_0 = QFCN
+   gcoef_function_1 = QFCN
+   gcoef_function_2 = QFCN
+   gcoef_function_3 = QFCN
+   gcoef_function_4 = QFCN
+   gcoef_function_5 = QFCN
+}
+
+U {
+   function_0 = "1.0"
+   function_1 = "1.0"
+   function_2 = "1.0"
+}
+
+Exact {
+   function = "-2*PI*(cos(2*PI*X_2)*cos(2*PI*X_0)*sin(2*PI*X_1) + sin(2*PI*(X_0+X_2))*cos(2*PI*X_1))"
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+   
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 2
+   viz_dump_dirname            = "viz_advect2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0,0,0
+   x_up = L,L,L
+   periodic_dimension = 0,0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/adv_diff/adv_diff_convec_opers_3d.constant.output
+++ b/tests/adv_diff/adv_diff_convec_opers_3d.constant.output
@@ -1,0 +1,16 @@
+Error using: CENTERED:
+  L1-norm :0.00626394
+  L2-norm :0.0107553
+  max-norm:0.229234
+Error using: CUI:
+  L1-norm :0.0130705
+  L2-norm :0.0397048
+  max-norm:0.692147
+Error using: PPM:
+  L1-norm :0.00427969
+  L2-norm :0.0151814
+  max-norm:0.325204
+Error using: WAVE_PROP:
+  L1-norm :0.00390492
+  L2-norm :0.0144823
+  max-norm:0.307654

--- a/tests/adv_diff/adv_diff_convec_opers_3d.linear.input
+++ b/tests/adv_diff/adv_diff_convec_opers_3d.linear.input
@@ -1,0 +1,109 @@
+// physical parameters
+L = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 2                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX  = L/NFINEST                                // mesh width on finest   grid level
+
+CONVECTIVE_DIFFERENCING_TYPE = "ADVECTIVE"
+OUTFLOW_EXTRAP_TYPE = "LINEAR"
+
+QFCN = "cos(2*PI*X_0)*cos(2*PI*X_1)*cos(2*PI*X_2)"
+
+ConvecOper {
+    outflow_bdry_extrap_type = OUTFLOW_EXTRAP_TYPE
+}
+
+Q {
+   function = QFCN
+}
+
+Q_bcs {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   acoef_function_4 = "1.0"
+   acoef_function_5 = "1.0"
+   
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+   bcoef_function_4 = "0.0"
+   bcoef_function_5 = "0.0"
+
+   gcoef_function_0 = QFCN
+   gcoef_function_1 = QFCN
+   gcoef_function_2 = QFCN
+   gcoef_function_3 = QFCN
+   gcoef_function_4 = QFCN
+   gcoef_function_5 = QFCN
+}
+
+U {
+   function_0 = "1.0"
+   function_1 = "1.0"
+   function_2 = "1.0"
+}
+
+Exact {
+   function = "-2*PI*(cos(2*PI*X_2)*cos(2*PI*X_0)*sin(2*PI*X_1) + sin(2*PI*(X_0+X_2))*cos(2*PI*X_1))"
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+      
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 2
+   viz_dump_dirname            = "viz_advect2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0,0,0
+   x_up = L,L,L
+   periodic_dimension = 0,0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/adv_diff/adv_diff_convec_opers_3d.linear.output
+++ b/tests/adv_diff/adv_diff_convec_opers_3d.linear.output
@@ -1,0 +1,16 @@
+Error using: CENTERED:
+  L1-norm :0.0116781
+  L2-norm :0.0354534
+  max-norm:0.919714
+Error using: CUI:
+  L1-norm :0.0149025
+  L2-norm :0.0450241
+  max-norm:0.82032
+Error using: PPM:
+  L1-norm :0.00714448
+  L2-norm :0.0267319
+  max-norm:0.657828
+Error using: WAVE_PROP:
+  L1-norm :0.0068402
+  L2-norm :0.026813
+  max-norm:0.664602

--- a/tests/adv_diff/adv_diff_convec_opers_3d.none.input
+++ b/tests/adv_diff/adv_diff_convec_opers_3d.none.input
@@ -1,0 +1,109 @@
+// physical parameters
+L = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 2                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX  = L/NFINEST                                // mesh width on finest   grid level
+
+CONVECTIVE_DIFFERENCING_TYPE = "ADVECTIVE"
+OUTFLOW_EXTRAP_TYPE = "NONE"
+
+QFCN = "cos(2*PI*X_0)*cos(2*PI*X_1)*cos(2*PI*X_2)"
+
+ConvecOper {
+    outflow_bdry_extrap_type = OUTFLOW_EXTRAP_TYPE
+}
+
+Q {
+   function = QFCN
+}
+
+Q_bcs {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "0.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "0.0"
+   acoef_function_4 = "1.0"
+   acoef_function_5 = "0.0"
+   
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "1.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "1.0"
+   bcoef_function_4 = "0.0"
+   bcoef_function_5 = "1.0"
+
+   gcoef_function_0 = QFCN
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = QFCN
+   gcoef_function_3 = "0.0"
+   gcoef_function_4 = QFCN
+   gcoef_function_5 = "0.0"
+}
+
+U {
+   function_0 = "1.0"
+   function_1 = "1.0"
+   function_2 = "1.0"
+}
+
+Exact {
+   function = "-2*PI*(cos(2*PI*X_2)*cos(2*PI*X_0)*sin(2*PI*X_1) + sin(2*PI*(X_0+X_2))*cos(2*PI*X_1))"
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+      
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 2
+   viz_dump_dirname            = "viz_advect2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0,0,0
+   x_up = L,L,L
+   periodic_dimension = 0,0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/adv_diff/adv_diff_convec_opers_3d.none.output
+++ b/tests/adv_diff/adv_diff_convec_opers_3d.none.output
@@ -1,0 +1,16 @@
+Error using: CENTERED:
+  L1-norm :0.00626394
+  L2-norm :0.0107553
+  max-norm:0.229234
+Error using: CUI:
+  L1-norm :0.0130705
+  L2-norm :0.0397048
+  max-norm:0.692147
+Error using: PPM:
+  L1-norm :0.00223355
+  L2-norm :0.00949624
+  max-norm:0.17703
+Error using: WAVE_PROP:
+  L1-norm :0.00206724
+  L2-norm :0.00926535
+  max-norm:0.191744

--- a/tests/adv_diff/adv_diff_convec_opers_3d.quadratic.input
+++ b/tests/adv_diff/adv_diff_convec_opers_3d.quadratic.input
@@ -1,0 +1,109 @@
+// physical parameters
+L = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 2                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX  = L/NFINEST                           // mesh width on finest   grid level
+
+CONVECTIVE_DIFFERENCING_TYPE = "ADVECTIVE"
+OUTFLOW_EXTRAP_TYPE = "QUADRATIC"
+
+QFCN = "cos(2*PI*X_0)*cos(2*PI*X_1)*cos(2*PI*X_2)"
+
+ConvecOper {
+    outflow_bdry_extrap_type = OUTFLOW_EXTRAP_TYPE
+}
+
+Q {
+   function = QFCN
+}
+
+Q_bcs {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   acoef_function_4 = "1.0"
+   acoef_function_5 = "1.0"
+   
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+   bcoef_function_4 = "0.0"
+   bcoef_function_5 = "0.0"
+
+   gcoef_function_0 = QFCN
+   gcoef_function_1 = QFCN
+   gcoef_function_2 = QFCN
+   gcoef_function_3 = QFCN
+   gcoef_function_4 = QFCN
+   gcoef_function_5 = QFCN
+}
+
+U {
+   function_0 = "1.0"
+   function_1 = "1.0"
+   function_2 = "1.0"
+}
+
+Exact {
+   function = "-2*PI*(cos(2*PI*X_2)*cos(2*PI*X_0)*sin(2*PI*X_1) + sin(2*PI*(X_0+X_2))*cos(2*PI*X_1))"
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+   
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 2
+   viz_dump_dirname            = "viz_advect2d"
+   visit_number_procs_per_file = 1
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0,0,0
+   x_up = L,L,L
+   periodic_dimension = 0,0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4, 4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/adv_diff/adv_diff_convec_opers_3d.quadratic.output
+++ b/tests/adv_diff/adv_diff_convec_opers_3d.quadratic.output
@@ -1,0 +1,16 @@
+Error using: CENTERED:
+  L1-norm :0.00626445
+  L2-norm :0.0107432
+  max-norm:0.229234
+Error using: CUI:
+  L1-norm :0.0129691
+  L2-norm :0.0395331
+  max-norm:0.692147
+Error using: PPM:
+  L1-norm :0.00227505
+  L2-norm :0.00950447
+  max-norm:0.17703
+Error using: WAVE_PROP:
+  L1-norm :0.00210397
+  L2-norm :0.00927543
+  max-norm:0.191744


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
