### PR TITLE
Replace SAMRAI_MPI with IBTK_MPI

### DIFF
--- a/doc/news/changes/incompatibilities/20200425AaronBarrett
+++ b/doc/news/changes/incompatibilities/20200425AaronBarrett
@@ -1,0 +1,8 @@
+New: IBAMR now requires the initialization object IBTKInit to be created upon
+program start. IBTKInit is responsible for initializing and deinitializing all
+libraries as well as registering the MPI communicator with IBTK_MPI. All
+SAMRAI_MPI calls in the library have been replaced with respective IBTK_MPI
+calls. The perl script scripts/code_updates/update_mpi_calls.pl will
+automatically complete most of the changes.
+<br>
+(Aaron Barrett, 2020/04/25)

--- a/examples/CIB/ex0/example.cpp
+++ b/examples/CIB/ex0/example.cpp
@@ -41,6 +41,7 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -90,12 +91,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
-    SAMRAIManager::setMaxNumberPatchDataEntries(2054);
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -358,9 +355,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void

--- a/examples/CIB/ex1/example.cpp
+++ b/examples/CIB/ex1/example.cpp
@@ -43,6 +43,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -121,12 +123,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
-    SAMRAIManager::setMaxNumberPatchDataEntries(2054);
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -304,7 +302,7 @@ main(int argc, char* argv[])
             direct_solvers->registerStructIDsWithMobilityMat(mat_name1, struct_ids1);
 
             int next_proc = 0;
-            if (SAMRAI_MPI::getNodes() > 1) next_proc = 1;
+            if (IBTK_MPI::getNodes() > 1) next_proc = 1;
             direct_solvers->registerMobilityMat(
                 mat_name2, prototype_structs2, EMPIRICAL, std::make_pair(LAPACK_SVD, LAPACK_SVD), next_proc);
             direct_solvers->registerStructIDsWithMobilityMat(mat_name2, struct_ids2);
@@ -513,9 +511,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void

--- a/examples/CIB/ex2/example.cpp
+++ b/examples/CIB/ex2/example.cpp
@@ -40,6 +40,7 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -97,12 +98,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
-    SAMRAIManager::setMaxNumberPatchDataEntries(2054);
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -376,9 +373,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void

--- a/examples/CIB/ex3/example.cpp
+++ b/examples/CIB/ex3/example.cpp
@@ -40,6 +40,7 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -76,12 +77,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
-    SAMRAIManager::setMaxNumberPatchDataEntries(2054);
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -341,9 +338,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void

--- a/examples/CIB/ex4/example.cpp
+++ b/examples/CIB/ex4/example.cpp
@@ -40,6 +40,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -109,12 +111,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
-    SAMRAIManager::setMaxNumberPatchDataEntries(2054);
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -323,7 +321,7 @@ main(int argc, char* argv[])
                         postproc_data_dump_dirname);
         }
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             U_stream.open("./Lambda/U.txt", std::ios_base::out | ios_base::trunc);
             U_stream.precision(10);
@@ -405,7 +403,7 @@ main(int argc, char* argv[])
             }
         }
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             U_stream.close();
         }
@@ -414,9 +412,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void

--- a/examples/ConstraintIB/eel2d/IBEELKinematics.cpp
+++ b/examples/ConstraintIB/eel2d/IBEELKinematics.cpp
@@ -14,11 +14,12 @@
 //////////////////////////// INCLUDES /////////////////////////////////////////
 #include "ibamr/namespaces.h"
 
+#include "ibtk/IBTK_MPI.h"
+
 #include "CartesianPatchGeometry.h"
 #include "IBEELKinematics.h"
 #include "PatchLevel.h"
 #include "tbox/MathUtilities.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "muParser.h"
 

--- a/examples/ConstraintIB/eel2d/example.cpp
+++ b/examples/ConstraintIB/eel2d/example.cpp
@@ -37,6 +37,8 @@
 #include <ibamr/INSStaggeredPressureBcCoef.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -69,11 +71,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -422,9 +421,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -441,7 +437,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/ConstraintIB/eel3d/IBEELKinematics3d.cpp
+++ b/examples/ConstraintIB/eel3d/IBEELKinematics3d.cpp
@@ -15,13 +15,14 @@
 
 #include "ibamr/namespaces.h"
 
+#include "ibtk/IBTK_MPI.h"
+
 #include "CartesianPatchGeometry.h"
 #include "IBEELKinematics3d.h"
 #include "PatchLevel.h"
 #include "gsl/gsl_integration.h"
 #include "gsl/gsl_linalg.h"
 #include "tbox/MathUtilities.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "muParser.h"

--- a/examples/ConstraintIB/eel3d/example.cpp
+++ b/examples/ConstraintIB/eel3d/example.cpp
@@ -36,6 +36,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -65,11 +67,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -296,9 +295,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -315,7 +311,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/ConstraintIB/falling_sphere/RigidBodyKinematics.cpp
+++ b/examples/ConstraintIB/falling_sphere/RigidBodyKinematics.cpp
@@ -15,9 +15,10 @@
 
 #include "ibamr/namespaces.h"
 
+#include "ibtk/IBTK_MPI.h"
+
 #include "RigidBodyKinematics.h"
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "muParser.h"

--- a/examples/ConstraintIB/falling_sphere/example.cpp
+++ b/examples/ConstraintIB/falling_sphere/example.cpp
@@ -36,6 +36,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -67,11 +69,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -316,9 +315,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -335,7 +331,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/ConstraintIB/flow_past_cylinder/RigidBodyKinematics.cpp
+++ b/examples/ConstraintIB/flow_past_cylinder/RigidBodyKinematics.cpp
@@ -16,8 +16,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/ConstraintIB/flow_past_cylinder/example.cpp
+++ b/examples/ConstraintIB/flow_past_cylinder/example.cpp
@@ -38,6 +38,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -67,11 +69,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -384,9 +383,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -403,7 +399,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/ConstraintIB/impulsively_started_cylinder/RigidBodyKinematics.cpp
+++ b/examples/ConstraintIB/impulsively_started_cylinder/RigidBodyKinematics.cpp
@@ -18,8 +18,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/ConstraintIB/impulsively_started_cylinder/example.cpp
+++ b/examples/ConstraintIB/impulsively_started_cylinder/example.cpp
@@ -39,6 +39,8 @@
 #include "ibtk/LData.h"
 #include "ibtk/muParserCartGridFunction.h"
 #include "ibtk/muParserRobinBcCoefs.h"
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 
 // Application
 #include "RigidBodyKinematics.h"
@@ -65,11 +67,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -296,9 +295,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -315,7 +311,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/ConstraintIB/knifefish/KnifeFishKinematics.cpp
+++ b/examples/ConstraintIB/knifefish/KnifeFishKinematics.cpp
@@ -14,8 +14,9 @@
 //////////////////////////// INCLUDES /////////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include <tbox/PIO.h>
-#include <tbox/SAMRAI_MPI.h>
 #include <tbox/Utilities.h>
 
 // IBAMR INCLUDES

--- a/examples/ConstraintIB/knifefish/example.cpp
+++ b/examples/ConstraintIB/knifefish/example.cpp
@@ -36,6 +36,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -65,11 +67,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -296,9 +295,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -315,7 +311,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/ConstraintIB/moving_plate/RigidBodyKinematics.cpp
+++ b/examples/ConstraintIB/moving_plate/RigidBodyKinematics.cpp
@@ -14,11 +14,12 @@
 //////////////////////////// INCLUDES /////////////////////////////////////////
 #include "ibamr/namespaces.h"
 
+#include "ibtk/IBTK_MPI.h"
+
 #include "CartesianPatchGeometry.h"
 #include "PatchLevel.h"
 #include "RigidBodyKinematics.h"
 #include "tbox/MathUtilities.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "muParser.h"
 

--- a/examples/ConstraintIB/moving_plate/example.cpp
+++ b/examples/ConstraintIB/moving_plate/example.cpp
@@ -38,6 +38,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -75,11 +77,8 @@ COMTransVelocity(const double /*time*/, IBTK::Vector3d& trans_vel)
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -424,9 +423,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -443,7 +439,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/ConstraintIB/oscillating_rigid_cylinder/OscillatingCylinderKinematics.cpp
+++ b/examples/ConstraintIB/oscillating_rigid_cylinder/OscillatingCylinderKinematics.cpp
@@ -16,11 +16,12 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "CartesianPatchGeometry.h"
 #include "PatchLevel.h"
 #include "tbox/MathUtilities.h"
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/ConstraintIB/oscillating_rigid_cylinder/example.cpp
+++ b/examples/ConstraintIB/oscillating_rigid_cylinder/example.cpp
@@ -36,6 +36,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -65,11 +67,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -296,9 +295,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -315,7 +311,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/ConstraintIB/stokes_first_problem/RigidBodyKinematics.cpp
+++ b/examples/ConstraintIB/stokes_first_problem/RigidBodyKinematics.cpp
@@ -17,8 +17,9 @@
 
 #include "ibamr/namespaces.h"
 
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "muParser.h"

--- a/examples/ConstraintIB/stokes_first_problem/example.cpp
+++ b/examples/ConstraintIB/stokes_first_problem/example.cpp
@@ -36,6 +36,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -65,11 +67,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -296,9 +295,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -315,7 +311,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IB/explicit/ex0/example.cpp
+++ b/examples/IB/explicit/ex0/example.cpp
@@ -36,6 +36,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -239,13 +241,8 @@ generate_springs(
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
-
-    // resize error vectors to hold data from u and p
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -557,9 +554,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -576,7 +570,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IB/explicit/ex1/example.cpp
+++ b/examples/IB/explicit/ex1/example.cpp
@@ -35,6 +35,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -65,11 +67,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -301,9 +300,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -320,7 +316,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IB/explicit/ex2/example.cpp
+++ b/examples/IB/explicit/ex2/example.cpp
@@ -36,6 +36,8 @@
 #include <ibamr/StaggeredStokesOpenBoundaryStabilizer.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -65,11 +67,8 @@ void postprocess_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -238,7 +237,7 @@ main(int argc, char* argv[])
 
         // Streams to write-out data.
         std::ofstream C_D_stream, C_L_stream;
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             C_D_stream.open("C_D.curve", ios_base::out | ios_base::trunc);
             C_L_stream.open("C_L.curve", ios_base::out | ios_base::trunc);
@@ -293,7 +292,7 @@ main(int argc, char* argv[])
         }
 
         // Close the logging streams.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             C_D_stream.close();
             C_L_stream.close();
@@ -304,9 +303,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -329,8 +325,8 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
             F[d] += F_arr[k][d];
         }
     }
-    SAMRAI_MPI::sumReduction(F, NDIM);
-    if (SAMRAI_MPI::getRank() == 0)
+    IBTK_MPI::sumReduction(F, NDIM);
+    if (IBTK_MPI::getRank() == 0)
     {
         C_D_stream.precision(12);
         C_D_stream.setf(ios::fixed, ios::floatfield);

--- a/examples/IB/explicit/ex3/example.cpp
+++ b/examples/IB/explicit/ex3/example.cpp
@@ -35,6 +35,8 @@
 #include <ibamr/PenaltyIBMethod.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -89,11 +91,8 @@ linear_spring_force_deriv(double /*R*/, const double* params, int /*lag_mastr_id
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -319,9 +318,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -338,7 +334,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IB/explicit/ex4/example.cpp
+++ b/examples/IB/explicit/ex4/example.cpp
@@ -35,6 +35,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/LEInteractor.h>
@@ -99,11 +101,8 @@ scaled_ib4_kernel_fcn(double r)
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -341,9 +340,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -360,7 +356,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IB/explicit/ex5/example.cpp
+++ b/examples/IB/explicit/ex5/example.cpp
@@ -36,6 +36,8 @@
 #include <ibamr/RNG.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -67,11 +69,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -321,9 +320,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -341,7 +337,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     }
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
 
     // Write Cartesian data.

--- a/examples/IB/explicit/ex6/example.cpp
+++ b/examples/IB/explicit/ex6/example.cpp
@@ -33,6 +33,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -66,11 +68,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -300,9 +299,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -319,7 +315,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IBFE/explicit/ex0/example.cpp
+++ b/examples/IBFE/explicit/ex0/example.cpp
@@ -41,6 +41,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -116,11 +118,9 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -402,7 +402,7 @@ main(int argc, char* argv[])
 
         // Open streams to save volume of structure.
         ofstream volume_stream;
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             volume_stream.open("volume.curve", ios_base::out | ios_base::trunc);
         }
@@ -566,8 +566,8 @@ main(int argc, char* argv[])
                     J_integral += abs(FF.det()) * JxW[qp];
                 }
             }
-            J_integral = SAMRAI_MPI::sumReduction(J_integral);
-            if (SAMRAI_MPI::getRank() == 0)
+            J_integral = IBTK_MPI::sumReduction(J_integral);
+            if (IBTK_MPI::getRank() == 0)
             {
                 volume_stream.precision(12);
                 volume_stream.setf(ios::fixed, ios::floatfield);
@@ -576,7 +576,7 @@ main(int argc, char* argv[])
         }
 
         // Close the logging streams.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             volume_stream.close();
         }
@@ -586,8 +586,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 }
 
 void
@@ -605,7 +603,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IBFE/explicit/ex1/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex1/convergence_tester.cpp
@@ -22,6 +22,7 @@
 // IBTK INCLUDES
 #include <ibtk/CartExtrapPhysBdryOp.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTK_MPI.h>
 
 // LIBMESH INCLUDES
 #include <libmesh/equation_systems.h>
@@ -30,6 +31,8 @@
 using namespace libMesh;
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTKInit.h"
+
 #include <tbox/Database.h>
 #include <tbox/HDFDatabase.h>
 #include <tbox/InputDatabase.h>
@@ -38,7 +41,6 @@ using namespace libMesh;
 #include <tbox/PIO.h>
 #include <tbox/Pointer.h>
 #include <tbox/SAMRAIManager.h>
-#include <tbox/SAMRAI_MPI.h>
 #include <tbox/Utilities.h>
 
 #include <CartesianGridGeometry.h>
@@ -58,19 +60,17 @@ using namespace std;
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    {
-        tbox::SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-        tbox::SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-        tbox::SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
+    {
         if (argc != 2)
         {
             tbox::pout << "USAGE:  " << argv[0] << " <input filename>\n"
                        << "  options:\n"
                        << "  none at this time" << endl;
-            tbox::SAMRAI_MPI::abort();
+            TBOX_ERROR("Not enough input arguments.\n");
             return (-1);
         }
 
@@ -164,17 +164,17 @@ main(int argc, char* argv[])
         {
             char temp_buf[128];
 
-            sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, tbox::SAMRAI_MPI::getRank());
+            sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
             string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
             coarse_file_name += temp_buf;
 
-            sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, tbox::SAMRAI_MPI::getRank());
+            sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
             string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
             fine_file_name += temp_buf;
 
-            for (int rank = 0; rank < tbox::SAMRAI_MPI::getNodes(); ++rank)
+            for (int rank = 0; rank < IBTK_MPI::getNodes(); ++rank)
             {
-                if (rank == tbox::SAMRAI_MPI::getRank())
+                if (rank == IBTK_MPI::getRank())
                 {
                     fstream coarse_fin, fine_fin;
                     coarse_fin.open(coarse_file_name.c_str(), ios::in);
@@ -186,7 +186,7 @@ main(int argc, char* argv[])
                     coarse_fin.close();
                     fine_fin.close();
                 }
-                tbox::SAMRAI_MPI::barrier();
+                IBTK_MPI::barrier();
             }
 
             if (!files_exist) break;
@@ -442,8 +442,6 @@ main(int argc, char* argv[])
             tbox::pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << endl;
             tbox::pout << endl;
         }
-
-        tbox::SAMRAIManager::shutdown();
     }
     return 0;
 } // main

--- a/examples/IBFE/explicit/ex1/example.cpp
+++ b/examples/IBFE/explicit/ex1/example.cpp
@@ -41,6 +41,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -115,11 +117,9 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -382,7 +382,7 @@ main(int argc, char* argv[])
 
         // Open streams to save volume of structure.
         ofstream volume_stream;
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             volume_stream.open("volume.curve", ios_base::out | ios_base::trunc);
         }
@@ -486,8 +486,8 @@ main(int argc, char* argv[])
                     J_integral += abs(FF.det()) * JxW[qp];
                 }
             }
-            J_integral = SAMRAI_MPI::sumReduction(J_integral);
-            if (SAMRAI_MPI::getRank() == 0)
+            J_integral = IBTK_MPI::sumReduction(J_integral);
+            if (IBTK_MPI::getRank() == 0)
             {
                 volume_stream.precision(12);
                 volume_stream.setf(ios::fixed, ios::floatfield);
@@ -496,7 +496,7 @@ main(int argc, char* argv[])
         }
 
         // Close the logging streams.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             volume_stream.close();
         }
@@ -506,8 +506,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main
 
 void
@@ -525,7 +523,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IBFE/explicit/ex2/example.cpp
+++ b/examples/IBFE/explicit/ex2/example.cpp
@@ -41,6 +41,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -111,11 +113,9 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -457,8 +457,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 }
 
 void
@@ -476,7 +474,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IBFE/explicit/ex3/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex3/convergence_tester.cpp
@@ -22,6 +22,8 @@
 // IBTK INCLUDES
 #include <ibtk/CartExtrapPhysBdryOp.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 
 // LIBMESH INCLUDES
 #include <libmesh/equation_systems.h>
@@ -38,7 +40,6 @@ using namespace libMesh;
 #include <tbox/PIO.h>
 #include <tbox/Pointer.h>
 #include <tbox/SAMRAIManager.h>
-#include <tbox/SAMRAI_MPI.h>
 #include <tbox/Utilities.h>
 
 #include <CartesianGridGeometry.h>
@@ -58,19 +59,16 @@ using namespace std;
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
     {
-        tbox::SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-        tbox::SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-        tbox::SAMRAIManager::startup();
-
         if (argc != 2)
         {
             tbox::pout << "USAGE:  " << argv[0] << " <input filename>\n"
                        << "  options:\n"
                        << "  none at this time" << endl;
-            tbox::SAMRAI_MPI::abort();
+            TBOX_ERROR("Not enough input arguments.\n");
             return (-1);
         }
 
@@ -164,17 +162,17 @@ main(int argc, char* argv[])
         {
             char temp_buf[128];
 
-            sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, tbox::SAMRAI_MPI::getRank());
+            sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
             string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
             coarse_file_name += temp_buf;
 
-            sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, tbox::SAMRAI_MPI::getRank());
+            sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
             string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
             fine_file_name += temp_buf;
 
-            for (int rank = 0; rank < tbox::SAMRAI_MPI::getNodes(); ++rank)
+            for (int rank = 0; rank < IBTK_MPI::getNodes(); ++rank)
             {
-                if (rank == tbox::SAMRAI_MPI::getRank())
+                if (rank == IBTK_MPI::getRank())
                 {
                     fstream coarse_fin, fine_fin;
                     coarse_fin.open(coarse_file_name.c_str(), ios::in);
@@ -186,7 +184,7 @@ main(int argc, char* argv[])
                     coarse_fin.close();
                     fine_fin.close();
                 }
-                tbox::SAMRAI_MPI::barrier();
+                IBTK_MPI::barrier();
             }
 
             if (!files_exist) break;
@@ -442,8 +440,6 @@ main(int argc, char* argv[])
             tbox::pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << endl;
             tbox::pout << endl;
         }
-
-        tbox::SAMRAIManager::shutdown();
     }
     return 0;
 } // main

--- a/examples/IBFE/explicit/ex3/example.cpp
+++ b/examples/IBFE/explicit/ex3/example.cpp
@@ -41,6 +41,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -111,11 +113,9 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -457,8 +457,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main
 
 void
@@ -476,7 +474,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -43,6 +43,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/BoxPartitioner.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -127,11 +129,9 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -448,7 +448,7 @@ main(int argc, char* argv[])
 
         // Open streams to save volume of structure.
         ofstream volume_stream;
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             volume_stream.open("volume.curve", ios_base::out | ios_base::trunc);
         }
@@ -559,8 +559,8 @@ main(int argc, char* argv[])
                     J_integral += abs(FF.det()) * JxW[qp];
                 }
             }
-            J_integral = SAMRAI_MPI::sumReduction(J_integral);
-            if (SAMRAI_MPI::getRank() == 0)
+            J_integral = IBTK_MPI::sumReduction(J_integral);
+            if (IBTK_MPI::getRank() == 0)
             {
                 volume_stream.precision(12);
                 volume_stream.setf(ios::fixed, ios::floatfield);
@@ -569,7 +569,7 @@ main(int argc, char* argv[])
         }
 
         // Close the logging streams.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             volume_stream.close();
         }
@@ -579,8 +579,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main
 
 void
@@ -598,7 +596,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IBFE/explicit/ex5/example.cpp
+++ b/examples/IBFE/explicit/ex5/example.cpp
@@ -43,6 +43,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LEInteractor.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -210,11 +212,9 @@ void postprocess_data(Pointer<Database> input_db,
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -530,7 +530,7 @@ main(int argc, char* argv[])
 
         // Open streams to save lift and drag coefficients and the norms of the
         // velocity.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             drag_stream.open("C_D.curve", ios_base::out | ios_base::trunc);
             lift_stream.open("C_L.curve", ios_base::out | ios_base::trunc);
@@ -620,7 +620,7 @@ main(int argc, char* argv[])
         }
 
         // Close the logging streams.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             drag_stream.close();
             lift_stream.close();
@@ -634,8 +634,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main
 
 void
@@ -748,11 +746,11 @@ postprocess_data(Pointer<Database> input_db,
             }
         }
     }
-    SAMRAI_MPI::sumReduction(F_integral, NDIM);
+    IBTK_MPI::sumReduction(F_integral, NDIM);
     static const double rho = 1.0;
     static const double U_max = 1.0;
     static const double D = 1.0;
-    if (SAMRAI_MPI::getRank() == 0)
+    if (IBTK_MPI::getRank() == 0)
     {
         drag_stream << loop_time << " " << -F_integral[0] / (0.5 * rho * U_max * U_max * D) << endl;
         lift_stream << loop_time << " " << -F_integral[1] / (0.5 * rho * U_max * U_max * D) << endl;

--- a/examples/IBFE/explicit/ex6/example.cpp
+++ b/examples/IBFE/explicit/ex6/example.cpp
@@ -42,6 +42,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -183,11 +185,9 @@ void postprocess_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -473,7 +473,7 @@ main(int argc, char* argv[])
         }
 
         // Open streams to save lift and drag coefficients.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             drag_stream.open("C_D.curve", ios_base::out | ios_base::trunc);
             lift_stream.open("C_L.curve", ios_base::out | ios_base::trunc);
@@ -554,7 +554,7 @@ main(int argc, char* argv[])
         }
 
         // Close the logging streams.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             drag_stream.close();
             lift_stream.close();
@@ -567,8 +567,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main
 
 void
@@ -625,8 +623,8 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
             }
         }
     }
-    SAMRAI_MPI::sumReduction(F_integral, NDIM);
-    if (SAMRAI_MPI::getRank() == 0)
+    IBTK_MPI::sumReduction(F_integral, NDIM);
+    if (IBTK_MPI::getRank() == 0)
     {
         drag_stream.precision(12);
         drag_stream.setf(ios::fixed, ios::floatfield);
@@ -649,7 +647,7 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
     X_fcn.init();
     DenseVector<double> X_A(2);
     X_fcn(libMesh::Point(0.6, 0.2, 0), 0.0, X_A);
-    if (SAMRAI_MPI::getRank() == 0)
+    if (IBTK_MPI::getRank() == 0)
     {
         A_x_posn_stream.precision(12);
         A_x_posn_stream.setf(ios::fixed, ios::floatfield);

--- a/examples/IBFE/explicit/ex7/example.cpp
+++ b/examples/IBFE/explicit/ex7/example.cpp
@@ -41,6 +41,8 @@
 #include <ibamr/SpongeLayerForceFunction.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -144,11 +146,9 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -459,8 +459,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main
 
 void
@@ -478,7 +476,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/IBFE/explicit/ex9/example.cpp
+++ b/examples/IBFE/explicit/ex9/example.cpp
@@ -43,6 +43,7 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/LEInteractor.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -114,11 +115,9 @@ using namespace ModelData;
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -531,6 +530,4 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main

--- a/examples/IBLevelSet/ex0/example.cpp
+++ b/examples/IBLevelSet/ex0/example.cpp
@@ -57,6 +57,8 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -243,9 +245,9 @@ calculate_error_near_band(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
             }
         }
     }
-    num_interface_pts = SAMRAI_MPI::sumReduction(num_interface_pts);
-    E_interface = SAMRAI_MPI::sumReduction(E_interface);
-    volume_near_interface = SAMRAI_MPI::sumReduction(volume_near_interface);
+    num_interface_pts = IBTK_MPI::sumReduction(num_interface_pts);
+    E_interface = IBTK_MPI::sumReduction(E_interface);
+    volume_near_interface = IBTK_MPI::sumReduction(volume_near_interface);
 
     return;
 } // calculate_error_near_band
@@ -324,11 +326,9 @@ static double shift_z;
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -935,7 +935,7 @@ main(int argc, char* argv[])
 
         // Open streams to save position and velocity of the structure.
         ofstream rbd_stream;
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             rbd_stream.open("rbd.curve", ios_base::out | ios_base::app);
         }
@@ -986,7 +986,7 @@ main(int argc, char* argv[])
                 TimerManager::getManager()->print(plog);
             }
 
-            if (SAMRAI_MPI::getRank() == 0)
+            if (IBTK_MPI::getRank() == 0)
             {
                 const Eigen::Vector3d& rbd_posn = bp_rbd->getCurrentCOMPosn();
                 const Eigen::Vector3d& rbd_trans_vel = bp_rbd->getCurrentCOMTransVelocity();
@@ -998,7 +998,7 @@ main(int argc, char* argv[])
         }
 
         // Close the logging streams.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             rbd_stream.close();
         }
@@ -1012,6 +1012,4 @@ main(int argc, char* argv[])
         delete phi_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main

--- a/examples/IMP/explicit/ex0/main.cpp
+++ b/examples/IMP/explicit/ex0/main.cpp
@@ -39,6 +39,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -93,11 +95,9 @@ using namespace ModelData;
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -296,7 +296,7 @@ main(int argc, char* argv[])
 
         // Open streams to save volume of structure.
         ofstream volume_stream;
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             volume_stream.open("volume.curve", ios_base::out | ios_base::trunc);
         }
@@ -349,7 +349,7 @@ main(int argc, char* argv[])
         }
 
         // Close the logging streams.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             volume_stream.close();
         }
@@ -359,7 +359,5 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
     return 0;
 } // main

--- a/examples/adv_diff/ex0/example.cpp
+++ b/examples/adv_diff/ex0/example.cpp
@@ -31,6 +31,7 @@
 #include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 
 #include <LocationIndexRobinBcCoefs.h>
 
@@ -54,11 +55,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -264,7 +262,4 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/examples/adv_diff/ex1/example.cpp
+++ b/examples/adv_diff/ex1/example.cpp
@@ -31,6 +31,7 @@
 #include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -51,11 +52,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -284,7 +282,4 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/examples/adv_diff/ex2/example.cpp
+++ b/examples/adv_diff/ex2/example.cpp
@@ -31,6 +31,7 @@
 #include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -51,11 +52,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -263,7 +261,4 @@ main(int argc, char* argv[])
         delete C_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/examples/advect/example.cpp
+++ b/examples/advect/example.cpp
@@ -33,6 +33,7 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
 
 #include <LocationIndexRobinBcCoefs.h>
 #include <TimeRefinementIntegrator.h>
@@ -57,10 +58,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize MPI and SAMRAI.
-    SAMRAI_MPI::init(&argc, &argv);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -282,7 +281,4 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    SAMRAI_MPI::finalize();
 } // main

--- a/examples/complex_fluids/ex0/example.cpp
+++ b/examples/complex_fluids/ex0/example.cpp
@@ -35,6 +35,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -61,13 +63,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::setMaxNumberPatchDataEntries(512);
-
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -379,9 +376,6 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -395,7 +389,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/complex_fluids/ex1/example.cpp
+++ b/examples/complex_fluids/ex1/example.cpp
@@ -35,6 +35,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -61,12 +63,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::setMaxNumberPatchDataEntries(512);
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -271,9 +269,6 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -287,7 +282,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/complex_fluids/ex2/InterpolationUtilities.cpp
+++ b/examples/complex_fluids/ex2/InterpolationUtilities.cpp
@@ -119,7 +119,7 @@ InterpolationUtilities::interpolate(const vector<double>& X,
         Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
         level->deallocatePatchData(data_idx_temp);
     }
-    q_val = SAMRAI_MPI::sumReduction(q_val);
+    q_val = IBTK_MPI::sumReduction(q_val);
     return q_val;
 }
 
@@ -244,7 +244,7 @@ InterpolationUtilities::interpolateL2(const std::vector<double>& X,
             }
         }
     }
-    q_val = SAMRAI_MPI::sumReduction(q_val);
+    q_val = IBTK_MPI::sumReduction(q_val);
 
     for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
     {

--- a/examples/complex_fluids/ex2/InterpolationUtilities.h
+++ b/examples/complex_fluids/ex2/InterpolationUtilities.h
@@ -21,6 +21,7 @@
 #include <ibamr/app_namespaces.h>
 
 #include "ibtk/HierarchyGhostCellInterpolation.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 
 #include "Box.h"
@@ -32,7 +33,6 @@
 #include "RobinBcCoefStrategy.h"
 #include "SAMRAI_config.h"
 #include "tbox/Pointer.h"
-#include <tbox/SAMRAI_MPI.h>
 
 #include <Patch.h>
 #include <PatchLevel.h>

--- a/examples/complex_fluids/ex3/example.cpp
+++ b/examples/complex_fluids/ex3/example.cpp
@@ -35,6 +35,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -61,12 +63,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::setMaxNumberPatchDataEntries(512);
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -262,9 +260,6 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -278,7 +273,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/complex_fluids/ex4/example.cpp
+++ b/examples/complex_fluids/ex4/example.cpp
@@ -49,6 +49,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LEInteractor.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -144,12 +146,9 @@ void postprocess_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::setMaxNumberPatchDataEntries(512);
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -472,7 +471,7 @@ main(int argc, char* argv[])
 
         // Open streams to save lift and drag coefficients and the norms of the
         // velocity.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             drag_force_stream.open("CD_Force_integral.curve", ios_base::out | ios_base::trunc);
             drag_force_stream.precision(10);
@@ -541,7 +540,7 @@ main(int argc, char* argv[])
         }
 
         // Close the logging streams.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             drag_force_stream.close();
             sxx_component_stream.close();
@@ -552,6 +551,4 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main

--- a/examples/level_set/ex0/example.cpp
+++ b/examples/level_set/ex0/example.cpp
@@ -34,6 +34,7 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/muParserCartGridFunction.h>
 
 #include <LocationIndexRobinBcCoefs.h>
@@ -59,10 +60,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize MPI and SAMRAI.
-    SAMRAI_MPI::init(&argc, &argv);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -301,7 +300,4 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    SAMRAI_MPI::finalize();
 } // main

--- a/examples/level_set/ex1/example.cpp
+++ b/examples/level_set/ex1/example.cpp
@@ -34,6 +34,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 
 #include <LocationIndexRobinBcCoefs.h>
@@ -59,10 +61,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize MPI and SAMRAI.
-    SAMRAI_MPI::init(&argc, &argv);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -298,9 +298,9 @@ main(int argc, char* argv[])
             }
         }
         // Perform sum reduction
-        num_interface_pts = SAMRAI_MPI::sumReduction(num_interface_pts);
-        E_interface = SAMRAI_MPI::sumReduction(E_interface);
-        E_domain = SAMRAI_MPI::sumReduction(E_domain);
+        num_interface_pts = IBTK_MPI::sumReduction(num_interface_pts);
+        E_interface = IBTK_MPI::sumReduction(E_interface);
+        E_domain = IBTK_MPI::sumReduction(E_domain);
 
         pout << "Error in Q near interface after level set initialization:" << std::endl
              << "L1-norm:  " << std::setprecision(10) << E_interface << std::endl;
@@ -384,7 +384,4 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    SAMRAI_MPI::finalize();
 } // main

--- a/examples/multiphase_flow/ex0/example.cpp
+++ b/examples/multiphase_flow/ex0/example.cpp
@@ -36,6 +36,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -65,11 +67,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -401,7 +400,7 @@ main(int argc, char* argv[])
             pout << std::setprecision(16) << "|U|_L1 = " << UL1 << std::endl;
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << "\t" << mass_fluid << std::endl;
                 dP_file << std::setprecision(16) << loop_time << "\t" << dP << std::endl;
@@ -457,9 +456,6 @@ main(int argc, char* argv[])
         delete ptr_LSLocateCircularInterface;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -475,7 +471,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex1/RigidBodyKinematics.cpp
+++ b/examples/multiphase_flow/ex1/RigidBodyKinematics.cpp
@@ -16,8 +16,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/multiphase_flow/ex1/example.cpp
+++ b/examples/multiphase_flow/ex1/example.cpp
@@ -43,6 +43,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -79,11 +81,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -481,7 +480,7 @@ main(int argc, char* argv[])
 
         // File to write to for fluid mass data
         ofstream mass_file;
-        if (!SAMRAI_MPI::getRank()) mass_file.open("mass_fluid.txt");
+        if (!IBTK_MPI::getRank()) mass_file.open("mass_fluid.txt");
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
@@ -533,7 +532,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_rho_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << "\t" << mass_fluid << std::endl;
             }
@@ -572,7 +571,7 @@ main(int argc, char* argv[])
         }
 
         // Close file
-        if (!SAMRAI_MPI::getRank()) mass_file.close();
+        if (!IBTK_MPI::getRank()) mass_file.close();
 
         // Cleanup Eulerian boundary condition specification objects (when
         // necessary).
@@ -586,9 +585,6 @@ main(int argc, char* argv[])
         delete phi_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -605,7 +601,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex10/RigidBodyKinematics.cpp
+++ b/examples/multiphase_flow/ex10/RigidBodyKinematics.cpp
@@ -16,8 +16,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/multiphase_flow/ex10/example.cpp
+++ b/examples/multiphase_flow/ex10/example.cpp
@@ -42,6 +42,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -79,11 +81,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -507,7 +506,7 @@ main(int argc, char* argv[])
 
         // File to write to for fluid mass data
         ofstream mass_file;
-        if (!SAMRAI_MPI::getRank())
+        if (!IBTK_MPI::getRank())
         {
             if (is_from_restart)
                 mass_file.open("mass_fluid.txt", std::fstream::app);
@@ -562,7 +561,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_sc_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << '\t' << mass_fluid << std::endl;
             }
@@ -601,7 +600,7 @@ main(int argc, char* argv[])
         }
 
         // Close files
-        if (!SAMRAI_MPI::getRank()) mass_file.close();
+        if (!IBTK_MPI::getRank()) mass_file.close();
 
         // Cleanup Eulerian boundary condition specification objects (when
         // necessary).
@@ -616,9 +615,6 @@ main(int argc, char* argv[])
         delete phi_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -635,7 +631,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex11/LSLocateStructureInterface.cpp
+++ b/examples/multiphase_flow/ex11/LSLocateStructureInterface.cpp
@@ -14,6 +14,7 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTK_MPI.h>
 
 #include "LSLocateStructureInterface.h"
 
@@ -232,10 +233,10 @@ LSLocateStructureInterface::getExtremeCoords(std::vector<IBTK::Vector>& corners,
 
     // For each of the coordinates, carry out reduction but keep track of which processor has the extreme value
     int rank_xmin, rank_xmax, rank_ymin, rank_ymax;
-    xmin = SAMRAI_MPI::minReduction(xmin, &rank_xmin);
-    xmax = SAMRAI_MPI::maxReduction(xmax, &rank_xmax);
-    ymin = SAMRAI_MPI::minReduction(ymin, &rank_ymin);
-    ymax = SAMRAI_MPI::maxReduction(ymax, &rank_ymax);
+    xmin = IBTK_MPI::minReduction(xmin, &rank_xmin);
+    xmax = IBTK_MPI::maxReduction(xmax, &rank_xmax);
+    ymin = IBTK_MPI::minReduction(ymin, &rank_ymin);
+    ymax = IBTK_MPI::maxReduction(ymax, &rank_ymax);
 
     // Broadcast via minReduction the missing coordinate from the appropriate rank.
     const int num_corners = 4;
@@ -244,11 +245,11 @@ LSLocateStructureInterface::getExtremeCoords(std::vector<IBTK::Vector>& corners,
     other_coords[1] = y_xmax;
     other_coords[2] = x_ymin;
     other_coords[3] = x_ymax;
-    if (SAMRAI_MPI::getRank() != rank_xmin) other_coords[0] = std::numeric_limits<double>::max();
-    if (SAMRAI_MPI::getRank() != rank_xmax) other_coords[1] = std::numeric_limits<double>::max();
-    if (SAMRAI_MPI::getRank() != rank_ymin) other_coords[2] = std::numeric_limits<double>::max();
-    if (SAMRAI_MPI::getRank() != rank_ymax) other_coords[3] = std::numeric_limits<double>::max();
-    SAMRAI_MPI::minReduction(&other_coords[0], num_corners);
+    if (IBTK_MPI::getRank() != rank_xmin) other_coords[0] = std::numeric_limits<double>::max();
+    if (IBTK_MPI::getRank() != rank_xmax) other_coords[1] = std::numeric_limits<double>::max();
+    if (IBTK_MPI::getRank() != rank_ymin) other_coords[2] = std::numeric_limits<double>::max();
+    if (IBTK_MPI::getRank() != rank_ymax) other_coords[3] = std::numeric_limits<double>::max();
+    IBTK_MPI::minReduction(&other_coords[0], num_corners);
     y_xmin = other_coords[0];
     y_xmax = other_coords[1];
     x_ymin = other_coords[2];

--- a/examples/multiphase_flow/ex11/RigidBodyKinematics.cpp
+++ b/examples/multiphase_flow/ex11/RigidBodyKinematics.cpp
@@ -16,8 +16,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/multiphase_flow/ex11/example.cpp
+++ b/examples/multiphase_flow/ex11/example.cpp
@@ -42,6 +42,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -79,11 +81,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -499,8 +498,8 @@ main(int argc, char* argv[])
 
         // File to write to for fluid mass data
         ofstream mass_file, angle_file;
-        if (!SAMRAI_MPI::getRank()) mass_file.open("mass_fluid.txt");
-        if (!SAMRAI_MPI::getRank()) angle_file.open("barge_angle.txt");
+        if (!IBTK_MPI::getRank()) mass_file.open("mass_fluid.txt");
+        if (!IBTK_MPI::getRank()) angle_file.open("barge_angle.txt");
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
@@ -548,7 +547,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_rho_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << '\t' << mass_fluid << std::endl;
                 angle_file << std::setprecision(10) << loop_time << '\t' << barge.theta << std::endl;
@@ -588,8 +587,8 @@ main(int argc, char* argv[])
         }
 
         // Close file
-        if (!SAMRAI_MPI::getRank()) mass_file.close();
-        if (!SAMRAI_MPI::getRank()) angle_file.close();
+        if (!IBTK_MPI::getRank()) mass_file.close();
+        if (!IBTK_MPI::getRank()) angle_file.close();
 
         // Cleanup Eulerian boundary condition specification objects (when
         // necessary).
@@ -604,9 +603,6 @@ main(int argc, char* argv[])
         delete phi_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -623,7 +619,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex12/LSLocateStructureInterface.cpp
+++ b/examples/multiphase_flow/ex12/LSLocateStructureInterface.cpp
@@ -14,6 +14,7 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTK_MPI.h>
 
 #include "LSLocateStructureInterface.h"
 
@@ -277,7 +278,7 @@ LSLocateStructureInterface::getMinimumWedgeCoord(Pointer<HierarchyMathOps> hier_
 
         X_data[ln]->restoreArrays();
     } // all levels
-    wedge_min = SAMRAI_MPI::minReduction(wedge_min);
+    wedge_min = IBTK_MPI::minReduction(wedge_min);
 
     return wedge_min;
 } // getMinimumWedgeCoord

--- a/examples/multiphase_flow/ex12/RigidBodyKinematics.cpp
+++ b/examples/multiphase_flow/ex12/RigidBodyKinematics.cpp
@@ -16,8 +16,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/multiphase_flow/ex12/example.cpp
+++ b/examples/multiphase_flow/ex12/example.cpp
@@ -42,6 +42,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -79,11 +81,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -494,7 +493,7 @@ main(int argc, char* argv[])
 
         // File to write to for fluid mass data
         ofstream mass_file;
-        if (!SAMRAI_MPI::getRank()) mass_file.open("mass_fluid.txt");
+        if (!IBTK_MPI::getRank()) mass_file.open("mass_fluid.txt");
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
@@ -538,7 +537,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_rho_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << "\t" << mass_fluid << std::endl;
             }
@@ -577,7 +576,7 @@ main(int argc, char* argv[])
         }
 
         // Close file
-        if (!SAMRAI_MPI::getRank()) mass_file.close();
+        if (!IBTK_MPI::getRank()) mass_file.close();
 
         // Cleanup Eulerian boundary condition specification objects (when
         // necessary).
@@ -592,9 +591,6 @@ main(int argc, char* argv[])
         delete phi_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -611,7 +607,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex13/RigidBodyKinematics.cpp
+++ b/examples/multiphase_flow/ex13/RigidBodyKinematics.cpp
@@ -16,8 +16,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/multiphase_flow/ex13/example.cpp
+++ b/examples/multiphase_flow/ex13/example.cpp
@@ -42,6 +42,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/IndexUtilities.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -82,11 +84,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -523,7 +522,7 @@ main(int argc, char* argv[])
             pressure_probe_points[i].resize(NDIM);
             pressure_probe_db->getDoubleArray(probe_name, &pressure_probe_points[i][0], NDIM);
 
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 if (is_from_restart)
                 {
@@ -547,7 +546,7 @@ main(int argc, char* argv[])
 
         // File to write to for fluid mass data
         ofstream mass_file;
-        if (!SAMRAI_MPI::getRank()) mass_file.open("mass_fluid.txt");
+        if (!IBTK_MPI::getRank()) mass_file.open("mass_fluid.txt");
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
@@ -587,7 +586,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_rho_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << "\t" << mass_fluid << std::endl;
             }
@@ -625,8 +624,8 @@ main(int argc, char* argv[])
                     if (found_point_in_patch) break;
                 }
             }
-            SAMRAI_MPI::maxReduction(&p_val[0], num_pressure_probes);
-            if (!SAMRAI_MPI::getRank())
+            IBTK_MPI::maxReduction(&p_val[0], num_pressure_probes);
+            if (!IBTK_MPI::getRank())
             {
                 for (int i = 0; i < num_pressure_probes; ++i)
                 {
@@ -668,7 +667,7 @@ main(int argc, char* argv[])
         }
 
         // Close file
-        if (!SAMRAI_MPI::getRank()) mass_file.close();
+        if (!IBTK_MPI::getRank()) mass_file.close();
 
         // Cleanup Eulerian boundary condition specification objects (when
         // necessary).
@@ -684,9 +683,6 @@ main(int argc, char* argv[])
         for (int i = 0; i < num_pressure_probes; ++i) delete pressure_probe_streams[i];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -703,7 +699,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex3/example.cpp
+++ b/examples/multiphase_flow/ex3/example.cpp
@@ -35,6 +35,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -66,11 +68,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -376,7 +375,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_rho_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << "\t" << mass_fluid << std::endl;
             }
@@ -421,9 +420,6 @@ main(int argc, char* argv[])
         delete ptr_LSLocateCircularInterface;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -439,7 +435,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex6/example.cpp
+++ b/examples/multiphase_flow/ex6/example.cpp
@@ -37,6 +37,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -70,11 +72,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -359,7 +358,7 @@ main(int argc, char* argv[])
         // File to write to for fluid mass data
         ofstream mass_file;
 
-        if (!SAMRAI_MPI::getRank())
+        if (!IBTK_MPI::getRank())
         {
             mass_file.open("mass_fluid.txt");
         }
@@ -401,7 +400,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_rho_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << "\t" << mass_fluid << std::endl;
             }
@@ -434,7 +433,7 @@ main(int argc, char* argv[])
         }
 
         // Close file
-        if (!SAMRAI_MPI::getRank())
+        if (!IBTK_MPI::getRank())
         {
             mass_file.close();
         }
@@ -449,9 +448,6 @@ main(int argc, char* argv[])
         delete ptr_LSLocateFluidInterface;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -467,7 +463,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex7/RigidBodyKinematics.cpp
+++ b/examples/multiphase_flow/ex7/RigidBodyKinematics.cpp
@@ -16,8 +16,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/multiphase_flow/ex7/example.cpp
+++ b/examples/multiphase_flow/ex7/example.cpp
@@ -42,6 +42,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -78,11 +80,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -489,7 +488,7 @@ main(int argc, char* argv[])
 
         // File to write to for fluid mass data
         ofstream mass_file;
-        if (!SAMRAI_MPI::getRank()) mass_file.open("mass_fluid.txt");
+        if (!IBTK_MPI::getRank()) mass_file.open("mass_fluid.txt");
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
@@ -537,7 +536,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_rho_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << "\t" << mass_fluid << std::endl;
             }
@@ -576,7 +575,7 @@ main(int argc, char* argv[])
         }
 
         // Close file
-        if (!SAMRAI_MPI::getRank()) mass_file.close();
+        if (!IBTK_MPI::getRank()) mass_file.close();
 
         // Cleanup Eulerian boundary condition specification objects (when
         // necessary).
@@ -591,9 +590,6 @@ main(int argc, char* argv[])
         delete phi_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -610,7 +606,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex8/RigidBodyKinematics.cpp
+++ b/examples/multiphase_flow/ex8/RigidBodyKinematics.cpp
@@ -16,8 +16,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/multiphase_flow/ex8/example.cpp
+++ b/examples/multiphase_flow/ex8/example.cpp
@@ -42,6 +42,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -78,11 +80,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -489,7 +488,7 @@ main(int argc, char* argv[])
 
         // File to write to for fluid mass data
         ofstream mass_file;
-        if (!SAMRAI_MPI::getRank()) mass_file.open("mass_fluid.txt");
+        if (!IBTK_MPI::getRank()) mass_file.open("mass_fluid.txt");
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
@@ -537,7 +536,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_rho_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << "\t" << mass_fluid << std::endl;
             }
@@ -576,7 +575,7 @@ main(int argc, char* argv[])
         }
 
         // Close file
-        if (!SAMRAI_MPI::getRank()) mass_file.close();
+        if (!IBTK_MPI::getRank()) mass_file.close();
 
         // Cleanup Eulerian boundary condition specification objects (when
         // necessary).
@@ -591,9 +590,6 @@ main(int argc, char* argv[])
         delete phi_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -610,7 +606,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex9/RigidBodyKinematics.cpp
+++ b/examples/multiphase_flow/ex9/RigidBodyKinematics.cpp
@@ -16,8 +16,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/examples/multiphase_flow/ex9/example.cpp
+++ b/examples/multiphase_flow/ex9/example.cpp
@@ -42,6 +42,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -79,11 +81,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -507,7 +506,7 @@ main(int argc, char* argv[])
 
         // File to write to for fluid mass data
         ofstream mass_file, umax_file;
-        if (!SAMRAI_MPI::getRank())
+        if (!IBTK_MPI::getRank())
         {
             if (is_from_restart)
                 mass_file.open("mass_fluid.txt", std::fstream::app);
@@ -571,7 +570,7 @@ main(int argc, char* argv[])
             const double umax_fluid = hier_sc_data_ops.maxNorm(u_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << '\t' << mass_fluid << std::endl;
                 umax_file << std::setprecision(13) << loop_time << '\t' << umax_fluid << std::endl;
@@ -611,8 +610,8 @@ main(int argc, char* argv[])
         }
 
         // Close files
-        if (!SAMRAI_MPI::getRank()) mass_file.close();
-        if (!SAMRAI_MPI::getRank()) umax_file.close();
+        if (!IBTK_MPI::getRank()) mass_file.close();
+        if (!IBTK_MPI::getRank()) umax_file.close();
 
         // Cleanup Eulerian boundary condition specification objects (when
         // necessary).
@@ -627,9 +626,6 @@ main(int argc, char* argv[])
         delete phi_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -646,7 +642,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/navier_stokes/ex0/example.cpp
+++ b/examples/navier_stokes/ex0/example.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -58,11 +60,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -322,9 +321,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-    // double test_results[2] = {uMax_norm, pMax_norm};
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -338,7 +334,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/navier_stokes/ex1/convergence_tester.cpp
+++ b/examples/navier_stokes/ex1/convergence_tester.cpp
@@ -26,6 +26,8 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartExtrapPhysBdryOp.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 
 /*******************************************************************************
  * For each run, the input filename must be given on the command line.  In all *
@@ -37,11 +39,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Parse command line options, set some standard options from the input
     // file, and enable file logging.
@@ -125,17 +124,17 @@ main(int argc, char* argv[])
     {
         char temp_buf[128];
 
-        sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, SAMRAI_MPI::getRank());
+        sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
         string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
         coarse_file_name += temp_buf;
 
-        sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, SAMRAI_MPI::getRank());
+        sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
         string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
         fine_file_name += temp_buf;
 
-        for (int rank = 0; rank < SAMRAI_MPI::getNodes(); ++rank)
+        for (int rank = 0; rank < IBTK_MPI::getNodes(); ++rank)
         {
-            if (rank == SAMRAI_MPI::getRank())
+            if (rank == IBTK_MPI::getRank())
             {
                 fstream coarse_fin, fine_fin;
                 coarse_fin.open(coarse_file_name.c_str(), ios::in);
@@ -147,7 +146,7 @@ main(int argc, char* argv[])
                 coarse_fin.close();
                 fine_fin.close();
             }
-            SAMRAI_MPI::barrier();
+            IBTK_MPI::barrier();
         }
 
         if (!files_exist) break;
@@ -344,8 +343,5 @@ main(int argc, char* argv[])
         pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << endl;
         pout << endl;
     }
-
-    SAMRAIManager::shutdown();
-    SAMRAI_MPI::finalize();
     return 0;
 } // main

--- a/examples/navier_stokes/ex1/example.cpp
+++ b/examples/navier_stokes/ex1/example.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -58,11 +60,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -249,9 +248,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -265,7 +261,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/navier_stokes/ex2/example.cpp
+++ b/examples/navier_stokes/ex2/example.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -58,11 +60,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -249,9 +248,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -265,7 +261,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/navier_stokes/ex3/example.cpp
+++ b/examples/navier_stokes/ex3/example.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -58,11 +60,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -249,9 +248,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -265,7 +261,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/navier_stokes/ex4/example.cpp
+++ b/examples/navier_stokes/ex4/example.cpp
@@ -33,6 +33,7 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -53,12 +54,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
-    // Initialize variable to store error in u to aid in testing
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -374,7 +371,4 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete U_adv_diff_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/examples/navier_stokes/ex5/example.cpp
+++ b/examples/navier_stokes/ex5/example.cpp
@@ -33,6 +33,7 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -56,11 +57,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -261,7 +259,4 @@ main(int argc, char* argv[])
         delete T_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/examples/navier_stokes/ex6/example.cpp
+++ b/examples/navier_stokes/ex6/example.cpp
@@ -34,6 +34,7 @@
 #include <ibamr/RNG.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -57,11 +58,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -251,7 +249,4 @@ main(int argc, char* argv[])
         delete T_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/examples/vc_navier_stokes/ex0/example.cpp
+++ b/examples/vc_navier_stokes/ex0/example.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/INSVCStaggeredNonConservativeHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -61,11 +63,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -379,9 +378,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-    // double test_results[2] = {uMax_norm, pMax_norm};
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -395,7 +391,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/vc_navier_stokes/ex1/example.cpp
+++ b/examples/vc_navier_stokes/ex1/example.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/INSVCStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -61,11 +63,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -440,9 +439,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-    // double test_results[2] = {uMax_norm, pMax_norm};
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -456,7 +452,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/vc_navier_stokes/ex2/example.cpp
+++ b/examples/vc_navier_stokes/ex2/example.cpp
@@ -35,6 +35,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -66,11 +68,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -384,7 +383,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_rho_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << "\t" << mass_fluid << std::endl;
             }
@@ -429,9 +428,6 @@ main(int argc, char* argv[])
         delete ptr_LSLocateCircularInterface;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -447,7 +443,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/wave_tank/ex0/example.cpp
+++ b/examples/wave_tank/ex0/example.cpp
@@ -75,6 +75,8 @@
 #include "ibtk/IndexUtilities.h"
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -106,11 +108,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -494,7 +493,7 @@ main(int argc, char* argv[])
             probe_points[i].resize(NDIM);
             probe_db->getDoubleArray(probe_name, &probe_points[i][0], NDIM);
 
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 if (is_from_restart)
                 {
@@ -519,7 +518,7 @@ main(int argc, char* argv[])
         // File to write to for fluid mass data and irregular wave data.
         ofstream mass_file, wave_stream;
 
-        if (!SAMRAI_MPI::getRank())
+        if (!IBTK_MPI::getRank())
         {
             mass_file.open("mass_fluid.txt");
 
@@ -573,7 +572,7 @@ main(int argc, char* argv[])
             const double mass_fluid = hier_rho_data_ops.integral(rho_ins_idx, wgt_sc_idx);
 
             // Write to file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 mass_file << std::setprecision(13) << loop_time << "\t" << mass_fluid << std::endl;
             }
@@ -610,8 +609,8 @@ main(int argc, char* argv[])
                     if (found_point_in_patch) break;
                 }
             }
-            SAMRAI_MPI::maxReduction(&ls_val[0], num_probes);
-            if (!SAMRAI_MPI::getRank())
+            IBTK_MPI::maxReduction(&ls_val[0], num_probes);
+            if (!IBTK_MPI::getRank())
             {
                 for (int i = 0; i < num_probes; ++i)
                 {
@@ -647,7 +646,7 @@ main(int argc, char* argv[])
         }
 
         // Close file
-        if (!SAMRAI_MPI::getRank())
+        if (!IBTK_MPI::getRank())
         {
             mass_file.close();
         }
@@ -664,9 +663,6 @@ main(int argc, char* argv[])
         for (int i = 0; i < num_probes; ++i) delete probe_streams[i];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -682,7 +678,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/wave_tank/ex1/RigidBodyKinematics.cpp
+++ b/examples/wave_tank/ex1/RigidBodyKinematics.cpp
@@ -47,8 +47,9 @@
 /////////////////////////////////// INCLUDES /////////////////////////////////////
 
 // SAMRAI INCLUDES
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 // IBAMR INCLUDES

--- a/ibtk/examples/CCLaplace/example.cpp
+++ b/ibtk/examples/CCLaplace/example.cpp
@@ -29,6 +29,7 @@
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CCLaplaceOperator.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/muParserCartGridFunction.h>
 
 // Set up application namespace declarations
@@ -44,11 +45,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Since SAMRAI and PETSc both require finalization routines we have to
     // ensure that no SAMRAI or PETSc objects are active at the point where we
@@ -257,9 +255,4 @@ main(int argc, char* argv[])
         // Output data for plotting.
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
     }
-
-    // At this point all SAMRAI, PETSc, and IBAMR objects have been cleaned
-    // up, so we shut things down in the opposite order of initialization:
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/ibtk/examples/CCPoisson/example.cpp
+++ b/ibtk/examples/CCPoisson/example.cpp
@@ -30,6 +30,7 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CCLaplaceOperator.h>
 #include <ibtk/CCPoissonSolverManager.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/muParserCartGridFunction.h>
 
 // Set up application namespace declarations
@@ -45,11 +46,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -223,7 +221,4 @@ main(int argc, char* argv[])
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/ibtk/examples/GhostCells/example.cpp
+++ b/ibtk/examples/GhostCells/example.cpp
@@ -29,6 +29,7 @@
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
 #include <ibtk/HierarchyGhostCellInterpolation.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/muParserCartGridFunction.h>
 
 #include "TotalAmountRefineAndCoarsen.h"
@@ -51,11 +52,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -298,7 +296,4 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/ibtk/examples/PETScOps/ProlongationMat/example.cpp
+++ b/ibtk/examples/PETScOps/ProlongationMat/example.cpp
@@ -35,6 +35,8 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/HierarchyGhostCellInterpolation.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/PETScMatUtilities.h>
 #include <ibtk/PETScVecUtilities.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -52,11 +54,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -176,7 +175,7 @@ main(int argc, char* argv[])
         }
 
         // Construct the coarse and fine level PETSc Vecs
-        const int mpi_rank = SAMRAI_MPI::getRank();
+        const int mpi_rank = IBTK_MPI::getRank();
         const int n_local_coarsest = num_dofs_per_proc[coarsest_ln][mpi_rank];
         const int n_total_coarsest =
             std::accumulate(num_dofs_per_proc[coarsest_ln].begin(), num_dofs_per_proc[coarsest_ln].end(), 0);
@@ -314,7 +313,4 @@ main(int argc, char* argv[])
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/ibtk/examples/PhysBdryOps/example.cpp
+++ b/ibtk/examples/PhysBdryOps/example.cpp
@@ -30,6 +30,7 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartCellRobinPhysBdryOp.h>
 #include <ibtk/CartExtrapPhysBdryOp.h>
+#include <ibtk/IBTKInit.h>
 
 #include <LocationIndexRobinBcCoefs.h>
 
@@ -46,11 +47,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -273,7 +271,4 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/ibtk/examples/SCLaplace/example.cpp
+++ b/ibtk/examples/SCLaplace/example.cpp
@@ -28,6 +28,7 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/SCLaplaceOperator.h>
 #include <ibtk/muParserCartGridFunction.h>
 
@@ -44,11 +45,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -217,7 +215,4 @@ main(int argc, char* argv[])
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/ibtk/examples/SCPoisson/example.cpp
+++ b/ibtk/examples/SCPoisson/example.cpp
@@ -28,6 +28,7 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/SCLaplaceOperator.h>
 #include <ibtk/SCPoissonSolverManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -45,11 +46,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -257,7 +255,4 @@ main(int argc, char* argv[])
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/ibtk/examples/VCLaplace/example.cpp
+++ b/ibtk/examples/VCLaplace/example.cpp
@@ -31,6 +31,7 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/HierarchyGhostCellInterpolation.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/ibtk_enums.h>
 #include <ibtk/muParserCartGridFunction.h>
 
@@ -47,11 +48,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -286,7 +284,4 @@ main(int argc, char* argv[])
         visit_data_writer->writePlotData(patch_hierarchy, 0, data_time);
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // run_example`

--- a/ibtk/examples/VCViscousSolver/example.cpp
+++ b/ibtk/examples/VCViscousSolver/example.cpp
@@ -28,6 +28,7 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/PETScKrylovPoissonSolver.h>
 #include <ibtk/SCLaplaceOperator.h>
 #include <ibtk/SCPoissonSolverManager.h>
@@ -61,11 +62,8 @@ allocate_vc_velocity_krylov_solver(const std::string& solver_object_name,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -483,7 +481,4 @@ main(int argc, char* argv[])
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/ibtk/include/ibtk/MergingLoadBalancer.h
+++ b/ibtk/include/ibtk/MergingLoadBalancer.h
@@ -16,11 +16,11 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include "ibtk/IBTK_MPI.h"
 #include <ibtk/box_utilities.h>
 
 #include <tbox/PIO.h>
 #include <tbox/Pointer.h>
-#include <tbox/SAMRAI_MPI.h>
 
 #include <Box.h>
 #include <BoxArray.h>

--- a/ibtk/include/ibtk/private/IBTK_MPI-inl.h
+++ b/ibtk/include/ibtk/private/IBTK_MPI-inl.h
@@ -87,7 +87,7 @@ IBTK_MPI::bcast(const T x, const int root, IBTK_MPI::comm communicator)
     int size = 1;
     T temp_copy = x;
     bcast(&temp_copy, size, root, communicator);
-    return x;
+    return temp_copy;
 }
 
 template <typename T>
@@ -170,7 +170,7 @@ IBTK_MPI::minMaxReduction(T* x, const int n, int* rank, MPI_Op op, IBTK_MPI::com
     for (int i = 0; i < n; ++i)
     {
         x[i] = recv[i].first;
-        rank[i] = send[i].second;
+        rank[i] = recv[i].second;
     }
 } // minMaxReduction
 } // namespace IBTK

--- a/ibtk/src/lagrangian/BoxPartitioner.cpp
+++ b/ibtk/src/lagrangian/BoxPartitioner.cpp
@@ -12,6 +12,7 @@
 // ---------------------------------------------------------------------
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/ibtk_utilities.h"
 #include <ibtk/BoxPartitioner.h>
 #include <ibtk/PartitioningBox.h>
@@ -19,7 +20,6 @@
 
 #include "tbox/Utilities.h"
 #include <tbox/PIO.h>
-#include <tbox/SAMRAI_MPI.h>
 
 #include "libmesh/id_types.h"
 #include "libmesh/libmesh_config.h"
@@ -80,7 +80,7 @@ BoxPartitioner::writePartitioning(const std::string& file_name) const
 {
     std::stringstream current_processor_output;
 
-    const int current_rank = SAMRAI_MPI::getRank();
+    const int current_rank = IBTK_MPI::getRank();
     for (const PartitioningBox& box : d_partitioning_boxes)
     {
         const Point bottom = box.bottom();
@@ -116,7 +116,7 @@ BoxPartitioner::writePartitioning(const std::string& file_name) const
     {
         std::remove(file_name.c_str());
     }
-    const int n_processes = SAMRAI_MPI::getNodes();
+    const int n_processes = IBTK_MPI::getNodes();
     for (int rank = 0; rank < n_processes; ++rank)
     {
         if (rank == current_rank)
@@ -128,7 +128,7 @@ BoxPartitioner::writePartitioning(const std::string& file_name) const
             }
             out << current_processor_output.rdbuf();
         }
-        SAMRAI_MPI::barrier();
+        IBTK_MPI::barrier();
     }
 } // writePartitioning
 
@@ -143,7 +143,7 @@ BoxPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
     TBOX_ASSERT(mesh.is_replicated());
 #endif
     // only implemented when we use SAMRAI's partitioning
-    TBOX_ASSERT(n == static_cast<unsigned int>(SAMRAI_MPI::getNodes()));
+    TBOX_ASSERT(n == static_cast<unsigned int>(IBTK_MPI::getNodes()));
 
     // convert the libMesh type to an MPI type
     MPI_Datatype pid_integral_type = 0;
@@ -163,7 +163,7 @@ BoxPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
         break;
     }
 
-    const int current_rank = SAMRAI_MPI::getRank();
+    const int current_rank = IBTK_MPI::getRank();
     auto to_ibtk_point = [](const libMesh::Point& p) -> IBTK::Point {
         IBTK::Point point;
         for (unsigned int d = 0; d < NDIM; ++d) point[d] = p(d);
@@ -261,7 +261,7 @@ BoxPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
     // step 1.5: log the current state of affairs:
     if (d_enable_logging)
     {
-        const int n_processes = SAMRAI_MPI::getNodes();
+        const int n_processes = IBTK_MPI::getNodes();
         std::vector<unsigned long> nodes_on_processors(n_processes);
         nodes_on_processors[current_rank] = n_local_nodes;
         const int ierr = MPI_Allreduce(MPI_IN_PLACE,
@@ -269,7 +269,7 @@ BoxPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
                                        nodes_on_processors.size(),
                                        MPI_UNSIGNED_LONG,
                                        MPI_SUM,
-                                       SAMRAI_MPI::commWorld);
+                                       IBTK_MPI::getCommunicator());
         TBOX_ASSERT(ierr == 0);
         if (current_rank == 0)
         {
@@ -282,10 +282,10 @@ BoxPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
 
     // step 2: communicate the partitioning across all processors:
     int ierr = MPI_Allreduce(
-        MPI_IN_PLACE, elem_ids.data(), elem_ids.size(), pid_integral_type, MPI_SUM, SAMRAI_MPI::commWorld);
+        MPI_IN_PLACE, elem_ids.data(), elem_ids.size(), pid_integral_type, MPI_SUM, IBTK_MPI::getCommunicator());
     TBOX_ASSERT(ierr == 0);
     ierr = MPI_Allreduce(
-        MPI_IN_PLACE, node_ids.data(), node_ids.size(), pid_integral_type, MPI_SUM, SAMRAI_MPI::commWorld);
+        MPI_IN_PLACE, node_ids.data(), node_ids.size(), pid_integral_type, MPI_SUM, IBTK_MPI::getCommunicator());
     TBOX_ASSERT(ierr == 0);
 
     // step 3: verify that we partitioned each elem and node exactly once:

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -19,6 +19,7 @@
 #include "ibtk/FEDataManager.h"
 #include "ibtk/FEProjector.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/JacobianCalculator.h"
 #include "ibtk/JacobianCalculatorCache.h"
@@ -64,7 +65,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/ShutdownRegistry.h"
 #include "tbox/Timer.h"
 #include "tbox/TimerManager.h"
@@ -2730,8 +2730,8 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
 
         if (d_enable_logging)
         {
-            const int n_processes = SAMRAI::tbox::SAMRAI_MPI::getNodes();
-            const int current_rank = SAMRAI::tbox::SAMRAI_MPI::getRank();
+            const int n_processes = IBTK_MPI::getNodes();
+            const int current_rank = IBTK_MPI::getRank();
             const auto right_padding = std::size_t(std::log10(n_processes)) + 1;
 
             std::vector<unsigned long> n_q_points_on_processors(n_processes);
@@ -2742,7 +2742,7 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
                                            n_q_points_on_processors.size(),
                                            MPI_UNSIGNED_LONG,
                                            MPI_SUM,
-                                           SAMRAI::tbox::SAMRAI_MPI::commWorld);
+                                           IBTK_MPI::getCommunicator());
             TBOX_ASSERT(ierr == 0);
             if (current_rank == 0)
             {
@@ -2804,7 +2804,7 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
         const Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
         dx_0 = std::min(dx_0, *std::min_element(pgeom->getDx(), pgeom->getDx() + NDIM));
     }
-    dx_0 = SAMRAI_MPI::minReduction(dx_0);
+    dx_0 = IBTK_MPI::minReduction(dx_0);
     TBOX_ASSERT(dx_0 != std::numeric_limits<double>::max());
 
     // be a bit paranoid by computing bounding boxes for elements as the union

--- a/ibtk/src/lagrangian/FEValues.cpp
+++ b/ibtk/src/lagrangian/FEValues.cpp
@@ -13,13 +13,13 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include "ibtk/IBTK_MPI.h"
 #include <ibtk/FECache.h>
 #include <ibtk/FEValues.h>
 #include <ibtk/JacobianCalculator.h>
 #include <ibtk/namespaces.h> // IWYU pragma: keep
 
 #include <tbox/PIO.h>
-#include <tbox/SAMRAI_MPI.h>
 #include <tbox/Utilities.h>
 
 #include "libmesh/enum_fe_family.h"

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -16,6 +16,7 @@
 #include <IBTK_config.h>
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LData.h"
 #include "ibtk/LDataManager.h"
@@ -84,7 +85,6 @@
 #include "tbox/MathUtilities.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Schedule.h"
 #include "tbox/ShutdownRegistry.h"
 #include "tbox/Timer.h"
@@ -930,8 +930,8 @@ LDataManager::computeLagrangianStructureCenterOfMass(const int structure_id, con
     }
     d_lag_mesh_data[level_number][POSN_DATA_NAME]->restoreArrays();
 
-    SAMRAI_MPI::sumReduction(X_com.data(), X_com.size());
-    node_counter = SAMRAI_MPI::sumReduction(node_counter);
+    IBTK_MPI::sumReduction(X_com.data(), X_com.size());
+    node_counter = IBTK_MPI::sumReduction(node_counter);
     for (unsigned int d = 0; d < NDIM; ++d)
     {
         X_com[d] /= static_cast<double>(node_counter);
@@ -969,8 +969,8 @@ LDataManager::computeLagrangianStructureBoundingBox(const int structure_id, cons
     }
     d_lag_mesh_data[level_number][POSN_DATA_NAME]->restoreArrays();
 
-    SAMRAI_MPI::minReduction(&X_lower[0], NDIM);
-    SAMRAI_MPI::maxReduction(&X_upper[0], NDIM);
+    IBTK_MPI::minReduction(&X_lower[0], NDIM);
+    IBTK_MPI::maxReduction(&X_upper[0], NDIM);
     return std::make_pair(X_lower, X_upper);
 } // computeLagrangianStructureBoundingBox
 
@@ -1005,8 +1005,8 @@ LDataManager::reinitLagrangianStructure(const Point& X_center, const int structu
             }
         }
     }
-    SAMRAI_MPI::minReduction(&X_lower[0], NDIM);
-    SAMRAI_MPI::maxReduction(&X_upper[0], NDIM);
+    IBTK_MPI::minReduction(&X_lower[0], NDIM);
+    IBTK_MPI::maxReduction(&X_upper[0], NDIM);
     std::pair<Point, Point> bounding_box = std::make_pair(X_lower, X_upper);
 
     // Compute the displacement.
@@ -1538,7 +1538,7 @@ LDataManager::endDataRedistribution(const int coarsest_ln_in, const int finest_l
     {
         if (!d_level_contains_lag_data[level_number] || d_displaced_strct_ids[level_number].empty()) continue;
 
-        const int num_procs = SAMRAI_MPI::getNodes();
+        const int num_procs = IBTK_MPI::getNodes();
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(level_number);
         Pointer<BoxTree<NDIM> > box_tree = level->getBoxTree();
         const ProcessorMapping& processor_mapping = level->getProcessorMapping();
@@ -1579,7 +1579,7 @@ LDataManager::endDataRedistribution(const int coarsest_ln_in, const int finest_l
         {
             for (int dst_proc = 0; dst_proc < num_procs; ++dst_proc)
             {
-                if (src_proc == SAMRAI_MPI::getRank())
+                if (src_proc == IBTK_MPI::getRank())
                 {
                     transactions[src_proc][dst_proc] =
                         new LNodeTransaction(src_proc, dst_proc, src_index_set[dst_proc]);
@@ -1604,7 +1604,7 @@ LDataManager::endDataRedistribution(const int coarsest_ln_in, const int finest_l
         {
             for (int dst_proc = 0; dst_proc < num_procs; ++dst_proc)
             {
-                if (dst_proc == SAMRAI_MPI::getRank())
+                if (dst_proc == IBTK_MPI::getRank())
                 {
                     Pointer<LNodeTransaction> transaction = transactions[src_proc][dst_proc];
                     const std::vector<LNodeTransactionComponent>& dst_index_set = transaction->getDestinationData();
@@ -2146,7 +2146,7 @@ LDataManager::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> > hiera
         const unsigned int num_local_nodes = d_lag_init->computeLocalNodeCountOnPatchLevel(
             hierarchy, level_number, init_data_time, can_be_refined, initial_time);
         const auto sum_num_local_nodes =
-            static_cast<unsigned int>(SAMRAI_MPI::sumReduction(static_cast<int>(num_local_nodes)));
+            static_cast<unsigned int>(IBTK_MPI::sumReduction(static_cast<int>(num_local_nodes)));
         if (num_global_nodes != sum_num_local_nodes)
         {
             TBOX_ERROR("LDataManager::initializeLevelData()"
@@ -2278,7 +2278,7 @@ LDataManager::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> > hiera
             }
         }
         const auto num_initialized_global_nodes =
-            static_cast<unsigned int>(SAMRAI_MPI::sumReduction(static_cast<int>(local_nodes.size())));
+            static_cast<unsigned int>(IBTK_MPI::sumReduction(static_cast<int>(local_nodes.size())));
         if (num_initialized_global_nodes != d_num_nodes[level_number])
         {
             TBOX_ERROR("LDataManager::initializeLevelData()"
@@ -3033,12 +3033,12 @@ LDataManager::computeNodeOffsets(unsigned int& num_nodes, unsigned int& node_off
 {
     IBTK_TIMER_START(t_compute_node_offsets);
 
-    const int mpi_size = SAMRAI_MPI::getNodes();
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_size = IBTK_MPI::getNodes();
+    const int mpi_rank = IBTK_MPI::getRank();
 
     std::vector<int> num_nodes_proc(mpi_size, 0);
 
-    SAMRAI_MPI::allGather(num_local_nodes, &num_nodes_proc[0]);
+    IBTK_MPI::allGather(static_cast<int>(num_local_nodes), &num_nodes_proc[0]);
 
     node_offset = std::accumulate(num_nodes_proc.begin(), num_nodes_proc.begin() + mpi_rank, 0);
 

--- a/ibtk/src/lagrangian/LSiloDataWriter.cpp
+++ b/ibtk/src/lagrangian/LSiloDataWriter.cpp
@@ -16,6 +16,7 @@
 #include <IBTK_config.h>
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LData.h"
 #include "ibtk/LSiloDataWriter.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
@@ -1197,8 +1198,8 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
     char temp_buf[SILO_NAME_BUFSIZE];
     std::string current_file_name;
     DBfile* dbfile;
-    const int mpi_rank = SAMRAI_MPI::getRank();
-    const int mpi_nodes = SAMRAI_MPI::getNodes();
+    const int mpi_rank = IBTK_MPI::getRank();
+    const int mpi_nodes = IBTK_MPI::getNodes();
 
     // Construct the VecScatter objects required to write the plot data.
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
@@ -1533,11 +1534,11 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
 
             if (mpi_rank == proc)
             {
-                SAMRAI_MPI::send(&d_nclouds[ln], one, SILO_MPI_ROOT, false);
+                IBTK_MPI::send(&d_nclouds[ln], one, SILO_MPI_ROOT, false);
             }
             if (mpi_rank == SILO_MPI_ROOT)
             {
-                SAMRAI_MPI::recv(&nclouds_per_proc[ln][proc], one, proc, false);
+                IBTK_MPI::recv(&nclouds_per_proc[ln][proc], one, proc, false);
             }
 
             if (mpi_rank == proc && d_nclouds[ln] > 0)
@@ -1546,8 +1547,8 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                 for (int cloud = 0; cloud < d_nclouds[ln]; ++cloud)
                 {
                     num_bytes = static_cast<int>((d_cloud_names[ln][cloud].size() + 1) * sizeof(char));
-                    SAMRAI_MPI::send(&num_bytes, one, SILO_MPI_ROOT, false);
-                    SAMRAI_MPI::sendBytes(
+                    IBTK_MPI::send(&num_bytes, one, SILO_MPI_ROOT, false);
+                    IBTK_MPI::sendBytes(
                         static_cast<const void*>(d_cloud_names[ln][cloud].c_str()), num_bytes, SILO_MPI_ROOT);
                 }
             }
@@ -1558,33 +1559,33 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                 int num_bytes;
                 for (int cloud = 0; cloud < nclouds_per_proc[ln][proc]; ++cloud)
                 {
-                    SAMRAI_MPI::recv(&num_bytes, one, proc, false);
+                    IBTK_MPI::recv(&num_bytes, one, proc, false);
                     std::vector<char> name(num_bytes / sizeof(char));
-                    SAMRAI_MPI::recvBytes(static_cast<void*>(name.data()), num_bytes);
+                    IBTK_MPI::recvBytes(static_cast<void*>(name.data()), num_bytes);
                     cloud_names_per_proc[ln][proc][cloud].assign(name.data());
                 }
             }
 
             if (mpi_rank == proc)
             {
-                SAMRAI_MPI::send(&d_nblocks[ln], one, SILO_MPI_ROOT, false);
+                IBTK_MPI::send(&d_nblocks[ln], one, SILO_MPI_ROOT, false);
             }
             if (mpi_rank == SILO_MPI_ROOT)
             {
-                SAMRAI_MPI::recv(&nblocks_per_proc[ln][proc], one, proc, false);
+                IBTK_MPI::recv(&nblocks_per_proc[ln][proc], one, proc, false);
             }
 
             if (mpi_rank == proc && d_nblocks[ln] > 0)
             {
-                SAMRAI_MPI::send(&meshtype[ln][0], d_nblocks[ln], SILO_MPI_ROOT, false);
-                SAMRAI_MPI::send(&vartype[ln][0], d_nblocks[ln], SILO_MPI_ROOT, false);
+                IBTK_MPI::send(&meshtype[ln][0], d_nblocks[ln], SILO_MPI_ROOT, false);
+                IBTK_MPI::send(&vartype[ln][0], d_nblocks[ln], SILO_MPI_ROOT, false);
 
                 int num_bytes;
                 for (int block = 0; block < d_nblocks[ln]; ++block)
                 {
                     num_bytes = static_cast<int>((d_block_names[ln][block].size() + 1) * sizeof(char));
-                    SAMRAI_MPI::send(&num_bytes, one, SILO_MPI_ROOT, false);
-                    SAMRAI_MPI::sendBytes(
+                    IBTK_MPI::send(&num_bytes, one, SILO_MPI_ROOT, false);
+                    IBTK_MPI::sendBytes(
                         static_cast<const void*>(d_block_names[ln][block].c_str()), num_bytes, SILO_MPI_ROOT);
                 }
             }
@@ -1594,40 +1595,40 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                 vartypes_per_proc[ln][proc].resize(nblocks_per_proc[ln][proc]);
                 block_names_per_proc[ln][proc].resize(nblocks_per_proc[ln][proc]);
 
-                SAMRAI_MPI::recv(&meshtypes_per_proc[ln][proc][0], nblocks_per_proc[ln][proc], proc, false);
-                SAMRAI_MPI::recv(&vartypes_per_proc[ln][proc][0], nblocks_per_proc[ln][proc], proc, false);
+                IBTK_MPI::recv(&meshtypes_per_proc[ln][proc][0], nblocks_per_proc[ln][proc], proc, false);
+                IBTK_MPI::recv(&vartypes_per_proc[ln][proc][0], nblocks_per_proc[ln][proc], proc, false);
 
                 int num_bytes;
                 for (int block = 0; block < nblocks_per_proc[ln][proc]; ++block)
                 {
-                    SAMRAI_MPI::recv(&num_bytes, one, proc, false);
+                    IBTK_MPI::recv(&num_bytes, one, proc, false);
                     std::vector<char> name(num_bytes / sizeof(char));
-                    SAMRAI_MPI::recvBytes(static_cast<void*>(name.data()), num_bytes);
+                    IBTK_MPI::recvBytes(static_cast<void*>(name.data()), num_bytes);
                     block_names_per_proc[ln][proc][block].assign(name.data());
                 }
             }
 
             if (mpi_rank == proc)
             {
-                SAMRAI_MPI::send(&d_nmbs[ln], one, SILO_MPI_ROOT, false);
+                IBTK_MPI::send(&d_nmbs[ln], one, SILO_MPI_ROOT, false);
             }
             if (mpi_rank == SILO_MPI_ROOT)
             {
-                SAMRAI_MPI::recv(&nmbs_per_proc[ln][proc], one, proc, false);
+                IBTK_MPI::recv(&nmbs_per_proc[ln][proc], one, proc, false);
             }
 
             if (mpi_rank == proc && d_nmbs[ln] > 0)
             {
-                SAMRAI_MPI::send(&d_mb_nblocks[ln][0], d_nmbs[ln], SILO_MPI_ROOT, false);
+                IBTK_MPI::send(&d_mb_nblocks[ln][0], d_nmbs[ln], SILO_MPI_ROOT, false);
 
                 int num_bytes;
                 for (int mb = 0; mb < d_nmbs[ln]; ++mb)
                 {
-                    SAMRAI_MPI::send(&multimeshtype[ln][mb][0], d_mb_nblocks[ln][mb], SILO_MPI_ROOT, false);
-                    SAMRAI_MPI::send(&multivartype[ln][mb][0], d_mb_nblocks[ln][mb], SILO_MPI_ROOT, false);
+                    IBTK_MPI::send(&multimeshtype[ln][mb][0], d_mb_nblocks[ln][mb], SILO_MPI_ROOT, false);
+                    IBTK_MPI::send(&multivartype[ln][mb][0], d_mb_nblocks[ln][mb], SILO_MPI_ROOT, false);
 
                     num_bytes = static_cast<int>(d_mb_names[ln][mb].size()) + 1;
-                    SAMRAI_MPI::send(&num_bytes, one, SILO_MPI_ROOT, false);
+                    IBTK_MPI::send(&num_bytes, one, SILO_MPI_ROOT, false);
 
                     const void* mb_name_ptr = d_mb_names[ln][mb].c_str();
                     MPI_Send(const_cast<void*>(mb_name_ptr),
@@ -1635,9 +1636,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                              MPI_CHAR,
                              SILO_MPI_ROOT,
                              SILO_MPI_TAG,
-                             SAMRAI_MPI::commWorld);
-                    const int tree = SAMRAI_MPI::getTreeDepth();
-                    SAMRAI_MPI::updateOutgoingStatistics(tree, num_bytes * sizeof(char));
+                             IBTK_MPI::getCommunicator());
                 }
             }
             if (mpi_rank == SILO_MPI_ROOT && nmbs_per_proc[ln][proc] > 0)
@@ -1647,7 +1646,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                 multivartypes_per_proc[ln][proc].resize(nmbs_per_proc[ln][proc]);
                 mb_names_per_proc[ln][proc].resize(nmbs_per_proc[ln][proc]);
 
-                SAMRAI_MPI::recv(&mb_nblocks_per_proc[ln][proc][0], nmbs_per_proc[ln][proc], proc, false);
+                IBTK_MPI::recv(&mb_nblocks_per_proc[ln][proc][0], nmbs_per_proc[ln][proc], proc, false);
 
                 int num_bytes;
                 for (int mb = 0; mb < nmbs_per_proc[ln][proc]; ++mb)
@@ -1655,18 +1654,17 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                     multimeshtypes_per_proc[ln][proc][mb].resize(mb_nblocks_per_proc[ln][proc][mb]);
                     multivartypes_per_proc[ln][proc][mb].resize(mb_nblocks_per_proc[ln][proc][mb]);
 
-                    SAMRAI_MPI::recv(
+                    IBTK_MPI::recv(
                         &multimeshtypes_per_proc[ln][proc][mb][0], mb_nblocks_per_proc[ln][proc][mb], proc, false);
-                    SAMRAI_MPI::recv(
+                    IBTK_MPI::recv(
                         &multivartypes_per_proc[ln][proc][mb][0], mb_nblocks_per_proc[ln][proc][mb], proc, false);
 
-                    SAMRAI_MPI::recv(&num_bytes, one, proc, false);
+                    IBTK_MPI::recv(&num_bytes, one, proc, false);
                     std::vector<char> name(num_bytes / sizeof(char));
 
                     MPI_Status status;
-                    MPI_Recv(name.data(), num_bytes, MPI_CHAR, proc, SILO_MPI_TAG, SAMRAI_MPI::commWorld, &status);
-                    const int tree = SAMRAI_MPI::getTreeDepth();
-                    SAMRAI_MPI::updateIncomingStatistics(tree, num_bytes * sizeof(char));
+                    MPI_Recv(
+                        name.data(), num_bytes, MPI_CHAR, proc, SILO_MPI_TAG, IBTK_MPI::getCommunicator(), &status);
 
                     mb_names_per_proc[ln][proc][mb].assign(name.data());
                 }
@@ -1674,11 +1672,11 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
 
             if (mpi_rank == proc)
             {
-                SAMRAI_MPI::send(&d_nucd_meshes[ln], one, SILO_MPI_ROOT, false);
+                IBTK_MPI::send(&d_nucd_meshes[ln], one, SILO_MPI_ROOT, false);
             }
             if (mpi_rank == SILO_MPI_ROOT)
             {
-                SAMRAI_MPI::recv(&nucd_meshes_per_proc[ln][proc], one, proc, false);
+                IBTK_MPI::recv(&nucd_meshes_per_proc[ln][proc], one, proc, false);
             }
 
             if (mpi_rank == proc && d_nucd_meshes[ln] > 0)
@@ -1687,8 +1685,8 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                 for (int mesh = 0; mesh < d_nucd_meshes[ln]; ++mesh)
                 {
                     num_bytes = static_cast<int>((d_ucd_mesh_names[ln][mesh].size() + 1) * sizeof(char));
-                    SAMRAI_MPI::send(&num_bytes, one, SILO_MPI_ROOT, false);
-                    SAMRAI_MPI::sendBytes(
+                    IBTK_MPI::send(&num_bytes, one, SILO_MPI_ROOT, false);
+                    IBTK_MPI::sendBytes(
                         static_cast<const void*>(d_ucd_mesh_names[ln][mesh].c_str()), num_bytes, SILO_MPI_ROOT);
                 }
             }
@@ -1698,14 +1696,14 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                 int num_bytes;
                 for (int mesh = 0; mesh < nucd_meshes_per_proc[ln][proc]; ++mesh)
                 {
-                    SAMRAI_MPI::recv(&num_bytes, one, proc, false);
+                    IBTK_MPI::recv(&num_bytes, one, proc, false);
                     std::vector<char> name(num_bytes / sizeof(char));
-                    SAMRAI_MPI::recvBytes(static_cast<void*>(name.data()), num_bytes);
+                    IBTK_MPI::recvBytes(static_cast<void*>(name.data()), num_bytes);
                     ucd_mesh_names_per_proc[ln][proc][mesh].assign(name.data());
                 }
             }
 
-            SAMRAI_MPI::barrier();
+            IBTK_MPI::barrier();
         }
     }
 
@@ -1960,7 +1958,7 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
             sfile.close();
         }
     }
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
 #else
     TBOX_WARNING("LSiloDataWriter::writePlotData(): SILO is not installed; cannot write data." << std::endl);
 #endif // if defined(IBTK_HAVE_SILO)

--- a/ibtk/src/lagrangian/StableCentroidPartitioner.cpp
+++ b/ibtk/src/lagrangian/StableCentroidPartitioner.cpp
@@ -12,12 +12,12 @@
 // ---------------------------------------------------------------------
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/ibtk_utilities.h"
 #include <ibtk/StableCentroidPartitioner.h>
 #include <ibtk/namespaces.h> // IWYU pragma: keep
 
 #include <tbox/PIO.h>
-#include <tbox/SAMRAI_MPI.h>
 
 #include <libmesh/elem.h>
 #include <libmesh/id_types.h>
@@ -53,7 +53,7 @@ StableCentroidPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
     TBOX_ASSERT(mesh.is_replicated());
 #endif
     // only implemented when we use SAMRAI's partitioning
-    TBOX_ASSERT(n == static_cast<unsigned int>(SAMRAI_MPI::getNodes()));
+    TBOX_ASSERT(n == static_cast<unsigned int>(IBTK_MPI::getNodes()));
 
     std::vector<std::pair<std::array<float, LIBMESH_DIM>, libMesh::Elem*> > centroids;
     auto el_end = mesh.elements_end();

--- a/ibtk/src/math/PETScMatUtilities.cpp
+++ b/ibtk/src/math/PETScMatUtilities.cpp
@@ -14,6 +14,7 @@
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/PETScMatUtilities.h"
 #include "ibtk/PoissonUtilities.h"
@@ -46,7 +47,6 @@
 #include "tbox/Array.h"
 #include "tbox/MathUtilities.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscao.h"
@@ -164,7 +164,7 @@ PETScMatUtilities::constructPatchLevelCCLaplaceOp(Mat& mat,
     }
 
     // Determine the index ranges.
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int n_local = num_dofs_per_proc[mpi_rank];
     const int i_lower = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
     const int i_upper = i_lower + n_local;
@@ -314,7 +314,7 @@ PETScMatUtilities::constructPatchLevelSCLaplaceOp(Mat& mat,
     }
 
     // Determine the index ranges.
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int n_local = num_dofs_per_proc[mpi_rank];
     const int i_lower = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
     const int i_upper = i_lower + n_local;
@@ -452,7 +452,7 @@ PETScMatUtilities::constructPatchLevelVCSCViscousOp(
     }
 
     // Determine the index ranges.
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int n_local = num_dofs_per_proc[mpi_rank];
     const int proc_lower = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
     const int proc_upper = proc_lower + n_local;
@@ -823,7 +823,7 @@ PETScMatUtilities::constructPatchLevelSCInterpOp(Mat& mat,
     ierr = VecGetOwnershipRange(X_vec, &i_lower, &i_upper);
     IBTK_CHKERRQ(ierr);
 
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int n_local = num_dofs_per_proc[mpi_rank];
     const int j_lower = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
     const int j_upper = j_lower + n_local;
@@ -1254,7 +1254,7 @@ PETScMatUtilities::constructConservativeProlongationOp_cell(Mat& mat,
     const IntVector<NDIM> fine_coarse_ratio = fine_ratio / coarse_ratio;
 
     // Determine the matrix dimensions and index ranges.
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int m_local = num_fine_dofs_per_proc[mpi_rank];
     const int n_local = num_coarse_dofs_per_proc[mpi_rank];
     const int i_fine_lower =
@@ -1408,7 +1408,7 @@ PETScMatUtilities::constructRT0ProlongationOp_side(Mat& mat,
     const IntVector<NDIM> fine_coarse_ratio = fine_ratio / coarse_ratio;
 
     // Determine the matrix dimensions and index ranges.
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int m_local = num_fine_dofs_per_proc[mpi_rank];
     const int n_local = num_coarse_dofs_per_proc[mpi_rank];
     const int i_fine_lower =
@@ -1684,7 +1684,7 @@ PETScMatUtilities::constructLinearProlongationOp_side(Mat& mat,
     const IntVector<NDIM> fine_coarse_ratio = fine_ratio / coarse_ratio;
 
     // Determine the matrix dimensions and index ranges.
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int m_local = num_fine_dofs_per_proc[mpi_rank];
     const int n_local = num_coarse_dofs_per_proc[mpi_rank];
     const int i_fine_lower =

--- a/ibtk/src/math/PETScVecUtilities.cpp
+++ b/ibtk/src/math/PETScVecUtilities.cpp
@@ -14,6 +14,7 @@
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/PETScVecUtilities.h"
 #include "ibtk/SideSynchCopyFillPattern.h"
@@ -44,7 +45,6 @@
 #include "VariableDatabase.h"
 #include "VariableFillPattern.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscao.h"
@@ -440,11 +440,11 @@ PETScVecUtilities::constructPatchLevelDOFIndices_cell(std::vector<int>& num_dofs
 
     // Determine the number of DOFs local to each MPI process and compute the
     // local DOF index offset.
-    const int mpi_size = SAMRAI_MPI::getNodes();
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_size = IBTK_MPI::getNodes();
+    const int mpi_rank = IBTK_MPI::getRank();
     num_dofs_per_proc.resize(mpi_size);
     std::fill(num_dofs_per_proc.begin(), num_dofs_per_proc.end(), 0);
-    SAMRAI_MPI::allGather(local_dof_count, &num_dofs_per_proc[0]);
+    IBTK_MPI::allGather(local_dof_count, &num_dofs_per_proc[0]);
     const int local_dof_offset = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
 
     // Assign local DOF indices.
@@ -552,11 +552,11 @@ PETScVecUtilities::constructPatchLevelDOFIndices_side(std::vector<int>& num_dofs
 
     // Determine the number of DOFs local to each MPI process and compute the
     // local DOF index offset.
-    const int mpi_size = SAMRAI_MPI::getNodes();
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_size = IBTK_MPI::getNodes();
+    const int mpi_rank = IBTK_MPI::getRank();
     num_dofs_per_proc.resize(mpi_size);
     std::fill(num_dofs_per_proc.begin(), num_dofs_per_proc.end(), 0);
-    SAMRAI_MPI::allGather(local_dof_count, &num_dofs_per_proc[0]);
+    IBTK_MPI::allGather(local_dof_count, &num_dofs_per_proc[0]);
     const int local_dof_offset = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
 
     // Assign local DOF indices.
@@ -639,7 +639,7 @@ PETScVecUtilities::constructPatchLevelAO_cell(AO& ao,
     // Note that num of local dofs can be greater than the local
     // mapping size, i.e., it is possible to map a sub-component of the
     // vector.
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int n_local = num_dofs_per_proc[mpi_rank];
     const int i_lower = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
     const int i_upper = i_lower + n_local;
@@ -708,7 +708,7 @@ PETScVecUtilities::constructPatchLevelAO_side(AO& ao,
     }
 
     // Compute PETSc to SAMRAI index mapping
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int n_local = num_dofs_per_proc[mpi_rank];
     const int i_lower = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
     const int i_upper = i_lower + n_local;

--- a/ibtk/src/math/SAMRAIGhostDataAccumulator.cpp
+++ b/ibtk/src/math/SAMRAIGhostDataAccumulator.cpp
@@ -15,6 +15,7 @@
 
 #include <IBTK_config.h>
 
+#include "ibtk/IBTK_MPI.h"
 #include <ibtk/IBTK_CHKERRQ.h>
 #include <ibtk/PETScVecUtilities.h>
 #include <ibtk/SAMRAIGhostDataAccumulator.h>
@@ -22,7 +23,6 @@
 #include <ibtk/namespaces.h> // IWYU pragma: keep
 
 #include <tbox/Pointer.h>
-#include <tbox/SAMRAI_MPI.h>
 #include <tbox/Utilities.h>
 
 #include <petscis.h>
@@ -181,7 +181,7 @@ SAMRAIGhostDataAccumulator::SAMRAIGhostDataAccumulator(Pointer<BasePatchHierarch
 
         std::vector<int> num_dofs_per_proc;
         PETScVecUtilities::constructPatchLevelDOFIndices(num_dofs_per_proc, d_global_dof_idx, level);
-        const int mpi_rank = SAMRAI_MPI::getRank();
+        const int mpi_rank = IBTK_MPI::getRank();
 
         // half-open range of DoFs on the current processor
         const int local_dofs_begin =

--- a/ibtk/src/solvers/impls/CCPoissonHypreLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonHypreLevelSolver.cpp
@@ -15,6 +15,7 @@
 
 #include "ibtk/CCPoissonHypreLevelSolver.h"
 #include "ibtk/GeneralSolver.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PoissonUtilities.h"
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
@@ -41,7 +42,6 @@
 #include "tbox/Database.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Timer.h"
 #include "tbox/TimerManager.h"
 #include "tbox/Utilities.h"
@@ -355,7 +355,7 @@ void
 CCPoissonHypreLevelSolver::allocateHypreData()
 {
     // Get the MPI communicator.
-    MPI_Comm communicator = SAMRAI_MPI::getCommunicator();
+    MPI_Comm communicator = IBTK_MPI::getCommunicator();
 
     // Setup the hypre grid.
     Pointer<CartesianGridGeometry<NDIM> > grid_geometry = d_hierarchy->getGridGeometry();
@@ -724,7 +724,7 @@ void
 CCPoissonHypreLevelSolver::setupHypreSolver()
 {
     // Get the MPI communicator.
-    MPI_Comm communicator = SAMRAI_MPI::getCommunicator();
+    MPI_Comm communicator = IBTK_MPI::getCommunicator();
 
     d_solvers.resize(d_depth);
     d_preconds.resize(d_depth);

--- a/ibtk/src/solvers/impls/CCPoissonPETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/CCPoissonPETScLevelSolver.cpp
@@ -16,6 +16,7 @@
 #include "ibtk/CCPoissonPETScLevelSolver.h"
 #include "ibtk/GeneralSolver.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PETScLevelSolver.h"
 #include "ibtk/PETScMatUtilities.h"
 #include "ibtk/PETScVecUtilities.h"
@@ -38,7 +39,6 @@
 #include "VariableContext.h"
 #include "VariableDatabase.h"
 #include "tbox/Array.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "petscvec.h"
 #include <petsclog.h>
@@ -126,7 +126,7 @@ CCPoissonPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVectorRe
     // Setup PETSc objects.
     int ierr;
     PETScVecUtilities::constructPatchLevelDOFIndices(d_num_dofs_per_proc, d_dof_index_idx, d_level);
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_x);
     IBTK_CHKERRQ(ierr);
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_b);

--- a/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScKrylovLinearSolver.cpp
@@ -15,6 +15,7 @@
 
 #include "ibtk/GeneralSolver.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/KrylovLinearSolver.h"
 #include "ibtk/LinearOperator.h"
 #include "ibtk/PETScKrylovLinearSolver.h"
@@ -30,7 +31,6 @@
 #include "SAMRAIVectorReal.h"
 #include "tbox/Database.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Timer.h"
 #include "tbox/Utilities.h"
 

--- a/ibtk/src/solvers/impls/PETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScLevelSolver.cpp
@@ -14,6 +14,7 @@
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PETScLevelSolver.h"
 #include "ibtk/SAMRAIDataCache.h"
 #include "ibtk/ibtk_utilities.h"
@@ -27,7 +28,6 @@
 #include "tbox/Database.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Timer.h"
 #include "tbox/TimerManager.h"
 #include "tbox/Utilities.h"
@@ -438,7 +438,7 @@ PETScLevelSolver::initializeSolverState(const SAMRAIVectorReal<NDIM, double>& x,
         std::vector<std::set<int> > overlap_is, nonoverlap_is;
         generateASMSubdomains(overlap_is, nonoverlap_is);
         d_n_local_subdomains = static_cast<int>(d_overlap_is.size());
-        d_n_subdomains_max = SAMRAI_MPI::maxReduction(d_n_local_subdomains);
+        d_n_subdomains_max = IBTK_MPI::maxReduction(d_n_local_subdomains);
 
         // Generate PETSc IS in cases where they have not been generated directly.
         if (!d_overlap_is.size())

--- a/ibtk/src/solvers/impls/PETScMFFDJacobianOperator.cpp
+++ b/ibtk/src/solvers/impls/PETScMFFDJacobianOperator.cpp
@@ -15,6 +15,7 @@
 
 #include "ibtk/GeneralOperator.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/JacobianOperator.h"
 #include "ibtk/PETScMFFDJacobianOperator.h"
 #include "ibtk/PETScNewtonKrylovSolver.h"
@@ -24,7 +25,6 @@
 #include "Box.h"
 #include "MultiblockDataTranslator.h"
 #include "SAMRAIVectorReal.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "petscmat.h"
 #include "petscsys.h"

--- a/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScNewtonKrylovSolver.cpp
@@ -16,6 +16,7 @@
 #include "ibtk/GeneralOperator.h"
 #include "ibtk/GeneralSolver.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/JacobianOperator.h"
 #include "ibtk/KrylovLinearSolver.h"
 #include "ibtk/LinearOperator.h"
@@ -33,7 +34,6 @@
 #include "tbox/Database.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Timer.h"
 #include "tbox/TimerManager.h"
 

--- a/ibtk/src/solvers/impls/SCPoissonHypreLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonHypreLevelSolver.cpp
@@ -16,6 +16,7 @@
 #include <IBTK_config.h>
 
 #include "ibtk/GeneralSolver.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PoissonUtilities.h"
 #include "ibtk/SCPoissonHypreLevelSolver.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
@@ -34,7 +35,6 @@
 #include "tbox/Database.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Timer.h"
 #include "tbox/TimerManager.h"
 #include "tbox/Utilities.h"
@@ -298,7 +298,7 @@ void
 SCPoissonHypreLevelSolver::allocateHypreData()
 {
     // Get the MPI communicator.
-    MPI_Comm communicator = SAMRAI_MPI::getCommunicator();
+    MPI_Comm communicator = IBTK_MPI::getCommunicator();
 
     // Setup the hypre grid and variables and assemble the grid.
     Pointer<CartesianGridGeometry<NDIM> > grid_geometry = d_hierarchy->getGridGeometry();
@@ -426,7 +426,7 @@ void
 SCPoissonHypreLevelSolver::setupHypreSolver()
 {
     // Get the MPI communicator.
-    MPI_Comm communicator = SAMRAI_MPI::getCommunicator();
+    MPI_Comm communicator = IBTK_MPI::getCommunicator();
 
     // Determine the split solver type.
     int split_solver_type_id = -1;

--- a/ibtk/src/solvers/impls/SCPoissonPETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/SCPoissonPETScLevelSolver.cpp
@@ -15,6 +15,7 @@
 
 #include "ibtk/GeneralSolver.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PETScMatUtilities.h"
 #include "ibtk/PETScVecUtilities.h"
 #include "ibtk/PoissonUtilities.h"
@@ -39,7 +40,6 @@
 #include "VariableContext.h"
 #include "VariableDatabase.h"
 #include "tbox/Array.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "petscvec.h"
 #include <petsclog.h>
@@ -128,7 +128,7 @@ SCPoissonPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVectorRe
 
     // Setup PETSc objects.
     int ierr;
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_x);
     IBTK_CHKERRQ(ierr);
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_b);

--- a/ibtk/src/solvers/impls/VCSCViscousPETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/VCSCViscousPETScLevelSolver.cpp
@@ -14,6 +14,7 @@
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PETScMatUtilities.h"
 #include "ibtk/PETScVecUtilities.h"
 #include "ibtk/PoissonUtilities.h"
@@ -35,7 +36,6 @@
 #include "SideData.h"
 #include "SideDataFactory.h"
 #include "tbox/Array.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "petscvec.h"
 #include <petsclog.h>
@@ -86,7 +86,7 @@ VCSCViscousPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVector
 
     // Setup PETSc objects.
     int ierr;
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_x);
     IBTK_CHKERRQ(ierr);
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_b);

--- a/ibtk/src/solvers/wrappers/PETScMatLOWrapper.cpp
+++ b/ibtk/src/solvers/wrappers/PETScMatLOWrapper.cpp
@@ -14,6 +14,7 @@
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LinearOperator.h"
 #include "ibtk/PETScMatLOWrapper.h"
 #include "ibtk/PETScSAMRAIVectorReal.h"
@@ -22,7 +23,6 @@
 #include "IntVector.h"
 #include "MultiblockDataTranslator.h"
 #include "SAMRAIVectorReal.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "petscmat.h"
 

--- a/ibtk/src/solvers/wrappers/PETScPCLSWrapper.cpp
+++ b/ibtk/src/solvers/wrappers/PETScPCLSWrapper.cpp
@@ -15,6 +15,7 @@
 
 #include "ibtk/GeneralSolver.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PETScPCLSWrapper.h"
 #include "ibtk/PETScSAMRAIVectorReal.h"
 #include "ibtk/ibtk_utilities.h"
@@ -24,7 +25,6 @@
 #include "MultiblockDataTranslator.h"
 #include "SAMRAIVectorReal.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "petscpc.h"
 #include "petscpctypes.h"

--- a/ibtk/src/solvers/wrappers/PETScSAMRAIVectorReal.cpp
+++ b/ibtk/src/solvers/wrappers/PETScSAMRAIVectorReal.cpp
@@ -14,6 +14,7 @@
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/NormOps.h"
 #include "ibtk/PETScSAMRAIVectorReal.h"
 #include "ibtk/ibtk_utilities.h"
@@ -310,7 +311,7 @@ PETScSAMRAIVectorReal::VecMDot_SAMRAI(Vec x, PetscInt nv, const Vec* y, PetscSca
     {
         val[i] = PSVR_CAST2(x)->dot(PSVR_CAST2(y[i]), local_only);
     }
-    SAMRAI_MPI::sumReduction(val, nv);
+    IBTK_MPI::sumReduction(val, nv);
     IBTK_TIMER_STOP(t_vec_m_dot);
     PetscFunctionReturn(0);
 }
@@ -338,7 +339,7 @@ PETScSAMRAIVectorReal::VecNorm_SAMRAI(Vec x, NormType type, PetscScalar* val)
         val[0] = NormOps::L1Norm(PSVR_CAST2(x), local_only);
         val[1] = NormOps::L2Norm(PSVR_CAST2(x), local_only);
         val[1] = val[1] * val[1];
-        SAMRAI_MPI::sumReduction(val, 2);
+        IBTK_MPI::sumReduction(val, 2);
         val[1] = std::sqrt(val[1]);
     }
     else
@@ -371,7 +372,7 @@ PETScSAMRAIVectorReal::VecMTDot_SAMRAI(Vec x, PetscInt nv, const Vec* y, PetscSc
     {
         val[i] = PSVR_CAST2(x)->dot(PSVR_CAST2(y[i]), local_only);
     }
-    SAMRAI_MPI::sumReduction(val, nv);
+    IBTK_MPI::sumReduction(val, nv);
     IBTK_TIMER_STOP(t_vec_m_t_dot);
     PetscFunctionReturn(0);
 }

--- a/ibtk/src/solvers/wrappers/PETScSNESFunctionGOWrapper.cpp
+++ b/ibtk/src/solvers/wrappers/PETScSNESFunctionGOWrapper.cpp
@@ -15,6 +15,7 @@
 
 #include "ibtk/GeneralOperator.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PETScSAMRAIVectorReal.h"
 #include "ibtk/PETScSNESFunctionGOWrapper.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
@@ -23,7 +24,6 @@
 #include "MultiblockDataTranslator.h"
 #include "SAMRAIVectorReal.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "petscvec.h"
 

--- a/ibtk/src/solvers/wrappers/PETScSNESJacobianJOWrapper.cpp
+++ b/ibtk/src/solvers/wrappers/PETScSNESJacobianJOWrapper.cpp
@@ -14,6 +14,7 @@
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/JacobianOperator.h"
 #include "ibtk/PETScSAMRAIVectorReal.h"
 #include "ibtk/PETScSNESJacobianJOWrapper.h"
@@ -23,7 +24,6 @@
 #include "MultiblockDataTranslator.h"
 #include "SAMRAIVectorReal.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "petscsnes.h"
 #include "petscvec.h"

--- a/ibtk/src/utilities/AppInitializer.cpp
+++ b/ibtk/src/utilities/AppInitializer.cpp
@@ -14,6 +14,7 @@
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include "ibtk/AppInitializer.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LSiloDataWriter.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
 
@@ -26,7 +27,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/TimerManager.h"
 #include "tbox/Utilities.h"
 
@@ -58,8 +58,8 @@ AppInitializer::AppInitializer(int argc, char* argv[], const std::string& defaul
     if (argc >= 4)
     {
         // Check whether this appears to be a restarted run.
-        FILE* fstream = (SAMRAI_MPI::getRank() == 0 ? fopen(argv[2], "r") : nullptr);
-        if (SAMRAI_MPI::bcast(fstream ? 1 : 0, 0) == 1)
+        FILE* fstream = (IBTK_MPI::getRank() == 0 ? fopen(argv[2], "r") : nullptr);
+        if (IBTK_MPI::bcast(fstream ? 1 : 0, 0) == 1)
         {
             d_restart_read_dirname = argv[2];
             d_restart_restore_num = atoi(argv[3]);
@@ -75,7 +75,7 @@ AppInitializer::AppInitializer(int argc, char* argv[], const std::string& defaul
     if (d_is_from_restart)
     {
         RestartManager::getManager()->openRestartFile(
-            d_restart_read_dirname, d_restart_restore_num, SAMRAI_MPI::getNodes());
+            d_restart_read_dirname, d_restart_restore_num, IBTK_MPI::getNodes());
     }
 
     // Create input database and parse all data in input file.

--- a/ibtk/src/utilities/CopyToRootSchedule.cpp
+++ b/ibtk/src/utilities/CopyToRootSchedule.cpp
@@ -15,6 +15,7 @@
 
 #include "ibtk/CopyToRootSchedule.h"
 #include "ibtk/CopyToRootTransaction.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
 
 #include "BoxArray.h"
@@ -94,7 +95,7 @@ CopyToRootSchedule::commonClassCtor()
     const size_t num_vars = d_src_patch_data_idxs.size();
 
     d_root_patch_data.resize(num_vars, Pointer<PatchData<NDIM> >(nullptr));
-    if (SAMRAI_MPI::getRank() == d_root_proc)
+    if (IBTK_MPI::getRank() == d_root_proc)
     {
         for (unsigned int k = 0; k < num_vars; ++k)
         {
@@ -104,7 +105,7 @@ CopyToRootSchedule::commonClassCtor()
         }
     }
 
-    const int mpi_nodes = SAMRAI_MPI::getNodes();
+    const int mpi_nodes = IBTK_MPI::getNodes();
     for (int src_proc = 0; src_proc < mpi_nodes; ++src_proc)
     {
         for (unsigned int k = 0; k < num_vars; ++k)

--- a/ibtk/src/utilities/DebuggingUtilities.cpp
+++ b/ibtk/src/utilities/DebuggingUtilities.cpp
@@ -16,6 +16,7 @@
 #include <IBTK_config.h>
 
 #include "ibtk/DebuggingUtilities.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LData.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
 
@@ -39,7 +40,6 @@
 #include "SideIndex.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 
 IBTK_DISABLE_EXTRA_WARNINGS
 #include <boost/multi_array.hpp>
@@ -102,7 +102,7 @@ DebuggingUtilities::checkCellDataForNaNs(const int patch_data_idx,
             }
         }
     }
-    return SAMRAI_MPI::minReduction(num_nans) > 0;
+    return IBTK_MPI::minReduction(num_nans) > 0;
 } // checkCellDataForNaNs
 
 bool
@@ -154,7 +154,7 @@ DebuggingUtilities::checkFaceDataForNaNs(const int patch_data_idx,
             }
         }
     }
-    return SAMRAI_MPI::minReduction(num_nans) > 0;
+    return IBTK_MPI::minReduction(num_nans) > 0;
 } // checkFaceDataForNaNs
 
 bool
@@ -203,7 +203,7 @@ DebuggingUtilities::checkNodeDataForNaNs(const int patch_data_idx,
             }
         }
     }
-    return SAMRAI_MPI::minReduction(num_nans) > 0;
+    return IBTK_MPI::minReduction(num_nans) > 0;
 } // checkNodeDataForNaNs
 
 bool
@@ -255,7 +255,7 @@ DebuggingUtilities::checkSideDataForNaNs(const int patch_data_idx,
             }
         }
     }
-    return SAMRAI_MPI::minReduction(num_nans) > 0;
+    return IBTK_MPI::minReduction(num_nans) > 0;
 } // checkSideDataForNaNs
 
 void
@@ -271,8 +271,8 @@ DebuggingUtilities::saveCellData(const int patch_data_idx,
     }
     Utilities::recursiveMkdir(truncated_dirname);
 
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     for (int n = 0; n < nodes; ++n)
     {
         if (n == rank)
@@ -310,7 +310,7 @@ DebuggingUtilities::saveCellData(const int patch_data_idx,
                 }
             }
         }
-        SAMRAI_MPI::barrier();
+        IBTK_MPI::barrier();
     }
     return;
 } // saveCellData
@@ -328,8 +328,8 @@ DebuggingUtilities::saveFaceData(const int patch_data_idx,
     }
     Utilities::recursiveMkdir(truncated_dirname);
 
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     for (int n = 0; n < nodes; ++n)
     {
         if (n == rank)
@@ -370,7 +370,7 @@ DebuggingUtilities::saveFaceData(const int patch_data_idx,
                 }
             }
         }
-        SAMRAI_MPI::barrier();
+        IBTK_MPI::barrier();
     }
     return;
 } // saveFaceData
@@ -388,8 +388,8 @@ DebuggingUtilities::saveNodeData(const int patch_data_idx,
     }
     Utilities::recursiveMkdir(truncated_dirname);
 
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     for (int n = 0; n < nodes; ++n)
     {
         if (n == rank)
@@ -427,7 +427,7 @@ DebuggingUtilities::saveNodeData(const int patch_data_idx,
                 }
             }
         }
-        SAMRAI_MPI::barrier();
+        IBTK_MPI::barrier();
     }
     return;
 } // saveNodeData
@@ -445,8 +445,8 @@ DebuggingUtilities::saveSideData(const int patch_data_idx,
     }
     Utilities::recursiveMkdir(truncated_dirname);
 
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     for (int n = 0; n < nodes; ++n)
     {
         if (n == rank)
@@ -487,7 +487,7 @@ DebuggingUtilities::saveSideData(const int patch_data_idx,
                 }
             }
         }
-        SAMRAI_MPI::barrier();
+        IBTK_MPI::barrier();
     }
     return;
 } // saveSideData
@@ -506,8 +506,8 @@ DebuggingUtilities::saveLagrangianData(const Pointer<LData> lag_data,
     Utilities::recursiveMkdir(truncated_dirname);
 
     const boost::multi_array_ref<double, 2>& array_data = *lag_data->getGhostedLocalFormVecArray();
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     for (int n = 0; n < nodes; ++n)
     {
         if (n == rank)
@@ -540,7 +540,7 @@ DebuggingUtilities::saveLagrangianData(const Pointer<LData> lag_data,
             }
             of.close();
         }
-        SAMRAI_MPI::barrier();
+        IBTK_MPI::barrier();
     }
     lag_data->restoreArrays();
     return;

--- a/ibtk/src/utilities/IBTKInit.cpp
+++ b/ibtk/src/utilities/IBTKInit.cpp
@@ -53,7 +53,6 @@ IBTKInit::IBTKInit(int argc, char** argv, MPI_Comm communicator, char* petsc_fil
 
 IBTKInit::~IBTKInit()
 {
-    pout << "IBTKInit destructor called. Shutting down libraries.\n";
     SAMRAIManager::shutdown();
 #if SAMRAI_VERSION_MAJOR > 2
     SAMRAIManager::finalize();

--- a/ibtk/src/utilities/IBTK_MPI.cpp
+++ b/ibtk/src/utilities/IBTK_MPI.cpp
@@ -77,7 +77,10 @@ IBTK_MPI::allToOneSumReduction(int* x, const int n, const int root, IBTK_MPI::co
 {
     if (getNodes(communicator) > 1)
     {
-        MPI_Reduce(MPI_IN_PLACE, x, n, MPI_INT, MPI_SUM, root, communicator);
+        if (IBTK_MPI::getRank() == root)
+            MPI_Reduce(MPI_IN_PLACE, x, n, MPI_INT, MPI_SUM, root, communicator);
+        else
+            MPI_Reduce(x, x, n, MPI_INT, MPI_SUM, root, communicator);
     }
 } // allToOneSumReduction
 

--- a/ibtk/src/utilities/LMarkerUtilities.cpp
+++ b/ibtk/src/utilities/LMarkerUtilities.cpp
@@ -13,6 +13,7 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LEInteractor.h"
 #include "ibtk/LMarker.h"
@@ -51,7 +52,6 @@
 #include "VariableDatabase.h"
 #include "tbox/MathUtilities.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -119,8 +119,8 @@ LMarkerUtilities::readMarkerPositions(std::vector<Point>& mark_init_posns,
     if (mark_input_file_name.empty()) return 0;
 
     // Read in the initial marker positions.
-    const int mpi_rank = SAMRAI_MPI::getRank();
-    const int mpi_size = SAMRAI_MPI::getNodes();
+    const int mpi_rank = IBTK_MPI::getRank();
+    const int mpi_size = IBTK_MPI::getNodes();
 
     const double* const grid_xLower = grid_geom->getXLower();
     const double* const grid_xUpper = grid_geom->getXUpper();
@@ -744,7 +744,7 @@ LMarkerUtilities::countMarkers(const int mark_idx,
             num_marks += countMarkersOnPatch(mark_data);
         }
     }
-    return static_cast<unsigned int>(SAMRAI_MPI::sumReduction(static_cast<int>(num_marks)));
+    return static_cast<unsigned int>(IBTK_MPI::sumReduction(static_cast<int>(num_marks)));
 } // countMarkers
 
 /////////////////////////////// PROTECTED ////////////////////////////////////

--- a/ibtk/src/utilities/MergingLoadBalancer.cpp
+++ b/ibtk/src/utilities/MergingLoadBalancer.cpp
@@ -13,6 +13,7 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/MergingLoadBalancer.h"
 #include "ibtk/box_utilities.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
@@ -20,7 +21,6 @@
 #include "Box.h"
 #include "PatchHierarchy.h"
 #include "ProcessorMapping.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include <memory>
 #include <string>
@@ -62,7 +62,7 @@ MergingLoadBalancer::loadBalanceBoxes(hier::BoxArray<NDIM>& out_boxes,
     // pairs of processors and boxes
     std::vector<std::pair<int, hier::Box<NDIM> > > new_boxes;
 
-    const int n_nodes = tbox::SAMRAI_MPI::getNodes();
+    const int n_nodes = IBTK_MPI::getNodes();
     for (int r = 0; r < n_nodes; ++r)
     {
         // get all boxes on processor r.

--- a/ibtk/src/utilities/NormOps.cpp
+++ b/ibtk/src/utilities/NormOps.cpp
@@ -13,6 +13,7 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/NormOps.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
 
@@ -29,7 +30,6 @@
 #include "SideData.h"
 #include "SideVariable.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include <algorithm>
 #include <cmath>
@@ -84,9 +84,9 @@ NormOps::L1Norm(const SAMRAIVectorReal<NDIM, double>* const samrai_vector, const
     const double L1_norm_local = L1Norm_local(samrai_vector);
     if (local_only) return L1_norm_local;
 
-    const int nprocs = SAMRAI_MPI::getNodes();
+    const int nprocs = IBTK_MPI::getNodes();
     std::vector<double> L1_norm_proc(nprocs, 0.0);
-    SAMRAI_MPI::allGather(L1_norm_local, &L1_norm_proc[0]);
+    IBTK_MPI::allGather(L1_norm_local, &L1_norm_proc[0]);
     const double ret_val = accurate_sum(L1_norm_proc);
     return ret_val;
 } // L1Norm
@@ -97,9 +97,9 @@ NormOps::L2Norm(const SAMRAIVectorReal<NDIM, double>* const samrai_vector, const
     const double L2_norm_local = L2Norm_local(samrai_vector);
     if (local_only) return L2_norm_local;
 
-    const int nprocs = SAMRAI_MPI::getNodes();
+    const int nprocs = IBTK_MPI::getNodes();
     std::vector<double> L2_norm_proc(nprocs, 0.0);
-    SAMRAI_MPI::allGather(L2_norm_local, &L2_norm_proc[0]);
+    IBTK_MPI::allGather(L2_norm_local, &L2_norm_proc[0]);
     const double ret_val = std::sqrt(accurate_sum_of_squares(L2_norm_proc));
     return ret_val;
 } // L2Norm

--- a/ibtk/src/utilities/ParallelEdgeMap.cpp
+++ b/ibtk/src/utilities/ParallelEdgeMap.cpp
@@ -13,10 +13,9 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/ParallelEdgeMap.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
-
-#include "tbox/SAMRAI_MPI.h"
 
 #include <algorithm>
 #include <map>
@@ -61,13 +60,13 @@ ParallelEdgeMap::removeEdge(const std::pair<int, int>& link, int mastr_idx)
 void
 ParallelEdgeMap::communicateData()
 {
-    const int size = SAMRAI_MPI::getNodes();
-    const int rank = SAMRAI_MPI::getRank();
+    const int size = IBTK_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
 
     std::vector<int> num_additions_and_removals(2 * size, 0);
     num_additions_and_removals[2 * rank] = static_cast<int>(d_pending_additions.size());
     num_additions_and_removals[2 * rank + 1] = static_cast<int>(d_pending_removals.size());
-    SAMRAI_MPI::sumReduction(&num_additions_and_removals[0], 2 * size);
+    IBTK_MPI::sumReduction(&num_additions_and_removals[0], 2 * size);
 
     int num_transactions = 0, offset = 0;
     for (int k = 0; k < size; ++k)
@@ -96,7 +95,7 @@ ParallelEdgeMap::communicateData()
         transactions[SIZE * offset + 1] = cit->second.first;
         transactions[SIZE * offset + 2] = cit->second.second;
     }
-    SAMRAI_MPI::sumReduction(&transactions[0], SIZE * num_transactions);
+    IBTK_MPI::sumReduction(&transactions[0], SIZE * num_transactions);
 
     offset = 0;
     for (int k = 0; k < size; ++k)

--- a/ibtk/src/utilities/ParallelSet.cpp
+++ b/ibtk/src/utilities/ParallelSet.cpp
@@ -13,10 +13,9 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/ParallelSet.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
-
-#include "tbox/SAMRAI_MPI.h"
 
 #include <set>
 #include <vector>
@@ -58,17 +57,17 @@ ParallelSet::removeItem(const int key)
 void
 ParallelSet::communicateData()
 {
-    const int size = SAMRAI_MPI::getNodes();
-    const int rank = SAMRAI_MPI::getRank();
+    const int size = IBTK_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
 
     // Add items from the set.
-    if (SAMRAI_MPI::maxReduction(static_cast<int>(d_pending_additions.size())) > 0)
+    if (IBTK_MPI::maxReduction(static_cast<int>(d_pending_additions.size())) > 0)
     {
         // Determine how many keys have been registered for addition on each
         // process.
         std::vector<int> num_additions(size, 0);
         num_additions[rank] = static_cast<int>(d_pending_additions.size());
-        SAMRAI_MPI::sumReduction(&num_additions[0], size);
+        IBTK_MPI::sumReduction(&num_additions[0], size);
 
         // Broadcast data from each process.
         for (int sending_proc = 0; sending_proc < size; ++sending_proc)
@@ -81,7 +80,7 @@ ParallelSet::communicateData()
 #if !defined(NDEBUG)
                 TBOX_ASSERT(static_cast<int>(d_pending_additions.size()) == num_keys);
 #endif
-                SAMRAI_MPI::bcast(&d_pending_additions[0], num_keys, sending_proc);
+                IBTK_MPI::bcast(&d_pending_additions[0], num_keys, sending_proc);
                 for (int k = 0; k < num_keys; ++k)
                 {
                     d_set.insert(d_pending_additions[k]);
@@ -91,7 +90,7 @@ ParallelSet::communicateData()
             {
                 // Receive and unpack data broadcast from process sending_proc.
                 std::vector<int> keys_received(num_additions[sending_proc]);
-                SAMRAI_MPI::bcast(&keys_received[0], num_keys, sending_proc);
+                IBTK_MPI::bcast(&keys_received[0], num_keys, sending_proc);
                 for (int k = 0; k < num_keys; ++k)
                 {
                     d_set.insert(keys_received[k]);
@@ -104,13 +103,13 @@ ParallelSet::communicateData()
     }
 
     // Remove items from the set.
-    if (SAMRAI_MPI::maxReduction(static_cast<int>(d_pending_removals.size())) > 0)
+    if (IBTK_MPI::maxReduction(static_cast<int>(d_pending_removals.size())) > 0)
     {
         // Determine how many keys have been registered for removal on each
         // process.
         std::vector<int> num_removals(size, 0);
         num_removals[rank] = static_cast<int>(d_pending_removals.size());
-        SAMRAI_MPI::sumReduction(&num_removals[0], size);
+        IBTK_MPI::sumReduction(&num_removals[0], size);
 
         // Broadcast data from each process.
         for (int sending_proc = 0; sending_proc < size; ++sending_proc)
@@ -123,7 +122,7 @@ ParallelSet::communicateData()
 #if !defined(NDEBUG)
                 TBOX_ASSERT(static_cast<int>(d_pending_removals.size()) == num_keys);
 #endif
-                SAMRAI_MPI::bcast(&d_pending_removals[0], num_keys, sending_proc);
+                IBTK_MPI::bcast(&d_pending_removals[0], num_keys, sending_proc);
                 for (int k = 0; k < num_keys; ++k)
                 {
                     d_set.erase(d_pending_removals[k]);
@@ -133,7 +132,7 @@ ParallelSet::communicateData()
             {
                 // Receive and unpack data broadcast from process sending_proc.
                 std::vector<int> keys_received(num_removals[sending_proc]);
-                SAMRAI_MPI::bcast(&keys_received[0], num_keys, sending_proc);
+                IBTK_MPI::bcast(&keys_received[0], num_keys, sending_proc);
                 for (int k = 0; k < num_keys; ++k)
                 {
                     d_set.erase(keys_received[k]);

--- a/ibtk/src/utilities/StreamableManager.cpp
+++ b/ibtk/src/utilities/StreamableManager.cpp
@@ -13,12 +13,12 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/StreamableFactory.h"
 #include "ibtk/StreamableManager.h"
 #include "ibtk/namespaces.h" // IWYU pragma: keep
 
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/ShutdownRegistry.h"
 
 #include <map>
@@ -84,9 +84,9 @@ StreamableManager::registerFactory(Pointer<StreamableFactory> factory)
 #endif
     // These barriers ensure that each factory is assigned the same class ID
     // number on each MPI process.
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     const int factory_id = createUniqueID();
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     factory->setStreamableClassID(factory_id);
     d_factory_map[factory_id] = factory;
     return factory_id;

--- a/scripts/code_updates/README
+++ b/scripts/code_updates/README
@@ -5,3 +5,6 @@ misc_cpp11_updates.pl
      -- replacing UniquePtr and AutoPtr with std::unique_ptr
      -- replacing libMesh headers with <memory> system header
      -- replacing boost objects with corresponding std:: objects
+
+update_mpi_calls.pl
+  -- Perl script to replace SAMRAI_MPI calls with IBTK_MPI calls.

--- a/scripts/code_updates/update_mpi_calls.pl
+++ b/scripts/code_updates/update_mpi_calls.pl
@@ -1,0 +1,84 @@
+#! /usr/bin/perl
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2019 - 2019 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+# This script replaces SAMRAI_MPI calls with the corresponding IBTK_MPI call
+# To use this file, use the command
+# perl update_mpi_calls.pl <directory>
+# where <directory> is the base path to be changed.
+use strict;
+
+use File::Basename;
+use File::Find;
+use File::Compare;
+use Cwd;
+
+my $replaceDir = $ARGV[0];
+my @fileExcludeList = ("IBTKInit.h","IBTKInit.cpp","IBTK_MPI.cpp","IBTK_MPI.h");
+
+my $debug = 0;
+
+my $end_of_line = $/;
+
+my $filePattern = q/(.*\.[ChI]$)|(.*\.CPP$)|(.*\.cpp$)|(.*\.cxx$)|(.*\.CXX$)|(.*\.H$)|(.*\.hxx$)|(.*\.Hxx$)|(.*\.HXX$)|(.*\.txx$)|(.*\.ixx$)/;
+my @filesToProcess = ();
+sub selectAllSourceFiles {
+    if ( $File::Find::name =~ m!/(build|\.git|CVS|contrib|scripts|config|configure|\{arch\})$!o ) {
+        $File::Find::prune = 1;
+    }
+    elsif ( -f && m/$filePattern/ ) {
+        push @filesToProcess, $File::Find::name;
+        $filesToProcess[$#filesToProcess] =~ s|^\./||o;
+   }
+}
+
+find( \&selectAllSourceFiles, $replaceDir );
+
+print "@filesToProcess\n";
+
+for my $file (@filesToProcess) {
+    print "Replacing SAMRAI_MPI for source file $file\n";
+    my $directory = dirname $file;
+    my $filebasename = basename $file;
+    my $tempFile = $filebasename . ".tmp";
+    if ( grep( /$filebasename/, @fileExcludeList) )
+    {
+        print "Skipping file $file\n";
+	next;
+    }
+    open FILE, "< $file" || die "Cannot open file $file";
+    open TEMPFILE, "> $tempFile" || die "Cannot open temporary work file $tempFile";
+    while ( my $str = <FILE> ) {
+        # Replace SAMRAI_MPI header file
+        $str =~ s/\#include\ [\"\<]tbox\/SAMRAI_MPI\.h[\"\>]/\#include\ "ibtk\/IBTK_MPI.h"/g;
+        
+        # Replace SAMRAI::tbox::SAMRAI_MPI::commWorld
+        $str =~ s/(SAMRAI::)?(tbox::)?SAMRAI_MPI::commWorld/IBTK_MPI::getCommunicator()/g;
+
+        # Replace SAMRAI_MPI with IBTK_MPI
+        $str =~ s/(SAMRAI::)?(tbox::)?SAMRAI_MPI::/IBTK_MPI::/g;
+
+        print TEMPFILE $str;
+    }
+
+    close FILE || die "Cannot close file $file\n";
+    close TEMPFILE || die "Cannot close file $tempFile\n";
+    if (compare($file,$tempFile) == 0) {
+        unlink($tempFile);
+    } else {
+        unlink($file);
+        rename($tempFile, $file);
+    }
+
+}
+

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -19,6 +19,7 @@
 #include "ibamr/app_namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/HierarchyMathOps.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LData.h"
 #include "ibtk/LDataManager.h"
 #include "ibtk/LMesh.h"
@@ -46,7 +47,6 @@
 #include "tbox/Database.h"
 #include "tbox/MathUtilities.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscis.h"
@@ -307,7 +307,7 @@ CIBMethod::preprocessIntegrateData(double current_time, double new_time, int num
         }
 
         // Set data for free bodies.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             if (num_free_dofs)
             {
@@ -346,7 +346,7 @@ CIBMethod::preprocessIntegrateData(double current_time, double new_time, int num
 
     // Create PETSc Vecs for free DOFs.
     const int n = free_dofs_counter;
-    const int N = SAMRAI_MPI::sumReduction(free_dofs_counter);
+    const int N = IBTK_MPI::sumReduction(free_dofs_counter);
     VecCreateMPI(PETSC_COMM_WORLD, n, N, &d_U);
     VecCreateMPI(PETSC_COMM_WORLD, n, N, &d_F);
 
@@ -391,7 +391,7 @@ CIBMethod::postprocessIntegrateData(double current_time, double new_time, int nu
         d_l_data_manager->scatterPETScToLagrangian(lambda_petsc_vec_parallel, lambda_lag_vec_parallel, finest_ln);
         d_l_data_manager->scatterToZero(lambda_lag_vec_parallel, lambda_lag_vec_seq);
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             const PetscScalar* L;
             VecGetArrayRead(lambda_lag_vec_seq, &L);
@@ -910,7 +910,7 @@ CIBMethod::midpointStep(double current_time, double new_time)
     d_center_of_mass_half = d_center_of_mass_new;
     d_quaternion_half = d_quaternion_new;
 
-    flag_regrid = SAMRAI_MPI::sumReduction(flag_regrid);
+    flag_regrid = IBTK_MPI::sumReduction(flag_regrid);
     if (flag_regrid)
     {
         d_time_integrator_needs_regrid = true;
@@ -1049,7 +1049,7 @@ CIBMethod::subtractMeanConstraintForce(Vec L, int f_data_idx, const double scale
             F[d] += L_array[k * NDIM + d];
         }
     }
-    SAMRAI_MPI::sumReduction(F, NDIM);
+    IBTK_MPI::sumReduction(F, NDIM);
 
     // Subtract the mean from Eulerian body force
     const int coarsest_ln = 0;
@@ -1250,7 +1250,7 @@ CIBMethod::computeNetRigidGeneralizedForce(const unsigned int part, Vec L, Rigid
         F[5] += P[1] * R_dr[0] - P[0] * R_dr[1];
 #endif
     }
-    SAMRAI_MPI::sumReduction(&F[0], s_max_free_dofs);
+    IBTK_MPI::sumReduction(&F[0], s_max_free_dofs);
     p_data.restoreArrays();
     d_l_data_manager->getLData("X0_unshifted", struct_ln)->restoreArrays();
 
@@ -1291,7 +1291,7 @@ CIBMethod::copyVecToArray(Vec b,
 
     // Wrap the raw data in a PETSc Vec
     PetscInt size = total_nodes * data_depth;
-    int rank = SAMRAI_MPI::getRank();
+    int rank = IBTK_MPI::getRank();
     PetscInt array_local_size = 0;
     if (rank == array_rank) array_local_size = size;
     Vec array_vec;
@@ -1364,7 +1364,7 @@ CIBMethod::copyArrayToVec(Vec b,
 
     // Wrap the array in a PETSc Vec
     PetscInt size = total_nodes * data_depth;
-    int rank = SAMRAI_MPI::getRank();
+    int rank = IBTK_MPI::getRank();
     PetscInt array_local_size = 0;
     if (rank == array_rank) array_local_size = size;
     Vec array_vec;
@@ -1420,7 +1420,7 @@ CIBMethod::constructMobilityMatrix(const std::string& /*mat_name*/,
     const double dt = d_new_time - d_current_time;
     const int struct_ln = getStructuresLevelNumber();
     const char* ib_kernel = d_l_data_manager->getDefaultInterpKernelFunction().c_str();
-    const int rank = SAMRAI_MPI::getRank();
+    const int rank = IBTK_MPI::getRank();
 
     // Get the size of matrix.
     unsigned num_nodes = 0;
@@ -1521,7 +1521,7 @@ CIBMethod::constructGeometricMatrix(const std::string& /*mat_name*/,
                                     const int managing_rank)
 {
     const int struct_ln = getStructuresLevelNumber();
-    const int rank = SAMRAI_MPI::getRank();
+    const int rank = IBTK_MPI::getRank();
 
     // Get the size of matrix
     unsigned num_nodes = 0;
@@ -1644,7 +1644,7 @@ CIBMethod::rotateArray(double* array,
     }
 #endif
 
-    if (SAMRAI_MPI::getRank() == managing_proc)
+    if (IBTK_MPI::getRank() == managing_proc)
     {
         const bool position_system = (depth % NDIM == 0);
         const bool force_system = (depth % s_max_free_dofs == 0);
@@ -1724,7 +1724,7 @@ CIBMethod::getFromInput(Pointer<Database> input_db)
         std::string dir_name = input_db->getStringWithDefault("lambda_dirname", "./lambda");
         if (!from_restart) Utilities::recursiveMkdir(dir_name);
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             std::string filename = dir_name + "/" + "lambda";
             if (from_restart)
@@ -1838,7 +1838,7 @@ CIBMethod::computeCOMOfStructures(IBTK::EigenAlignedVector<Eigen::Vector3d>& cen
 
         for (unsigned struct_no = 0; struct_no < structs_on_this_ln; ++struct_no)
         {
-            SAMRAI_MPI::sumReduction(center_of_mass[struct_no].data(), center_of_mass[struct_no].size());
+            IBTK_MPI::sumReduction(center_of_mass[struct_no].data(), center_of_mass[struct_no].size());
             const int total_nodes = getNumberOfNodes(struct_no);
             center_of_mass[struct_no] /= total_nodes;
         }

--- a/src/IB/CIBStrategy.cpp
+++ b/src/IB/CIBStrategy.cpp
@@ -16,10 +16,10 @@
 #include "ibamr/CIBStrategy.h"
 #include "ibamr/app_namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/ibtk_utilities.h"
 
 #include "tbox/MathUtilities.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "petscis.h"
 #include "petscistypes.h"
@@ -570,7 +570,7 @@ CIBStrategy::copyFreeDOFsVecToArray(Vec b, double* array, const std::vector<unsi
 #endif
 
     // Wrap the raw data in a PETSc Vec.
-    int rank = SAMRAI_MPI::getRank();
+    int rank = IBTK_MPI::getRank();
     PetscInt array_size = num_structs * s_max_free_dofs;
     PetscInt array_local_size = 0;
     if (rank == array_rank) array_local_size = array_size;
@@ -653,7 +653,7 @@ CIBStrategy::copyFreeDOFsArrayToVec(Vec b, double* array, const std::vector<unsi
 #endif
 
     // Wrap the raw data in a PETSc Vec.
-    int rank = SAMRAI_MPI::getRank();
+    int rank = IBTK_MPI::getRank();
     PetscInt array_size = num_structs * s_max_free_dofs;
     PetscInt array_local_size = 0;
     if (rank == array_rank) array_local_size = array_size;
@@ -704,7 +704,7 @@ CIBStrategy::vecToRDV(Vec U, RigidDOFVector& Ur)
         Ur.setZero();
     }
 
-    SAMRAI_MPI::sumReduction(&Ur[0], s);
+    IBTK_MPI::sumReduction(&Ur[0], s);
     VecRestoreArray(U, &a);
     return;
 } // vecToRDV
@@ -715,7 +715,7 @@ CIBStrategy::rdvToVec(const RigidDOFVector& Ur, Vec& U)
     if (U == nullptr)
     {
         PetscInt n = 0, N = s_max_free_dofs;
-        if (!SAMRAI_MPI::getRank()) n = N;
+        if (!IBTK_MPI::getRank()) n = N;
         VecCreateMPI(PETSC_COMM_WORLD, n, N, &U);
     }
 

--- a/src/IB/DirectMobilitySolver.cpp
+++ b/src/IB/DirectMobilitySolver.cpp
@@ -20,6 +20,7 @@
 #include "ibamr/ibamr_enums.h"
 #include "ibamr/ibamr_utilities.h"
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PETScSAMRAIVectorReal.h"
 #include "ibtk/ibtk_utilities.h"
 
@@ -32,7 +33,6 @@
 #include "tbox/MathUtilities.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Timer.h"
 #include "tbox/TimerManager.h"
 #include "tbox/Utilities.h"
@@ -224,7 +224,7 @@ DirectMobilitySolver::registerMobilityMat(const std::string& mat_name,
     // Allocate the actual matrices.
     const int mobility_mat_size = num_nodes * NDIM;
     const int body_mobility_mat_size = d_mat_parts_map[mat_name] * s_max_free_dofs;
-    const int rank = SAMRAI_MPI::getRank();
+    const int rank = IBTK_MPI::getRank();
 
     if (rank == managing_proc)
     {
@@ -322,7 +322,7 @@ DirectMobilitySolver::solveSystem(Vec x, Vec b)
     const bool deallocate_after_solve = !d_is_initialized;
     if (deallocate_after_solve) initializeSolverState(x, b);
 
-    const int rank = SAMRAI_MPI::getRank();
+    const int rank = IBTK_MPI::getRank();
     static const int data_depth = NDIM;
 
     for (const auto& petsc_mat_pair : d_petsc_mat_map)
@@ -375,7 +375,7 @@ DirectMobilitySolver::solveBodySystem(Vec x, Vec b)
     const bool deallocate_after_solve = !d_is_initialized;
     if (deallocate_after_solve) initializeSolverState(x, b);
 
-    const int rank = SAMRAI_MPI::getRank();
+    const int rank = IBTK_MPI::getRank();
     static const int data_depth = s_max_free_dofs;
 
     for (const auto& petsc_mat_pair : d_petsc_mat_map)
@@ -426,7 +426,7 @@ DirectMobilitySolver::initializeSolverState(Vec x, Vec /*b*/)
 
     IBAMR_TIMER_START(t_initialize_solver_state);
 
-    int rank = SAMRAI_MPI::getRank();
+    int rank = IBTK_MPI::getRank();
     auto managed_mats = static_cast<unsigned>(d_mat_map.size());
 
     static bool recreate_mobility_matrices = true;
@@ -565,7 +565,7 @@ DirectMobilitySolver::getFromInput(Pointer<Database> input_db)
 void
 DirectMobilitySolver::factorizeMobilityMatrix()
 {
-    int rank = SAMRAI_MPI::getRank();
+    int rank = IBTK_MPI::getRank();
     for (const auto& petsc_mat_pair : d_petsc_mat_map)
     {
         const std::string& mat_name = petsc_mat_pair.first;
@@ -586,7 +586,7 @@ DirectMobilitySolver::factorizeMobilityMatrix()
 void
 DirectMobilitySolver::constructBodyMobilityMatrix()
 {
-    int rank = SAMRAI_MPI::getRank();
+    int rank = IBTK_MPI::getRank();
     for (const auto& petsc_mat_pair : d_petsc_mat_map)
     {
         const std::string& mat_name = petsc_mat_pair.first;
@@ -626,7 +626,7 @@ DirectMobilitySolver::constructBodyMobilityMatrix()
 void
 DirectMobilitySolver::factorizeBodyMobilityMatrix()
 {
-    int rank = SAMRAI_MPI::getRank();
+    int rank = IBTK_MPI::getRank();
     for (const auto& petsc_mat_pair : d_petsc_mat_map)
     {
         const std::string& mat_name = petsc_mat_pair.first;

--- a/src/IB/FEMechanicsBase.cpp
+++ b/src/IB/FEMechanicsBase.cpp
@@ -24,6 +24,7 @@
 #include "ibtk/FEDataManager.h"
 #include "ibtk/FEProjector.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LibMeshSystemVectors.h"
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/libmesh_utilities.h"
@@ -1074,8 +1075,8 @@ FEMechanicsBase::commonConstructor(const std::string& object_name,
             mesh_has_first_order_elems = mesh_has_first_order_elems || elem->default_order() == FIRST;
             mesh_has_second_order_elems = mesh_has_second_order_elems || elem->default_order() == SECOND;
         }
-        mesh_has_first_order_elems = SAMRAI_MPI::maxReduction(mesh_has_first_order_elems);
-        mesh_has_second_order_elems = SAMRAI_MPI::maxReduction(mesh_has_second_order_elems);
+        mesh_has_first_order_elems = IBTK_MPI::maxReduction(mesh_has_first_order_elems ? 1 : 0);
+        mesh_has_second_order_elems = IBTK_MPI::maxReduction(mesh_has_second_order_elems ? 1 : 0);
         if ((mesh_has_first_order_elems && mesh_has_second_order_elems) ||
             (!mesh_has_first_order_elems && !mesh_has_second_order_elems))
         {

--- a/src/IB/IBAnchorPointSpec.cpp
+++ b/src/IB/IBAnchorPointSpec.cpp
@@ -16,10 +16,9 @@
 #include "ibamr/IBAnchorPointSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/StreamableFactory.h"
 #include "ibtk/StreamableManager.h"
-
-#include "tbox/SAMRAI_MPI.h"
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
@@ -35,7 +34,7 @@ IBAnchorPointSpec::registerWithStreamableManager()
     // We place MPI barriers here to ensure that all MPI processes actually
     // register the factory class with the StreamableManager, and to ensure that
     // all processes employ the same class ID for the IBAnchorPointSpec object.
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     if (!getIsRegisteredWithStreamableManager())
     {
 #if !defined(NDEBUG)
@@ -43,7 +42,7 @@ IBAnchorPointSpec::registerWithStreamableManager()
 #endif
         STREAMABLE_CLASS_ID = StreamableManager::getManager()->registerFactory(new IBAnchorPointSpecFactory());
     }
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     return;
 } // registerWithStreamableManager
 

--- a/src/IB/IBBeamForceSpec.cpp
+++ b/src/IB/IBBeamForceSpec.cpp
@@ -16,10 +16,9 @@
 #include "ibamr/IBBeamForceSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/StreamableFactory.h"
 #include "ibtk/StreamableManager.h"
-
-#include "tbox/SAMRAI_MPI.h"
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
@@ -35,7 +34,7 @@ IBBeamForceSpec::registerWithStreamableManager()
     // We place MPI barriers here to ensure that all MPI processes actually
     // register the factory class with the StreamableManager, and to ensure that
     // all processes employ the same class ID for the IBBeamForceSpec object.
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     if (!getIsRegisteredWithStreamableManager())
     {
 #if !defined(NDEBUG)
@@ -43,7 +42,7 @@ IBBeamForceSpec::registerWithStreamableManager()
 #endif
         STREAMABLE_CLASS_ID = StreamableManager::getManager()->registerFactory(new IBBeamForceSpecFactory());
     }
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     return;
 } // registerWithStreamableManager
 

--- a/src/IB/IBExplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBExplicitHierarchyIntegrator.cpp
@@ -21,6 +21,7 @@
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/CartGridFunction.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/RobinPhysBdryPatchStrategy.h"
 #include "ibtk/ibtk_enums.h"
 
@@ -42,7 +43,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -450,7 +450,7 @@ IBExplicitHierarchyIntegrator::postprocessIntegrateHierarchy(const double curren
             cfl_max = std::max(cfl_max, u_max * dt / dx_min);
         }
     }
-    cfl_max = SAMRAI_MPI::maxReduction(cfl_max);
+    cfl_max = IBTK_MPI::maxReduction(cfl_max);
     d_regrid_cfl_estimate += cfl_max;
     if (d_enable_logging)
     {

--- a/src/IB/IBFEDirectForcingKinematics.cpp
+++ b/src/IB/IBFEDirectForcingKinematics.cpp
@@ -19,12 +19,12 @@
 
 #include "ibtk/FEDataManager.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/libmesh_utilities.h"
 
 #include "tbox/Database.h"
 #include "tbox/MathUtilities.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "libmesh/dof_map.h"
@@ -270,7 +270,7 @@ IBFEDirectForcingKinematics::forwardEulerStep(double current_time,
     const unsigned int X_sys_num = X_system.number();
 
     MeshBase& mesh = equation_systems->get_mesh();
-    const unsigned int total_local_nodes = mesh.n_nodes_on_proc(SAMRAI_MPI::getRank());
+    const unsigned int total_local_nodes = mesh.n_nodes_on_proc(IBTK_MPI::getRank());
     std::vector<std::vector<numeric_index_type> > nodal_X_indices(NDIM);
     std::vector<std::vector<double> > nodal_X0_values(NDIM);
     for (unsigned int d = 0; d < NDIM; ++d)
@@ -354,7 +354,7 @@ IBFEDirectForcingKinematics::midpointStep(double current_time,
     const unsigned int X_sys_num = X_system.number();
 
     MeshBase& mesh = equation_systems->get_mesh();
-    const unsigned int total_local_nodes = mesh.n_nodes_on_proc(SAMRAI_MPI::getRank());
+    const unsigned int total_local_nodes = mesh.n_nodes_on_proc(IBTK_MPI::getRank());
     std::vector<std::vector<numeric_index_type> > nodal_X_indices(NDIM);
     std::vector<std::vector<double> > nodal_X0_values(NDIM);
     for (unsigned int d = 0; d < NDIM; ++d)
@@ -599,8 +599,8 @@ IBFEDirectForcingKinematics::computeCOMOfStructure(Eigen::Vector3d& X0)
             vol_part += JxW[qp];
         }
     }
-    SAMRAI_MPI::sumReduction(X0.data(), X0.size());
-    vol_part = SAMRAI_MPI::sumReduction(vol_part);
+    IBTK_MPI::sumReduction(X0.data(), X0.size());
+    vol_part = IBTK_MPI::sumReduction(vol_part);
     X0 /= vol_part;
 
     VecRestoreArray(X_local_ghost_vec, &X_local_ghost_soln);
@@ -680,7 +680,7 @@ IBFEDirectForcingKinematics::computeMOIOfStructure(Eigen::Matrix3d& I, const Eig
 #endif
         }
     }
-    SAMRAI_MPI::sumReduction(&I(0, 0), 9);
+    IBTK_MPI::sumReduction(&I(0, 0), 9);
 
     // Fill-in the symmetric part of inertia tensor.
     I(1, 0) = I(0, 1);
@@ -709,7 +709,7 @@ IBFEDirectForcingKinematics::computeImposedLagrangianForceDensity(PetscVector<do
     const unsigned int U_sys_num = U_system.number();
 
     MeshBase& mesh = equation_systems->get_mesh();
-    const unsigned int total_local_nodes = mesh.n_nodes_on_proc(SAMRAI_MPI::getRank());
+    const unsigned int total_local_nodes = mesh.n_nodes_on_proc(IBTK_MPI::getRank());
     std::vector<std::vector<numeric_index_type> > nodal_indices(NDIM);
     std::vector<std::vector<double> > nodal_X_values(NDIM);
     for (unsigned int d = 0; d < NDIM; ++d)
@@ -869,9 +869,9 @@ IBFEDirectForcingKinematics::computeMixedLagrangianForceDensity(PetscVector<doub
 #endif
         }
     }
-    SAMRAI_MPI::sumReduction(&F[0], 3);
-    SAMRAI_MPI::sumReduction(&L[0], 3);
-    vol_mesh = SAMRAI_MPI::sumReduction(vol_mesh);
+    IBTK_MPI::sumReduction(&F[0], 3);
+    IBTK_MPI::sumReduction(&L[0], 3);
+    vol_mesh = IBTK_MPI::sumReduction(vol_mesh);
 
     ierr = VecRestoreArray(X_local_ghost_vec, &X_local_ghost_soln);
     IBTK_CHKERRQ(ierr);

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -21,6 +21,7 @@
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/FEDataManager.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/ibtk_utilities.h"
 
@@ -41,7 +42,6 @@
 #include "tbox/Array.h"
 #include "tbox/Database.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "libmesh/boundary_info.h"
@@ -794,7 +794,7 @@ IBFEInstrumentPanel::readInstrumentData(const int U_data_idx,
 
     // check to make sure we don't double count quadrature points because
     // of overlapping patches or something else.
-    const int count_qp_3 = SAMRAI_MPI::sumReduction(count_qp_2);
+    const int count_qp_3 = IBTK_MPI::sumReduction(count_qp_2);
     if (count_qp_1 != count_qp_3)
     {
         TBOX_WARNING("IBFEInstrumentPanel::readInstrumentData :"
@@ -805,9 +805,9 @@ IBFEInstrumentPanel::readInstrumentData(const int U_data_idx,
     }
 
     // Synchronize the values across all processes.
-    SAMRAI_MPI::sumReduction(&d_flow_values[0], d_num_meters);
-    SAMRAI_MPI::sumReduction(&d_mean_pressure_values[0], d_num_meters);
-    SAMRAI_MPI::sumReduction(&A[0], d_num_meters);
+    IBTK_MPI::sumReduction(&d_flow_values[0], d_num_meters);
+    IBTK_MPI::sumReduction(&d_mean_pressure_values[0], d_num_meters);
+    IBTK_MPI::sumReduction(&A[0], d_num_meters);
 
     // Normalize the mean pressure.
     for (unsigned int jj = 0; jj < d_num_meters; ++jj)
@@ -879,7 +879,7 @@ IBFEInstrumentPanel::readInstrumentData(const int U_data_idx,
             }
         }
 
-        const double total_correction = SAMRAI_MPI::sumReduction(flux_correction);
+        const double total_correction = IBTK_MPI::sumReduction(flux_correction);
         d_flow_values[jj] -= total_correction;
 
     } // loop over meters
@@ -1089,7 +1089,7 @@ void
 IBFEInstrumentPanel::outputData(const double data_time)
 {
     static const int mpi_root = 0;
-    if (SAMRAI_MPI::getRank() == mpi_root)
+    if (IBTK_MPI::getRank() == mpi_root)
     {
         d_mean_pressure_stream.open(d_plot_directory_name + "/mean_pressure.dat", std::ofstream::app);
         d_flux_stream.open(d_plot_directory_name + "/flux.dat", std::ofstream::app);

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -27,6 +27,7 @@
 #include "ibtk/FEDataInterpolation.h"
 #include "ibtk/FEDataManager.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LEInteractor.h"
 #include "ibtk/LibMeshSystemIBVectors.h"
@@ -77,7 +78,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "libmesh/boundary_info.h"
@@ -1250,8 +1250,8 @@ IBFEMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const 
 
     if (d_do_log)
     {
-        const int n_processes = SAMRAI::tbox::SAMRAI_MPI::getNodes();
-        const int current_rank = SAMRAI::tbox::SAMRAI_MPI::getRank();
+        const int n_processes = IBTK_MPI::getNodes();
+        const int current_rank = IBTK_MPI::getRank();
 
         std::vector<double> workload_per_processor(n_processes);
         HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(hierarchy);
@@ -1264,7 +1264,7 @@ IBFEMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const 
                                  workload_per_processor.size(),
                                  MPI_DOUBLE,
                                  MPI_SUM,
-                                 SAMRAI::tbox::SAMRAI_MPI::commWorld);
+                                 IBTK_MPI::getCommunicator());
         TBOX_ASSERT(ierr == 0);
         if (current_rank == 0)
         {
@@ -1290,7 +1290,7 @@ IBFEMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const 
                              dofs_per_processor.size(),
                              MPI_UNSIGNED_LONG,
                              MPI_SUM,
-                             SAMRAI::tbox::SAMRAI_MPI::commWorld);
+                             IBTK_MPI::getCommunicator());
         TBOX_ASSERT(ierr == 0);
         if (current_rank == 0)
         {
@@ -2813,8 +2813,8 @@ IBFEMethod::commonConstructor(const std::string& object_name,
             mesh_has_first_order_elems = mesh_has_first_order_elems || elem->default_order() == FIRST;
             mesh_has_second_order_elems = mesh_has_second_order_elems || elem->default_order() == SECOND;
         }
-        mesh_has_first_order_elems = SAMRAI_MPI::maxReduction(mesh_has_first_order_elems);
-        mesh_has_second_order_elems = SAMRAI_MPI::maxReduction(mesh_has_second_order_elems);
+        mesh_has_first_order_elems = IBTK_MPI::maxReduction(static_cast<int>(mesh_has_first_order_elems));
+        mesh_has_second_order_elems = IBTK_MPI::maxReduction(static_cast<int>(mesh_has_second_order_elems));
         if ((mesh_has_first_order_elems && mesh_has_second_order_elems) ||
             (!mesh_has_first_order_elems && !mesh_has_second_order_elems))
         {

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -22,6 +22,7 @@
 #include "ibtk/FEDataInterpolation.h"
 #include "ibtk/FEDataManager.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LEInteractor.h"
 #include "ibtk/RobinPhysBdryPatchStrategy.h"
@@ -55,7 +56,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "libmesh/compare_types.h"
@@ -1079,7 +1079,7 @@ IBFESurfaceMethod::computeLagrangianForce(const double data_time)
             }
         }
 
-        SAMRAI_MPI::sumReduction(&F_integral(0), LIBMESH_DIM);
+        IBTK_MPI::sumReduction(&F_integral(0), LIBMESH_DIM);
 
         // Solve for F.
         d_fe_data_managers[part]->computeL2Projection(
@@ -1088,8 +1088,8 @@ IBFESurfaceMethod::computeLagrangianForce(const double data_time)
         {
             d_fe_data_managers[part]->computeL2Projection(
                 *DP_vec, *DP_rhs_vec, PRESSURE_JUMP_SYSTEM_NAME, d_use_consistent_mass_matrix);
-            DP_rhs_integral = SAMRAI_MPI::sumReduction(DP_rhs_integral);
-            surface_area = SAMRAI_MPI::sumReduction(surface_area);
+            DP_rhs_integral = IBTK_MPI::sumReduction(DP_rhs_integral);
+            surface_area = IBTK_MPI::sumReduction(surface_area);
             if (d_normalize_pressure_jump) DP_vec->add(-DP_rhs_integral / surface_area);
             DP_vec->close();
         }
@@ -2055,8 +2055,8 @@ IBFESurfaceMethod::commonConstructor(const std::string& object_name,
             mesh_has_first_order_elems = mesh_has_first_order_elems || elem->default_order() == FIRST;
             mesh_has_second_order_elems = mesh_has_second_order_elems || elem->default_order() == SECOND;
         }
-        mesh_has_first_order_elems = SAMRAI_MPI::maxReduction(mesh_has_first_order_elems);
-        mesh_has_second_order_elems = SAMRAI_MPI::maxReduction(mesh_has_second_order_elems);
+        mesh_has_first_order_elems = IBTK_MPI::maxReduction(static_cast<int>(mesh_has_first_order_elems));
+        mesh_has_second_order_elems = IBTK_MPI::maxReduction(static_cast<int>(mesh_has_second_order_elems));
         if ((mesh_has_first_order_elems && mesh_has_second_order_elems) ||
             (!mesh_has_first_order_elems && !mesh_has_second_order_elems))
         {

--- a/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
@@ -22,6 +22,7 @@
 #include "ibamr/app_namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/HierarchyGhostCellInterpolation.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/ibtk_utilities.h"
 
@@ -47,7 +48,6 @@
 #include "tbox/MathUtilities.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "Eigen/Core"
@@ -183,7 +183,7 @@ IBHydrodynamicSurfaceForceEvaluator::computeHydrodynamicForceTorque(IBTK::Vector
     computeHydrodynamicForceTorque(
         pressure_force, viscous_force, pressure_torque, viscous_torque, X0, time, time, time);
 
-    if (d_write_to_file && SAMRAI_MPI::getRank() == 0)
+    if (d_write_to_file && IBTK_MPI::getRank() == 0)
     {
         *d_hydro_force_stream << time << '\t' << pressure_force[0] << '\t' << pressure_force[1] << '\t'
                               << pressure_force[2] << '\t' << viscous_force[0] << '\t' << viscous_force[1] << '\t'
@@ -348,10 +348,10 @@ IBHydrodynamicSurfaceForceEvaluator::computeHydrodynamicForceTorque(IBTK::Vector
         }
     }
     // Sum the net force and torque across processors.
-    SAMRAI_MPI::sumReduction(pressure_force.data(), pressure_force.size());
-    SAMRAI_MPI::sumReduction(viscous_force.data(), viscous_force.size());
-    SAMRAI_MPI::sumReduction(pressure_torque.data(), pressure_torque.size());
-    SAMRAI_MPI::sumReduction(viscous_torque.data(), viscous_force.size());
+    IBTK_MPI::sumReduction(pressure_force.data(), pressure_force.size());
+    IBTK_MPI::sumReduction(viscous_force.data(), viscous_force.size());
+    IBTK_MPI::sumReduction(pressure_torque.data(), pressure_torque.size());
+    IBTK_MPI::sumReduction(viscous_torque.data(), viscous_force.size());
 
     // Deallocate patch data
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
@@ -381,7 +381,7 @@ IBHydrodynamicSurfaceForceEvaluator::writeToFile(bool write_to_file)
     d_write_to_file = write_to_file;
 
     // Set up the streams for printing force and torque
-    if (d_write_to_file && SAMRAI_MPI::getRank() == 0)
+    if (d_write_to_file && IBTK_MPI::getRank() == 0)
     {
         std::string force;
         force = "Hydro_Force_" + d_ls_solid_var->getName();

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -30,6 +30,7 @@
 #include "ibtk/CartGridFunction.h"
 #include "ibtk/HierarchyMathOps.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/KrylovLinearSolver.h"
 #include "ibtk/PETScSAMRAIVectorReal.h"
 #include "ibtk/RobinPhysBdryPatchStrategy.h"
@@ -57,7 +58,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscksp.h"
@@ -326,7 +326,7 @@ IBImplicitStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const doub
             cfl_max = std::max(cfl_max, u_max * dt / dx_min);
         }
     }
-    cfl_max = SAMRAI_MPI::maxReduction(cfl_max);
+    cfl_max = IBTK_MPI::maxReduction(cfl_max);
     d_regrid_cfl_estimate += cfl_max;
     if (d_enable_logging)
     {

--- a/src/IB/IBInstrumentPanel.cpp
+++ b/src/IB/IBInstrumentPanel.cpp
@@ -22,6 +22,7 @@
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LData.h"
 #include "ibtk/LDataManager.h"
@@ -48,7 +49,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Timer.h"
 #include "tbox/TimerManager.h"
 #include "tbox/Utilities.h"
@@ -523,7 +523,7 @@ IBInstrumentPanel::IBInstrumentPanel(std::string object_name, Pointer<Database> 
 IBInstrumentPanel::~IBInstrumentPanel()
 {
     // Close the log file stream.
-    if (SAMRAI_MPI::getRank() == 0)
+    if (IBTK_MPI::getRank() == 0)
     {
         d_log_file_stream.close();
     }
@@ -608,7 +608,7 @@ IBInstrumentPanel::initializeHierarchyIndependentData(const Pointer<PatchHierarc
     }
 
     // Communicate local data to all processes.
-    d_num_meters = SAMRAI_MPI::maxReduction(max_meter_index) + 1;
+    d_num_meters = IBTK_MPI::maxReduction(max_meter_index) + 1;
     max_node_index.resize(d_num_meters, -1);
     d_num_perimeter_nodes.clear();
     d_num_perimeter_nodes.resize(d_num_meters, -1);
@@ -616,7 +616,7 @@ IBInstrumentPanel::initializeHierarchyIndependentData(const Pointer<PatchHierarc
     {
         d_num_perimeter_nodes[m] = max_node_index[m] + 1;
     }
-    SAMRAI_MPI::maxReduction(d_num_meters > 0 ? &d_num_perimeter_nodes[0] : nullptr, d_num_meters);
+    IBTK_MPI::maxReduction(d_num_meters > 0 ? &d_num_perimeter_nodes[0] : nullptr, d_num_meters);
 #if !defined(NDEBUG)
     for (unsigned int m = 0; m < d_num_meters; ++m)
     {
@@ -658,7 +658,7 @@ IBInstrumentPanel::initializeHierarchyIndependentData(const Pointer<PatchHierarc
             std::max(d_max_instrument_name_len, static_cast<int>(d_instrument_names[m].length()));
     }
 
-    if (d_output_log_file && SAMRAI_MPI::getRank() == 0 && !d_log_file_stream.is_open())
+    if (d_output_log_file && IBTK_MPI::getRank() == 0 && !d_log_file_stream.is_open())
     {
         const bool from_restart = RestartManager::getManager()->isFromRestart();
         if (from_restart)
@@ -761,7 +761,7 @@ IBInstrumentPanel::initializeHierarchyDependentData(const Pointer<PatchHierarchy
                 X_perimeter_flattened.end(), d_X_perimeter[m][n].data(), d_X_perimeter[m][n].data() + NDIM);
         }
     }
-    SAMRAI_MPI::sumReduction(&X_perimeter_flattened[0], static_cast<int>(X_perimeter_flattened.size()));
+    IBTK_MPI::sumReduction(&X_perimeter_flattened[0], static_cast<int>(X_perimeter_flattened.size()));
     for (unsigned int m = 0, k = 0; m < d_num_meters; ++m)
     {
         for (int n = 0; n < d_num_perimeter_nodes[m]; ++n, ++k)
@@ -1054,10 +1054,10 @@ IBInstrumentPanel::readInstrumentData(const int U_data_idx,
     }
 
     // Synchronize the values across all processes.
-    SAMRAI_MPI::sumReduction(&d_flow_values[0], d_num_meters);
-    SAMRAI_MPI::sumReduction(&d_mean_pres_values[0], d_num_meters);
-    SAMRAI_MPI::sumReduction(&d_point_pres_values[0], d_num_meters);
-    SAMRAI_MPI::sumReduction(&A[0], d_num_meters);
+    IBTK_MPI::sumReduction(&d_flow_values[0], d_num_meters);
+    IBTK_MPI::sumReduction(&d_mean_pres_values[0], d_num_meters);
+    IBTK_MPI::sumReduction(&d_point_pres_values[0], d_num_meters);
+    IBTK_MPI::sumReduction(&A[0], d_num_meters);
 
     // Normalize the mean pressure.
     for (unsigned int m = 0; m < d_num_meters; ++m)
@@ -1119,7 +1119,7 @@ IBInstrumentPanel::readInstrumentData(const int U_data_idx,
                 U_perimeter_flattened.end(), U_perimeter[m][n].data(), U_perimeter[m][n].data() + NDIM);
         }
     }
-    SAMRAI_MPI::sumReduction(&U_perimeter_flattened[0], static_cast<int>(U_perimeter_flattened.size()));
+    IBTK_MPI::sumReduction(&U_perimeter_flattened[0], static_cast<int>(U_perimeter_flattened.size()));
     for (unsigned int m = 0, k = 0; m < d_num_meters; ++m)
     {
         for (int n = 0; n < d_num_perimeter_nodes[m]; ++n, ++k)
@@ -1162,7 +1162,7 @@ IBInstrumentPanel::readInstrumentData(const int U_data_idx,
     if (d_flow_units != "" || d_pres_units != "") plog << "\n";
     plog << std::string(d_max_instrument_name_len + 94, '*') << "\n";
 
-    if (d_output_log_file && SAMRAI_MPI::getRank() == 0)
+    if (d_output_log_file && IBTK_MPI::getRank() == 0)
     {
         outputLogData(d_log_file_stream);
         d_log_file_stream.flush();
@@ -1207,8 +1207,8 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
     char temp_buf[SILO_NAME_BUFSIZE];
     std::string current_file_name;
     DBfile* dbfile;
-    const int mpi_rank = SAMRAI_MPI::getRank();
-    const int mpi_nodes = SAMRAI_MPI::getNodes();
+    const int mpi_rank = IBTK_MPI::getRank();
+    const int mpi_nodes = IBTK_MPI::getNodes();
 
     // Create the working directory.
     sprintf(temp_buf, "%06d", d_instrument_read_timestep_num);

--- a/src/IB/IBInstrumentationSpec.cpp
+++ b/src/IB/IBInstrumentationSpec.cpp
@@ -16,10 +16,9 @@
 #include "ibamr/IBInstrumentationSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/StreamableFactory.h"
 #include "ibtk/StreamableManager.h"
-
-#include "tbox/SAMRAI_MPI.h"
 
 #include <algorithm>
 #include <string>
@@ -42,7 +41,7 @@ IBInstrumentationSpec::registerWithStreamableManager()
     // register the factory class with the StreamableManager, and to ensure that
     // all processes employ the same class ID for the IBInstrumentationSpec
     // object.
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     if (!getIsRegisteredWithStreamableManager())
     {
 #if !defined(NDEBUG)
@@ -50,7 +49,7 @@ IBInstrumentationSpec::registerWithStreamableManager()
 #endif
         STREAMABLE_CLASS_ID = StreamableManager::getManager()->registerFactory(new IBInstrumentationSpecFactory());
     }
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     return;
 } // registerWithStreamableManager
 

--- a/src/IB/IBInterpolantHierarchyIntegrator.cpp
+++ b/src/IB/IBInterpolantHierarchyIntegrator.cpp
@@ -24,6 +24,7 @@
 #include "ibamr/app_namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/CartGridFunction.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/ibtk_enums.h"
 
 #include "CartesianPatchGeometry.h"
@@ -44,7 +45,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "Eigen/Core"
@@ -218,7 +218,7 @@ IBInterpolantHierarchyIntegrator::postprocessIntegrateHierarchy(const double cur
             cfl_max = std::max(cfl_max, u_max * dt / dx_min);
         }
     }
-    cfl_max = SAMRAI_MPI::maxReduction(cfl_max);
+    cfl_max = IBTK_MPI::maxReduction(cfl_max);
     d_regrid_cfl_estimate += cfl_max;
     if (d_enable_logging)
     {

--- a/src/IB/IBInterpolantMethod.cpp
+++ b/src/IB/IBInterpolantMethod.cpp
@@ -18,6 +18,7 @@
 
 #include "ibtk/HierarchyIntegrator.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LData.h"
 #include "ibtk/LDataManager.h"
 #include "ibtk/LEInteractor.h"
@@ -51,7 +52,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscvec.h"
@@ -966,7 +966,7 @@ IBInterpolantMethod::computeCenterOfMass(EigenAlignedVector<Eigen::Vector3d>& ce
 
         for (unsigned struct_no = 0; struct_no < structs_on_this_ln; ++struct_no)
         {
-            SAMRAI_MPI::sumReduction(&center_of_mass[struct_no][0], NDIM);
+            IBTK_MPI::sumReduction(&center_of_mass[struct_no][0], NDIM);
             const int total_nodes = getNumberOfNodes(struct_no);
             center_of_mass[struct_no] /= total_nodes;
         }

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -28,6 +28,7 @@
 
 #include "ibtk/HierarchyMathOps.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LData.h"
 #include "ibtk/LDataManager.h"
@@ -72,7 +73,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscmat.h"
@@ -1284,8 +1284,8 @@ IBMethod::interpolatePressure(int p_data_idx,
                 }
             }
         }
-        SAMRAI_MPI::sumReduction(&p_norm, 1);
-        SAMRAI_MPI::sumReduction(&vol, 1);
+        IBTK_MPI::sumReduction(&p_norm, 1);
+        IBTK_MPI::sumReduction(&vol, 1);
         p_norm /= vol;
     }
 
@@ -1344,7 +1344,7 @@ IBMethod::interpolatePressure(int p_data_idx,
                 }
             }
         }
-        SAMRAI_MPI::sumReduction(&d_P_src[ln][0], static_cast<int>(d_P_src[ln].size()));
+        IBTK_MPI::sumReduction(&d_P_src[ln][0], static_cast<int>(d_P_src[ln].size()));
         std::for_each(d_P_src[ln].begin(), d_P_src[ln].end(), [=](double& P) { P -= p_norm; });
 
         // Update the pressures stored by the Lagrangian source strategy.

--- a/src/IB/IBRedundantInitializer.cpp
+++ b/src/IB/IBRedundantInitializer.cpp
@@ -26,6 +26,7 @@
 #include "ibamr/IBTargetPointForceSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LData.h"
 #include "ibtk/LIndexSetData.h"
@@ -50,7 +51,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 IBTK_DISABLE_EXTRA_WARNINGS
@@ -1280,7 +1280,7 @@ IBRedundantInitializer::initializeLSiloDataWriter(const int level_number)
     // WARNING: For now, we just register the visualization data on MPI process
     // 0.  This will fail if the structure is too large to be stored in the
     // memory available to a single MPI process.
-    if (SAMRAI_MPI::getRank() == 0)
+    if (IBTK_MPI::getRank() == 0)
     {
         for (unsigned int j = 0; j < d_num_vertex[level_number].size(); ++j)
         {

--- a/src/IB/IBRodForceSpec.cpp
+++ b/src/IB/IBRodForceSpec.cpp
@@ -16,10 +16,9 @@
 #include "ibamr/IBRodForceSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/StreamableFactory.h"
 #include "ibtk/StreamableManager.h"
-
-#include "tbox/SAMRAI_MPI.h"
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
@@ -35,7 +34,7 @@ IBRodForceSpec::registerWithStreamableManager()
     // We place MPI barriers here to ensure that all MPI processes actually
     // register the factory class with the StreamableManager, and to ensure that
     // all processes employ the same class ID for the IBRodForceSpec object.
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     if (!getIsRegisteredWithStreamableManager())
     {
 #if !defined(NDEBUG)
@@ -43,7 +42,7 @@ IBRodForceSpec::registerWithStreamableManager()
 #endif
         STREAMABLE_CLASS_ID = StreamableManager::getManager()->registerFactory(new IBRodForceSpecFactory());
     }
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     return;
 } // registerWithStreamableManager
 

--- a/src/IB/IBSourceSpec.cpp
+++ b/src/IB/IBSourceSpec.cpp
@@ -16,10 +16,9 @@
 #include "ibamr/IBSourceSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/StreamableFactory.h"
 #include "ibtk/StreamableManager.h"
-
-#include "tbox/SAMRAI_MPI.h"
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
@@ -35,7 +34,7 @@ IBSourceSpec::registerWithStreamableManager()
     // We place MPI barriers here to ensure that all MPI processes actually
     // register the factory class with the StreamableManager, and to ensure that
     // all processes employ the same class ID for the IBSourceSpec object.
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     if (!getIsRegisteredWithStreamableManager())
     {
 #if !defined(NDEBUG)
@@ -43,7 +42,7 @@ IBSourceSpec::registerWithStreamableManager()
 #endif
         STREAMABLE_CLASS_ID = StreamableManager::getManager()->registerFactory(new IBSourceSpecFactory());
     }
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     return;
 } // registerWithStreamableManager
 

--- a/src/IB/IBSpringForceSpec.cpp
+++ b/src/IB/IBSpringForceSpec.cpp
@@ -16,10 +16,9 @@
 #include "ibamr/IBSpringForceSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/StreamableFactory.h"
 #include "ibtk/StreamableManager.h"
-
-#include "tbox/SAMRAI_MPI.h"
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
@@ -35,7 +34,7 @@ IBSpringForceSpec::registerWithStreamableManager()
     // We place MPI barriers here to ensure that all MPI processes actually
     // register the factory class with the StreamableManager, and to ensure that
     // all processes employ the same class ID for the IBSpringForceSpec object.
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     if (!getIsRegisteredWithStreamableManager())
     {
 #if !defined(NDEBUG)
@@ -43,7 +42,7 @@ IBSpringForceSpec::registerWithStreamableManager()
 #endif
         STREAMABLE_CLASS_ID = StreamableManager::getManager()->registerFactory(new IBSpringForceSpecFactory());
     }
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     return;
 } // registerWithStreamableManager
 

--- a/src/IB/IBStandardForceGen.cpp
+++ b/src/IB/IBStandardForceGen.cpp
@@ -23,6 +23,7 @@
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LData.h"
 #include "ibtk/LDataManager.h"
 #include "ibtk/LMesh.h"
@@ -40,7 +41,6 @@
 #include "tbox/Database.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscmat.h"
@@ -1287,7 +1287,7 @@ IBStandardForceGen::computeLagrangianTargetPointForce(Pointer<LData> F_data,
 
     if (d_log_target_point_displacements)
     {
-        max_displacement = SAMRAI_MPI::maxReduction(max_displacement);
+        max_displacement = IBTK_MPI::maxReduction(max_displacement);
         plog << "IBStandardForceGen: maximum target point displacement: " << max_displacement << "\n";
     }
 

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -27,6 +27,7 @@
 #include "ibamr/IBTargetPointForceSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LSiloDataWriter.h"
 #include "ibtk/Streamable.h"
 #include "ibtk/ibtk_utilities.h"
@@ -36,7 +37,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -188,8 +188,8 @@ void
 IBStandardInitializer::readVertexFiles(const std::string& extension)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -202,7 +202,7 @@ IBStandardInitializer::readVertexFiles(const std::string& extension)
         for (unsigned int j = 0; j < num_base_filename; ++j)
         {
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             if (j == 0)
             {
@@ -220,7 +220,7 @@ IBStandardInitializer::readVertexFiles(const std::string& extension)
             {
                 plog << d_object_name << ":  "
                      << "processing vertex data from ASCII input file named " << vertex_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first entry in the file is the number of vertices.
                 if (!std::getline(file_stream, line_string))
@@ -280,7 +280,7 @@ IBStandardInitializer::readVertexFiles(const std::string& extension)
                 plog << d_object_name << ":  "
                      << "read " << d_num_vertex[ln][j] << " vertices from ASCII input file named " << vertex_filename
                      << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
@@ -288,12 +288,12 @@ IBStandardInitializer::readVertexFiles(const std::string& extension)
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
     }
 
     // Synchronize the processes.
-    if (d_use_file_batons) SAMRAI_MPI::barrier();
+    if (d_use_file_batons) IBTK_MPI::barrier();
     return;
 } // readVertexFiles
 
@@ -301,8 +301,8 @@ void
 IBStandardInitializer::readSpringFiles(const std::string& extension, const bool input_uses_global_idxs)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -322,7 +322,7 @@ IBStandardInitializer::readSpringFiles(const std::string& extension, const bool 
                                           d_num_vertex[ln][j]);
 
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             // Ensure that the file exists.
             const std::string spring_filename = d_base_filename[ln][j] + extension;
@@ -331,7 +331,7 @@ IBStandardInitializer::readSpringFiles(const std::string& extension, const bool 
             {
                 plog << d_object_name << ":  "
                      << "processing spring data from ASCII input file named " << spring_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first line in the file indicates the number of edges in the input
                 // file.
@@ -512,22 +512,22 @@ IBStandardInitializer::readSpringFiles(const std::string& extension, const bool 
 
                 plog << d_object_name << ":  "
                      << "read " << num_edges << " edges from ASCII input file named " << spring_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
                 plog << d_object_name << ":  "
-                     << " file " << spring_filename << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " file " << spring_filename << " on MPI process " << IBTK_MPI::getRank()
                      << " does not exist: skipping read." << std::endl;
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
     }
 
     // Synchronize the processes.
-    if (d_use_file_batons) SAMRAI_MPI::barrier();
+    if (d_use_file_batons) IBTK_MPI::barrier();
     return;
 } // readSpringFiles
 
@@ -535,8 +535,8 @@ void
 IBStandardInitializer::readXSpringFiles(const std::string& extension, const bool input_uses_global_idxs)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -556,7 +556,7 @@ IBStandardInitializer::readXSpringFiles(const std::string& extension, const bool
                                           d_num_vertex[ln][j]);
 
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             // Ensure that the file exists.
             const std::string xspring_filename = d_base_filename[ln][j] + extension;
@@ -565,7 +565,7 @@ IBStandardInitializer::readXSpringFiles(const std::string& extension, const bool
             {
                 plog << d_object_name << ":  "
                      << "processing crosslink spring data from ASCII input file named " << xspring_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first line in the file indicates the number of edges in the input
                 // file.
@@ -747,22 +747,22 @@ IBStandardInitializer::readXSpringFiles(const std::string& extension, const bool
 
                 plog << d_object_name << ":  "
                      << "read " << num_edges << " edges from ASCII input file named " << xspring_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
                 plog << d_object_name << ":  "
-                     << " file " << xspring_filename << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " file " << xspring_filename << " on MPI process " << IBTK_MPI::getRank()
                      << " does not exist: skipping read." << std::endl;
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
     }
 
     // Synchronize the processes.
-    if (d_use_file_batons) SAMRAI_MPI::barrier();
+    if (d_use_file_batons) IBTK_MPI::barrier();
     return;
 } // readXSpringFiles
 
@@ -770,8 +770,8 @@ void
 IBStandardInitializer::readBeamFiles(const std::string& extension, const bool input_uses_global_idxs)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -790,7 +790,7 @@ IBStandardInitializer::readBeamFiles(const std::string& extension, const bool in
                                           d_num_vertex[ln][j]);
 
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             const std::string beam_filename = d_base_filename[ln][j] + extension;
             std::ifstream file_stream(beam_filename);
@@ -798,7 +798,7 @@ IBStandardInitializer::readBeamFiles(const std::string& extension, const bool in
             {
                 plog << d_object_name << ":  "
                      << "processing beam data from ASCII input file named " << beam_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first line in the file indicates the number of beams in
                 // the input file.
@@ -986,22 +986,22 @@ IBStandardInitializer::readBeamFiles(const std::string& extension, const bool in
 
                 plog << d_object_name << ":  "
                      << "read " << num_beams << " beams from ASCII input file named " << beam_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
                 plog << d_object_name << ":  "
-                     << " file " << beam_filename << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " file " << beam_filename << " on MPI process " << IBTK_MPI::getRank()
                      << " does not exist: skipping read." << std::endl;
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
     }
 
     // Synchronize the processes.
-    if (d_use_file_batons) SAMRAI_MPI::barrier();
+    if (d_use_file_batons) IBTK_MPI::barrier();
     return;
 } // readBeamFiles
 
@@ -1009,8 +1009,8 @@ void
 IBStandardInitializer::readRodFiles(const std::string& extension, const bool input_uses_global_idxs)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -1028,7 +1028,7 @@ IBStandardInitializer::readRodFiles(const std::string& extension, const bool inp
                                           d_num_vertex[ln][j]);
 
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             const std::string rod_filename = d_base_filename[ln][j] + extension;
             std::ifstream file_stream(rod_filename);
@@ -1036,7 +1036,7 @@ IBStandardInitializer::readRodFiles(const std::string& extension, const bool inp
             {
                 plog << d_object_name << ":  "
                      << "processing rod data from ASCII input file named " << rod_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first line in the file indicates the number of rods in
                 // the input file.
@@ -1303,22 +1303,22 @@ IBStandardInitializer::readRodFiles(const std::string& extension, const bool inp
 
                 plog << d_object_name << ":  "
                      << "read " << num_rods << " rods from ASCII input file named " << rod_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
                 plog << d_object_name << ":  "
-                     << " file " << rod_filename << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " file " << rod_filename << " on MPI process " << IBTK_MPI::getRank()
                      << " does not exist: skipping read." << std::endl;
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
     }
 
     // Synchronize the processes.
-    if (d_use_file_batons) SAMRAI_MPI::barrier();
+    if (d_use_file_batons) IBTK_MPI::barrier();
     return;
 } // readRodFiles
 
@@ -1326,8 +1326,8 @@ void
 IBStandardInitializer::readTargetPointFiles(const std::string& extension)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -1344,7 +1344,7 @@ IBStandardInitializer::readTargetPointFiles(const std::string& extension)
             const int max_idx = d_num_vertex[ln][j];
 
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             std::set<int> target_point_idxs;
             TargetSpec default_spec;
@@ -1359,7 +1359,7 @@ IBStandardInitializer::readTargetPointFiles(const std::string& extension)
                 plog << d_object_name << ":  "
                      << "processing target point data from ASCII input file named " << target_point_stiffness_filename
                      << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first line in the file indicates the number of target
                 // point specifications in the input file.
@@ -1472,12 +1472,12 @@ IBStandardInitializer::readTargetPointFiles(const std::string& extension)
                 plog << d_object_name << ":  "
                      << "read " << num_target_points << " target points from ASCII input file named "
                      << target_point_stiffness_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
                 plog << d_object_name << ":  "
-                     << " file " << target_point_stiffness_filename << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " file " << target_point_stiffness_filename << " on MPI process " << IBTK_MPI::getRank()
                      << " does not exist: skipping read." << std::endl;
             }
 
@@ -1511,12 +1511,12 @@ IBStandardInitializer::readTargetPointFiles(const std::string& extension)
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
     }
 
     // Synchronize the processes.
-    if (d_use_file_batons) SAMRAI_MPI::barrier();
+    if (d_use_file_batons) IBTK_MPI::barrier();
     return;
 } // readTargetPointFiles
 
@@ -1524,8 +1524,8 @@ void
 IBStandardInitializer::readAnchorPointFiles(const std::string& extension)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -1540,7 +1540,7 @@ IBStandardInitializer::readAnchorPointFiles(const std::string& extension)
             const int max_idx = d_num_vertex[ln][j];
 
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             std::set<int> anchor_point_idxs;
             AnchorSpec default_spec;
@@ -1554,7 +1554,7 @@ IBStandardInitializer::readAnchorPointFiles(const std::string& extension)
                 plog << d_object_name << ":  "
                      << "processing anchor point data from ASCII input file named " << anchor_point_filename
                      << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first line in the file indicates the number of anchor
                 // points in the input file.
@@ -1630,17 +1630,17 @@ IBStandardInitializer::readAnchorPointFiles(const std::string& extension)
                 plog << d_object_name << ":  "
                      << "read " << num_anchor_pts << " anchor points from ASCII input file named "
                      << anchor_point_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
                 plog << d_object_name << ":  "
-                     << " file " << anchor_point_filename << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " file " << anchor_point_filename << " on MPI process " << IBTK_MPI::getRank()
                      << " does not exist: skipping read." << std::endl;
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
     }
     return;
@@ -1650,8 +1650,8 @@ void
 IBStandardInitializer::readBoundaryMassFiles(const std::string& extension)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -1666,7 +1666,7 @@ IBStandardInitializer::readBoundaryMassFiles(const std::string& extension)
             const int max_idx = d_num_vertex[ln][j];
 
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             std::set<int> mass_point_idxs;
             BdryMassSpec default_spec;
@@ -1680,7 +1680,7 @@ IBStandardInitializer::readBoundaryMassFiles(const std::string& extension)
             {
                 plog << d_object_name << ":  "
                      << "processing boundary mass data from ASCII input file named " << bdry_mass_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first line in the file indicates the number of massive IB
                 // points in the input file.
@@ -1780,12 +1780,12 @@ IBStandardInitializer::readBoundaryMassFiles(const std::string& extension)
                 plog << d_object_name << ":  "
                      << "read " << num_bdry_mass_pts << " boundary mass points from ASCII input file named "
                      << bdry_mass_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
                 plog << d_object_name << ":  "
-                     << " file " << bdry_mass_filename << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " file " << bdry_mass_filename << " on MPI process " << IBTK_MPI::getRank()
                      << " does not exist: skipping read." << std::endl;
             }
 
@@ -1819,7 +1819,7 @@ IBStandardInitializer::readBoundaryMassFiles(const std::string& extension)
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
     }
     return;
@@ -1829,8 +1829,8 @@ void
 IBStandardInitializer::readDirectorFiles(const std::string& extension)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -1841,7 +1841,7 @@ IBStandardInitializer::readDirectorFiles(const std::string& extension)
         for (unsigned int j = 0; j < num_base_filename; ++j)
         {
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             d_directors[ln][j].resize(d_num_vertex[ln][j], std::vector<double>(3 * 3, 0.0));
 
@@ -1851,7 +1851,7 @@ IBStandardInitializer::readDirectorFiles(const std::string& extension)
             {
                 plog << d_object_name << ":  "
                      << "processing director data from ASCII input file named " << directors_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first line in the file indicates the number of sets of
                 // directors in the input file.
@@ -1929,17 +1929,17 @@ IBStandardInitializer::readDirectorFiles(const std::string& extension)
                 plog << d_object_name << ":  "
                      << "read " << num_directors_pts << " director triads from ASCII input file named "
                      << directors_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
                 plog << d_object_name << ":  "
-                     << " file " << directors_filename << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " file " << directors_filename << " on MPI process " << IBTK_MPI::getRank()
                      << " does not exist: skipping read." << std::endl;
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
     }
     return;
@@ -1949,8 +1949,8 @@ void
 IBStandardInitializer::readInstrumentationFiles(const std::string& extension)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -1967,7 +1967,7 @@ IBStandardInitializer::readInstrumentationFiles(const std::string& extension)
             const int max_idx = d_num_vertex[ln][j];
 
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             const std::string inst_filename = d_base_filename[ln][j] + extension;
             std::ifstream file_stream(inst_filename);
@@ -1975,7 +1975,7 @@ IBStandardInitializer::readInstrumentationFiles(const std::string& extension)
             {
                 plog << d_object_name << ":  "
                      << "processing instrumentation data from ASCII input file named " << inst_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first line in the file indicates the number of
                 // instruments in the input file.
@@ -2172,17 +2172,17 @@ IBStandardInitializer::readInstrumentationFiles(const std::string& extension)
                 plog << d_object_name << ":  "
                      << "read " << num_inst_pts << " instrumentation points from ASCII input file named "
                      << inst_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
                 plog << d_object_name << ":  "
-                     << " Either file " << inst_filename << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " Either file " << inst_filename << " on MPI process " << IBTK_MPI::getRank()
                      << " does not exist or instrumentation is disabled : skipping read." << std::endl;
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
     }
     IBInstrumentationSpec::setInstrumentNames(instrument_names);
@@ -2193,8 +2193,8 @@ void
 IBStandardInitializer::readSourceFiles(const std::string& extension)
 {
     std::string line_string;
-    const int rank = SAMRAI_MPI::getRank();
-    const int nodes = SAMRAI_MPI::getNodes();
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
     int flag = 1;
     int sz = 1;
 
@@ -2212,7 +2212,7 @@ IBStandardInitializer::readSourceFiles(const std::string& extension)
             const int max_idx = d_num_vertex[ln][j];
 
             // Wait for the previous MPI process to finish reading the current file.
-            if (d_use_file_batons && rank != 0) SAMRAI_MPI::recv(&flag, sz, rank - 1, false, j);
+            if (d_use_file_batons && rank != 0) IBTK_MPI::recv(&flag, sz, rank - 1, false, j);
 
             const std::string source_filename = d_base_filename[ln][j] + extension;
             std::ifstream file_stream(source_filename);
@@ -2220,7 +2220,7 @@ IBStandardInitializer::readSourceFiles(const std::string& extension)
             {
                 plog << d_object_name << ":  "
                      << "processing source data from ASCII input file named " << source_filename << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
 
                 // The first line in the file indicates the number of sources in
                 // the input file.
@@ -2377,17 +2377,17 @@ IBStandardInitializer::readSourceFiles(const std::string& extension)
                 plog << d_object_name << ":  "
                      << "read " << num_source_pts << " source points from ASCII input file named " << source_filename
                      << std::endl
-                     << "  on MPI process " << SAMRAI_MPI::getRank() << std::endl;
+                     << "  on MPI process " << IBTK_MPI::getRank() << std::endl;
             }
             else
             {
                 plog << d_object_name << ":  "
-                     << " Either file " << source_filename << " on MPI process " << SAMRAI_MPI::getRank()
+                     << " Either file " << source_filename << " on MPI process " << IBTK_MPI::getRank()
                      << " does not exist or sources are disabled : skipping read." << std::endl;
             }
 
             // Free the next MPI process to start reading the current file.
-            if (d_use_file_batons && rank != nodes - 1) SAMRAI_MPI::send(&flag, sz, rank + 1, false, j);
+            if (d_use_file_batons && rank != nodes - 1) IBTK_MPI::send(&flag, sz, rank + 1, false, j);
         }
         IBStandardSourceGen::setNumSources(ln, source_offset);
         IBStandardSourceGen::setSourceNames(ln, source_names);

--- a/src/IB/IBStandardSourceGen.cpp
+++ b/src/IB/IBStandardSourceGen.cpp
@@ -19,6 +19,7 @@
 #include "ibamr/IBStandardSourceGen.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LData.h"
 #include "ibtk/LDataManager.h"
 #include "ibtk/LMesh.h"
@@ -33,7 +34,6 @@
 #include "tbox/Database.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 IBTK_DISABLE_EXTRA_WARNINGS
@@ -172,8 +172,8 @@ IBStandardSourceGen::initializeLevelData(const Pointer<PatchHierarchy<NDIM> > /*
         const int source_idx = spec->getSourceIndex();
         ++d_num_perimeter_nodes[level_number][source_idx];
     }
-    SAMRAI_MPI::sumReduction(&d_num_perimeter_nodes[level_number][0],
-                             static_cast<int>(d_num_perimeter_nodes[level_number].size()));
+    IBTK_MPI::sumReduction(&d_num_perimeter_nodes[level_number][0],
+                           static_cast<int>(d_num_perimeter_nodes[level_number].size()));
     return;
 } // initializeLevelData
 
@@ -235,7 +235,7 @@ IBStandardSourceGen::getSourceLocations(std::vector<Point>& X_src,
             X_src_flattened[NDIM * k + d] = X_src[k][d];
         }
     }
-    SAMRAI_MPI::sumReduction(&X_src_flattened[0], static_cast<int>(X_src_flattened.size()));
+    IBTK_MPI::sumReduction(&X_src_flattened[0], static_cast<int>(X_src_flattened.size()));
     for (unsigned int k = 0; k < X_src.size(); ++k)
     {
         for (unsigned int d = 0; d < NDIM; ++d)

--- a/src/IB/IBTargetPointForceSpec.cpp
+++ b/src/IB/IBTargetPointForceSpec.cpp
@@ -16,10 +16,9 @@
 #include "ibamr/IBTargetPointForceSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/StreamableFactory.h"
 #include "ibtk/StreamableManager.h"
-
-#include "tbox/SAMRAI_MPI.h"
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
@@ -36,7 +35,7 @@ IBTargetPointForceSpec::registerWithStreamableManager()
     // register the factory class with the StreamableManager, and to ensure that
     // all processes employ the same class ID for the IBTargetPointForceSpec
     // object.
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     if (!getIsRegisteredWithStreamableManager())
     {
 #if !defined(NDEBUG)
@@ -44,7 +43,7 @@ IBTargetPointForceSpec::registerWithStreamableManager()
 #endif
         STREAMABLE_CLASS_ID = StreamableManager::getManager()->registerFactory(new IBTargetPointForceSpecFactory());
     }
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     return;
 } // registerWithStreamableManager
 

--- a/src/IB/IMPInitializer.cpp
+++ b/src/IB/IMPInitializer.cpp
@@ -19,6 +19,7 @@
 #include "ibamr/MaterialPointSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/LData.h"
 #include "ibtk/LIndexSetData.h"
@@ -47,7 +48,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "libmesh/elem.h"
@@ -458,7 +458,7 @@ IMPInitializer::writeVertexFile(std::string filename, int mesh_no, int level_num
     if (level_number < 0) level_number = max_levels - 1;
     level_number = std::min(level_number, max_levels - 1);
 
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     if (mpi_rank == 0)
     {
         if (filename.find(".vertex") == std::string::npos)
@@ -500,7 +500,7 @@ IMPInitializer::initializeLSiloDataWriter(const int level_number)
     // WARNING: For now, we just register the visualization data on MPI process
     // 0.  This will fail if the structure is too large to be stored in the
     // memory available to a single MPI process.
-    if (SAMRAI_MPI::getRank() == 0)
+    if (IBTK_MPI::getRank() == 0)
     {
         for (unsigned int j = 0; j < d_num_vertex[level_number].size(); ++j)
         {

--- a/src/IB/MaterialPointSpec.cpp
+++ b/src/IB/MaterialPointSpec.cpp
@@ -16,10 +16,9 @@
 #include "ibamr/MaterialPointSpec.h"
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/StreamableFactory.h"
 #include "ibtk/StreamableManager.h"
-
-#include "tbox/SAMRAI_MPI.h"
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
@@ -36,7 +35,7 @@ MaterialPointSpec::registerWithStreamableManager()
     // register the factory class with the StreamableManager, and to ensure that
     // all processes employ the same class ID for the MaterialPointSpec
     // object.
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     if (!getIsRegisteredWithStreamableManager())
     {
 #if !defined(NDEBUG)
@@ -44,7 +43,7 @@ MaterialPointSpec::registerWithStreamableManager()
 #endif
         STREAMABLE_CLASS_ID = StreamableManager::getManager()->registerFactory(new MaterialPointSpecFactory());
     }
-    SAMRAI_MPI::barrier();
+    IBTK_MPI::barrier();
     return;
 } // registerWithStreamableManager
 

--- a/src/IB/PenaltyIBMethod.cpp
+++ b/src/IB/PenaltyIBMethod.cpp
@@ -20,6 +20,7 @@
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LData.h"
 #include "ibtk/LDataManager.h"
 #include "ibtk/LInitStrategy.h"
@@ -36,7 +37,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscvec.h"
@@ -358,7 +358,7 @@ PenaltyIBMethod::computeLagrangianForce(const double data_time)
 
     if (d_do_log)
     {
-        max_displacement = SAMRAI_MPI::maxReduction(max_displacement);
+        max_displacement = IBTK_MPI::maxReduction(max_displacement);
         plog << d_object_name << "::computeLagrangianForce(): maximum point displacement: " << max_displacement << "\n";
     }
     return;

--- a/src/IB/StaggeredStokesIBLevelRelaxationFACOperator.cpp
+++ b/src/IB/StaggeredStokesIBLevelRelaxationFACOperator.cpp
@@ -24,6 +24,7 @@
 
 #include "ibtk/CoarseFineBoundaryRefinePatchStrategy.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PETScMatUtilities.h"
 
 #include "ArrayData.h"
@@ -49,7 +50,6 @@
 #include "tbox/Array.h"
 #include "tbox/Database.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscksp.h"
@@ -249,7 +249,7 @@ StaggeredStokesIBLevelRelaxationFACOperator::computeResidual(SAMRAIVectorReal<ND
         const int P_sol_idx = solution.getComponentDescriptorIndex(1);
 
         // Update the residual, r = f - A*u, to include the IB part of the operator.
-        int rank = SAMRAI_MPI::getRank();
+        int rank = IBTK_MPI::getRank();
         for (int ln = coarsest_level_num; ln <= finest_level_num; ++ln)
         {
             Vec solution_vec, residual_vec;
@@ -294,7 +294,7 @@ StaggeredStokesIBLevelRelaxationFACOperator::computeResidual(SAMRAIVectorReal<ND
         const int P_rhs_idx = rhs.getComponentDescriptorIndex(1);
 
         // Compute the residual, r = f - A*u.
-        int rank = SAMRAI_MPI::getRank();
+        int rank = IBTK_MPI::getRank();
         for (int ln = coarsest_level_num; ln <= finest_level_num; ++ln)
         {
             Vec solution_vec;

--- a/src/adv_diff/AdvDiffHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffHierarchyIntegrator.cpp
@@ -27,6 +27,7 @@
 #include "ibtk/HierarchyGhostCellInterpolation.h"
 #include "ibtk/HierarchyIntegrator.h"
 #include "ibtk/HierarchyMathOps.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LaplaceOperator.h"
 #include "ibtk/PoissonSolver.h"
 
@@ -978,7 +979,7 @@ AdvDiffHierarchyIntegrator::getMaximumTimeStepSizeSpecialized()
             }
         }
     }
-    return SAMRAI_MPI::minReduction(dt);
+    return IBTK_MPI::minReduction(dt);
 } // getMaximumTimeStepSizeSpecialized
 
 void

--- a/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
@@ -25,6 +25,7 @@
 #include "ibtk/HierarchyGhostCellInterpolation.h"
 #include "ibtk/HierarchyIntegrator.h"
 #include "ibtk/HierarchyMathOps.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LaplaceOperator.h"
 #include "ibtk/PoissonSolver.h"
 
@@ -61,7 +62,6 @@
 #include "tbox/NullDatabase.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -646,7 +646,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::postprocessIntegrateHierarchy(cons
             }
         }
     }
-    cfl_max = SAMRAI_MPI::maxReduction(cfl_max);
+    cfl_max = IBTK_MPI::maxReduction(cfl_max);
     if (d_enable_logging)
         plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
 

--- a/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
@@ -22,6 +22,7 @@
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/CartGridFunction.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LaplaceOperator.h"
 #include "ibtk/PoissonSolver.h"
 
@@ -54,7 +55,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -891,7 +891,7 @@ AdvDiffSemiImplicitHierarchyIntegrator::postprocessIntegrateHierarchy(const doub
             }
         }
     }
-    cfl_max = SAMRAI_MPI::maxReduction(cfl_max);
+    cfl_max = IBTK_MPI::maxReduction(cfl_max);
     if (d_enable_logging)
         plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
 

--- a/src/complex_fluids/CFINSForcing.cpp
+++ b/src/complex_fluids/CFINSForcing.cpp
@@ -21,6 +21,7 @@
 #include "ibamr/app_namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/HierarchyGhostCellInterpolation.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/muParserRobinBcCoefs.h"
 
@@ -45,7 +46,6 @@
 #include "VisItDataWriter.h"
 #include "tbox/Database.h"
 #include "tbox/PIO.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 IBTK_DISABLE_EXTRA_WARNINGS
@@ -395,7 +395,7 @@ CFINSForcing::setDataOnPatchHierarchy(const int data_idx,
     d_positive_def = true;
     checkPositiveDefinite(d_W_scratch_idx, d_W_cc_var, data_time, initial_time);
     int temp = d_positive_def ? 1 : 0;
-    d_positive_def = SAMRAI_MPI::maxReduction(temp) == 1 ? true : false;
+    d_positive_def = IBTK_MPI::maxReduction(temp) == 1 ? true : false;
     plog << "Conformation tensor is " << (d_positive_def ? "SPD" : "NOT SPD") << "\n";
     if (d_error_on_spd && !d_positive_def)
     {
@@ -409,8 +409,8 @@ CFINSForcing::setDataOnPatchHierarchy(const int data_idx,
         d_max_det = 0.0;
         d_min_det = std::numeric_limits<double>::max();
         findDeterminant(d_W_scratch_idx, d_W_cc_var, data_time, initial_time);
-        d_max_det = SAMRAI_MPI::maxReduction(d_max_det);
-        d_min_det = SAMRAI_MPI::minReduction(d_min_det);
+        d_max_det = IBTK_MPI::maxReduction(d_max_det);
+        d_min_det = IBTK_MPI::minReduction(d_min_det);
         plog << "Largest det:  " << d_max_det << "\n";
         plog << "Smallest det: " << d_min_det << "\n";
     }
@@ -425,8 +425,8 @@ CFINSForcing::setDataOnPatchHierarchy(const int data_idx,
     // Output largest and smallest max norm of Div W
     if (d_log_divW || d_divW_rel_tag)
     {
-        SAMRAI_MPI::maxReduction(d_max_norm);
-        SAMRAI_MPI::minReduction(d_min_norm);
+        IBTK_MPI::maxReduction(d_max_norm);
+        IBTK_MPI::minReduction(d_min_norm);
         plog << "Largest max norm of Div W:  " << d_max_norm << "\n";
         plog << "Smallest max norm of Div W: " << d_min_norm << "\n";
     }

--- a/src/level_set/FESurfaceDistanceEvaluator.cpp
+++ b/src/level_set/FESurfaceDistanceEvaluator.cpp
@@ -49,6 +49,7 @@
 #include "ibamr/FESurfaceDistanceEvaluator.h"
 #include "ibamr/app_namespaces.h"
 
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/ibtk_utilities.h"
 
@@ -73,7 +74,6 @@
 #include "VariableDatabase.h"
 #include "tbox/MathUtilities.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Timer.h"
 #include "tbox/TimerManager.h"
 #include "tbox/Utilities.h"
@@ -266,8 +266,8 @@ FESurfaceDistanceEvaluator::mapIntersections()
 #endif
         }
     }
-    SAMRAI_MPI::minReduction(elem_bl.data(), 3);
-    SAMRAI_MPI::maxReduction(elem_tr.data(), 3);
+    IBTK_MPI::minReduction(elem_bl.data(), 3);
+    IBTK_MPI::maxReduction(elem_tr.data(), 3);
 
     // Structure bounding box, taking into account ghost cell width.
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = level->getGridGeometry();
@@ -689,7 +689,7 @@ FESurfaceDistanceEvaluator::updateSignAwayFromInterface(int D_idx,
                           large_distance,
                           n_local_updates);
         }
-        n_global_updates = SAMRAI_MPI::sumReduction(n_local_updates);
+        n_global_updates = IBTK_MPI::sumReduction(n_local_updates);
     }
 
     // Copy D_iter_idx to D_idx and deallocate D_iter_idx.

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -34,6 +34,7 @@
 #include "ibtk/HierarchyGhostCellInterpolation.h"
 #include "ibtk/HierarchyIntegrator.h"
 #include "ibtk/HierarchyMathOps.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LinearSolver.h"
 #include "ibtk/PoissonSolver.h"
 #include "ibtk/ibtk_enums.h"
@@ -80,7 +81,6 @@
 #include "tbox/MathUtilities.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -1484,7 +1484,7 @@ INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(const double cur
                 cfl_max = std::max(cfl_max, u_max * dt / dx_min);
             }
         }
-        cfl_max = SAMRAI_MPI::maxReduction(cfl_max);
+        cfl_max = IBTK_MPI::maxReduction(cfl_max);
         if (d_enable_logging)
             plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
     }

--- a/src/navier_stokes/INSHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSHierarchyIntegrator.cpp
@@ -26,6 +26,7 @@
 #include "ibtk/CartGridFunctionSet.h"
 #include "ibtk/HierarchyGhostCellInterpolation.h"
 #include "ibtk/HierarchyIntegrator.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/PoissonSolver.h"
 
 #include "FaceVariable.h"
@@ -44,7 +45,6 @@
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
 #include "tbox/RestartManager.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -504,7 +504,7 @@ INSHierarchyIntegrator::getStableTimestep(Pointer<PatchLevel<NDIM> > level) cons
         Pointer<Patch<NDIM> > patch = level->getPatch(p());
         stable_dt = std::min(stable_dt, getStableTimestep(patch));
     }
-    stable_dt = SAMRAI_MPI::minReduction(stable_dt);
+    stable_dt = IBTK_MPI::minReduction(stable_dt);
     return stable_dt;
 } // getStableTimestep
 

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -44,6 +44,7 @@
 #include "ibtk/HierarchyGhostCellInterpolation.h"
 #include "ibtk/HierarchyIntegrator.h"
 #include "ibtk/HierarchyMathOps.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/KrylovLinearSolver.h"
 #include "ibtk/LinearSolver.h"
 #include "ibtk/NewtonKrylovSolver.h"
@@ -103,7 +104,6 @@
 #include "tbox/MemoryDatabase.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -1518,7 +1518,7 @@ INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double curr
                 cfl_max = std::max(cfl_max, u_max * dt / dx_min);
             }
         }
-        cfl_max = SAMRAI_MPI::maxReduction(cfl_max);
+        cfl_max = IBTK_MPI::maxReduction(cfl_max);
         if (d_enable_logging)
             plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
     }

--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -45,6 +45,7 @@
 #include "ibtk/HierarchyGhostCellInterpolation.h"
 #include "ibtk/HierarchyIntegrator.h"
 #include "ibtk/HierarchyMathOps.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/KrylovLinearSolver.h"
 #include "ibtk/LinearOperator.h"
 #include "ibtk/LinearSolver.h"
@@ -110,7 +111,6 @@
 #include "tbox/MemoryDatabase.h"
 #include "tbox/PIO.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -1265,7 +1265,7 @@ INSVCStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double cu
                 cfl_max = std::max(cfl_max, u_max * dt / dx_min);
             }
         }
-        cfl_max = SAMRAI_MPI::maxReduction(cfl_max);
+        cfl_max = IBTK_MPI::maxReduction(cfl_max);
         if (d_enable_logging)
             plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
     }

--- a/src/navier_stokes/StaggeredStokesPETScLevelSolver.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScLevelSolver.cpp
@@ -21,6 +21,7 @@
 
 #include "ibtk/GeneralSolver.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/LinearSolver.h"
 #include "ibtk/PETScLevelSolver.h"
 #include "ibtk/PoissonUtilities.h"
@@ -46,7 +47,6 @@
 #include "tbox/Array.h"
 #include "tbox/Database.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 
 #include "petscvec.h"
 #include <petsclog.h>
@@ -170,7 +170,7 @@ StaggeredStokesPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVe
 
     // Setup PETSc objects.
     int ierr;
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_x);
     IBTK_CHKERRQ(ierr);
     ierr = VecCreateMPI(PETSC_COMM_WORLD, d_num_dofs_per_proc[mpi_rank], PETSC_DETERMINE, &d_petsc_b);
@@ -199,7 +199,7 @@ StaggeredStokesPETScLevelSolver::initializeSolverStateSpecialized(const SAMRAIVe
                                                                                                /* boundary type */ 1);
                 local_cf_bdry_box_size += type_1_cf_bdry.size();
             }
-            level_covers_entire_domain = SAMRAI_MPI::sumReduction(local_cf_bdry_box_size) == 0;
+            level_covers_entire_domain = IBTK_MPI::sumReduction(local_cf_bdry_box_size) == 0;
         }
 
         if (level_covers_entire_domain)

--- a/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
@@ -18,6 +18,7 @@
 
 #include "ibtk/ExtendedRobinBcCoefStrategy.h"
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/PETScMatUtilities.h"
 #include "ibtk/PhysicalBoundaryUtilities.h"
@@ -56,7 +57,6 @@
 #include "tbox/Array.h"
 #include "tbox/MathUtilities.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscmat.h"
@@ -141,7 +141,7 @@ StaggeredStokesPETScMatUtilities::constructPatchLevelMACStokesOp(
     }
 
     // Determine the index ranges.
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int nlocal = num_dofs_per_proc[mpi_rank];
     const int ilower = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
     const int iupper = ilower + nlocal;
@@ -832,7 +832,7 @@ StaggeredStokesPETScMatUtilities::constructPatchLevelFields(
     is_field_name[P_FIELD_IDX] = "pressure";
 
     // DOFs on this processor.
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int n_local_dofs = num_dofs_per_proc[mpi_rank];
 
     const int first_local_dof = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);

--- a/src/navier_stokes/StaggeredStokesPETScVecUtilities.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScVecUtilities.cpp
@@ -19,6 +19,7 @@
 #include "ibamr/namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IBTK_MPI.h"
 #include "ibtk/IndexUtilities.h"
 #include "ibtk/SideSynchCopyFillPattern.h"
 
@@ -47,7 +48,6 @@
 #include "VariableDatabase.h"
 #include "VariableFillPattern.h"
 #include "tbox/Pointer.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include "petscao.h"
@@ -345,7 +345,7 @@ StaggeredStokesPETScVecUtilities::constructPatchLevelAO(AO& ao,
     p_ao_offset = u_ao_offset + n_u_samrai_dofs;
 
     // Compute PETSc to SAMRAI index mapping
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int n_local = num_dofs_per_proc[mpi_rank];
     const int i_lower = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
     const int i_upper = i_lower + n_local;
@@ -655,11 +655,11 @@ StaggeredStokesPETScVecUtilities::constructPatchLevelDOFIndices_MAC(std::vector<
 
     // Determine the number of DOFs local to each MPI process and compute the
     // local DOF index offset.
-    const int mpi_size = SAMRAI_MPI::getNodes();
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_size = IBTK_MPI::getNodes();
+    const int mpi_rank = IBTK_MPI::getRank();
     num_dofs_per_proc.resize(mpi_size);
     std::fill(num_dofs_per_proc.begin(), num_dofs_per_proc.end(), 0);
-    SAMRAI_MPI::allGather(local_dof_count, &num_dofs_per_proc[0]);
+    IBTK_MPI::allGather(local_dof_count, &num_dofs_per_proc[0]);
     const int local_dof_offset = std::accumulate(num_dofs_per_proc.begin(), num_dofs_per_proc.begin() + mpi_rank, 0);
 
     // Assign local DOF indices.

--- a/src/wave_generation/IrregularWaveBcCoef.cpp
+++ b/src/wave_generation/IrregularWaveBcCoef.cpp
@@ -17,6 +17,8 @@
 #include "ibamr/RNG.h"
 #include "ibamr/namespaces.h"
 
+#include "ibtk/IBTK_MPI.h"
+
 #include "ArrayData.h"
 #include "BoundaryBox.h"
 #include "Box.h"
@@ -26,7 +28,6 @@
 #include "IntVector.h"
 #include "Patch.h"
 #include "tbox/Database.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -131,7 +132,7 @@ IrregularWaveBcCoef::IrregularWaveBcCoef(std::string object_name,
         }
     }
 
-    if (!SAMRAI_MPI::getRank())
+    if (!IBTK_MPI::getRank())
     {
         std::ofstream wave_stream;
         wave_stream.open("irregular_wave.txt", std::fstream::out);

--- a/src/wave_generation/IrregularWaveGenerator.cpp
+++ b/src/wave_generation/IrregularWaveGenerator.cpp
@@ -17,8 +17,9 @@
 #include "ibamr/RNG.h"
 #include "ibamr/app_namespaces.h" // IWYU pragma: keep
 
+#include "ibtk/IBTK_MPI.h"
+
 #include "tbox/Database.h"
-#include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
 #include <algorithm>
@@ -159,7 +160,7 @@ IrregularWaveGenerator::getVelocity(const double x, const double z_plus_d, const
 void
 IrregularWaveGenerator::printWaveData(ofstream& ostream) const
 {
-    if (!SAMRAI_MPI::getRank())
+    if (!IBTK_MPI::getRank())
     {
         for (int i = 0; i < d_num_waves; ++i)
         {

--- a/tests/IB/explicit_ex0.cpp
+++ b/tests/IB/explicit_ex0.cpp
@@ -36,6 +36,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -220,11 +222,8 @@ generate_springs(
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     std::array<double, 3> u_err;
     std::array<double, 3> p_err;
@@ -481,7 +480,4 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/IB/explicit_ex1.cpp
+++ b/tests/IB/explicit_ex1.cpp
@@ -35,6 +35,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -74,11 +76,8 @@ main(int argc, char* argv[])
         structure_spring_cwd << structure_spring_stream.rdbuf();
     }
 
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
         TimerManager::createManager(nullptr);
@@ -315,9 +314,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -334,7 +330,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/IBFE/explicit_ex0.cpp
+++ b/tests/IBFE/explicit_ex0.cpp
@@ -41,6 +41,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -121,11 +123,9 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char** argv)
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     PetscOptionsSetValue(nullptr, "-ksp_rtol", "1e-16");
     PetscOptionsSetValue(nullptr, "-ksp_rtol", "1e-16");
@@ -403,7 +403,7 @@ main(int argc, char** argv)
 
         // Open streams to save volume of structure.
         ofstream volume_stream;
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             volume_stream.open("volume.curve", ios_base::out | ios_base::trunc);
         }
@@ -567,8 +567,8 @@ main(int argc, char** argv)
                     J_integral += abs(FF.det()) * JxW[qp];
                 }
             }
-            J_integral = SAMRAI_MPI::sumReduction(J_integral);
-            if (SAMRAI_MPI::getRank() == 0)
+            J_integral = IBTK_MPI::sumReduction(J_integral);
+            if (IBTK_MPI::getRank() == 0)
             {
                 volume_stream.precision(12);
                 volume_stream.setf(ios::fixed, ios::floatfield);
@@ -577,7 +577,7 @@ main(int argc, char** argv)
         }
 
         // Close the logging streams.
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             volume_stream.close();
         }
@@ -587,8 +587,6 @@ main(int argc, char** argv)
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 }
 
 void
@@ -606,7 +604,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/IBFE/explicit_ex2.cpp
+++ b/tests/IBFE/explicit_ex2.cpp
@@ -43,6 +43,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -117,11 +119,9 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     // suppress warnings caused by using a refinement ratio of 4 and not
     // setting up coarsening correctly
@@ -480,7 +480,6 @@ main(int argc, char* argv[])
 
     } // cleanup dynamically allocated objects prior to shutdown
 
-    SAMRAIManager::shutdown();
 }
 
 void
@@ -498,7 +497,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/IBFE/explicit_ex4.cpp
+++ b/tests/IBFE/explicit_ex4.cpp
@@ -42,6 +42,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/StableCentroidPartitioner.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -162,11 +164,9 @@ using namespace ModelData;
 int
 main(int argc, char** argv)
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     // suppress warnings caused by using a refinement ratio of 4 and not
     // setting up coarsening correctly
@@ -595,8 +595,8 @@ main(int argc, char** argv)
                     J_integral += abs(FF.det()) * JxW[qp];
                 }
             }
-            J_integral = SAMRAI_MPI::sumReduction(J_integral);
-            if (SAMRAI_MPI::getRank() == 0)
+            J_integral = IBTK_MPI::sumReduction(J_integral);
+            if (IBTK_MPI::getRank() == 0)
             {
                 plog << std::setprecision(12) << std::fixed << loop_time << " " << J_integral << std::endl;
             }
@@ -617,6 +617,4 @@ main(int argc, char** argv)
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main

--- a/tests/IBFE/explicit_ex8.cpp
+++ b/tests/IBFE/explicit_ex8.cpp
@@ -40,6 +40,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/StableCentroidPartitioner.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -293,7 +295,7 @@ compute_inflow_flux(const Pointer<PatchHierarchy<NDIM> > hierarchy, const int U_
             }
         }
     }
-    SAMRAI_MPI::sumReduction(&Q_in, 1);
+    IBTK_MPI::sumReduction(&Q_in, 1);
     return Q_in;
 }
 
@@ -320,11 +322,9 @@ using namespace ModelData;
 int
 main(int argc, char** argv)
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    //  SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     PetscOptionsSetValue(nullptr, "-ksp_rtol", "1e-16");
     PetscOptionsSetValue(nullptr, "-ksp_rtol", "1e-16");
@@ -647,8 +647,8 @@ main(int argc, char** argv)
             time_integrator->advanceHierarchy(dt);
             loop_time += dt;
 
-            J_dil_min = SAMRAI_MPI::minReduction(J_dil_min);
-            J_dil_max = SAMRAI_MPI::maxReduction(J_dil_max);
+            J_dil_min = IBTK_MPI::minReduction(J_dil_min);
+            J_dil_max = IBTK_MPI::maxReduction(J_dil_max);
 
             pout << "J_min = " << J_dil_min << "\n"
                  << "J_max = " << J_dil_max << "\n";
@@ -719,6 +719,4 @@ main(int argc, char** argv)
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // runExample

--- a/tests/IBFE/ib_partitioning_01.cpp
+++ b/tests/IBFE/ib_partitioning_01.cpp
@@ -20,6 +20,8 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/StableCentroidPartitioner.h>
 #include <ibtk/libmesh_utilities.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -64,11 +66,9 @@ coordinate_mapping_function(libMesh::Point& X, const libMesh::Point& s, void* /*
 int
 main(int argc, char** argv)
 {
-    // Initialize libMesh, PETSc, MPI, and SAMRAI.
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     // prevent a warning about timer initializations
     TimerManager::createManager(nullptr);
@@ -201,8 +201,8 @@ main(int argc, char** argv)
         const int length_tag = 1;
         const int index_tag = 2;
 
-        const int rank = SAMRAI_MPI::getRank();
-        const int n_nodes = SAMRAI_MPI::getNodes();
+        const int rank = IBTK_MPI::getRank();
+        const int n_nodes = IBTK_MPI::getNodes();
         if (rank == 0)
         {
             for (int r = 0; r < n_nodes; ++r)
@@ -230,15 +230,16 @@ main(int argc, char** argv)
                 }
                 else
                 {
-                    int ierr = MPI_Recv(bounds, 2, MPIU_INT, r, range_tag, SAMRAI_MPI::commWorld, MPI_STATUS_IGNORE);
+                    int ierr =
+                        MPI_Recv(bounds, 2, MPIU_INT, r, range_tag, IBTK_MPI::getCommunicator(), MPI_STATUS_IGNORE);
                     TBOX_ASSERT(ierr == 0);
 
                     PetscInt n = std::numeric_limits<PetscInt>::max();
-                    ierr = MPI_Recv(&n, 1, MPIU_INT, r, length_tag, SAMRAI_MPI::commWorld, MPI_STATUS_IGNORE);
+                    ierr = MPI_Recv(&n, 1, MPIU_INT, r, length_tag, IBTK_MPI::getCommunicator(), MPI_STATUS_IGNORE);
                     TBOX_ASSERT(ierr == 0);
                     indices.resize(n);
-                    ierr =
-                        MPI_Recv(indices.data(), n, MPIU_INT, r, index_tag, SAMRAI_MPI::commWorld, MPI_STATUS_IGNORE);
+                    ierr = MPI_Recv(
+                        indices.data(), n, MPIU_INT, r, index_tag, IBTK_MPI::getCommunicator(), MPI_STATUS_IGNORE);
                     TBOX_ASSERT(ierr == 0);
                 }
 
@@ -272,7 +273,7 @@ main(int argc, char** argv)
             PetscInt bounds[2];
             int ierr = VecGetOwnershipRange(petsc_vec, &bounds[0], &bounds[1]);
             TBOX_ASSERT(ierr == 0);
-            ierr = MPI_Send(bounds, 2, MPIU_INT, 0, range_tag, SAMRAI_MPI::commWorld);
+            ierr = MPI_Send(bounds, 2, MPIU_INT, 0, range_tag, IBTK_MPI::getCommunicator());
             TBOX_ASSERT(ierr == 0);
 
             // send locally stored global indices
@@ -287,13 +288,11 @@ main(int argc, char** argv)
             ierr = ISLocalToGlobalMappingGetIndices(mapping, &indices);
             TBOX_ASSERT(ierr == 0);
 
-            ierr = MPI_Send(&n, 1, MPIU_INT, 0, length_tag, SAMRAI_MPI::commWorld);
+            ierr = MPI_Send(&n, 1, MPIU_INT, 0, length_tag, IBTK_MPI::getCommunicator());
             TBOX_ASSERT(ierr == 0);
 
-            ierr = MPI_Send(indices, n, MPIU_INT, 0, index_tag, SAMRAI_MPI::commWorld);
+            ierr = MPI_Send(indices, n, MPIU_INT, 0, index_tag, IBTK_MPI::getCommunicator());
             TBOX_ASSERT(ierr == 0);
         }
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main

--- a/tests/IBTK/Makefile.am
+++ b/tests/IBTK/Makefile.am
@@ -19,7 +19,7 @@ laplace_01_3d laplace_02_2d laplace_02_3d laplace_03_2d laplace_03_3d ldata_01 \
 prolongation_mat_2d prolongation_mat_3d phys_boundary_ops_2d phys_boundary_ops_3d \
 vc_viscous_solver_2d vc_viscous_solver_3d box_utilities_01_2d box_utilities_01_3d \
 ghost_accumulation_01_2d ghost_accumulation_01_3d ghost_indices_01_2d \
-ghost_indices_01_3d ibtk_init hierarchy_callbacks
+ghost_indices_01_3d ibtk_init hierarchy_callbacks ibtk_mpi
 
 if LIBMESH_ENABLED
 EXTRA_PROGRAMS += elem_hmax_01 elem_hmax_02 jacobian_calc_01 bounding_boxes_01_2d \
@@ -41,6 +41,10 @@ endif
 ibtk_init_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 ibtk_init_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 ibtk_init_SOURCES = ibtk_init.cpp
+
+ibtk_mpi_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
+ibtk_mpi_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+ibtk_mpi_SOURCES = ibtk_mpi.cpp
 
 mpi_type_wrappers_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 mpi_type_wrappers_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)

--- a/tests/IBTK/Makefile.in
+++ b/tests/IBTK/Makefile.in
@@ -100,7 +100,7 @@ EXTRA_PROGRAMS = mpi_type_wrappers$(EXEEXT) poisson_01_2d$(EXEEXT) \
 	ghost_accumulation_01_2d$(EXEEXT) \
 	ghost_accumulation_01_3d$(EXEEXT) ghost_indices_01_2d$(EXEEXT) \
 	ghost_indices_01_3d$(EXEEXT) ibtk_init$(EXEEXT) \
-	hierarchy_callbacks$(EXEEXT) $(am__EXEEXT_1)
+	hierarchy_callbacks$(EXEEXT) ibtk_mpi$(EXEEXT) $(am__EXEEXT_1)
 @LIBMESH_ENABLED_TRUE@am__append_1 = elem_hmax_01 elem_hmax_02 jacobian_calc_01 bounding_boxes_01_2d \
 @LIBMESH_ENABLED_TRUE@bounding_boxes_01_3d mapping_01 fe_values_01 fe_values_02
 
@@ -264,6 +264,12 @@ ibtk_init_OBJECTS = $(am_ibtk_init_OBJECTS)
 ibtk_init_DEPENDENCIES = $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 ibtk_init_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(ibtk_init_CXXFLAGS) \
+	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
+am_ibtk_mpi_OBJECTS = ibtk_mpi-ibtk_mpi.$(OBJEXT)
+ibtk_mpi_OBJECTS = $(am_ibtk_mpi_OBJECTS)
+ibtk_mpi_DEPENDENCIES = $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+ibtk_mpi_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(ibtk_mpi_CXXFLAGS) \
 	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 am__jacobian_calc_01_SOURCES_DIST = jacobian_calc_01.cpp
 @LIBMESH_ENABLED_TRUE@am_jacobian_calc_01_OBJECTS = jacobian_calc_01-jacobian_calc_01.$(OBJEXT)
@@ -447,6 +453,7 @@ am__depfiles_remade =  \
 	./$(DEPDIR)/ghost_indices_01_3d-ghost_indices_01.Po \
 	./$(DEPDIR)/hierarchy_callbacks-hierarchy_callbacks.Po \
 	./$(DEPDIR)/ibtk_init-ibtk_init.Po \
+	./$(DEPDIR)/ibtk_mpi-ibtk_mpi.Po \
 	./$(DEPDIR)/jacobian_calc_01-jacobian_calc_01.Po \
 	./$(DEPDIR)/laplace_01_2d-laplace_01.Po \
 	./$(DEPDIR)/laplace_01_3d-laplace_01.Po \
@@ -494,12 +501,12 @@ SOURCES = $(bounding_boxes_01_2d_SOURCES) \
 	$(ghost_accumulation_01_3d_SOURCES) \
 	$(ghost_indices_01_2d_SOURCES) $(ghost_indices_01_3d_SOURCES) \
 	$(hierarchy_callbacks_SOURCES) $(ibtk_init_SOURCES) \
-	$(jacobian_calc_01_SOURCES) $(laplace_01_2d_SOURCES) \
-	$(laplace_01_3d_SOURCES) $(laplace_02_2d_SOURCES) \
-	$(laplace_02_3d_SOURCES) $(laplace_03_2d_SOURCES) \
-	$(laplace_03_3d_SOURCES) $(ldata_01_SOURCES) \
-	$(mapping_01_SOURCES) $(mpi_type_wrappers_SOURCES) \
-	$(phys_boundary_ops_2d_SOURCES) \
+	$(ibtk_mpi_SOURCES) $(jacobian_calc_01_SOURCES) \
+	$(laplace_01_2d_SOURCES) $(laplace_01_3d_SOURCES) \
+	$(laplace_02_2d_SOURCES) $(laplace_02_3d_SOURCES) \
+	$(laplace_03_2d_SOURCES) $(laplace_03_3d_SOURCES) \
+	$(ldata_01_SOURCES) $(mapping_01_SOURCES) \
+	$(mpi_type_wrappers_SOURCES) $(phys_boundary_ops_2d_SOURCES) \
 	$(phys_boundary_ops_3d_SOURCES) $(poisson_01_2d_SOURCES) \
 	$(poisson_01_3d_SOURCES) $(prolongation_mat_2d_SOURCES) \
 	$(prolongation_mat_3d_SOURCES) \
@@ -518,12 +525,12 @@ DIST_SOURCES = $(am__bounding_boxes_01_2d_SOURCES_DIST) \
 	$(ghost_accumulation_01_3d_SOURCES) \
 	$(ghost_indices_01_2d_SOURCES) $(ghost_indices_01_3d_SOURCES) \
 	$(hierarchy_callbacks_SOURCES) $(ibtk_init_SOURCES) \
-	$(am__jacobian_calc_01_SOURCES_DIST) $(laplace_01_2d_SOURCES) \
-	$(laplace_01_3d_SOURCES) $(laplace_02_2d_SOURCES) \
-	$(laplace_02_3d_SOURCES) $(laplace_03_2d_SOURCES) \
-	$(laplace_03_3d_SOURCES) $(ldata_01_SOURCES) \
-	$(am__mapping_01_SOURCES_DIST) $(mpi_type_wrappers_SOURCES) \
-	$(phys_boundary_ops_2d_SOURCES) \
+	$(ibtk_mpi_SOURCES) $(am__jacobian_calc_01_SOURCES_DIST) \
+	$(laplace_01_2d_SOURCES) $(laplace_01_3d_SOURCES) \
+	$(laplace_02_2d_SOURCES) $(laplace_02_3d_SOURCES) \
+	$(laplace_03_2d_SOURCES) $(laplace_03_3d_SOURCES) \
+	$(ldata_01_SOURCES) $(am__mapping_01_SOURCES_DIST) \
+	$(mpi_type_wrappers_SOURCES) $(phys_boundary_ops_2d_SOURCES) \
 	$(phys_boundary_ops_3d_SOURCES) $(poisson_01_2d_SOURCES) \
 	$(poisson_01_3d_SOURCES) $(prolongation_mat_2d_SOURCES) \
 	$(prolongation_mat_3d_SOURCES) \
@@ -831,6 +838,9 @@ SUFFIXES = .f.m4
 ibtk_init_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 ibtk_init_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 ibtk_init_SOURCES = ibtk_init.cpp
+ibtk_mpi_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
+ibtk_mpi_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+ibtk_mpi_SOURCES = ibtk_mpi.cpp
 mpi_type_wrappers_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 mpi_type_wrappers_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 mpi_type_wrappers_SOURCES = mpi_type_wrappers.cpp
@@ -1019,6 +1029,10 @@ ibtk_init$(EXEEXT): $(ibtk_init_OBJECTS) $(ibtk_init_DEPENDENCIES) $(EXTRA_ibtk_
 	@rm -f ibtk_init$(EXEEXT)
 	$(AM_V_CXXLD)$(ibtk_init_LINK) $(ibtk_init_OBJECTS) $(ibtk_init_LDADD) $(LIBS)
 
+ibtk_mpi$(EXEEXT): $(ibtk_mpi_OBJECTS) $(ibtk_mpi_DEPENDENCIES) $(EXTRA_ibtk_mpi_DEPENDENCIES) 
+	@rm -f ibtk_mpi$(EXEEXT)
+	$(AM_V_CXXLD)$(ibtk_mpi_LINK) $(ibtk_mpi_OBJECTS) $(ibtk_mpi_LDADD) $(LIBS)
+
 jacobian_calc_01$(EXEEXT): $(jacobian_calc_01_OBJECTS) $(jacobian_calc_01_DEPENDENCIES) $(EXTRA_jacobian_calc_01_DEPENDENCIES) 
 	@rm -f jacobian_calc_01$(EXEEXT)
 	$(AM_V_CXXLD)$(jacobian_calc_01_LINK) $(jacobian_calc_01_OBJECTS) $(jacobian_calc_01_LDADD) $(LIBS)
@@ -1119,6 +1133,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ghost_indices_01_3d-ghost_indices_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/hierarchy_callbacks-hierarchy_callbacks.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ibtk_init-ibtk_init.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ibtk_mpi-ibtk_mpi.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/jacobian_calc_01-jacobian_calc_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/laplace_01_2d-laplace_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/laplace_01_3d-laplace_01.Po@am__quote@ # am--include-marker
@@ -1365,6 +1380,20 @@ ibtk_init-ibtk_init.obj: ibtk_init.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='ibtk_init.cpp' object='ibtk_init-ibtk_init.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ibtk_init_CXXFLAGS) $(CXXFLAGS) -c -o ibtk_init-ibtk_init.obj `if test -f 'ibtk_init.cpp'; then $(CYGPATH_W) 'ibtk_init.cpp'; else $(CYGPATH_W) '$(srcdir)/ibtk_init.cpp'; fi`
+
+ibtk_mpi-ibtk_mpi.o: ibtk_mpi.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ibtk_mpi_CXXFLAGS) $(CXXFLAGS) -MT ibtk_mpi-ibtk_mpi.o -MD -MP -MF $(DEPDIR)/ibtk_mpi-ibtk_mpi.Tpo -c -o ibtk_mpi-ibtk_mpi.o `test -f 'ibtk_mpi.cpp' || echo '$(srcdir)/'`ibtk_mpi.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/ibtk_mpi-ibtk_mpi.Tpo $(DEPDIR)/ibtk_mpi-ibtk_mpi.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='ibtk_mpi.cpp' object='ibtk_mpi-ibtk_mpi.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ibtk_mpi_CXXFLAGS) $(CXXFLAGS) -c -o ibtk_mpi-ibtk_mpi.o `test -f 'ibtk_mpi.cpp' || echo '$(srcdir)/'`ibtk_mpi.cpp
+
+ibtk_mpi-ibtk_mpi.obj: ibtk_mpi.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ibtk_mpi_CXXFLAGS) $(CXXFLAGS) -MT ibtk_mpi-ibtk_mpi.obj -MD -MP -MF $(DEPDIR)/ibtk_mpi-ibtk_mpi.Tpo -c -o ibtk_mpi-ibtk_mpi.obj `if test -f 'ibtk_mpi.cpp'; then $(CYGPATH_W) 'ibtk_mpi.cpp'; else $(CYGPATH_W) '$(srcdir)/ibtk_mpi.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/ibtk_mpi-ibtk_mpi.Tpo $(DEPDIR)/ibtk_mpi-ibtk_mpi.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='ibtk_mpi.cpp' object='ibtk_mpi-ibtk_mpi.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ibtk_mpi_CXXFLAGS) $(CXXFLAGS) -c -o ibtk_mpi-ibtk_mpi.obj `if test -f 'ibtk_mpi.cpp'; then $(CYGPATH_W) 'ibtk_mpi.cpp'; else $(CYGPATH_W) '$(srcdir)/ibtk_mpi.cpp'; fi`
 
 jacobian_calc_01-jacobian_calc_01.o: jacobian_calc_01.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(jacobian_calc_01_CXXFLAGS) $(CXXFLAGS) -MT jacobian_calc_01-jacobian_calc_01.o -MD -MP -MF $(DEPDIR)/jacobian_calc_01-jacobian_calc_01.Tpo -c -o jacobian_calc_01-jacobian_calc_01.o `test -f 'jacobian_calc_01.cpp' || echo '$(srcdir)/'`jacobian_calc_01.cpp
@@ -1791,6 +1820,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/ghost_indices_01_3d-ghost_indices_01.Po
 	-rm -f ./$(DEPDIR)/hierarchy_callbacks-hierarchy_callbacks.Po
 	-rm -f ./$(DEPDIR)/ibtk_init-ibtk_init.Po
+	-rm -f ./$(DEPDIR)/ibtk_mpi-ibtk_mpi.Po
 	-rm -f ./$(DEPDIR)/jacobian_calc_01-jacobian_calc_01.Po
 	-rm -f ./$(DEPDIR)/laplace_01_2d-laplace_01.Po
 	-rm -f ./$(DEPDIR)/laplace_01_3d-laplace_01.Po
@@ -1870,6 +1900,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/ghost_indices_01_3d-ghost_indices_01.Po
 	-rm -f ./$(DEPDIR)/hierarchy_callbacks-hierarchy_callbacks.Po
 	-rm -f ./$(DEPDIR)/ibtk_init-ibtk_init.Po
+	-rm -f ./$(DEPDIR)/ibtk_mpi-ibtk_mpi.Po
 	-rm -f ./$(DEPDIR)/jacobian_calc_01-jacobian_calc_01.Po
 	-rm -f ./$(DEPDIR)/laplace_01_2d-laplace_01.Po
 	-rm -f ./$(DEPDIR)/laplace_01_3d-laplace_01.Po

--- a/tests/IBTK/bounding_boxes_01.cpp
+++ b/tests/IBTK/bounding_boxes_01.cpp
@@ -12,10 +12,11 @@
 // ---------------------------------------------------------------------
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/libmesh_utilities.h>
 
 #include <tbox/SAMRAIManager.h>
-#include <tbox/SAMRAI_MPI.h>
 
 #include <libmesh/enum_order.h>
 #include <libmesh/enum_quadrature_type.h>
@@ -190,12 +191,11 @@ test(LibMeshInit& init,
 int
 main(int argc, char** argv)
 {
-    LibMeshInit init(argc, argv);
     std::ofstream out("output");
 
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "cc_laplace.log");
     Pointer<Database> input_db = app_initializer->getInputDatabase();

--- a/tests/IBTK/box_utilities_01.cpp
+++ b/tests/IBTK/box_utilities_01.cpp
@@ -11,10 +11,11 @@
 //
 // ---------------------------------------------------------------------
 
+#include "ibtk/IBTK_MPI.h"
+#include <ibtk/IBTKInit.h>
 #include <ibtk/box_utilities.h>
 
 #include <tbox/SAMRAIManager.h>
-#include <tbox/SAMRAI_MPI.h>
 
 #include <petscsys.h>
 
@@ -36,11 +37,8 @@ check_box_contained(const std::vector<hier::Box<NDIM> >& boxes, const hier::Box<
 int
 main(int argc, char** argv)
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    tbox::SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    tbox::SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    tbox::SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTK::IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     std::ofstream out("output");
 
@@ -149,7 +147,4 @@ main(int argc, char** argv)
             }
         }
     }
-
-    tbox::SAMRAIManager::shutdown();
-    PetscFinalize();
 }

--- a/tests/IBTK/elem_hmax_01.cpp
+++ b/tests/IBTK/elem_hmax_01.cpp
@@ -23,6 +23,7 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/libmesh_utilities.h>
 
 // Set up application namespace declarations
@@ -59,10 +60,9 @@ log_max_edge_length(const ReplicatedMesh& mesh)
 int
 main(int argc, char** argv)
 {
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     {
         Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "IB.log");
@@ -99,6 +99,4 @@ main(int argc, char** argv)
             log_max_edge_length(mesh);
         }
     }
-
-    SAMRAIManager::shutdown();
 } // main

--- a/tests/IBTK/elem_hmax_02.cpp
+++ b/tests/IBTK/elem_hmax_02.cpp
@@ -23,6 +23,7 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/libmesh_utilities.h>
 
 // Set up application namespace declarations
@@ -59,10 +60,9 @@ log_max_edge_length(const ReplicatedMesh& mesh)
 int
 main(int argc, char** argv)
 {
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     {
         Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "IB.log");
@@ -120,6 +120,4 @@ main(int argc, char** argv)
             log_max_edge_length(mesh);
         }
     }
-
-    SAMRAIManager::shutdown();
 } // main

--- a/tests/IBTK/fe_values_01.cpp
+++ b/tests/IBTK/fe_values_01.cpp
@@ -29,6 +29,7 @@
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
 #include <ibtk/FEValues.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/libmesh_utilities.h>
 
 // Set up application namespace declarations
@@ -155,10 +156,9 @@ test(LibMeshInit& init, const MeshType mesh_type = MeshType::libmesh)
 int
 main(int argc, char** argv)
 {
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     // 2d, libMesh meshes:
     test<2, FIRST, LAGRANGE, TRI3>(init);

--- a/tests/IBTK/fe_values_02.cpp
+++ b/tests/IBTK/fe_values_02.cpp
@@ -29,6 +29,7 @@
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
 #include <ibtk/FEValues.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/libmesh_utilities.h>
 
 // Set up application namespace declarations
@@ -195,10 +196,9 @@ test(LibMeshInit& init, const MeshType mesh_type = MeshType::libmesh)
 int
 main(int argc, char** argv)
 {
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     // 2d, libMesh meshes:
     test<1, FIRST, LAGRANGE, TRI3>(init);

--- a/tests/IBTK/ghost_accumulation_01.cpp
+++ b/tests/IBTK/ghost_accumulation_01.cpp
@@ -15,6 +15,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CCLaplaceOperator.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LEInteractor.h>
 #include <ibtk/PETScVecUtilities.h>
 #include <ibtk/SAMRAIGhostDataAccumulator.h>
@@ -40,11 +42,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // prevent a warning about timer initializations
     TimerManager::createManager(nullptr);
@@ -170,7 +169,7 @@ main(int argc, char* argv[])
             IBTK::VectorNd x_up;
             std::copy(patch_geo->getXLower(), patch_geo->getXLower() + NDIM, x_lo.data());
             std::copy(patch_geo->getXUpper(), patch_geo->getXUpper() + NDIM, x_up.data());
-            out << "\nRank: " << SAMRAI_MPI::getRank() << '\n';
+            out << "\nRank: " << IBTK_MPI::getRank() << '\n';
             out << "x lower:\n" << x_lo << '\n';
             out << "x upper:\n" << x_up << '\n';
 
@@ -186,13 +185,8 @@ main(int argc, char* argv[])
                 u_data->print(patch_box, out, 16);
             }
         }
-        SAMRAI_MPI::barrier();
+        IBTK_MPI::barrier();
 
         print_strings_on_plog_0(out.str());
     }
-
-    // At this point all SAMRAI, PETSc, and IBAMR objects have been cleaned
-    // up, so we shut things down in the opposite order of initialization:
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // run_example

--- a/tests/IBTK/hierarchy_callbacks.cpp
+++ b/tests/IBTK/hierarchy_callbacks.cpp
@@ -30,6 +30,8 @@
 #include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 
 #include <LocationIndexRobinBcCoefs.h>
@@ -107,11 +109,8 @@ regridHierarchyCallback(Pointer<BasePatchHierarchy<NDIM> > /*hierarchy*/,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
       // prevent a warning about timer initialization
@@ -266,6 +265,4 @@ main(int argc, char* argv[])
 
     } // cleanup dynamically allocated objects prior to shutdown
 
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/IBTK/ibtk_init.output
+++ b/tests/IBTK/ibtk_init.output
@@ -1,2 +1,1 @@
 MPI is initialized.
-IBTKInit destructor called. Shutting down libraries.

--- a/tests/IBTK/ibtk_mpi.cpp
+++ b/tests/IBTK/ibtk_mpi.cpp
@@ -1,0 +1,194 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2017 - 2019 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+// Config files
+#include <IBTK_config.h>
+
+// Set up application namespace declarations
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
+#include <ibtk/app_namespaces.h>
+
+template <typename T>
+bool minReduction(T x, T exact, int proc);
+
+template <typename T>
+bool maxReduction(T x, T exact, int proc);
+
+template <typename T>
+bool sumReduction(T x, T exact);
+
+template <typename T>
+bool allToOneSumReduction(T x, T exact, int root);
+
+template <typename T>
+bool bcast(T x, T exact, int root);
+
+template <typename T>
+bool sendAndRecv(T x, T exact);
+
+template <typename T>
+bool allGather(T x);
+
+/*******************************************************************************
+ * For each run, the input filename must be given on the command line.  In all *
+ * cases, the command line is:                                                 *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize IBTK
+    IBTKInit ibtkInit(argc, argv, MPI_COMM_WORLD);
+
+    int num_nodes = IBTK_MPI::getNodes();
+    int rank = IBTK_MPI::getRank();
+
+    ofstream output_file;
+    if (!rank) output_file.open("output");
+
+    // integers
+    int x = IBTK_MPI::getRank();
+    bool passed = minReduction(x, 0, 0);
+
+    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    if (!rank) output_file << "Min test " << (passed ? "passed" : "failed") << ".\n";
+
+    passed = maxReduction(x, IBTK_MPI::getNodes() - 1, IBTK_MPI::getNodes() - 1);
+
+    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    if (!rank) output_file << "Max test " << (passed ? "passed" : "failed") << ".\n";
+
+    passed = sumReduction(x, num_nodes * (num_nodes - 1) / 2);
+
+    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    if (!rank) output_file << "sumReduction test " << (passed ? "passed" : "failed") << ".\n";
+
+    passed = allToOneSumReduction(x, num_nodes * (num_nodes - 1) / 2, 0);
+
+    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    if (!rank) output_file << "allToOneSum test " << (passed ? "passed" : "failed") << ".\n";
+
+    passed = bcast(x, num_nodes - 1, num_nodes - 1);
+
+    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    if (!rank) output_file << "bcast test " << (passed ? "passed" : "failed") << ".\n";
+
+    passed = sendAndRecv(x, (x - 1 + num_nodes) % num_nodes);
+
+    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    if (!rank) output_file << "send and recv test " << (passed ? "passed" : "failed") << ".\n";
+    passed = allGather(x);
+
+    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    if (!rank) output_file << "all gather test " << (passed ? "passed" : "failed") << ".\n";
+
+    if (!rank) output_file.close();
+} // main
+
+template <typename T>
+bool
+minReduction(T x, T exact, int proc)
+{
+    int min_proc = std::numeric_limits<int>::max();
+    // perform a min reduction
+    T val = IBTK_MPI::minReduction(x, &min_proc);
+    if (val == exact && proc == min_proc)
+        return true;
+    else
+        return false;
+}
+
+template <typename T>
+bool
+maxReduction(T x, T exact, int proc)
+{
+    int max_proc = std::numeric_limits<int>::min();
+    // perform a max reduction
+    T val = IBTK_MPI::maxReduction(x, &max_proc);
+    if (val == exact && proc == max_proc)
+        return true;
+    else
+        return false;
+}
+
+template <typename T>
+bool
+sumReduction(T x, T exact)
+{
+    T val = IBTK_MPI::sumReduction(x);
+    if (val == exact)
+        return true;
+    else
+        return false;
+}
+
+template <typename T>
+bool
+allToOneSumReduction(T x, T exact, int root)
+{
+    IBTK_MPI::allToOneSumReduction(&x, 1, root);
+    if (IBTK_MPI::getRank() == root)
+    {
+        if (x == exact)
+            return true;
+        else
+            return false;
+    }
+    else
+    {
+        return true;
+    }
+}
+
+template <typename T>
+bool
+bcast(T x, T exact, int root)
+{
+    T other = IBTK_MPI::bcast(x, root);
+    if (other == exact)
+        return true;
+    else
+        return false;
+}
+
+template <typename T>
+bool
+sendAndRecv(T x, T exact)
+{
+    T other;
+    int num_nodes = IBTK_MPI::getNodes();
+    int size = 1;
+    IBTK_MPI::send(&x, size, (IBTK_MPI::getRank() + 1) % num_nodes, false);
+    IBTK_MPI::recv(&other, size, (IBTK_MPI::getRank() - 1 + num_nodes) % num_nodes, false);
+
+    if (other == exact)
+        return true;
+    else
+        return false;
+}
+
+template <typename T>
+bool
+allGather(T x)
+{
+    std::vector<T> other(IBTK_MPI::getNodes());
+    IBTK_MPI::allGather(x, other.data());
+
+    bool passed = true;
+    for (int i = 0; i < IBTK_MPI::getNodes(); ++i)
+        if (other[i] != i) passed = false;
+    return passed;
+}

--- a/tests/IBTK/ibtk_mpi.mpirun=8.input
+++ b/tests/IBTK/ibtk_mpi.mpirun=8.input
@@ -1,0 +1,1 @@
+intentionally blank

--- a/tests/IBTK/ibtk_mpi.mpirun=8.output
+++ b/tests/IBTK/ibtk_mpi.mpirun=8.output
@@ -1,0 +1,7 @@
+Min test passed.
+Max test passed.
+sumReduction test passed.
+allToOneSum test passed.
+bcast test passed.
+send and recv test passed.
+all gather test passed.

--- a/tests/IBTK/jacobian_calc_01.cpp
+++ b/tests/IBTK/jacobian_calc_01.cpp
@@ -27,6 +27,7 @@
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
 #include <ibtk/FEMapCache.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/JacobianCalculator.h>
 #include <ibtk/QuadratureCache.h>
 #include <ibtk/libmesh_utilities.h>
@@ -218,10 +219,9 @@ test_circle(LibMeshInit& init,
 int
 main(int argc, char** argv)
 {
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     {
         Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "IB.log");
@@ -354,6 +354,4 @@ main(int argc, char** argv)
             ++test_n;
         }
     }
-
-    SAMRAIManager::shutdown();
 } // main

--- a/tests/IBTK/laplace_01.cpp
+++ b/tests/IBTK/laplace_01.cpp
@@ -29,6 +29,8 @@
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CCLaplaceOperator.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 
 // Set up application namespace declarations
@@ -46,11 +48,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // prevent a warning about timer initializations
     TimerManager::createManager(nullptr);
@@ -187,7 +186,7 @@ main(int argc, char* argv[])
         const double l2_norm = e_vec.L2Norm();
         const double l1_norm = e_vec.L1Norm();
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             std::ofstream out("output");
             out << "|e|_oo = " << max_norm << "\n";
@@ -221,9 +220,4 @@ main(int argc, char* argv[])
             }
         }
     }
-
-    // At this point all SAMRAI, PETSc, and IBAMR objects have been cleaned
-    // up, so we shut things down in the opposite order of initialization:
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // run_example

--- a/tests/IBTK/laplace_02.cpp
+++ b/tests/IBTK/laplace_02.cpp
@@ -28,6 +28,8 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/SCLaplaceOperator.h>
 #include <ibtk/muParserCartGridFunction.h>
 
@@ -47,11 +49,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -184,7 +183,7 @@ main(int argc, char* argv[])
         const double l2_norm = e_vec.L2Norm();
         const double l1_norm = e_vec.L1Norm();
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             std::ofstream out("output");
             out << "|e|_oo = " << max_norm << "\n";
@@ -228,7 +227,4 @@ main(int argc, char* argv[])
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // run_example

--- a/tests/IBTK/laplace_03.cpp
+++ b/tests/IBTK/laplace_03.cpp
@@ -31,6 +31,8 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/HierarchyGhostCellInterpolation.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/ibtk_enums.h>
 #include <ibtk/muParserCartGridFunction.h>
 
@@ -51,11 +53,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -250,7 +249,7 @@ main(int argc, char* argv[])
         const double l2_norm = hier_side_data_ops->L2Norm(e_side_idx, dx_side_idx);
         const double l1_norm = hier_side_data_ops->L1Norm(e_side_idx, dx_side_idx);
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             std::ofstream out("output");
             out << "|e|_oo = " << max_norm << "\n";
@@ -298,7 +297,4 @@ main(int argc, char* argv[])
         visit_data_writer->writePlotData(patch_hierarchy, 0, data_time);
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // run_example`

--- a/tests/IBTK/mapping_01.cpp
+++ b/tests/IBTK/mapping_01.cpp
@@ -28,6 +28,7 @@
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
 #include <ibtk/FEMapCache.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/JacobianCalculator.h>
 #include <ibtk/QuadratureCache.h>
 #include <ibtk/libmesh_utilities.h>
@@ -98,10 +99,9 @@ test(LibMeshInit& init)
 int
 main(int argc, char** argv)
 {
-    LibMeshInit init(argc, argv);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     // 2d
     test<2, FIRST, LAGRANGE, TRI3>(init);

--- a/tests/IBTK/mpi_type_wrappers.cpp
+++ b/tests/IBTK/mpi_type_wrappers.cpp
@@ -15,11 +15,12 @@
 #include <IBAMR_config.h>
 #include <IBTK_config.h>
 
+#include "ibtk/IBTK_MPI.h"
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/IBTK_MPI.h>
 
 #include <tbox/SAMRAIManager.h>
-#include <tbox/SAMRAI_MPI.h>
 
 #include <SAMRAI_config.h>
 
@@ -72,10 +73,8 @@ size_check_pair()
 int
 main(int argc, char** argv)
 {
-    MPI_Init(&argc, &argv);
-    SAMRAI_MPI::setCommunicator(MPI_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "IB.log");
 
@@ -90,5 +89,4 @@ main(int argc, char** argv)
     size_check_pair<int, int>();
     // size_check_pair<long double, int>();
     plog << "OK\n";
-    MPI_Finalize();
 } // main

--- a/tests/IBTK/phys_boundary_ops.cpp
+++ b/tests/IBTK/phys_boundary_ops.cpp
@@ -30,6 +30,8 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartCellRobinPhysBdryOp.h>
 #include <ibtk/CartExtrapPhysBdryOp.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 
 #include <LocationIndexRobinBcCoefs.h>
 
@@ -48,11 +50,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -278,13 +277,10 @@ main(int argc, char* argv[])
             }
         }
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             std::ofstream out("output");
             out << "found warning = " << found_warning << '\n';
         }
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/IBTK/poisson_01.cpp
+++ b/tests/IBTK/poisson_01.cpp
@@ -30,6 +30,7 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CCLaplaceOperator.h>
 #include <ibtk/CCPoissonSolverManager.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/muParserCartGridFunction.h>
 
 // Set up application namespace declarations
@@ -40,11 +41,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // prevent a warning about timer initializations
     TimerManager::createManager(nullptr);
@@ -207,7 +205,4 @@ main(int argc, char* argv[])
             }
         }
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/IBTK/prolongation_mat.cpp
+++ b/tests/IBTK/prolongation_mat.cpp
@@ -35,6 +35,8 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/HierarchyGhostCellInterpolation.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/PETScMatUtilities.h>
 #include <ibtk/PETScVecUtilities.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -54,11 +56,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -178,7 +177,7 @@ main(int argc, char* argv[])
         }
 
         // Construct the coarse and fine level PETSc Vecs
-        const int mpi_rank = SAMRAI_MPI::getRank();
+        const int mpi_rank = IBTK_MPI::getRank();
         const int n_local_coarsest = num_dofs_per_proc[coarsest_ln][mpi_rank];
         const int n_total_coarsest =
             std::accumulate(num_dofs_per_proc[coarsest_ln].begin(), num_dofs_per_proc[coarsest_ln].end(), 0);
@@ -261,7 +260,7 @@ main(int argc, char* argv[])
         const double max_norm = e_vec.maxNorm();
         const double l2_norm = e_vec.L2Norm();
         const double l1_norm = e_vec.L1Norm();
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             std::ofstream out("output");
             out << "|e|_oo = " << max_norm << "\n";
@@ -323,7 +322,4 @@ main(int argc, char* argv[])
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/IBTK/samraidatacache_01.cpp
+++ b/tests/IBTK/samraidatacache_01.cpp
@@ -23,6 +23,7 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/SAMRAIDataCache.h>
 
 #include <CellVariable.h>
@@ -65,11 +66,9 @@ print_patch_descriptor_data(Pointer<PatchDescriptor<NDIM> > descriptor)
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     // prevent a warning about timer initializations
     TimerManager::createManager(nullptr);
@@ -197,7 +196,4 @@ main(int argc, char* argv[])
         print_patch_descriptor_data(patch_hierarchy->getPatchDescriptor());
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/IBTK/vc_viscous_solver.cpp
+++ b/tests/IBTK/vc_viscous_solver.cpp
@@ -28,6 +28,8 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/PETScKrylovPoissonSolver.h>
 #include <ibtk/SCLaplaceOperator.h>
 #include <ibtk/SCPoissonSolverManager.h>
@@ -61,11 +63,8 @@ allocate_vc_velocity_krylov_solver(const std::string& solver_object_name,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -415,7 +414,7 @@ main(int argc, char* argv[])
         r_vec.subtract(Pointer<SAMRAIVectorReal<NDIM, double> >(&f_vec, false),
                        Pointer<SAMRAIVectorReal<NDIM, double> >(&r_vec, false));
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             std::ofstream out("output");
             out << "|e|_oo = " << e_max_norm << "\n";
@@ -491,7 +490,4 @@ main(int argc, char* argv[])
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // run_example

--- a/tests/adv_diff/adv_diff_01.cpp
+++ b/tests/adv_diff/adv_diff_01.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 
 #include <LocationIndexRobinBcCoefs.h>
 
@@ -54,11 +56,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -258,7 +257,7 @@ main(int argc, char* argv[])
         const double l2_norm = hier_cc_data_ops.L2Norm(Q_idx, wgt_idx);
         const double max_norm = hier_cc_data_ops.maxNorm(Q_idx, wgt_idx);
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             std::ofstream out("output");
             out << "Error in U at time " << loop_time << ":\n"
@@ -277,7 +276,4 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/adv_diff/adv_diff_02.cpp
+++ b/tests/adv_diff/adv_diff_02.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -40,11 +42,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -262,7 +261,7 @@ main(int argc, char* argv[])
         const double l1_norm = hier_cc_data_ops.L1Norm(U_idx, wgt_cc_idx);
         const double l2_norm = hier_cc_data_ops.L2Norm(U_idx, wgt_cc_idx);
         const double max_norm = hier_cc_data_ops.maxNorm(U_idx, wgt_cc_idx);
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             std::ofstream out("output");
             out << "Error in U at time " << loop_time << ":\n"
@@ -281,7 +280,4 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/adv_diff/adv_diff_03.cpp
+++ b/tests/adv_diff/adv_diff_03.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -40,11 +42,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -253,7 +252,4 @@ main(int argc, char* argv[])
         delete C_bc_coef;
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/adv_diff/adv_diff_convec_opers.cpp
+++ b/tests/adv_diff/adv_diff_convec_opers.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 
 #include <LocationIndexRobinBcCoefs.h>
 
@@ -57,11 +59,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -204,7 +203,4 @@ main(int argc, char* argv[])
             level->deallocatePatchData(u_idx);
         }
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/advect/advect_01.cpp
+++ b/tests/advect/advect_01.cpp
@@ -33,6 +33,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 
 #include <LocationIndexRobinBcCoefs.h>
 #include <TimeRefinementIntegrator.h>
@@ -49,10 +51,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize MPI and SAMRAI.
-    SAMRAI_MPI::init(&argc, &argv);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     std::ofstream output("output");
     { // cleanup dynamically allocated objects prior to shutdown
@@ -230,7 +230,4 @@ main(int argc, char* argv[])
                << "  max-norm: " << hier_cc_data_ops.maxNorm(Q_idx, wgt_idx) << "\n"
                << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    SAMRAI_MPI::finalize();
 } // main

--- a/tests/complex_fluids/cf_forcing_op_01.cpp
+++ b/tests/complex_fluids/cf_forcing_op_01.cpp
@@ -41,6 +41,8 @@
 #include <ibtk/CartCellRobinPhysBdryOp.h>
 #include <ibtk/CartExtrapPhysBdryOp.h>
 #include <ibtk/CartSideRobinPhysBdryOp.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/PhysicalBoundaryUtilities.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -59,11 +61,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
         // prevent a warning about timer initialization
@@ -173,8 +172,5 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
     return 0;
 } // main

--- a/tests/complex_fluids/cf_four_roll_mill.cpp
+++ b/tests/complex_fluids/cf_four_roll_mill.cpp
@@ -36,6 +36,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -45,12 +47,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::setMaxNumberPatchDataEntries(512);
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
         TimerManager::createManager(nullptr);
@@ -209,7 +207,4 @@ main(int argc, char* argv[])
              << "  max-norm: " << std::setprecision(10) << hier_cc_data_ops.maxNorm(sxy_idx, wgt_cc_idx) << "\n";
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main

--- a/tests/complex_fluids/cf_relaxation_op_01.cpp
+++ b/tests/complex_fluids/cf_relaxation_op_01.cpp
@@ -39,6 +39,8 @@
 #include <ibtk/CartCellRobinPhysBdryOp.h>
 #include <ibtk/CartExtrapPhysBdryOp.h>
 #include <ibtk/CartSideRobinPhysBdryOp.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/PhysicalBoundaryUtilities.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -57,11 +59,8 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
         // prevent a warning about timer initialization
@@ -224,8 +223,5 @@ main(int argc, char* argv[])
         }
 
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
-    PetscFinalize();
     return 0;
 } // main

--- a/tests/interpolate/interpolate_01.cpp
+++ b/tests/interpolate/interpolate_01.cpp
@@ -29,6 +29,8 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/LEInteractor.h>
 #include <ibtk/SCLaplaceOperator.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -56,11 +58,8 @@
 int
 main(int argc, char** argv)
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // prevent a warning about timer initializations
     TimerManager::createManager(nullptr);
@@ -240,6 +239,4 @@ main(int argc, char** argv)
         // Output data for plotting.
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
     } // cleanup dynamically allocated objects prior to shutdown
-
-    SAMRAIManager::shutdown();
 } // main

--- a/tests/multiphase_flow/LSLocateBargeInterface.h
+++ b/tests/multiphase_flow/LSLocateBargeInterface.h
@@ -27,10 +27,16 @@
 #include <ibamr/ConstraintIBMethod.h>
 
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/ibtk_utilities.h>
 
 #ifndef included_IBAMR_multiphase_flow_LSLocateBargeInterface
 #define included_IBAMR_multiphase_flow_LSLocateBargeInterface
+
+namespace IBTK
+{
+class IBTK_MPI;
+};
 
 // Struct to maintain the properties of the barge interface
 struct BargeInterface
@@ -283,10 +289,10 @@ private:
 
         // For each of the coordinates, carry out reduction but keep track of which processor has the extreme value
         int rank_xmin, rank_xmax, rank_ymin, rank_ymax;
-        xmin = SAMRAI::tbox::SAMRAI_MPI::minReduction(xmin, &rank_xmin);
-        xmax = SAMRAI::tbox::SAMRAI_MPI::maxReduction(xmax, &rank_xmax);
-        ymin = SAMRAI::tbox::SAMRAI_MPI::minReduction(ymin, &rank_ymin);
-        ymax = SAMRAI::tbox::SAMRAI_MPI::maxReduction(ymax, &rank_ymax);
+        xmin = IBTK_MPI::minReduction(xmin, &rank_xmin);
+        xmax = IBTK_MPI::maxReduction(xmax, &rank_xmax);
+        ymin = IBTK_MPI::minReduction(ymin, &rank_ymin);
+        ymax = IBTK_MPI::maxReduction(ymax, &rank_ymax);
 
         // Broadcast via minReduction the missing coordinate from the appropriate rank.
         const int num_corners = 4;
@@ -295,11 +301,11 @@ private:
         other_coords[1] = y_xmax;
         other_coords[2] = x_ymin;
         other_coords[3] = x_ymax;
-        if (SAMRAI::tbox::SAMRAI_MPI::getRank() != rank_xmin) other_coords[0] = std::numeric_limits<double>::max();
-        if (SAMRAI::tbox::SAMRAI_MPI::getRank() != rank_xmax) other_coords[1] = std::numeric_limits<double>::max();
-        if (SAMRAI::tbox::SAMRAI_MPI::getRank() != rank_ymin) other_coords[2] = std::numeric_limits<double>::max();
-        if (SAMRAI::tbox::SAMRAI_MPI::getRank() != rank_ymax) other_coords[3] = std::numeric_limits<double>::max();
-        SAMRAI::tbox::SAMRAI_MPI::minReduction(&other_coords[0], num_corners);
+        if (IBTK_MPI::getRank() != rank_xmin) other_coords[0] = std::numeric_limits<double>::max();
+        if (IBTK_MPI::getRank() != rank_xmax) other_coords[1] = std::numeric_limits<double>::max();
+        if (IBTK_MPI::getRank() != rank_ymin) other_coords[2] = std::numeric_limits<double>::max();
+        if (IBTK_MPI::getRank() != rank_ymax) other_coords[3] = std::numeric_limits<double>::max();
+        IBTK_MPI::minReduction(&other_coords[0], num_corners);
         y_xmin = other_coords[0];
         y_xmax = other_coords[1];
         x_ymin = other_coords[2];

--- a/tests/multiphase_flow/check_hydro_force.cpp
+++ b/tests/multiphase_flow/check_hydro_force.cpp
@@ -41,6 +41,8 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -117,11 +119,8 @@ calculate_distance_analytically(Pointer<PatchHierarchy<NDIM> > patch_hierarchy, 
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -421,7 +420,7 @@ main(int argc, char* argv[])
         force_evaluator.computeHydrodynamicForceTorque(
             pressure_force, viscous_force, pressure_torque, viscous_torque, circle.X0);
 
-        if (SAMRAI_MPI::getRank() == 0)
+        if (IBTK_MPI::getRank() == 0)
         {
             std::ofstream out("output");
             out << "Vertical pressure force analytical = " << M_PI * circle.R * circle.R << std::endl;
@@ -442,7 +441,5 @@ main(int argc, char* argv[])
 
     } // cleanup dynamically allocated objects prior to shutdown
 
-    SAMRAIManager::shutdown();
-    PetscFinalize();
     return 0;
 } // main

--- a/tests/multiphase_flow/free_falling_cyl_cib.cpp
+++ b/tests/multiphase_flow/free_falling_cyl_cib.cpp
@@ -43,6 +43,8 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -59,17 +61,14 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Several parts of the code (such as LDataManager) expect mesh files,
     // specified in the input file, to exist in the current working
     // directory. Since tests are run in temporary directories we need to regenerate these input
     // to work.
-    if (SAMRAI_MPI::getRank() == 0)
+    if (IBTK_MPI::getRank() == 0)
     {
         std::ifstream structure_vertex_stream(SOURCE_DIR "/cylinder2d_free_fall.vertex");
         std::ofstream structure_cwd("cylinder2d_free_fall.vertex");
@@ -454,7 +453,7 @@ main(int argc, char* argv[])
 
         // File to write to for fluid mass data
         ofstream output_file;
-        if (!SAMRAI_MPI::getRank()) output_file.open("output");
+        if (!IBTK_MPI::getRank()) output_file.open("output");
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
@@ -492,7 +491,7 @@ main(int argc, char* argv[])
             IBTK::Vector3d pressure_force, viscous_force, pressure_torque, viscous_torque;
             hydro_force_evaluator->computeHydrodynamicForceTorque(
                 pressure_force, viscous_force, pressure_torque, viscous_torque, circle.X0);
-            if (SAMRAI_MPI::getRank() == 0)
+            if (IBTK_MPI::getRank() == 0)
             {
                 plog << "hyro forces: " << loop_time << '\t' << pressure_force[0] << '\t' << pressure_force[1] << '\t'
                      << pressure_force[2] << '\t' << viscous_force[0] << '\t' << viscous_force[1] << '\t'
@@ -503,7 +502,7 @@ main(int argc, char* argv[])
             }
 
             // Write the center of mass vertical position and velocity to a file
-            if (!SAMRAI_MPI::getRank())
+            if (!IBTK_MPI::getRank())
             {
                 output_file << std::setprecision(13) << loop_time << "\t" << structure_COM[0][1] << "\t"
                             << structure_Trans_Vel[0][1] << std::endl;
@@ -534,7 +533,7 @@ main(int argc, char* argv[])
         }
 
         // Close file
-        if (!SAMRAI_MPI::getRank()) output_file.close();
+        if (!IBTK_MPI::getRank()) output_file.close();
 
         // Cleanup Eulerian boundary condition specification objects (when
         // necessary).
@@ -549,7 +548,5 @@ main(int argc, char* argv[])
 
     } // cleanup dynamically allocated objects prior to shutdown
 
-    SAMRAIManager::shutdown();
-    PetscFinalize();
     return 0;
 } // main

--- a/tests/navier_stokes/navier_stokes_01.cpp
+++ b/tests/navier_stokes/navier_stokes_01.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -58,11 +60,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
         // prevent a warning about timer initializations
@@ -324,9 +323,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-    // double test_results[2] = {uMax_norm, pMax_norm};
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -340,7 +336,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/physical_boundary/01.cpp
+++ b/tests/physical_boundary/01.cpp
@@ -31,6 +31,7 @@
 #include <ibtk/CartCellRobinPhysBdryOp.h>
 #include <ibtk/CartExtrapPhysBdryOp.h>
 #include <ibtk/CartSideRobinPhysBdryOp.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/PhysicalBoundaryUtilities.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -71,11 +72,8 @@ quadratic_f(const double* const x)
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
         // prevent a warning about timer initialization
@@ -315,7 +313,5 @@ main(int argc, char* argv[])
 
     } // cleanup dynamically allocated objects prior to shutdown
 
-    SAMRAIManager::shutdown();
-    PetscFinalize();
     return 0;
 } // main

--- a/tests/physical_boundary/extrapolation_01.cpp
+++ b/tests/physical_boundary/extrapolation_01.cpp
@@ -30,6 +30,7 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartCellRobinPhysBdryOp.h>
 #include <ibtk/CartExtrapPhysBdryOp.h>
+#include <ibtk/IBTKInit.h>
 
 #include <LocationIndexRobinBcCoefs.h>
 
@@ -76,11 +77,8 @@ using fcn_type = double (*)(const double* const);
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
         // prevent a warning about timer initializations
@@ -332,7 +330,5 @@ main(int argc, char* argv[])
 
     } // cleanup dynamically allocated objects prior to shutdown
 
-    SAMRAIManager::shutdown();
-    PetscFinalize();
     return 0;
 } // main

--- a/tests/refine/rt0_refine_01.cpp
+++ b/tests/refine/rt0_refine_01.cpp
@@ -34,6 +34,8 @@
 #include <ibtk/CartSideDoubleRT0Refine.h>
 #include <ibtk/HierarchyGhostCellInterpolation.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 
 // Set up application namespace declarations
@@ -50,14 +52,11 @@
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // this test only works in serial
-    TBOX_ASSERT(SAMRAI_MPI::getNodes() == 1);
+    TBOX_ASSERT(IBTK_MPI::getNodes() == 1);
 
     // prevent a warning about timer initializations
     TimerManager::createManager(nullptr);
@@ -186,9 +185,4 @@ main(int argc, char* argv[])
         visit_writer->writePlotData(patch_hierarchy, 0, 0.0);
 #endif
     }
-
-    // At this point all SAMRAI, PETSc, and IBAMR objects have been cleaned
-    // up, so we shut things down in the opposite order of initialization:
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -24,29 +24,28 @@ inline void
 print_strings_on_plog_0(const std::string& out)
 {
     using namespace SAMRAI::tbox;
-    const int n_nodes = SAMRAI_MPI::getNodes();
+    const int n_nodes = IBTK_MPI::getNodes();
     std::vector<unsigned long> string_sizes(n_nodes);
 
     const unsigned long size = out.size();
     int ierr = MPI_Gather(
-        &size, 1, MPI_UNSIGNED_LONG, string_sizes.data(), 1, MPI_UNSIGNED_LONG, 0, SAMRAI_MPI::getCommunicator());
+        &size, 1, MPI_UNSIGNED_LONG, string_sizes.data(), 1, MPI_UNSIGNED_LONG, 0, IBTK_MPI::getCommunicator());
     TBOX_ASSERT(ierr == 0);
 
     // MPI_Gatherv would be more efficient, but this just a test so its
     // not too important
-    if (SAMRAI_MPI::getRank() == 0)
+    if (IBTK_MPI::getRank() == 0)
     {
         plog << out;
         for (int r = 1; r < n_nodes; ++r)
         {
             std::string input;
             input.resize(string_sizes[r]);
-            ierr =
-                MPI_Recv(&input[0], string_sizes[r], MPI_CHAR, r, 0, SAMRAI_MPI::getCommunicator(), MPI_STATUS_IGNORE);
+            ierr = MPI_Recv(&input[0], string_sizes[r], MPI_CHAR, r, 0, IBTK_MPI::getCommunicator(), MPI_STATUS_IGNORE);
             TBOX_ASSERT(ierr == 0);
             plog << input;
         }
     }
     else
-        MPI_Send(out.data(), size, MPI_CHAR, 0, 0, SAMRAI_MPI::getCommunicator());
+        MPI_Send(out.data(), size, MPI_CHAR, 0, 0, IBTK_MPI::getCommunicator());
 }

--- a/tests/unfinished-tests/Stokes-IB/test0/main.cpp
+++ b/tests/unfinished-tests/Stokes-IB/test0/main.cpp
@@ -44,6 +44,7 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartSideDoubleRT0Coarsen.h>
 #include <ibtk/CartSideDoubleRT0Refine.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/PETScMatUtilities.h>
@@ -480,11 +481,8 @@ void buildSAJCoarsestFromSAMRAIOperators(Mat& SAJ_coarse,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -683,7 +681,7 @@ main(int argc, char* argv[])
         // Get a sense of Lagrangian nodes distribution among processors
         PetscSynchronizedPrintf(PETSC_COMM_WORLD,
                                 "Local Lagrangian nodes on proc [%d] are : %d\n",
-                                SAMRAI_MPI::getRank(),
+                                IBTK_MPI::getRank(),
                                 lag_data_manager->getNumberOfLocalNodes(finest_ln));
         PetscSynchronizedFlush(PETSC_COMM_WORLD, PETSC_STDOUT);
 
@@ -885,8 +883,6 @@ main(int argc, char* argv[])
 
     } // cleanup dynamically allocated objects prior to shutdown
 
-    SAMRAIManager::shutdown();
-    PetscFinalize();
     return 0;
 } // main
 
@@ -930,7 +926,7 @@ buildSAJCoarsestFromSAMRAIOperators(Mat& SAJ_coarse,
         restriction_coarsen_algorithm->createSchedule(coarsest_level, finest_level);
 
     // Get DOFs info at the coarse and fine levels.
-    const int mpi_rank = SAMRAI_MPI::getRank();
+    const int mpi_rank = IBTK_MPI::getRank();
     const int n_local_coarsest = num_dofs_per_proc[coarsest_ln][mpi_rank];
     const int i_lower_coarsest =
         std::accumulate(num_dofs_per_proc[coarsest_ln].begin(), num_dofs_per_proc[coarsest_ln].begin() + mpi_rank, 0);

--- a/tests/unfinished-tests/Stokes-IB/test1/main.cpp
+++ b/tests/unfinished-tests/Stokes-IB/test1/main.cpp
@@ -36,6 +36,7 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/LData.h>
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
@@ -63,12 +64,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
-    SAMRAIManager::setMaxNumberPatchDataEntries(2056);
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -284,8 +281,6 @@ main(int argc, char* argv[])
 
     } // cleanup dynamically allocated objects prior to shutdown
 
-    SAMRAIManager::shutdown();
-    PetscFinalize();
     return 0;
 } // main
 
@@ -303,7 +298,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/unfinished-tests/Stokes/test0/main.cpp
+++ b/tests/unfinished-tests/Stokes/test0/main.cpp
@@ -33,6 +33,7 @@
 #include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 #include <ibtk/KrylovLinearSolver.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
@@ -58,11 +59,9 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -305,8 +304,6 @@ main(int argc, char* argv[])
 
     } // cleanup dynamically allocated objects prior to shutdown
 
-    SAMRAIManager::shutdown();
-    PetscFinalize();
     return 0;
 } // main
 
@@ -321,7 +318,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/vc_navier_stokes/vc_navier_stokes_01.cpp
+++ b/tests/vc_navier_stokes/vc_navier_stokes_01.cpp
@@ -31,6 +31,8 @@
 #include <ibamr/INSVCStaggeredNonConservativeHierarchyIntegrator.h>
 
 #include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
 
@@ -63,11 +65,8 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize PETSc, MPI, and SAMRAI.
-    PetscInitialize(&argc, &argv, NULL, NULL);
-    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
-    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
-    SAMRAIManager::startup();
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
 
     // Increase maximum patch data component indices
     SAMRAIManager::setMaxNumberPatchDataEntries(2500);
@@ -375,9 +374,6 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
-    // double test_results[2] = {uMax_norm, pMax_norm};
-    SAMRAIManager::shutdown();
-    PetscFinalize();
 } // main
 
 void
@@ -391,7 +387,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);


### PR DESCRIPTION
This replaces all instances of `SAMRAI_MPI` with the equivalent `IBTK_MPI` function. This also modifies all the examples and tests to use `IBTKInit` to initialize all the libraries. There is a perl script in `scripts/code_updates` that should automatically do most of the changes except for initializing the library. I couldn't find an effective way to automatically set up appropriate `IBTKInit` calls since that could change based on what libraries are being used, but it is simple to do by hand.

I also added an `IBTK_MPI` test and fixed a couple of bugs in `IBTK_MPI`.

 This will be the first set of changes that require users to change their code, so I suggest we don't merge until closer to a release (perhaps 1.0?). I'm posting this now so that we can start a review and so we don't forget about it. Any merge conflicts (of which there will probably be many) can be handled easily. This is a required patch before we can proceed with SAMRAI 3 updates.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
