### PR TITLE
Fix detection of newer versions of hypre.

### DIFF
--- a/configure
+++ b/configure
@@ -28828,9 +28828,9 @@ fi
 
   LDFLAGS="$HYPRE_LDFLAGS $LDFLAGS"
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for BoomerAMGCreate in -lHYPRE" >&5
-$as_echo_n "checking for BoomerAMGCreate in -lHYPRE... " >&6; }
-if ${ac_cv_lib_HYPRE_BoomerAMGCreate+:} false; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for HYPRE_BoomerAMGCreate in -lHYPRE" >&5
+$as_echo_n "checking for HYPRE_BoomerAMGCreate in -lHYPRE... " >&6; }
+if ${ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
@@ -28844,7 +28844,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char BoomerAMGCreate ();
+char HYPRE_BoomerAMGCreate ();
 #ifdef FC_DUMMY_MAIN
 #ifndef FC_DUMMY_MAIN_EQ_F77
 #  ifdef __cplusplus
@@ -28856,23 +28856,23 @@ char BoomerAMGCreate ();
 int
 main ()
 {
-return BoomerAMGCreate ();
+return HYPRE_BoomerAMGCreate ();
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_cxx_try_link "$LINENO"; then :
-  ac_cv_lib_HYPRE_BoomerAMGCreate=yes
+  ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate=yes
 else
-  ac_cv_lib_HYPRE_BoomerAMGCreate=no
+  ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_HYPRE_BoomerAMGCreate" >&5
-$as_echo "$ac_cv_lib_HYPRE_BoomerAMGCreate" >&6; }
-if test "x$ac_cv_lib_HYPRE_BoomerAMGCreate" = xyes; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate" >&5
+$as_echo "$ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate" >&6; }
+if test "x$ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate" = xyes; then :
   cat >>confdefs.h <<_ACEOF
 #define HAVE_LIBHYPRE 1
 _ACEOF

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -27767,9 +27767,9 @@ fi
 
   LDFLAGS="$HYPRE_LDFLAGS $LDFLAGS"
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for BoomerAMGCreate in -lHYPRE" >&5
-$as_echo_n "checking for BoomerAMGCreate in -lHYPRE... " >&6; }
-if ${ac_cv_lib_HYPRE_BoomerAMGCreate+:} false; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for HYPRE_BoomerAMGCreate in -lHYPRE" >&5
+$as_echo_n "checking for HYPRE_BoomerAMGCreate in -lHYPRE... " >&6; }
+if ${ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
@@ -27783,7 +27783,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char BoomerAMGCreate ();
+char HYPRE_BoomerAMGCreate ();
 #ifdef FC_DUMMY_MAIN
 #ifndef FC_DUMMY_MAIN_EQ_F77
 #  ifdef __cplusplus
@@ -27795,23 +27795,23 @@ char BoomerAMGCreate ();
 int
 main ()
 {
-return BoomerAMGCreate ();
+return HYPRE_BoomerAMGCreate ();
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_cxx_try_link "$LINENO"; then :
-  ac_cv_lib_HYPRE_BoomerAMGCreate=yes
+  ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate=yes
 else
-  ac_cv_lib_HYPRE_BoomerAMGCreate=no
+  ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_HYPRE_BoomerAMGCreate" >&5
-$as_echo "$ac_cv_lib_HYPRE_BoomerAMGCreate" >&6; }
-if test "x$ac_cv_lib_HYPRE_BoomerAMGCreate" = xyes; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate" >&5
+$as_echo "$ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate" >&6; }
+if test "x$ac_cv_lib_HYPRE_HYPRE_BoomerAMGCreate" = xyes; then :
   cat >>confdefs.h <<_ACEOF
 #define HAVE_LIBHYPRE 1
 _ACEOF

--- a/m4/configure_hypre.m4
+++ b/m4/configure_hypre.m4
@@ -43,7 +43,7 @@ else
   AC_CHECK_HEADER([HYPRE.h],,AC_MSG_ERROR([could not find header file HYPRE.h]))
 
   LDFLAGS_PREPEND($HYPRE_LDFLAGS)
-  AC_CHECK_LIB([HYPRE], BoomerAMGCreate, [],
+  AC_CHECK_LIB([HYPRE], HYPRE_BoomerAMGCreate, [],
                [AC_MSG_ERROR([could not find working libHYPRE])])
   ADD_RPATH_LDFLAG(${HYPRE_DIR}/lib)
 fi


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

New versions of hypre removed these very old symbols. I checked that the version of hypre downloaded with PETSc 3.7.7 still works with IBAMR.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
