### PR TITLE
Fixed namespace issue for Vector in CIBMethod

### DIFF
--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -593,7 +593,7 @@ CIBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy,
         for (const auto& node_idx : local_nodes)
         {
             const int local_idx = node_idx->getLocalPETScIndex();
-            const Vector& displacement_0 = node_idx->getInitialPeriodicDisplacement();
+            const IBTK::Vector& displacement_0 = node_idx->getInitialPeriodicDisplacement();
             double* const X0_unshifted = &X0_unshifted_data_array[local_idx][0];
             const double* const X0 = &X0_data_array[local_idx][0];
 


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

Added IBTK namespace to a call to Vector in CIBMethod that was leading to compilation errors on the UNC longleaf system when using gcc 4.8.5 compilers.


### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
