### PR TITLE
Fix edge case in HR limiters

### DIFF
--- a/doc/news/changes/minor/20200528NishantNangia
+++ b/doc/news/changes/minor/20200528NishantNangia
@@ -1,0 +1,3 @@
+Bug Fix: Fixed a small bug in an edge case for the HR limiters used in the CUI, MGAMMA, and FBICS convective operators. Updated vc_navier_stokes tests."
+<br>
+(Nishant Nangia, 2020/05/28)

--- a/src/navier_stokes/fortran/navier_stokes_staggered_helpers2d.f.m4
+++ b/src/navier_stokes/fortran/navier_stokes_staggered_helpers2d.f.m4
@@ -886,18 +886,20 @@ c     High-resolution scheme (HR)
       ac = (qC - qU)/(qD - qU)
 
       if (qD - qU .eq. zero) then
-c       ac will be NaN, but qf = qU, so af can be any number
-        af = zero
-      else if (zero .lt. ac .and. ac .le. 2.d0/13.d0) then
-        af = three*ac
-      else if (2.d0/13.d0 .lt. ac .and. ac .le. 4.d0/5.d0) then
-        af = ac*5.d0/6.d0 + third
-      else if (4.d0/5.d0 .lt. ac .and. ac .le. one) then
-        af = one
+c       default to upwinding
+        qf = qC
       else
-        af = ac
+        if (zero .lt. ac .and. ac .le. 2.d0/13.d0) then
+          af = three*ac
+        else if (2.d0/13.d0 .lt. ac .and. ac .le. 4.d0/5.d0) then
+          af = ac*5.d0/6.d0 + third
+        else if (4.d0/5.d0 .lt. ac .and. ac .le. one) then
+          af = one
+        else
+          af = ac
+        endif
+        qf = af*(qD - qU) + qU
       endif
-      qf = af*(qD - qU) + qU
 
       return
       end
@@ -930,16 +932,18 @@ c     High-resolution scheme (HR)
       ac = (qC - qU)/(qD - qU)
 
       if (qD - qU .eq. zero) then
-c       ac will be NaN, but qf = qU, so af can be any number
-        af = zero
-      else if (zero .lt. ac .and. ac .le. third) then
-        af = three*ac
-      else if (third .lt. ac .and. ac .le. one) then
-        af = one
+c       default to upwinding
+        qf = qC
       else
-        af = ac
+        if (zero .lt. ac .and. ac .le. third) then
+          af = three*ac
+        else if (third .lt. ac .and. ac .le. one) then
+          af = one
+        else
+          af = ac
+        endif
+        qf = af*(qD - qU) + qU
       endif
-      qf = af*(qD - qU) + qU
 
       return
       end
@@ -972,18 +976,20 @@ c     High-resolution scheme (HR)
       ac = (qC - qU)/(qD - qU)
 
       if (qD - qU .eq. zero) then
-c       ac will be NaN, but qf = qU, so af can be any number
-        af = zero
-      else if (zero .lt. ac .and. ac .le. eighth) then
-        af = three*ac
-      else if (eighth .lt. ac .and. ac .le. threefourth) then
-        af = ac + fourth
-      else if (threefourth .lt. ac .and. ac .le. one) then
-        af = one
+c       default to upwinding
+        qf = qC
       else
-        af = ac
+        if (zero .lt. ac .and. ac .le. eighth) then
+          af = three*ac
+        else if (eighth .lt. ac .and. ac .le. threefourth) then
+          af = ac + fourth
+        else if (threefourth .lt. ac .and. ac .le. one) then
+          af = one
+        else
+          af = ac
+        endif
+        qf = af*(qD - qU) + qU
       endif
-      qf = af*(qD - qU) + qU
 
       return
       end
@@ -1016,16 +1022,18 @@ c     High-resolution scheme (HR)
       ac = (qC - qU)/(qD - qU)
 
       if (qD - qU .eq. zero) then
-c       ac will be NaN, but qf = qU, so af can be any number
-        af = zero
-      else if (zero .lt. ac .and. ac .le. fourth) then
-        af = 5.d0/2.d0*ac
-      else if (fourth .lt. ac .and. ac .le. one) then
-        af = half*ac + half
+c       default to upwinding
+        qf = qC
       else
-        af = ac
+        if (zero .lt. ac .and. ac .le. fourth) then
+          af = 5.d0/2.d0*ac
+        else if (fourth .lt. ac .and. ac .le. one) then
+          af = half*ac + half
+        else
+          af = ac
+        endif
+        qf = af*(qD - qU) + qU
       endif
-      qf = af*(qD - qU) + qU
 
       return
       end

--- a/src/navier_stokes/fortran/navier_stokes_staggered_helpers3d.f.m4
+++ b/src/navier_stokes/fortran/navier_stokes_staggered_helpers3d.f.m4
@@ -1530,18 +1530,20 @@ c     High-resolution scheme (HR)
       ac = (qC - qU)/(qD - qU)
 
       if (qD - qU .eq. zero) then
-c       ac will be NaN, but qf = qU, so af can be any number
-        af = zero
-      else if (zero .lt. ac .and. ac .le. 2.d0/13.d0) then
-        af = three*ac
-      else if (2.d0/13.d0 .lt. ac .and. ac .le. 4.d0/5.d0) then
-        af = ac*5.d0/6.d0 + third
-      else if (4.d0/5.d0 .lt. ac .and. ac .le. one) then
-        af = one
+c       default to upwinding
+        qf = qC
       else
-        af = ac
+        if (zero .lt. ac .and. ac .le. 2.d0/13.d0) then
+          af = three*ac
+        else if (2.d0/13.d0 .lt. ac .and. ac .le. 4.d0/5.d0) then
+          af = ac*5.d0/6.d0 + third
+        else if (4.d0/5.d0 .lt. ac .and. ac .le. one) then
+          af = one
+        else
+          af = ac
+        endif
+        qf = af*(qD - qU) + qU
       endif
-      qf = af*(qD - qU) + qU
 
       return
       end
@@ -1574,16 +1576,18 @@ c     High-resolution scheme (HR)
       ac = (qC - qU)/(qD - qU)
 
       if (qD - qU .eq. zero) then
-c       ac will be NaN, but qf = qU, so af can be any number
-        af = zero
-      else if (zero .lt. ac .and. ac .le. third) then
-        af = three*ac
-      else if (third .lt. ac .and. ac .le. one) then
-        af = one
+c       default to upwinding
+        qf = qC
       else
-        af = ac
+        if (zero .lt. ac .and. ac .le. third) then
+          af = three*ac
+        else if (third .lt. ac .and. ac .le. one) then
+          af = one
+        else
+          af = ac
+        endif
+        qf = af*(qD - qU) + qU
       endif
-      qf = af*(qD - qU) + qU
 
       return
       end
@@ -1616,18 +1620,20 @@ c     High-resolution scheme (HR)
       ac = (qC - qU)/(qD - qU)
 
       if (qD - qU .eq. zero) then
-c       ac will be NaN, but qf = qU, so af can be any number
-        af = zero
-      else if (zero .lt. ac .and. ac .le. eighth) then
-        af = three*ac
-      else if (eighth .lt. ac .and. ac .le. threefourth) then
-        af = ac + fourth
-      else if (threefourth .lt. ac .and. ac .le. one) then
-        af = one
+c       default to upwinding
+        qf = qC
       else
-        af = ac
+        if (zero .lt. ac .and. ac .le. eighth) then
+          af = three*ac
+        else if (eighth .lt. ac .and. ac .le. threefourth) then
+          af = ac + fourth
+        else if (threefourth .lt. ac .and. ac .le. one) then
+          af = one
+        else
+          af = ac
+        endif
+        qf = af*(qD - qU) + qU
       endif
-      qf = af*(qD - qU) + qU
 
       return
       end
@@ -1660,16 +1666,18 @@ c     High-resolution scheme (HR)
       ac = (qC - qU)/(qD - qU)
 
       if (qD - qU .eq. zero) then
-c       ac will be NaN, but qf = qU, so af can be any number
-        af = zero
-      else if (zero .lt. ac .and. ac .le. fourth) then
-        af = 5.d0/2.d0*ac
-      else if (fourth .lt. ac .and. ac .le. one) then
-        af = half*ac + half
-      else
-        af = ac
+c       default to upwinding
+        qf = qC
+        else
+        if (zero .lt. ac .and. ac .le. fourth) then
+          af = 5.d0/2.d0*ac
+        else if (fourth .lt. ac .and. ac .le. one) then
+          af = half*ac + half
+        else
+          af = ac
+        endif
+        qf = af*(qD - qU) + qU
       endif
-      qf = af*(qD - qU) + qU
 
       return
       end

--- a/tests/vc_navier_stokes/vc_navier_stokes_01_2d.output
+++ b/tests/vc_navier_stokes/vc_navier_stokes_01_2d.output
@@ -3,11 +3,11 @@
 Computing error norms.
 
 Error in u_sc at time 0.1:
-  L1-norm:  0.07771807007
-  L2-norm:  0.07174795242
-  max-norm: 0.1657323505
+  L1-norm:  0.07771976289
+  L2-norm:  0.07174914666
+  max-norm: 0.1657349066
 Error in p at time 0.0995:
-  L1-norm:  3.306383248
-  L2-norm:  15.79553067
-  max-norm: 149.7104123
+  L1-norm:  3.306466776
+  L2-norm:  15.7960284
+  max-norm: 149.7152267
 +++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/tests/vc_navier_stokes/vc_navier_stokes_01_3d.output
+++ b/tests/vc_navier_stokes/vc_navier_stokes_01_3d.output
@@ -3,11 +3,11 @@
 Computing error norms.
 
 Error in u_sc at time 0.01:
-  L1-norm:  0.02156099041
-  L2-norm:  0.0259667868
-  max-norm: 0.2549433518
+  L1-norm:  0.02155960838
+  L2-norm:  0.02596636562
+  max-norm: 0.2550021169
 Error in p at time 0.00975:
-  L1-norm:  0.859512265
-  L2-norm:  4.653779979
-  max-norm: 147.3544914
+  L1-norm:  0.8595617532
+  L2-norm:  4.655556503
+  max-norm: 147.3943065
 +++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?

This PR fixes a small bug in an edge case in the HR limiters used for the CUI, MGAMMA, and FBICS convective operator. I verified that this fix does not significantly change the order of accuracy of these operators, but it does change the output of two of the tests (which I went ahead and modified so that they pass).
