### PR TITLE
Fix attest's busy wait again.

### DIFF
--- a/attest
+++ b/attest
@@ -452,7 +452,6 @@ def main():
     # 2. Run the tests!
     processors_in_use = 0
     n_tests = len(unstarted_tests)
-    n_executing_tests = 0
     n_passed_tests = 0
     n_finished_tests = 0
     failed_test_outputs = list()
@@ -471,7 +470,6 @@ def main():
         with result_update_lock:
             nonlocal n_passed_tests
             nonlocal processors_in_use
-            nonlocal n_executing_tests
             nonlocal failed_test_outputs
             nonlocal n_finished_tests
             test_output = future.result()
@@ -485,7 +483,6 @@ def main():
                 failed_test_outputs.append(test_output)
             processors_in_use -= test_output.n_mpi_processes()
             n_finished_tests += 1
-            n_executing_tests -= 1
 
             worker_available.set()
 
@@ -495,6 +492,7 @@ def main():
     with cf.ThreadPoolExecutor(2*n_processors) as executor:
         while len(unstarted_tests) != 0 or n_finished_tests < n_tests:
             # 2a. Start new tests:
+            n_new_tests = 0
             index = len(unstarted_tests) - 1
             while processors_in_use <= n_processors and len(unstarted_tests) != 0 and index != -1:
                 test = unstarted_tests[index]
@@ -510,15 +508,15 @@ def main():
                     future = executor.submit(test.run)
                     future.add_done_callback(deal_with_result)
                     processors_in_use += test.n_mpi_processes()
-                    n_executing_tests += 1
+                    n_new_tests += 1
                 index -= 1
 
             # Set 'no workers available' if either:
             # 1. we have maxed out the number of processors
-            # 2. we can only start one test (e.g., we have 6 processors and only
+            # 2. we cannot start any new tests (e.g., we have 6 processors and only
             #    tests that require 4 processors remaining)
             with result_update_lock:
-                if n_processors <= processors_in_use or n_executing_tests == 1:
+                if n_processors <= processors_in_use or n_new_tests == 0:
                     worker_available.clear()
 
             worker_available.wait()


### PR DESCRIPTION
The old check was too imprecise: if we are executing a single test we may still
be able to run more tests at the current time. Instead of waiting if we are only
running one test, instead wait if we couldn't launch any new tests.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?