### PR TITLE
split LibMeshSystemVectors into base and derived classes

### DIFF
--- a/ibtk/include/ibtk/LibMeshSystemIBVectors.h
+++ b/ibtk/include/ibtk/LibMeshSystemIBVectors.h
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2020 - 2020 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#ifndef included_IBTK_LibMeshSystemIBVectors
+#define included_IBTK_LibMeshSystemIBVectors
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include <ibtk/FEDataManager.h>
+#include <ibtk/LibMeshSystemVectors.h>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+namespace IBTK
+{
+/*!
+ * \brief Class LibMeshSystemIBVectors is a convenience class that manages
+ * access to libMesh vectors for the same system defined on multiple
+ * parts. It extends the base class LibMeshSystemVectors to provide access
+ * to vectors ghosted with both the Lagrangian partitioning (i.e., libMesh's
+ * computed partitioning, as in the base class) as well as the IB
+ * partitioning (i.e., the partitioning based on the distribution of SAMRAI
+ * data).
+ *
+ * This class stores information that depends on SAMRAI's parallel
+ * partitioning: LibMeshSystemIBVectors::reinit() should be called after
+ * regridding to clear this data.
+ *
+ * @note This class is intended for internal use in IBAMR. It is used in
+ * IBFEMethod and IBFESurfaceMethod.
+ */
+class LibMeshSystemIBVectors : public LibMeshSystemVectors
+{
+public:
+    /*!
+     * Constructor.
+     *
+     * @param[in] fe_data_managers IBTK::FEDataManager objects for each
+     * part. These are used to get libMesh vectors with ghost regions
+     * corresponding to the Eulerian partitioning.
+     *
+     * @param[in] system_name Name of the libMesh::System whose vectors we are accessing.
+     */
+    LibMeshSystemIBVectors(const std::vector<IBTK::FEDataManager*>& fe_data_managers, std::string system_name);
+
+    /*!
+     * Constructor, taking a mask argument indicating which systems actually exist.
+     *
+     * @param[in] fe_data_managers IBTK::FEDataManager objects for each
+     * part. These are used to get libMesh vectors with ghost regions
+     * corresponding to the Eulerian partitioning.
+     *
+     * @param[in] part_mask A vector indicating on which parts the given
+     * system actually exists (for example, only some parts have fluid
+     * sources)
+     *
+     * @param[in] system_name Name of the libMesh::System whose vectors we are accessing.
+     */
+    LibMeshSystemIBVectors(const std::vector<IBTK::FEDataManager*>& fe_data_managers,
+                           const std::vector<bool>& part_mask,
+                           std::string system_name);
+
+    /*!
+     * Get an IB-ghosted vector for a specific part.
+     *
+     * @param[in] vec_name Name of the vector.
+     *
+     * @param[in] part Part number.
+     */
+    libMesh::PetscVector<double>& getIBGhosted(const std::string& vec_name, const unsigned int part);
+
+    /**
+     * Get, for each part, the IB-ghosted vectors corresponding to the name @p
+     * vec_name These vectors are ghosted with values determined by
+     * IBTK::FEDataManager (i.e., based on SAMRAI's parallel partitioning).
+     *
+     * @note These vectors are managed by this object: the ghosted information
+     * will not be valid after a regrid.
+     */
+    std::vector<libMesh::PetscVector<double>*> getIBGhosted(const std::string& vec_name);
+
+    /*!
+     * Reinitialize the object. This method must be called after the Eulerian
+     * data is updated.
+     */
+    void reinit() override;
+
+protected:
+    /// Add an IB ghosted vector.
+    std::vector<std::unique_ptr<libMesh::PetscVector<double> > >& maybeAddIBGhosted(const std::string& vec_name);
+
+    /// Pointers to IBTK::FEDataManager objects. These are needed to get IB ghosted vectors.
+    std::vector<IBTK::FEDataManager*> d_fe_data_managers;
+
+    /// Previously computed IB ghosted vectors.
+    std::map<std::string, std::vector<std::unique_ptr<libMesh::PetscVector<double> > > > d_ib_ghosted_vectors;
+};
+} // namespace IBTK
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif //#ifndef included_IBTK_AppInitializer

--- a/ibtk/include/ibtk/LibMeshSystemVectors.h
+++ b/ibtk/include/ibtk/LibMeshSystemVectors.h
@@ -16,8 +16,6 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
-#include <ibtk/FEDataManager.h>
-
 #include <libmesh/equation_systems.h>
 #include <libmesh/petsc_vector.h>
 #include <libmesh/system.h>
@@ -34,10 +32,10 @@ namespace IBTK
 /*!
  * \brief Class LibMeshSystemVectors is a convenience class that manages
  * access to libMesh vectors for the same system defined on multiple
- * parts. This class supports access to vectors ghosted with the Lagrangian
- * partitioning (i.e., libMesh's computed partitioning) as well as the IB
- * partitioning (i.e., the partitioning based on the distribution of SAMRAI
- * data).
+ * parts. This class only supports access to vectors ghosted with the
+ * Lagrangian partitioning (i.e., libMesh's computed partitioning).  The
+ * subclass LibMeshSystemIBVectors provides access to the IB partitioning
+ * (i.e., the partitioning based on the distribution of SAMRAI data).
  *
  * A libMesh::System stores vectors in two different ways: the
  * <tt>solution</tt> and <tt>current_local_solution</tt> vectors are stored
@@ -57,10 +55,6 @@ namespace IBTK
  * ghost data computed by the System) and registered for projection (i.e., if
  * the mesh changes, these vectors will be automatically updated).
  *
- * This class stores information that depends on SAMRAI's parallel
- * partitioning: LibMeshSystemVectors::reinit() should be called after
- * regridding to clear this data.
- *
  * @note This class is intended for internal use in IBAMR. It is used in
  * IBFEMethod and IBFESurfaceMethod.
  */
@@ -70,20 +64,8 @@ public:
     /*!
      * Constructor.
      *
-     * @param[in] fe_data_managers IBTK::FEDataManager objects for each
-     * part. These are used to get libMesh vectors with ghost regions
-     * corresponding to the Eulerian partitioning.
-     *
-     * @param[in] system_name Name of the libMesh::System whose vectors we are accessing.
-     */
-    LibMeshSystemVectors(const std::vector<IBTK::FEDataManager*>& fe_data_managers, std::string system_name);
-
-    /*!
-     * Constructor, taking a mask argument indicating which systems actually exist.
-     *
-     * @param[in] fe_data_managers IBTK::FEDataManager objects for each
-     * part. These are used to get libMesh vectors with ghost regions
-     * corresponding to the Eulerian partitioning.
+     * @param[in] equation_systems libMesh::EquationSystems objects for each
+     * part.
      *
      * @param[in] part_mask A vector indicating on which parts the given
      * system actually exists (for example, only some parts have fluid
@@ -91,9 +73,19 @@ public:
      *
      * @param[in] system_name Name of the libMesh::System whose vectors we are accessing.
      */
-    LibMeshSystemVectors(const std::vector<IBTK::FEDataManager*>& fe_data_managers,
+    LibMeshSystemVectors(const std::vector<libMesh::EquationSystems*>& equation_systems,
                          const std::vector<bool>& part_mask,
                          std::string system_name);
+
+    /*!
+     * Constructor.
+     *
+     * @param[in] equation_systems libMesh::EquationSystems objects for each
+     * part.
+     *
+     * @param[in] system_name Name of the libMesh::System whose vectors we are accessing.
+     */
+    LibMeshSystemVectors(const std::vector<libMesh::EquationSystems*>& equation_systems, std::string system_name);
 
     /*!
      * Get a specific vector for a specific part. These vectors are managed by
@@ -108,15 +100,6 @@ public:
     libMesh::PetscVector<double>& get(const std::string& vec_name, const unsigned int part);
 
     /*!
-     * Get an IB-ghosted vector for a specific part.
-     *
-     * @param[in] vec_name Name of the vector.
-     *
-     * @param[in] part Part number.
-     */
-    libMesh::PetscVector<double>& getIBGhosted(const std::string& vec_name, const unsigned int part);
-
-    /*!
      * Get, for each part, the vector corresponding to the name @p
      * vec_name. These vectors are managed by libMesh::System objects.
      *
@@ -126,21 +109,10 @@ public:
      */
     std::vector<libMesh::PetscVector<double>*> get(const std::string& vec_name);
 
-    /**
-     * Get, for each part, the IB-ghosted vectors corresponding to the name @p
-     * vec_name These vectors are ghosted with values determined by
-     * IBTK::FEDataManager (i.e., based on SAMRAI's parallel partitioning).
-     *
-     * @note These vectors are managed by this object: the ghosted information
-     * will not be valid after a regrid.
-     */
-    std::vector<libMesh::PetscVector<double>*> getIBGhosted(const std::string& vec_name);
-
     /*!
-     * Reinitialize the object. This method must be called after the Eulerian
-     * data is updated.
+     * Reinitialize the object.
      */
-    void reinit();
+    virtual void reinit();
 
     /*!
      * Convenience function for copying libMesh vectors.
@@ -158,14 +130,15 @@ public:
     void zero(const std::string& vec_name);
 
 protected:
+    /// Returns false if a standard libMesh vector; otherwise returns true.
+    inline static bool vec_stored_in_map(const std::string& vec_name)
+    {
+        if (vec_name == "solution" || vec_name == "current" || vec_name == "current_local_solution") return false;
+        return true;
+    }
+
     /// Check if a vector exists and, if not, add it.
     void maybeAdd(const std::string& vec_name);
-
-    /// Add an IB ghosted vector.
-    std::vector<std::unique_ptr<libMesh::PetscVector<double> > >& maybeAddIBGhosted(const std::string& vec_name);
-
-    /// Pointers to IBTK::FEDataManager objects. These are needed to get IB ghosted vectors.
-    std::vector<IBTK::FEDataManager*> d_fe_data_managers;
 
     /// Mask indicating which parts actually have a system with the given name.
     std::vector<bool> d_part_mask;
@@ -175,9 +148,6 @@ protected:
 
     /// libMesh::System objects.
     std::vector<libMesh::System*> d_systems;
-
-    /// Previously computed IB ghosted vectors.
-    std::map<std::string, std::vector<std::unique_ptr<libMesh::PetscVector<double> > > > d_ib_ghosted_vectors;
 };
 } // namespace IBTK
 

--- a/ibtk/lib/Makefile.am
+++ b/ibtk/lib/Makefile.am
@@ -190,6 +190,7 @@ DIM_DEPENDENT_SOURCES += \
 ../src/lagrangian/JacobianCalculator.cpp \
 ../src/lagrangian/FEDataInterpolation.cpp \
 ../src/lagrangian/FEDataManager.cpp \
+../src/utilities/LibMeshSystemIBVectors.cpp \
 ../src/utilities/LibMeshSystemVectors.cpp \
 ../src/utilities/libmesh_utilities.cpp
 endif
@@ -360,6 +361,7 @@ DIM_DEPENDENT_SOURCES += \
 ../src/lagrangian/JacobianCalculator.h \
 ../include/ibtk/FEDataInterpolation.h \
 ../include/ibtk/FEDataManager.h \
+../include/ibtk/LibMeshSystemIBVectors.h \
 ../include/ibtk/LibMeshSystemVectors.h \
 ../include/ibtk/libmesh_utilities.h
 endif

--- a/ibtk/lib/Makefile.in
+++ b/ibtk/lib/Makefile.in
@@ -107,12 +107,14 @@ host_triplet = @host@
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/JacobianCalculator.cpp \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/FEDataInterpolation.cpp \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/FEDataManager.cpp \
+@LIBMESH_ENABLED_TRUE@	../src/utilities/LibMeshSystemIBVectors.cpp \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/LibMeshSystemVectors.cpp \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libmesh_utilities.cpp \
 @LIBMESH_ENABLED_TRUE@	../include/lagrangian/BoxPartitioner.h \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/JacobianCalculator.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/FEDataInterpolation.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/FEDataManager.h \
+@LIBMESH_ENABLED_TRUE@	../include/ibtk/LibMeshSystemIBVectors.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/LibMeshSystemVectors.h \
 @LIBMESH_ENABLED_TRUE@	../include/ibtk/libmesh_utilities.h
 subdir = lib
@@ -334,12 +336,14 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 	../src/lagrangian/JacobianCalculator.cpp \
 	../src/lagrangian/FEDataInterpolation.cpp \
 	../src/lagrangian/FEDataManager.cpp \
+	../src/utilities/LibMeshSystemIBVectors.cpp \
 	../src/utilities/LibMeshSystemVectors.cpp \
 	../src/utilities/libmesh_utilities.cpp \
 	../include/lagrangian/BoxPartitioner.h \
 	../src/lagrangian/JacobianCalculator.h \
 	../include/ibtk/FEDataInterpolation.h \
 	../include/ibtk/FEDataManager.h \
+	../include/ibtk/LibMeshSystemIBVectors.h \
 	../include/ibtk/LibMeshSystemVectors.h \
 	../include/ibtk/libmesh_utilities.h \
 	$(top_builddir)/src/boundary/cf_interface/fortran/linearcfinterpolation2d.f \
@@ -366,6 +370,7 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK2d_a-JacobianCalculator.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK2d_a-FEDataInterpolation.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK2d_a-FEDataManager.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK2d_a-LibMeshSystemVectors.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK2d_a-libmesh_utilities.$(OBJEXT)
 am__objects_3 = ../src/boundary/libIBTK2d_a-HierarchyGhostCellInterpolation.$(OBJEXT) \
@@ -634,12 +639,14 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 	../src/lagrangian/JacobianCalculator.cpp \
 	../src/lagrangian/FEDataInterpolation.cpp \
 	../src/lagrangian/FEDataManager.cpp \
+	../src/utilities/LibMeshSystemIBVectors.cpp \
 	../src/utilities/LibMeshSystemVectors.cpp \
 	../src/utilities/libmesh_utilities.cpp \
 	../include/lagrangian/BoxPartitioner.h \
 	../src/lagrangian/JacobianCalculator.h \
 	../include/ibtk/FEDataInterpolation.h \
 	../include/ibtk/FEDataManager.h \
+	../include/ibtk/LibMeshSystemIBVectors.h \
 	../include/ibtk/LibMeshSystemVectors.h \
 	../include/ibtk/libmesh_utilities.h \
 	$(top_builddir)/src/boundary/cf_interface/fortran/linearcfinterpolation3d.f \
@@ -666,6 +673,7 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK3d_a-JacobianCalculator.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK3d_a-FEDataInterpolation.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/lagrangian/libIBTK3d_a-FEDataManager.$(OBJEXT) \
+@LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK3d_a-LibMeshSystemVectors.$(OBJEXT) \
 @LIBMESH_ENABLED_TRUE@	../src/utilities/libIBTK3d_a-libmesh_utilities.$(OBJEXT)
 am__objects_5 = ../src/boundary/libIBTK3d_a-HierarchyGhostCellInterpolation.$(OBJEXT) \
@@ -1041,6 +1049,7 @@ am__depfiles_remade = ../contrib/muparser/src/$(DEPDIR)/muParser.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-HierarchyIntegrator.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-IndexUtilities.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-LMarkerUtilities.Po \
+	../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemIBVectors.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemVectors.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-MergingLoadBalancer.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-NodeDataSynchronization.Po \
@@ -1075,6 +1084,7 @@ am__depfiles_remade = ../contrib/muparser/src/$(DEPDIR)/muParser.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-HierarchyIntegrator.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-IndexUtilities.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-LMarkerUtilities.Po \
+	../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemIBVectors.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemVectors.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-MergingLoadBalancer.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-NodeDataSynchronization.Po \
@@ -2321,6 +2331,9 @@ libIBTK.a: $(libIBTK_a_OBJECTS) $(libIBTK_a_DEPENDENCIES) $(EXTRA_libIBTK_a_DEPE
 ../src/lagrangian/libIBTK2d_a-FEDataManager.$(OBJEXT):  \
 	../src/lagrangian/$(am__dirstamp) \
 	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.$(OBJEXT):  \
+	../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 ../src/utilities/libIBTK2d_a-LibMeshSystemVectors.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
@@ -2806,6 +2819,9 @@ libIBTK2d.a: $(libIBTK2d_a_OBJECTS) $(libIBTK2d_a_DEPENDENCIES) $(EXTRA_libIBTK2
 ../src/lagrangian/libIBTK3d_a-FEDataManager.$(OBJEXT):  \
 	../src/lagrangian/$(am__dirstamp) \
 	../src/lagrangian/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.$(OBJEXT):  \
+	../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 ../src/utilities/libIBTK3d_a-LibMeshSystemVectors.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
@@ -3114,6 +3130,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-HierarchyIntegrator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-IndexUtilities.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-LMarkerUtilities.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemIBVectors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemVectors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-MergingLoadBalancer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-NodeDataSynchronization.Po@am__quote@ # am--include-marker
@@ -3148,6 +3165,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-HierarchyIntegrator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-IndexUtilities.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-LMarkerUtilities.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemIBVectors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemVectors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-MergingLoadBalancer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-NodeDataSynchronization.Po@am__quote@ # am--include-marker
@@ -4948,6 +4966,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK2d_a-FEDataManager.obj `if test -f '../src/lagrangian/FEDataManager.cpp'; then $(CYGPATH_W) '../src/lagrangian/FEDataManager.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/FEDataManager.cpp'; fi`
 
+../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.o: ../src/utilities/LibMeshSystemIBVectors.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemIBVectors.Tpo -c -o ../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.o `test -f '../src/utilities/LibMeshSystemIBVectors.cpp' || echo '$(srcdir)/'`../src/utilities/LibMeshSystemIBVectors.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemIBVectors.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemIBVectors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/LibMeshSystemIBVectors.cpp' object='../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.o `test -f '../src/utilities/LibMeshSystemIBVectors.cpp' || echo '$(srcdir)/'`../src/utilities/LibMeshSystemIBVectors.cpp
+
+../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.obj: ../src/utilities/LibMeshSystemIBVectors.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.obj -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemIBVectors.Tpo -c -o ../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.obj `if test -f '../src/utilities/LibMeshSystemIBVectors.cpp'; then $(CYGPATH_W) '../src/utilities/LibMeshSystemIBVectors.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/LibMeshSystemIBVectors.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemIBVectors.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemIBVectors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/LibMeshSystemIBVectors.cpp' object='../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-LibMeshSystemIBVectors.obj `if test -f '../src/utilities/LibMeshSystemIBVectors.cpp'; then $(CYGPATH_W) '../src/utilities/LibMeshSystemIBVectors.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/LibMeshSystemIBVectors.cpp'; fi`
+
 ../src/utilities/libIBTK2d_a-LibMeshSystemVectors.o: ../src/utilities/LibMeshSystemVectors.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-LibMeshSystemVectors.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemVectors.Tpo -c -o ../src/utilities/libIBTK2d_a-LibMeshSystemVectors.o `test -f '../src/utilities/LibMeshSystemVectors.cpp' || echo '$(srcdir)/'`../src/utilities/LibMeshSystemVectors.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemVectors.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemVectors.Po
@@ -6726,6 +6758,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/lagrangian/libIBTK3d_a-FEDataManager.obj `if test -f '../src/lagrangian/FEDataManager.cpp'; then $(CYGPATH_W) '../src/lagrangian/FEDataManager.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/lagrangian/FEDataManager.cpp'; fi`
 
+../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.o: ../src/utilities/LibMeshSystemIBVectors.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemIBVectors.Tpo -c -o ../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.o `test -f '../src/utilities/LibMeshSystemIBVectors.cpp' || echo '$(srcdir)/'`../src/utilities/LibMeshSystemIBVectors.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemIBVectors.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemIBVectors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/LibMeshSystemIBVectors.cpp' object='../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.o `test -f '../src/utilities/LibMeshSystemIBVectors.cpp' || echo '$(srcdir)/'`../src/utilities/LibMeshSystemIBVectors.cpp
+
+../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.obj: ../src/utilities/LibMeshSystemIBVectors.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.obj -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemIBVectors.Tpo -c -o ../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.obj `if test -f '../src/utilities/LibMeshSystemIBVectors.cpp'; then $(CYGPATH_W) '../src/utilities/LibMeshSystemIBVectors.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/LibMeshSystemIBVectors.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemIBVectors.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemIBVectors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/LibMeshSystemIBVectors.cpp' object='../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-LibMeshSystemIBVectors.obj `if test -f '../src/utilities/LibMeshSystemIBVectors.cpp'; then $(CYGPATH_W) '../src/utilities/LibMeshSystemIBVectors.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/LibMeshSystemIBVectors.cpp'; fi`
+
 ../src/utilities/libIBTK3d_a-LibMeshSystemVectors.o: ../src/utilities/LibMeshSystemVectors.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-LibMeshSystemVectors.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemVectors.Tpo -c -o ../src/utilities/libIBTK3d_a-LibMeshSystemVectors.o `test -f '../src/utilities/LibMeshSystemVectors.cpp' || echo '$(srcdir)/'`../src/utilities/LibMeshSystemVectors.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemVectors.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemVectors.Po
@@ -7171,6 +7217,7 @@ distclean: distclean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-HierarchyIntegrator.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-IndexUtilities.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-LMarkerUtilities.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemIBVectors.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemVectors.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-MergingLoadBalancer.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-NodeDataSynchronization.Po
@@ -7205,6 +7252,7 @@ distclean: distclean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-HierarchyIntegrator.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-IndexUtilities.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-LMarkerUtilities.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemIBVectors.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemVectors.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-MergingLoadBalancer.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-NodeDataSynchronization.Po
@@ -7483,6 +7531,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-HierarchyIntegrator.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-IndexUtilities.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-LMarkerUtilities.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemIBVectors.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-LibMeshSystemVectors.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-MergingLoadBalancer.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-NodeDataSynchronization.Po
@@ -7517,6 +7566,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-HierarchyIntegrator.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-IndexUtilities.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-LMarkerUtilities.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemIBVectors.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-LibMeshSystemVectors.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-MergingLoadBalancer.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-NodeDataSynchronization.Po

--- a/ibtk/src/utilities/LibMeshSystemIBVectors.cpp
+++ b/ibtk/src/utilities/LibMeshSystemIBVectors.cpp
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2020 - 2020 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include <ibtk/LibMeshSystemIBVectors.h>
+#include <ibtk/namespaces.h>
+
+#include <tbox/Utilities.h>
+
+#include <libmesh/equation_systems.h>
+#include <libmesh/petsc_vector.h>
+#include <libmesh/system.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+/////////////////////////////// STATIC ///////////////////////////////////////
+
+namespace
+{
+inline std::vector<EquationSystems*>
+extract_equation_systems(const std::vector<FEDataManager*>& fe_data_managers)
+{
+    std::vector<EquationSystems*> equation_systems;
+    std::transform(fe_data_managers.begin(),
+                   fe_data_managers.end(),
+                   std::back_inserter(equation_systems),
+                   [](FEDataManager* fe_data_manager) { return fe_data_manager->getEquationSystems(); });
+    return equation_systems;
+}
+} // namespace
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace IBTK
+{
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+LibMeshSystemIBVectors::LibMeshSystemIBVectors(const std::vector<FEDataManager*>& fe_data_managers,
+                                               std::string system_name)
+    : LibMeshSystemIBVectors(fe_data_managers, std::vector<bool>(fe_data_managers.size(), true), system_name)
+{
+}
+
+LibMeshSystemIBVectors::LibMeshSystemIBVectors(const std::vector<FEDataManager*>& fe_data_managers,
+                                               const std::vector<bool>& part_mask,
+                                               std::string system_name)
+    : LibMeshSystemVectors(extract_equation_systems(fe_data_managers), part_mask, system_name),
+      d_fe_data_managers(fe_data_managers)
+{
+}
+
+libMesh::PetscVector<double>&
+LibMeshSystemIBVectors::getIBGhosted(const std::string& vec_name, const unsigned int part)
+{
+    TBOX_ASSERT(part < d_systems.size());
+    TBOX_ASSERT(d_part_mask[part]);
+    return *maybeAddIBGhosted(vec_name)[part];
+}
+
+std::vector<libMesh::PetscVector<double>*>
+LibMeshSystemIBVectors::getIBGhosted(const std::string& vec_name)
+{
+    std::vector<std::unique_ptr<libMesh::PetscVector<double> > >& stored_vectors = maybeAddIBGhosted(vec_name);
+    std::vector<libMesh::PetscVector<double>*> result;
+    for (std::unique_ptr<libMesh::PetscVector<double> >& ptr : stored_vectors) result.push_back(ptr.get());
+    return result;
+}
+
+void
+LibMeshSystemIBVectors::reinit()
+{
+    LibMeshSystemVectors::reinit();
+    d_ib_ghosted_vectors.clear();
+}
+
+/////////////////////////////// PROTECTED ////////////////////////////////////
+
+std::vector<std::unique_ptr<libMesh::PetscVector<double> > >&
+LibMeshSystemIBVectors::maybeAddIBGhosted(const std::string& vec_name)
+{
+    TBOX_ASSERT(d_fe_data_managers.size() == d_systems.size());
+    std::vector<std::unique_ptr<libMesh::PetscVector<double> > >& stored_vectors = d_ib_ghosted_vectors[vec_name];
+    if (stored_vectors.empty())
+        for (unsigned int part = 0; part < d_systems.size(); ++part)
+            if (d_part_mask[part])
+                stored_vectors.emplace_back(d_fe_data_managers[part]->buildIBGhostedVector(d_system_name));
+    return stored_vectors;
+}
+
+/////////////////////////////// PRIVATE //////////////////////////////////////
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+} // namespace IBTK
+
+//////////////////////////////////////////////////////////////////////////////

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -21,7 +21,7 @@
 #include "ibamr/ibamr_enums.h"
 
 #include "ibtk/FEDataManager.h"
-#include "ibtk/LibMeshSystemVectors.h"
+#include "ibtk/LibMeshSystemIBVectors.h"
 #include "ibtk/SAMRAIDataCache.h"
 #include "ibtk/SAMRAIGhostDataAccumulator.h"
 #include "ibtk/ibtk_utilities.h"
@@ -1169,17 +1169,17 @@ protected:
     /*!
      * Object managing access to libMesh system vectors for the structure position.
      */
-    std::unique_ptr<IBTK::LibMeshSystemVectors> d_X_vecs;
+    std::unique_ptr<IBTK::LibMeshSystemIBVectors> d_X_vecs;
 
     /*!
      * Object managing access to libMesh system vectors for the structure velocity.
      */
-    std::unique_ptr<IBTK::LibMeshSystemVectors> d_U_vecs;
+    std::unique_ptr<IBTK::LibMeshSystemIBVectors> d_U_vecs;
 
     /*!
      * Object managing access to libMesh system vectors for the structure force.
      */
-    std::unique_ptr<IBTK::LibMeshSystemVectors> d_F_vecs;
+    std::unique_ptr<IBTK::LibMeshSystemIBVectors> d_F_vecs;
 
     /*!
      * Vectors of pointers to the fluid source or sink density vectors. All of

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -28,7 +28,7 @@
 #include "ibtk/IBTK_CHKERRQ.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LEInteractor.h"
-#include "ibtk/LibMeshSystemVectors.h"
+#include "ibtk/LibMeshSystemIBVectors.h"
 #include "ibtk/MergingLoadBalancer.h"
 #include "ibtk/PartitioningBox.h"
 #include "ibtk/QuadratureCache.h"
@@ -1448,9 +1448,9 @@ IBFEMethod::doInitializeFEData(const bool use_present_data)
 {
     // The choice of FEDataManager set is important here since it determines the
     // IB ghost regions.
-    d_X_vecs.reset(new LibMeshSystemVectors(d_active_fe_data_managers, COORDS_SYSTEM_NAME));
-    d_U_vecs.reset(new LibMeshSystemVectors(d_active_fe_data_managers, VELOCITY_SYSTEM_NAME));
-    d_F_vecs.reset(new LibMeshSystemVectors(d_active_fe_data_managers, FORCE_SYSTEM_NAME));
+    d_X_vecs.reset(new LibMeshSystemIBVectors(d_active_fe_data_managers, COORDS_SYSTEM_NAME));
+    d_U_vecs.reset(new LibMeshSystemIBVectors(d_active_fe_data_managers, VELOCITY_SYSTEM_NAME));
+    d_F_vecs.reset(new LibMeshSystemIBVectors(d_active_fe_data_managers, FORCE_SYSTEM_NAME));
     for (unsigned int part = 0; part < d_num_parts; ++part)
     {
         // Initialize FE equation systems.


### PR DESCRIPTION
The base class, `LibMeshSystemVectors`, now only needs to use `libMesh::EquationSystem` objects to track the vectors. The new derived class, `LibMeshSystemIBVectors`, uses `FEDataManager` objects to determine IB ghosting.

Part of #966.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
