### PR TITLE
Fix a memory consumption bug in SAMRAIGhostDataAccumulator.

### DIFF
--- a/ibtk/src/math/SAMRAIGhostDataAccumulator.cpp
+++ b/ibtk/src/math/SAMRAIGhostDataAccumulator.cpp
@@ -160,16 +160,16 @@ SAMRAIGhostDataAccumulator::SAMRAIGhostDataAccumulator(Pointer<BasePatchHierarch
     }
     TBOX_ASSERT(depth != 0);
 
-    // make sure that we always have unique variable names (the
-    // VariableDatabase never deletes variables)
-    static int index = 0;
-    const std::string name = "SAMRAIGhostDataAccumulator::dof_" + std::to_string(index);
-    ++index;
+    const std::string name = "SAMRAIGhostDataAccumulator::dof_" + var->getName();
 
     // Create the dof indexing variable and its data:
     d_vecs.resize(d_finest_ln + 1); // be lazy and index this array directly by level number
-    Pointer<Variable<NDIM> > dof_var = d_cc_data ? Pointer<Variable<NDIM> >(new CellVariable<NDIM, int>(name, depth)) :
-                                                   Pointer<Variable<NDIM> >(new SideVariable<NDIM, int>(name, depth));
+    Pointer<Variable<NDIM> > dof_var;
+    if (var_db->checkVariableExists(name))
+        dof_var = var_db->getVariable(name);
+    else
+        dof_var = d_cc_data ? Pointer<Variable<NDIM> >(new CellVariable<NDIM, int>(name, depth)) :
+                              Pointer<Variable<NDIM> >(new SideVariable<NDIM, int>(name, depth));
 
     d_global_dof_idx = var_db->registerVariableAndContext(dof_var, context, d_gcw);
     d_local_dof_idx = var_db->registerClonedPatchDataIndex(dof_var, d_global_dof_idx);


### PR DESCRIPTION
Caught by massif while looking around for other problems. I modified a test to create `SAMRAIDataAccumulator`s in a loop - it leaks on master but doesn't with this patch.

We shouldn't create multiple variables - this actually uses a noticeable amount of memory in long time integrations.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?