### PR TITLE
Fix the merging algorithm used by MergingLoadBalancer.

### DIFF
--- a/ibtk/src/utilities/box_utilities.cpp
+++ b/ibtk/src/utilities/box_utilities.cpp
@@ -176,7 +176,10 @@ merge_boxes_by_longest_edge(const std::vector<SAMRAI::hier::Box<NDIM> >& input_b
         // 2. sort faces by size in *descending* order:
         std::vector<std::pair<hier::Index<NDIM>, hier::Index<NDIM> > > faces;
         for (const auto& pair : face_to_boxes) faces.push_back(pair.first);
-        std::sort(faces.begin(), faces.end(), IndexPairMagnitudeGreater());
+        // Since some faces have equal magnitudes but don't refer to the same
+        // slice of index space, use a stable sort to get platform-independent
+        // iteration order in step 3:
+        std::stable_sort(faces.begin(), faces.end(), IndexPairMagnitudeGreater());
 
         // 3. merge boxes.
         std::set<hier::Box<NDIM>, BoxLexical> removed_boxes;


### PR DESCRIPTION
We get different partitions with the libc++ version of std::sort() than the
libstdc++ version of std::sort(), so just use std::stable_sort() to get the same
thing in both cases.

Note that this is a problem with the original algorithm: since we sort by magnitudes many entries have (as far as the sorting algorithm can see) the same value. Hence two different unstable sorting algorithms yield two different results.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
