### PR TITLE
CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,9 @@ SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 #
 # With modern CMake, each find module uses the environment variable ending in
 # _ROOT to look for an installation.
-SET(_roots "Boost_ROOT" "Eigen3_ROOT" "HDF5_ROOT" "HYPRE_ROOT" "LIBMESH_ROOT"
-  "MUPARSER_ROOT" "MPI_ROOT" "NUMDIFF_ROOT" "PETSC_ROOT" "SAMRAI_ROOT"
-  "SILO_ROOT" "ZLIB_ROOT")
+SET(_roots "Boost_ROOT" "Eigen3_ROOT" "GSL_ROOT" "HDF5_ROOT" "HYPRE_ROOT"
+  "LIBMESH_ROOT" "MUPARSER_ROOT" "MPI_ROOT" "NUMDIFF_ROOT" "PETSC_ROOT"
+  "SAMRAI_ROOT" "SILO_ROOT" "ZLIB_ROOT")
 FOREACH(_root ${_roots})
   IF("${${_root}}" STREQUAL "")
     MESSAGE(STATUS "${_root} was not provided to CMake: default search paths will be used.")
@@ -465,6 +465,15 @@ ELSE()
   MESSAGE(STATUS "SILO_ROOT was not specified so IBAMR will be configured without it.")
 ENDIF()
 
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Setting up GSL")
+SET(IBAMR_HAVE_GSL FALSE)
+# GSL has not yet been updated to the modern convention so help it
+SET(GSL_ROOT_DIR GSL_ROOT)
+FIND_PACKAGE(GSL)
+IF(GSL_FOUND)
+  SET(IBAMR_HAVE_GSL TRUE)
+ENDIF()
 
 # ---------------------------------------------------------------------------- #
 #                       3: IBAMR-specific configuration                        #
@@ -695,3 +704,4 @@ ADD_SUBDIRECTORY(ibtk)
 ADD_SUBDIRECTORY(src)
 
 ADD_SUBDIRECTORY(tests)
+ADD_SUBDIRECTORY(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,8 @@ SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # With modern CMake, each find module uses the environment variable ending in
 # _ROOT to look for an installation.
 SET(_roots "Boost_ROOT" "Eigen3_ROOT" "HDF5_ROOT" "HYPRE_ROOT" "LIBMESH_ROOT"
-  "MUPARSER_ROOT" "MPI_ROOT" "PETSC_ROOT" "SAMRAI_ROOT" "SILO_ROOT" "ZLIB_ROOT")
+  "MUPARSER_ROOT" "MPI_ROOT" "NUMDIFF_ROOT" "PETSC_ROOT" "SAMRAI_ROOT"
+  "SILO_ROOT" "ZLIB_ROOT")
 FOREACH(_root ${_roots})
   IF("${${_root}}" STREQUAL "")
     MESSAGE(STATUS "${_root} was not provided to CMake: default search paths will be used.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,696 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------- #
+#            0: Set up some basic information about the environment            #
+# ---------------------------------------------------------------------------- #
+CMAKE_MINIMUM_REQUIRED(VERSION 3.15.0)
+FILE(STRINGS "${CMAKE_SOURCE_DIR}/VERSION" _version LIMIT_COUNT 1)
+STRING(REGEX REPLACE "^([0-9]+)\\..*" "\\1" IBTK_VERSION_MAJOR "${_version}")
+
+STRING(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" IBTK_VERSION_MINOR "${_version}")
+STRING(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" IBTK_VERSION_SUBMINOR "${_version}")
+SET(IBTK_VERSION ${IBTK_VERSION_MAJOR}.${IBTK_VERSION_MINOR}.${IBTK_VERSION_SUBMINOR})
+SET(IBAMR_VERSION ${IBTK_VERSION})
+
+PROJECT(IBAMR
+  DESCRIPTION "Software infrastructure for the IB method with adaptively-refined grids"
+  VERSION ${IBAMR_VERSION}
+  HOMEPAGE_URL "https://ibamr.github.io"
+  # include C so that we can link against C libraries (e.g., MPI::MPI_C) easily
+  LANGUAGES C CXX Fortran)
+SET(IBAMR_DIMENSIONS "2" "3")
+
+MESSAGE(STATUS "This is CMake ${CMAKE_VERSION}")
+MESSAGE(STATUS "")
+INCLUDE(GNUInstallDirs)
+INCLUDE(CMakePackageConfigHelpers)
+LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
+
+# determine some details about the current Fortran compiler:
+INCLUDE(FortranCInterface)
+IF("${FortranCInterface_GLOBAL_CASE}" STREQUAL "LOWER")
+  SET(_name "name")
+ELSE()
+  SET(_name "NAME")
+ENDIF()
+STRING(JOIN " ## " IBTK_FC_FUNC ${FortranCInterface_GLOBAL_PREFIX} ${_name}
+  ${FortranCInterface_GLOBAL_SUFFIX})
+
+IF("${FortranCInterface_GLOBAL__CASE}" STREQUAL "LOWER")
+  SET(_name "name")
+ELSE()
+  SET(_name "NAME")
+ENDIF()
+STRING(JOIN " ## " IBTK_FC_FUNC_ ${FortranCInterface_GLOBAL__PREFIX} ${_name}
+  ${FortranCInterface_GLOBAL__SUFFIX})
+
+# also look for a compatible _Pragma implementation:
+INCLUDE(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES(
+  "
+  _Pragma(\"GCC diagnostic push\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunknown-pragmas\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wpragmas\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wextra\\\\\\\"\")
+  _Pragma(\"GCC diagnostic pop\")
+  int main() {}
+  "
+  IBTK_HAVE_PRAGMA_KEYWORD)
+
+# we need this since SAMRAI is usually statically linked
+SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# print out the relevant command line arguments to make debugging easier
+#
+# With modern CMake, each find module uses the environment variable ending in
+# _ROOT to look for an installation.
+SET(_roots "Boost_ROOT" "Eigen3_ROOT" "HDF5_ROOT" "HYPRE_ROOT" "LIBMESH_ROOT"
+  "MUPARSER_ROOT" "MPI_ROOT" "PETSC_ROOT" "SAMRAI_ROOT" "SILO_ROOT" "ZLIB_ROOT")
+FOREACH(_root ${_roots})
+  IF("${${_root}}" STREQUAL "")
+    MESSAGE(STATUS "${_root} was not provided to CMake: default search paths will be used.")
+  ELSE()
+    MESSAGE(STATUS "${_root}=${${_root}}")
+  ENDIF()
+ENDFOREACH()
+
+# ---------------------------------------------------------------------------- #
+#                       1: manage mandatory dependencies                       #
+# ---------------------------------------------------------------------------- #
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Setting up MPI")
+FIND_PACKAGE(MPI REQUIRED)
+MESSAGE(STATUS "MPI_C_INCLUDE_DIRS: ${MPI_C_INCLUDE_DIRS}")
+MESSAGE(STATUS "MPI_C_LIBRARIES: ${MPI_C_LIBRARIES}")
+
+#
+# Boost, which may be bundled:
+#
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Setting up Boost")
+FIND_PACKAGE(Boost 1.57 QUIET)
+IF(${Boost_FOUND})
+  SET(IBAMR_USE_BUNDLED_Boost FALSE)
+  MESSAGE(STATUS "Found external boost ${Boost_VERSION} at ${Boost_INCLUDE_DIRS}")
+ELSE()
+  SET(IBAMR_USE_BUNDLED_Boost TRUE)
+  MESSAGE(STATUS "Setting up boost as a bundled dependency")
+  ADD_LIBRARY(BUNDLED_Boost INTERFACE)
+  TARGET_INCLUDE_DIRECTORIES(
+    BUNDLED_Boost
+    INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/ibtk/contrib/boost>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/contrib/boost>)
+  INSTALL(DIRECTORY ${PROJECT_SOURCE_DIR}/ibtk/contrib/boost DESTINATION include/contrib)
+  INSTALL(TARGETS BUNDLED_Boost EXPORT IBAMRTargets)
+ENDIF()
+
+#
+# Eigen, which may be bundled:
+#
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Setting up Eigen")
+FIND_PACKAGE(Eigen3 3.2.5 QUIET)
+IF(${Eigen3_FOUND})
+  SET(IBAMR_USE_BUNDLED_Eigen FALSE)
+  MESSAGE(STATUS "Found external Eigen ${Eigen3_VERSION} at ${EIGEN3_INCLUDE_DIRS}")
+ELSE()
+  SET(IBAMR_USE_BUNDLED_Eigen TRUE)
+  MESSAGE(STATUS "Setting up Eigen as a bundled dependency")
+  ADD_LIBRARY(BUNDLED_Eigen INTERFACE)
+  TARGET_INCLUDE_DIRECTORIES(
+    BUNDLED_Eigen
+    INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/ibtk/contrib/eigen>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/contrib/eigen>)
+  INSTALL(DIRECTORY ${PROJECT_SOURCE_DIR}/ibtk/contrib/eigen/Eigen DESTINATION include/contrib)
+  INSTALL(DIRECTORY ${PROJECT_SOURCE_DIR}/ibtk/contrib/eigen/unsupported DESTINATION include/contrib)
+  INSTALL(TARGETS BUNDLED_Eigen EXPORT IBAMRTargets)
+ENDIF()
+
+#
+# muParser, which may be bundled:
+#
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Setting up muParser")
+FIND_PATH(MUPARSER_INCLUDE_DIRS NAMES muParser.h HINTS ${MUPARSER_ROOT}/include /usr/include/)
+FIND_LIBRARY(MUPARSER_LIBRARIES NAMES muparser HINTS ${MUPARSER_ROOT}/lib /usr/lib)
+IF("${MUPARSER_INCLUDE_DIRS}" STREQUAL "MUPARSER_INCLUDE_DIRS-NOTFOUND" OR
+   "${MUPARSER_LIBRARIES}" STREQUAL "MUPARSER_LIBRARIES-NOTFOUND")
+  SET(IBAMR_USE_BUNDLED_muParser TRUE)
+  MESSAGE(STATUS "Setting up muParser as a bundled dependency")
+  ADD_LIBRARY(BUNDLED_muParser SHARED)
+  TARGET_INCLUDE_DIRECTORIES(
+    BUNDLED_muParser
+    PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/ibtk/contrib/muparser/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/contrib/muparser>)
+  SET_PROPERTY(TARGET BUNDLED_muParser PROPERTY CXX_STANDARD 11)
+  TARGET_COMPILE_FEATURES(BUNDLED_muParser PUBLIC cxx_std_11)
+
+  TARGET_SOURCES(BUNDLED_muParser
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/src/muParser.cpp
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/src/muParserBase.cpp
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/src/muParserBytecode.cpp
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/src/muParserCallback.cpp
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/src/muParserDLL.cpp
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/src/muParserError.cpp
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/src/muParserInt.cpp
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/src/muParserTest.cpp
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/src/muParserTokenReader.cpp)
+
+  INSTALL(FILES
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParser.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserBase.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserBytecode.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserCallback.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserDLL.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserDef.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserError.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserFixes.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserInt.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserStack.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserTemplateMagic.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserTest.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserToken.h
+    ${CMAKE_SOURCE_DIR}/ibtk/contrib/muparser/include/muParserTokenReader.h
+    DESTINATION include/contrib/muparser)
+  INSTALL(TARGETS BUNDLED_muParser EXPORT IBAMRTargets)
+ELSE()
+  SET(IBAMR_USE_BUNDLED_muParser FALSE)
+  MESSAGE(STATUS "MUPARSER_INCLUDE_DIRS: ${MUPARSER_INCLUDE_DIRS}")
+  MESSAGE(STATUS "MUPARSER_LIBRARIES: ${MUPARSER_LIBRARIES}")
+ENDIF()
+
+#
+# HDF5:
+#
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Setting up HDF5")
+SET(HDF5_FIND_DEBUG TRUE)
+FIND_PACKAGE(HDF5 REQUIRED COMPONENTS C)
+IF("${HDF5_LIBRARIES}" STREQUAL "HDF5_LIBRARIES-NOTFOUND")
+  MESSAGE(FATAL_ERROR "Unable to find a valid HDF5 installation.")
+ENDIF()
+
+#
+# hypre:
+#
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Setting up HYPRE")
+FIND_PATH(HYPRE_INCLUDE_DIRS REQUIRED NAMES HYPRE.h HINTS ${HYPRE_ROOT}/include /usr/include/hypre)
+MESSAGE(STATUS "HYPRE_INCLUDE_DIRS: ${HYPRE_INCLUDE_DIRS}")
+FIND_LIBRARY(HYPRE_LIBRARIES REQUIRED NAMES HYPRE HINTS ${HYPRE_ROOT}/lib /usr/lib)
+MESSAGE(STATUS "HYPRE_LIBRARIES: ${HYPRE_LIBRARIES}")
+IF(${HYPRE_INCLUDE_DIRS} STREQUAL "HYPRE_INCLUDE_DIRS-NOTFOUND" OR
+   ${HYPRE_LIBRARIES} STREQUAL "HYPRE_LIBRARIES-NOTFOUND")
+  MESSAGE(FATAL_ERROR "Unable to find a valid HYPRE installation.")
+ENDIF()
+
+#
+# SAMRAI:
+#
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Setting up SAMRAI")
+SET(_samrai_library_suffixes "algs" "appu" "geom" "hier"
+  "math_std" "mesh" "pdat_std" "solv" "xfer")
+
+# samrai version info:
+FILE(STRINGS "${SAMRAI_ROOT}/include/SAMRAI_config.h" SAMRAI_VERSION_MAJOR_LINE
+  REGEX "#define.*SAMRAI_VERSION_MAJOR")
+STRING(REGEX REPLACE "^.*SAMRAI_VERSION_MAJOR.* ([0-9]+).*" "\\1"
+  SAMRAI_VERSION_MAJOR "${SAMRAI_VERSION_MAJOR_LINE}"
+  )
+FILE(STRINGS "${SAMRAI_ROOT}/include/SAMRAI_config.h" SAMRAI_VERSION_MINOR_LINE
+  REGEX "#define.*SAMRAI_VERSION_MINOR")
+STRING(REGEX REPLACE "^.*SAMRAI_VERSION_MINOR.* ([0-9]+).*" "\\1"
+  SAMRAI_VERSION_MINOR "${SAMRAI_VERSION_MINOR_LINE}"
+  )
+FILE(STRINGS "${SAMRAI_ROOT}/include/SAMRAI_config.h" SAMRAI_VERSION_PATCHLEVEL_LINE
+  REGEX "#define.*SAMRAI_VERSION_PATCHLEVEL")
+STRING(REGEX REPLACE "^.*SAMRAI_VERSION_PATCHLEVEL.* ([0-9]+).*" "\\1"
+  SAMRAI_VERSION_PATCHLEVEL "${SAMRAI_VERSION_PATCHLEVEL_LINE}"
+  )
+SET(SAMRAI_VERSION_STRING "${SAMRAI_VERSION_MAJOR}.${SAMRAI_VERSION_MINOR}\
+.${SAMRAI_VERSION_PATCHLEVEL}")
+MESSAGE(STATUS "Found SAMRAI ${SAMRAI_VERSION_STRING} at ${SAMRAI_ROOT}")
+
+# samrai libs:
+SET(SAMRAI_INCLUDE_DIRS "${SAMRAI_ROOT}/include")
+SET(SAMRAI2d_LIBRARIES)
+SET(SAMRAI3d_LIBRARIES)
+ADD_LIBRARY(SAMRAI UNKNOWN IMPORTED)
+FIND_LIBRARY(SAMRAI_path SAMRAI REQUIRED HINTS "${SAMRAI_ROOT}/lib")
+LIST(APPEND SAMRAI2d_LIBRARIES ${SAMRAI_path})
+LIST(APPEND SAMRAI3d_LIBRARIES ${SAMRAI_path})
+
+FOREACH(_d ${IBAMR_DIMENSIONS})
+  FOREACH(_suffix ${_samrai_library_suffixes})
+    SET(_lib_name "SAMRAI${_d}d_${_suffix}")
+    ADD_LIBRARY( ${_lib_name} UNKNOWN IMPORTED)
+
+    FIND_LIBRARY("${_lib_name}_path" ${_lib_name} REQUIRED
+      HINTS "${SAMRAI_ROOT}/lib")
+    IF("${${_lib_name}_path}" STREQUAL "${_lib_name}-NOTFOUND")
+      MESSAGE(FATAL_ERROR
+"Unable to find required library ${_lib_name} in directory ${SAMRAI_ROOT}/lib")
+    ENDIF()
+
+    LIST(APPEND "SAMRAI${_d}d_LIBRARIES" "${${_lib_name}_path}")
+  ENDFOREACH()
+ENDFOREACH()
+
+#
+# PETSc:
+#
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Setting up PETSc")
+FIND_FILE(PETSC_VARIABLES_FILE petscvariables HINTS ${PETSC_ROOT} PATH_SUFFIXES conf lib/petsc/conf)
+IF(${PETSC_VARIABLES_FILE} STREQUAL "PETSC_VARIABLES_FILE-NOTFOUND")
+  MESSAGE(FATAL_ERROR "unable to find the petscvariables configuration file")
+ELSE()
+  FILE(STRINGS ${PETSC_VARIABLES_FILE} _petsc_raw_includes REGEX "^PETSC_CC_INCLUDES =.*")
+  IF ("${_petsc_raw_includes}" STREQUAL "")
+    MESSAGE(FATAL_ERROR
+"The configuration script was unable to find the list of                       \
+PETSc include directories in the file ${PETSC_VARIABLES_FILE}. This usually    \
+indicates that PETSC_ROOT was set to PETSC_DIR when it should be set to        \
+PETSC_DIR/PETSC_ARCH (i.e., PETSC_ROOT must be set to the complete path to the \
+PETSc installation).")
+  ENDIF()
+  STRING(REGEX REPLACE "^PETSC_CC_INCLUDES =(.*)" "\\1" _petsc_raw_includes ${_petsc_raw_includes})
+  SEPARATE_ARGUMENTS(_petsc_raw_includes)
+  # Get rid of preceding -Is (CMake wants just directory names):
+  FOREACH(_include ${_petsc_raw_includes})
+    STRING(REGEX REPLACE "^-I" "" _directory "${_include}")
+    LIST(APPEND PETSC_INCLUDE_DIRS ${_directory})
+  ENDFOREACH()
+
+  FILE(STRINGS ${PETSC_VARIABLES_FILE} PETSC_LIBRARIES REGEX "^PETSC_WITH_EXTERNAL_LIB =.*")
+  STRING(REGEX REPLACE "^PETSC_WITH_EXTERNAL_LIB =(.*)" "\\1" PETSC_LIBRARIES ${PETSC_LIBRARIES})
+  SEPARATE_ARGUMENTS(PETSC_LIBRARIES)
+
+  # extract the version numbers:
+  FIND_FILE(PETSC_VERSION_FILE petscversion.h HINTS ${PETSC_ROOT} PATH_SUFFIXES include)
+  FILE(STRINGS "${PETSC_VERSION_FILE}" PETSC_VERSION_MAJOR_STRING
+    REGEX "#define.*PETSC_VERSION_MAJOR")
+  STRING(REGEX REPLACE "^.*PETSC_VERSION_MAJOR.* ([0-9]+).*" "\\1"
+    PETSC_VERSION_MAJOR "${PETSC_VERSION_MAJOR_STRING}"
+    )
+  FILE(STRINGS "${PETSC_VERSION_FILE}" PETSC_VERSION_MINOR_STRING
+    REGEX "#define.*PETSC_VERSION_MINOR")
+  STRING(REGEX REPLACE "^.*PETSC_VERSION_MINOR.* ([0-9]+).*" "\\1"
+    PETSC_VERSION_MINOR "${PETSC_VERSION_MINOR_STRING}"
+    )
+  FILE(STRINGS "${PETSC_VERSION_FILE}" PETSC_VERSION_SUBMINOR_STRING
+    REGEX "#define.*PETSC_VERSION_SUBMINOR")
+  STRING(REGEX REPLACE "^.*PETSC_VERSION_SUBMINOR.* ([0-9]+).*" "\\1"
+    PETSC_VERSION_SUBMINOR "${PETSC_VERSION_SUBMINOR_STRING}"
+    )
+  SET(PETSC_VERSION
+    "${PETSC_VERSION_MAJOR}.${PETSC_VERSION_MINOR}.${PETSC_VERSION_SUBMINOR}")
+  IF(${PETSC_VERSION} VERSION_LESS 3.7.0)
+    MESSAGE(FATAL_ERROR
+"IBAMR requires PETSc version 3.7.0 or newer but the version provided at
+${PETSC_ROOT} is version ${PETSC_VERSION}")
+    ENDIF()
+ENDIF()
+
+# ---------------------------------------------------------------------------- #
+#                       2: manage optional dependencies                        #
+# ---------------------------------------------------------------------------- #
+MESSAGE(STATUS "")
+SET(IBAMR_HAVE_LIBMESH FALSE)
+IF(NOT "${LIBMESH_ROOT}" STREQUAL "")
+  MESSAGE(STATUS "Setting up libMesh")
+  FIND_PROGRAM(_libmesh_config "libmesh-config" HINTS ${LIBMESH_ROOT}/bin/)
+  IF("${_libmesh_config}" STREQUAL "_libmesh_config-NOTFOUND")
+    MESSAGE(FATAL_ERROR "\
+libMesh (an optional dependency) was specified with LIBMESH_ROOT=${LIBMESH_ROOT}
+but a valid libmesh-config script could not be found in ${LIBMESH_ROOT}/bin/.
+Please check the value of LIBMESH_ROOT and rerun CMake.")
+  ELSE()
+    SET(IBAMR_HAVE_LIBMESH TRUE)
+    # libMesh requires that we set an environment variable to query libmesh-config
+    STRING(TOLOWER ${LIBMESH_METHOD} _lower_method)
+    SET(ENV{METHOD} ${_lower_method})
+    EXECUTE_PROCESS(COMMAND "${_libmesh_config}" "--version"
+      OUTPUT_VARIABLE LIBMESH_VERSION)
+    STRING(REGEX REPLACE "\n$" "" LIBMESH_VERSION ${LIBMESH_VERSION})
+    IF(${LIBMESH_VERSION} VERSION_LESS 1.1.0)
+      MESSAGE(FATAL_ERROR
+"IBAMR requires libMesh version 1.1.0 or newer but the version provided at
+${LIBMESH_ROOT} is version ${LIBMESH_VERSION}")
+    ENDIF()
+
+    # Extract libraries and convert to a CMake list:
+    EXECUTE_PROCESS(COMMAND "${_libmesh_config}" "--libs" OUTPUT_VARIABLE LIBMESH_LIBRARIES)
+    STRING(REGEX REPLACE "\n$" "" LIBMESH_LIBRARIES ${LIBMESH_LIBRARIES})
+    SEPARATE_ARGUMENTS(LIBMESH_LIBRARIES)
+    FIND_LIBRARY(LIBMESH_LIBRARY REQUIRED NAMES "mesh_${_lower_method}" HINTS ${LIBMESH_ROOT}/lib)
+    IF("${LIBMESH_LIBRARY}" STREQUAL "${LIBMESH_LIBRARY}-NOTFOUND")
+      MESSAGE(FATAL_ERROR "
+Unable to find the libMesh library itself. This usually happens when either \
+libMesh is installed incorrectly or the wrong LIBMESH_METHOD was given to \
+CMake.")
+    ENDIF()
+    LIST(PREPEND LIBMESH_LIBRARIES ${LIBMESH_LIBRARY})
+    MESSAGE(STATUS "LIBMESH_LIBRARIES: ${LIBMESH_LIBRARIES}")
+
+    EXECUTE_PROCESS(COMMAND "${_libmesh_config}" "--include" OUTPUT_VARIABLE _libmesh_raw_includes)
+    STRING(REGEX REPLACE "\n$" "" _libmesh_raw_includes ${_libmesh_raw_includes})
+    SEPARATE_ARGUMENTS(_libmesh_raw_includes)
+    MESSAGE(STATUS "LIBMESH_INCLUDES: ${LIBMESH_INCLUDES}")
+    # Get rid of preceding -Is (CMake wants just directory names):
+    SET(LIBMESH_INCLUDE_DIRS)
+    FOREACH(_include ${_libmesh_raw_includes})
+      STRING(REGEX REPLACE "^-I" "" _directory "${_include}")
+      LIST(APPEND LIBMESH_INCLUDE_DIRS ${_directory})
+    ENDFOREACH()
+
+    # we won't use it directly but see if libMesh expects C++14 by checking its C++ flags:
+    EXECUTE_PROCESS(COMMAND "${_libmesh_config}" "--cxxflags" OUTPUT_VARIABLE _libmesh_cxxflags)
+    STRING(REGEX REPLACE "\n$" "" _libmesh_cxxflags ${_libmesh_cxxflags})
+    SEPARATE_ARGUMENTS(_libmesh_cxxflags)
+
+    SET(CMAKE_REQUIRED_INCLUDES "${LIBMESH_INCLUDE_DIRS}")
+    SET(CMAKE_REQUIRED_FLAGS "${_libmesh_cxxflags}")
+    CHECK_CXX_SOURCE_COMPILES(
+      "
+      #include <libmesh/libmesh_config.h>
+      #ifdef LIBMESH_HAVE_CXX14_MAKE_UNIQUE
+      // OK
+      #else
+      #error
+      #endif
+      int main() {}
+      "
+      LIBMESH_WITH_CXX14
+      )
+    CHECK_CXX_SOURCE_COMPILES(
+      "
+      #include <libmesh/libmesh_config.h>
+      #ifdef LIBMESH_HAVE_PETSC
+      // OK
+      #else
+      #error
+      #endif
+      int main() {}
+      "
+      LIBMESH_WITH_PETSC
+      )
+    IF(NOT "${LIBMESH_WITH_PETSC}")
+      MESSAGE(FATAL_ERROR "IBAMR requires that libMesh be compiled with PETSc.")
+    ENDIF()
+    CHECK_CXX_SOURCE_COMPILES(
+      "
+      #include <libmesh/libmesh_config.h>
+      #if LIBMESH_DETECTED_PETSC_VERSION_MAJOR != ${PETSC_VERSION_MAJOR}
+      #error
+      #endif
+      #if LIBMESH_DETECTED_PETSC_VERSION_MINOR != ${PETSC_VERSION_MINOR}
+      #error
+      #endif
+      #if LIBMESH_DETECTED_PETSC_VERSION_SUBMINOR != ${PETSC_VERSION_SUBMINOR}
+      #error
+      #endif
+      int main() {}
+      "
+      LIBMESH_WITH_SAME_PETSC
+      )
+    IF(NOT "${LIBMESH_WITH_SAME_PETSC}")
+      MESSAGE(FATAL_ERROR "\
+The version of PETSc detected by libMesh differs from the version of PETSc
+detected by IBAMR. This is not allowed.")
+    ENDIF()
+
+    SET(CMAKE_REQUIRED_INCLUDES "")
+    SET(CMAKE_REQUIRED_FLAGS "")
+  ENDIF()
+ELSE()
+  MESSAGE(STATUS "LIBMESH_ROOT was not specified so IBAMR will be configured without it.")
+ENDIF()
+
+MESSAGE(STATUS "")
+SET(IBAMR_HAVE_SILO FALSE)
+IF(NOT "${LIBMESH_ROOT}" STREQUAL "")
+  MESSAGE(STATUS "Setting up Silo")
+  FIND_PATH(SILO_INCLUDE_DIRS NAMES silo.h HINTS ${SILO_ROOT}/include /usr/include/)
+  FIND_LIBRARY(SILO_LIBRARIES NAMES silo siloh5 HINTS ${SILO_ROOT}/lib /usr/lib)
+  IF(NOT "${SILO_LIBRARIES}" STREQUAL "SILO_LIBRARIES-NOTFOUND" AND
+      NOT "${SILO_INCLUDE_DIRS}" STREQUAL "SILO_INCLUDE_DIRS-NOTFOUND")
+    MESSAGE(STATUS "SILO_INCLUDE_DIRS: ${SILO_INCLUDE_DIRS}")
+    MESSAGE(STATUS "SILO_LIBRARIES: ${SILO_LIBRARIES}")
+    SET(IBAMR_HAVE_SILO TRUE)
+
+    # Silo depends on zlib
+    FIND_PACKAGE(ZLIB REQUIRED)
+  ELSE()
+    MESSAGE(FATAL_ERROR "\
+Silo (an optional dependency) was specified with SILO_ROOT=${SILO_ROOT} but a
+silo installation could not be found in that location. Please check the value
+of SILO_ROOT and rerun CMake.")
+  ENDIF()
+ELSE()
+  MESSAGE(STATUS "SILO_ROOT was not specified so IBAMR will be configured without it.")
+ENDIF()
+
+
+# ---------------------------------------------------------------------------- #
+#                       3: IBAMR-specific configuration                        #
+# ---------------------------------------------------------------------------- #
+
+# generate the configuration header. Define a few more things for IBTK.
+SET(IBTK_HAVE_LIBMESH ${IBAMR_HAVE_LIBMESH})
+SET(IBTK_HAVE_SILO ${IBAMR_HAVE_SILO})
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/ibtk/include/ibtk/config.h.in
+  ${CMAKE_BINARY_DIR}/ibtk/include/ibtk/config.h)
+INSTALL(FILES ${CMAKE_BINARY_DIR}/ibtk/include/ibtk/config.h
+  DESTINATION include/ibtk/)
+
+INCLUDE(CMakeParseArguments)
+#
+# Macro to process m4 files to generate Fortran.
+#
+# This macro includes some ad-hoc logic to attempt to detect M4 dependencies
+# (i.e., include() statements in the provided file) so that the build system is
+# aware of them. However, since this is done with regular expressions it is
+# fragile and may not always pick up file dependencies. For example, writing
+#
+# input(
+# dnl skip this line
+# /path/to/file.m4
+# )
+#
+# is perfectly valid M4 but beyond the capacity of this macro to parse. In such
+# cases we simply do not add the dependency and print a warning - compilation
+# from scratch will still succeed but the build system will not be able to track
+# the dependency.
+#
+# Required arguments:
+#
+# - NAME: Relative path (from the directory in which the macro is called) to the
+#   relevant Fortran file. For example: if we want to preprocess
+#   foo/bar/baz.f.m4 then we should pass foo/bar/baz.f as the NAME argument.
+MACRO(IBAMR_PROCESS_M4)
+  SET(options)
+  SET(singleValueArgs NAME)
+
+  CMAKE_PARSE_ARGUMENTS(arg "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN})
+  GET_FILENAME_COMPONENT(_in_directory "${CMAKE_CURRENT_SOURCE_DIR}/${arg_NAME}.m4" DIRECTORY)
+  GET_FILENAME_COMPONENT(_out_directory "${CMAKE_CURRENT_BINARY_DIR}/${arg_NAME}.f" DIRECTORY)
+  FILE(MAKE_DIRECTORY ${_out_directory})
+
+  SET(_samrai_fortdir ${SAMRAI_ROOT}/include)
+  SET(_current_srcdir ${_in_directory})
+  SET(_top_srcdir ${CMAKE_SOURCE_DIR})
+  SET(_input "${CMAKE_CURRENT_SOURCE_DIR}/${arg_NAME}.m4")
+  SET(_output "${CMAKE_CURRENT_BINARY_DIR}/${arg_NAME}")
+  SET(_args "-DSAMRAI_FORTDIR=${_samrai_fortdir}"
+    "-DCURRENT_SRCDIR=${_current_srcdir}"
+    "-DTOP_SRCDIR=${_top_srcdir}")
+
+  FILE(STRINGS ${_input} _parsed_includes REGEX "include.*DIR")
+  SET(_expanded_files)
+  FOREACH(_parsed_include ${_parsed_includes})
+    STRING(REGEX REPLACE "include\\((.*)\\)(dnl)?$" "\\1" _tmp ${_parsed_include})
+    STRING(REGEX REPLACE "SAMRAI_FORTDIR" "${_samrai_fortdir}" _tmp ${_tmp})
+    STRING(REGEX REPLACE "CURRENT_SRCDIR" "${_current_srcdir}" _tmp ${_tmp})
+    STRING(REGEX REPLACE "TOP_SRCDIR" "${_top_srcdir}" _tmp ${_tmp})
+    LIST(APPEND _expanded_files ${_tmp})
+  ENDFOREACH()
+
+  SET(_dependencies)
+  LIST(APPEND _dependencies ${_input})
+  FOREACH(_expanded_file ${_expanded_files})
+    IF (EXISTS ${_expanded_file})
+      LIST(APPEND _dependencies ${_expanded_file})
+    ELSE()
+      MESSAGE(WARNING
+"Unable to locate file\n    ${_expanded_file}\n which is a dependency of
+${_input_file}. Since dependency tracking of M4 files is done manually this is
+not a fatal problem but it may result in compilation failures later in the build process.")
+    ENDIF()
+  ENDFOREACH()
+
+  ADD_CUSTOM_COMMAND(
+    OUTPUT ${_output}
+    DEPENDS ${_dependencies}
+    COMMAND m4 ${_args} ${_input} > ${_output}
+    VERBATIM)
+
+  SET_SOURCE_FILES_PROPERTIES(${_output} PROPERTIES GENERATED true)
+  SET_SOURCE_FILES_PROPERTIES(${_output} PROPERTIES LANGUAGE Fortran)
+ENDMACRO()
+
+# Macro to setup an IBAMR target library with all common features (i.e.,
+# everything but the source files)
+FUNCTION(IBAMR_SETUP_TARGET_LIBRARY target_library)
+  MESSAGE(STATUS "setting up target ${target_library}")
+  IF(${IBAMR_HAVE_LIBMESH} AND "${LIBMESH_WITH_CXX14}")
+    MESSAGE(STATUS "libMesh expects C++14, so ${target_library} will be built with C++14 as a requirement.")
+    SET_PROPERTY(TARGET ${target_library} PROPERTY CXX_STANDARD 14)
+    TARGET_COMPILE_FEATURES(${target_library} PUBLIC cxx_std_14)
+  ELSE()
+    SET_PROPERTY(TARGET ${target_library} PROPERTY CXX_STANDARD 11)
+    TARGET_COMPILE_FEATURES(${target_library} PUBLIC cxx_std_11)
+  ENDIF()
+  # we and our users will use these MPI functions so make the interface public:
+  TARGET_LINK_LIBRARIES(${target_library} PUBLIC MPI::MPI_C)
+  # libMesh is underlinked and needs MPI's C++ library
+  IF(${IBAMR_HAVE_LIBMESH})
+    TARGET_LINK_LIBRARIES(${target_library} PUBLIC MPI::MPI_CXX)
+  ENDIF()
+  # HDF5:
+  TARGET_LINK_LIBRARIES(${target_library} PUBLIC "${HDF5_LIBRARIES}")
+  TARGET_INCLUDE_DIRECTORIES(${target_library} PUBLIC "${HDF5_INCLUDE_DIRS}")
+  # Hypre:
+  TARGET_LINK_LIBRARIES(${target_library} PUBLIC "${HYPRE_LIBRARIES}")
+  TARGET_INCLUDE_DIRECTORIES(${target_library} PUBLIC "${HYPRE_INCLUDE_DIRS}")
+  # Boost (we only need headers):
+  IF(IBAMR_USE_BUNDLED_Boost)
+    TARGET_LINK_LIBRARIES(${target_library} PUBLIC BUNDLED_Boost)
+  ELSE()
+    TARGET_LINK_LIBRARIES(${target_library} PUBLIC Boost::headers)
+  ENDIF()
+  # Eigen:
+  IF(IBAMR_USE_BUNDLED_Eigen)
+    TARGET_LINK_LIBRARIES(${target_library} PUBLIC BUNDLED_Eigen)
+  ELSE()
+    TARGET_LINK_LIBRARIES(${target_library} PUBLIC Eigen3::Eigen)
+  ENDIF()
+  # muParser:
+  IF(IBAMR_USE_BUNDLED_muParser)
+    TARGET_LINK_LIBRARIES(${target_library} PUBLIC BUNDLED_muParser)
+  ELSE()
+    TARGET_LINK_LIBRARIES(${target_library} PUBLIC "${MUPARSER_LIBRARIES}")
+    TARGET_INCLUDE_DIRECTORIES(${target_library} PUBLIC "${MUPARSER_INCLUDE_DIRS}")
+  ENDIF()
+  # PETSc:
+  TARGET_LINK_LIBRARIES(${target_library} PUBLIC "${PETSC_LIBRARIES}")
+  TARGET_INCLUDE_DIRECTORIES(${target_library} PUBLIC "${PETSC_INCLUDE_DIRS}")
+  # libMesh:
+  IF(IBAMR_HAVE_LIBMESH)
+    TARGET_LINK_LIBRARIES(${target_library} PUBLIC "${LIBMESH_LIBRARIES}")
+    TARGET_INCLUDE_DIRECTORIES(${target_library} PUBLIC "${LIBMESH_INCLUDE_DIRS}")
+  ENDIF()
+  # Silo:
+  IF(IBAMR_HAVE_SILO)
+    TARGET_LINK_LIBRARIES(${target_library} PRIVATE "${SILO_LIBRARIES}")
+    TARGET_INCLUDE_DIRECTORIES(${target_library} PUBLIC "${SILO_INCLUDE_DIRS}")
+    TARGET_LINK_LIBRARIES(${target_library} PRIVATE ZLIB::ZLIB)
+  ENDIF()
+
+  # Figure out if we are a 2D or a 3D library:
+  SET(_2_location = -1)
+  SET(_3_location = -1)
+  STRING(FIND "${target_library}" "2" _2_location)
+  STRING(FIND "${target_library}" "3" _3_location)
+  SET(_d "")
+  IF(NOT ${_2_location} STREQUAL "-1")
+    SET(_d "2")
+  ELSE()
+    SET(_d "3")
+  ENDIF()
+
+  # SAMRAI:
+  TARGET_INCLUDE_DIRECTORIES(${target_library} PUBLIC ${SAMRAI_INCLUDE_DIRS})
+  FOREACH(_lib ${SAMRAI${_d}d_LIBRARIES})
+    TARGET_LINK_LIBRARIES(${target_library} PUBLIC ${_lib})
+  ENDFOREACH()
+
+  MESSAGE(STATUS "Adding flag -DNDIM=${_d} to target ${target_library}")
+  TARGET_COMPILE_OPTIONS(${target_library} PUBLIC -DNDIM=${_d})
+ENDFUNCTION()
+
+MESSAGE(STATUS "")
+MESSAGE(STATUS "IBAMR dependencies have been successfully set up.")
+
+#
+# IBTK and IBAMR are compiled in 2D and 3D, but the headers are only installed
+# once - hence set up the headers as separate targets
+#
+ADD_LIBRARY(IBTKHeaders INTERFACE)
+TARGET_INCLUDE_DIRECTORIES(
+  IBTKHeaders
+  INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/ibtk/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>)
+
+ADD_LIBRARY(IBAMRHeaders INTERFACE)
+TARGET_INCLUDE_DIRECTORIES(
+  IBAMRHeaders
+  INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>)
+
+INSTALL(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ibamr DESTINATION include)
+INSTALL(DIRECTORY ${PROJECT_SOURCE_DIR}/ibtk/include/ibtk DESTINATION include)
+
+INSTALL(TARGETS IBTKHeaders EXPORT IBAMRTargets)
+INSTALL(TARGETS IBAMRHeaders EXPORT IBAMRTargets)
+
+# ---------------------------------------------------------------------------- #
+#                               4: Define targets                              #
+# ---------------------------------------------------------------------------- #
+
+#
+# Set up specific targets for executables and libraries that want to link to
+# IBAMR. As noted above, we have to do this since SAMRAI might not be compiled
+# with -fPIC: i.e., if we added SAMRAI as a link dependency to libIBTK and
+# libIBTK as a link dependency to libFoo, then the linker would encounter errors
+# as a result. With executables we can use the full link interface.
+#
+SET(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/ibamr/)
+
+# Set up actual files containing the export target information:
+INSTALL(EXPORT "IBAMRTargets" FILE "IBAMRTargets.cmake"
+  NAMESPACE IBAMR::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ibamr/)
+
+WRITE_BASIC_PACKAGE_VERSION_FILE(
+  ${CMAKE_CURRENT_BINARY_DIR}/IBAMRConfigVersion.cmake
+  VERSION ${IBTK_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+CONFIGURE_PACKAGE_CONFIG_FILE(
+  ${CMAKE_SOURCE_DIR}/cmake/IBAMRConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/IBAMRConfig.cmake
+  INSTALL_DESTINATION ${INSTALL_CONFIGDIR})
+
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/IBAMRConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/IBAMRConfigVersion.cmake
+  DESTINATION ${INSTALL_CONFIGDIR})
+
+# proceed to compilation units:
+ADD_SUBDIRECTORY(ibtk)
+ADD_SUBDIRECTORY(src)
+
+ADD_SUBDIRECTORY(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,21 @@ ENDFOREACH()
 # ---------------------------------------------------------------------------- #
 #                       1: manage mandatory dependencies                       #
 # ---------------------------------------------------------------------------- #
+
+#
+# We and our dependencies require MPI so set that up first:
+#
 MESSAGE(STATUS "")
 MESSAGE(STATUS "Setting up MPI")
 FIND_PACKAGE(MPI REQUIRED)
+# If we are using the compiler wrappers then CMake may not set MPI_C_LIBRARIES -
+# if its empty then try to add something in anyway
+IF("${MPI_C_LIBRARIES}" STREQUAL "")
+  FIND_LIBRARY(_mpi_lib NAMES mpi HINTS ${MPI_ROOT}/lib)
+  IF(NOT "${_mpi_lib}" STREQUAL "_mpi_lib-NOTFOUND")
+    SET(MPI_C_LIBRARIES ${_mpi_lib})
+  ENDIF()
+ENDIF()
 MESSAGE(STATUS "MPI_C_INCLUDE_DIRS: ${MPI_C_INCLUDE_DIRS}")
 MESSAGE(STATUS "MPI_C_LIBRARIES: ${MPI_C_LIBRARIES}")
 
@@ -299,9 +311,12 @@ PETSc installation).")
   FILE(STRINGS ${PETSC_VARIABLES_FILE} PETSC_LIBRARIES REGEX "^PETSC_WITH_EXTERNAL_LIB =.*")
   STRING(REGEX REPLACE "^PETSC_WITH_EXTERNAL_LIB =(.*)" "\\1" PETSC_LIBRARIES ${PETSC_LIBRARIES})
   SEPARATE_ARGUMENTS(PETSC_LIBRARIES)
+  FIND_LIBRARY(PETSC_LIBRARY REQUIRED NAMES "petsc" HINTS ${PETSC_ROOT}/lib)
+  LIST(PREPEND PETSC_LIBRARIES ${PETSC_LIBRARY})
+  MESSAGE(STATUS "PETSC LIBRARIES: ${PETSC_LIBRARIES}")
 
   # extract the version numbers:
-  FIND_FILE(PETSC_VERSION_FILE petscversion.h HINTS ${PETSC_ROOT} PATH_SUFFIXES include)
+  FIND_FILE(PETSC_VERSION_FILE petscversion.h HINTS ${PETSC_INCLUDE_DIRS})
   FILE(STRINGS "${PETSC_VERSION_FILE}" PETSC_VERSION_MAJOR_STRING
     REGEX "#define.*PETSC_VERSION_MAJOR")
   STRING(REGEX REPLACE "^.*PETSC_VERSION_MAJOR.* ([0-9]+).*" "\\1"
@@ -476,7 +491,171 @@ IF(GSL_FOUND)
 ENDIF()
 
 # ---------------------------------------------------------------------------- #
-#                       3: IBAMR-specific configuration                        #
+#                 3: Check for conflicts between dependencies                  #
+# ---------------------------------------------------------------------------- #
+
+#
+# Helper function that checks that we can compile and link _src with the given
+# dependency libraries and dependency includes against the copy of MPI we found
+# - i.e., this function verifies that a dependency uses the same MPI as the one
+# we just found. As an extra check we use PETSc's MPI consistency checks in
+# petscsys.h to verify that we do have the same MPI version at the preprocessor
+# step.
+#
+FUNCTION(IBAMR_CHECK_COMPILATION_WITH_MPI _dependency_name _src _dependency_libraries
+    _dependency_includes)
+  MESSAGE(STATUS "Verifying that ${_dependency_name} is configured with the same version of MPI as IBAMR is:")
+  SET(CMAKE_REQUIRED_INCLUDES)
+  LIST(APPEND CMAKE_REQUIRED_INCLUDES "${_dependency_includes}")
+  LIST(APPEND CMAKE_REQUIRED_INCLUDES "${PETSC_INCLUDE_DIRS}")
+  LIST(APPEND CMAKE_REQUIRED_LIBRARIES "${MPI_C_INCLUDE_DIRS}")
+  SET(CMAKE_REQUIRED_LIBRARIES)
+  LIST(APPEND CMAKE_REQUIRED_LIBRARIES "${_dependency_libraries}")
+  LIST(APPEND CMAKE_REQUIRED_LIBRARIES "${PETSC_LIBRARIES}")
+  LIST(APPEND CMAKE_REQUIRED_LIBRARIES "${MPI_C_LIBRARIES}")
+  LIST(APPEND CMAKE_REQUIRED_LIBRARIES "${MPI_CXX_LIBRARIES}")
+
+  SET(_test_name "${_dependency_name}_SAME_MPI_COMPILE_TEST")
+  CHECK_CXX_SOURCE_COMPILES("${_src}" ${_test_name})
+  IF(NOT "${${_test_name}}")
+    MESSAGE(FATAL_ERROR "\
+Unable to compile a test program dependent on ${_dependency} that links against
+MPI. This usually means that the dependency is misconfigured or is using a
+different version of MPI than the one supplied to IBAMR.")
+  ENDIF()
+  SET(CMAKE_REQUIRED_INCLUDES)
+  SET(CMAKE_REQUIRED_LIBRARIES)
+
+  MESSAGE(STATUS "Checking that we do not link against a different MPI library - ")
+  FIND_PROGRAM(_ldd "ldd")
+  FIND_PROGRAM(_readlink "readlink")
+  IF(NOT ${_ldd} STREQUAL "ldd-NOTFOUND" AND NOT ${_readlink} STREQUAL "readlink-NOTFOUND")
+    FOREACH(_lib ${_dependency_libraries})
+      IF(EXISTS ${_lib})
+        EXECUTE_PROCESS(COMMAND "${_ldd}" "${_lib}"
+          OUTPUT_VARIABLE _libs ERROR_QUIET)
+        SEPARATE_ARGUMENTS(_libs)
+        FOREACH(_dep ${_libs})
+          STRING(REGEX MATCH "libmpi\." _has_mpi ${_dep})
+          IF("${_has_mpi}" STREQUAL "libmpi\." AND EXISTS "${_dep}")
+            # We found an MPI library: first resolve symbolic links and then
+            # check for equality
+            SET(_found FALSE)
+            EXECUTE_PROCESS(COMMAND "${_readlink}" "-f" "${_dep}"
+              OUTPUT_VARIABLE _resolved_dep)
+            FOREACH(_mpi_lib "${MPI_C_LIBRARIES}")
+              EXECUTE_PROCESS(COMMAND "${_readlink}" "-f" "${_mpi_lib}"
+                OUTPUT_VARIABLE _resolved_mpi_lib)
+              IF("${_resolved_mpi_lib}" STREQUAL "${_resolved_dep}")
+                SET(_found TRUE)
+                BREAK()
+              ENDIF()
+            ENDFOREACH()
+            IF(NOT ${_found})
+              MESSAGE(FATAL_ERROR "\
+The library
+    ${_lib}
+a part of ${_dependency_name}, links against
+    ${_dep}
+which conflicts with the MPI implementation explicitly provided to IBAMR, which includes
+    ${MPI_C_LIBRARIES}
+Please recompile ${_dependency} to link against the same version of MPI.")
+            ENDIF()
+          ENDIF()
+        ENDFOREACH()
+      ENDIF()
+    ENDFOREACH()
+  ENDIF()
+  MESSAGE(STATUS "Checking that we do not link against a different MPI library - Success")
+ENDFUNCTION()
+
+#
+# PETSc:
+IBAMR_CHECK_COMPILATION_WITH_MPI(PETSC
+  "\
+#include <mpi.h>
+#include <petscvec.h>
+
+int main(int argc, char **argv)
+{
+    PetscInitialize(&argc, &argv, NULL, NULL);
+
+    Vec vec;
+    double values[2] = {42.0, 42.0};
+    VecCreateGhostWithArray(MPI_COMM_WORLD, 2, PETSC_DECIDE, 0, NULL,
+                            values, &vec);
+    VecDestroy(&vec);
+
+    PetscFinalize();
+}"
+  "${PETSC_LIBRARIES}"
+  "${PETSC_INCLUDE_DIRS}")
+
+#
+# HDF5:
+#
+IBAMR_CHECK_COMPILATION_WITH_MPI(HDF5
+  "\
+#include <hdf5.h>
+#include <mpi.h>
+#include <petscsys.h> // this is the preprocessor check
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    hid_t  file_id = H5Fcreate(\"file.h5\", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    (void)file_id;
+    herr_t status  = H5Fclose(file_id);
+    (void)status;
+    MPI_Finalize();
+}"
+  "${HDF5_LIBRARIES}"
+  "${HDF5_INCLUDE_DIRS}")
+
+#
+# HYPRE:
+#
+IBAMR_CHECK_COMPILATION_WITH_MPI(HYPRE
+  "\
+#include <HYPRE_struct_ls.h>
+#include <mpi.h>
+#include <petscsys.h>
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    HYPRE_StructGrid grid;
+    HYPRE_StructGridCreate(MPI_COMM_WORLD, 2, &grid);
+    HYPRE_StructGridAssemble(grid);
+    HYPRE_StructGridDestroy(grid);
+    MPI_Finalize();
+}"
+  "${HYPRE_LIBRARIES}"
+  "${HYPRE_INCLUDE_DIRS}")
+
+# SAMRAI is statically linked and doesn't export its linkage information in a
+# way that's easy to parse so we cannot execute the MPI check
+
+#
+# libMesh:
+#
+IBAMR_CHECK_COMPILATION_WITH_MPI(LIBMESH
+      "\
+#include <mpi.h>
+#include <petscsys.h>
+// This test is a little different: since libMesh may use C++11 or C++14 but we
+// have not yet configured that flag yet, we instead use libMesh's petsc dependency
+// to check that we have the same MPI version.
+int main(int argc, char **argv)
+{
+    PetscInitialize(&argc, &argv, NULL, NULL);
+    PetscFinalize();
+}"
+  "${LIBMESH_LIBRARIES}"
+  "${LIBMESH_INCLUDE_DIRS}")
+
+# ---------------------------------------------------------------------------- #
+#                       4: IBAMR-specific configuration                        #
 # ---------------------------------------------------------------------------- #
 
 # generate the configuration header. Define a few more things for IBTK.
@@ -668,7 +847,7 @@ INSTALL(TARGETS IBTKHeaders EXPORT IBAMRTargets)
 INSTALL(TARGETS IBAMRHeaders EXPORT IBAMRTargets)
 
 # ---------------------------------------------------------------------------- #
-#                               4: Define targets                              #
+#                               5: Define targets                              #
 # ---------------------------------------------------------------------------- #
 
 #

--- a/cmake/IBAMRConfig.cmake.in
+++ b/cmake/IBAMRConfig.cmake.in
@@ -1,0 +1,34 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+# This file is a template that is populated by CMake with the actual locations
+# of external dependencies and also the file containing information on IBAMR's
+# own targets.
+@PACKAGE_INIT@
+
+SET(MPI_ROOT "@MPI_ROOT@")
+FIND_PACKAGE(MPI REQUIRED)
+
+SET(Boost_FOUND "@Boost_FOUND@")
+SET(BOOST_ROOT "@BOOST_ROOT@")
+IF(${Boost_FOUND})
+  FIND_PACKAGE(Boost 1.57 REQUIRED)
+ENDIF()
+
+SET(Eigen3_FOUND @Eigen3_FOUND@)
+SET(EIGEN_ROOT "@EIGEN_ROOT@")
+IF(${Eigen3_FOUND})
+  FIND_PACKAGE(Eigen3 3.2.5 REQUIRED)
+ENDIF()
+
+INCLUDE(${CMAKE_CURRENT_LIST_DIR}/IBAMRTargets.cmake)

--- a/doc/cmake.md
+++ b/doc/cmake.md
@@ -1,0 +1,145 @@
+# The CMake-based IBAMR build system
+
+## Introduction
+
+IBAMR 0.8.0 introduced a complete rewrite of its build system (that is, the set
+of scripts that detect IBAMR's dependencies and then compile and install the
+library). The new build system requires CMake version 3.15 or newer.
+
+CMake is a build system generator - i.e., unlike traditional autotools usage,
+users will use the `cmake` executable to generate a build system instead of
+relying on a prepackaged `configure` script. Hence users must have CMake
+installed on their computer to compile IBAMR.
+
+## Advantages of the CMake build system
+
+A few things are now possible with CMake that were not possible before:
+1. `make install` works correctly.
+2. In the future, IBAMR will go one step further than installation and offer
+   downloadable Mac packages.
+3. IBAMR can now be compiled with either dynamicly or staticly linked libraries.
+4. IBAMR now exports its targets - i.e., IBAMR can be added as a dependency to
+   your own projects with the standard `FIND_PACKAGE` CMake macro, which sets up
+   the complete header and link interface.
+5. The build system itself is much easier to maintain and modify since it is written
+   in CMake code instead of shell and m4. Boilerplate files like `aclocal.m4` no
+   longer exist and there is no need to rerun `autoreconf`, `autoheader`, or any
+   other such program (CMake will do this automatically if scripts are updated).
+6. The CMake build system integrates well with most IDEs.
+
+## How to use the CMake build system
+
+This is similar to how autotools is used with a separate build directory
+`build`. IBAMR's configuration scripts expect all dependencies to have their
+paths provided in the standard way for CMake (i.e., we pass in the root path of
+the directory for things installed outside the system search path). Here, for
+example, `PETSC_ROOT` is typically `$PETSC_DIR/$PETSC_ARCH`.
+```
+mkdir build
+cd build
+cmake -DCMAKE_C_FLAGS="-O3 -march=native"                     \
+      -DCMAKE_CXX_FLAGS="-O3 -march=native"                   \
+      -DCMAKE_Fortran_FLAGS="-O3 -march=native"               \
+      -DCMAKE_INSTALL_PREFIX=$HOME/Applications/ibamr         \
+      -DSAMRAI_ROOT=$HOME/Applications/samrai-2.4.4           \
+      -DLIBMESH_ROOT=$HOME/Applications/libmesh-dev           \
+      -DLIBMESH_METHOD=OPT                                    \
+      -DPETSC_ROOT=$HOME/Applications/petsc-3.13.0/x86_64-opt \
+      ../
+make -j6
+make -j6 install
+```
+IBAMR requires
+- Boost,
+- Eigen3,
+- HDF5,
+- Hypre,
+- MPI,
+- muParser,
+- PETSc, and
+- SAMRAI.
+
+The CMake build system will attempt to find these with default search paths and
+also in the directory provided by `PKG_ROOT` (i.e., for Boost, the build system
+will search in `BOOST_ROOT`).
+
+IBAMR's optional dependencies are
+- Silo, and
+- libMesh.
+
+These are only searched for if a directory path is provided (i.e., by passing
+`-DSILO_ROOT=/usr/`). libMesh also requires that the caller pass
+`LIBMESH_METHOD` to CMake to indicate which libMesh variant we should use (e.g.,
+above we use the optimized version by passing `OPT`: `DBG` and `DEVELOP` are
+alternative options).
+
+Subsequent runs of CMake are much faster than the initial run since CMake will
+cache some computed values (such as the MPI configuration). If you run into
+problems with CMake, a good way to get out of trouble is to delete
+`CMakeCache.txt`, which will delete the cache. Deleting the cache is harmless -
+the subsequent initial configuration run will just take a few more seconds.
+
+## Debugging configuration issues
+- If you need to change a parameter passed to CMake and things don't work then
+  try deleting the `CMakeCache.txt` file.
+- If CMake cannot find your MPI implementation then try explicitly passing in
+  the MPI compiler wrappers - e.g.,
+ ```sh
+     cmake -DCMAKE_C_COMPILER=/path/to/mpicc \
+           -DCMAKE_CXX_COMPILER=/path/to/mpicxx \
+           -DCMAKE_Fortran_COMPILER=/path/to/mpifort \
+           -DPETSC_ROOT=/path/to/petsc
+     # etc.
+ ```
+- The CMake build system is new and may still contain bugs. If things don't seem
+  to work then post a message on the IBAMR mailing list.
+- If all else fails use the autotools-based build system, which is currently
+  known to work well on a wide variety of computers.
+
+## How to use IBAMR in your own project
+
+If you have installed IBAMR correctly then it is easy to add it as a dependency
+to your own project using standard CMake tools. You can configure your project
+(here assumed to consist of a single file, `main.cpp`, which will be compiled in
+2D) with the following `CMakeLists.txt` script:
+```cmake
+PROJECT(main2d)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.15.0)
+
+ADD_EXECUTABLE(main2d main.cpp)
+
+FIND_PACKAGE(IBAMR 0.8.0 REQUIRED)
+TARGET_LINK_LIBRARIES(main2d IBAMR::IBAMR2d)
+```
+Run cmake as
+```
+cmake -DIBAMR_ROOT=/path/to/ibamr/installation ./
+```
+where `/path/to/ibamr/installation` should be replaced by the directory path
+(either relative or absolute) to the installation location of IBAMR or IBAMR's
+build directory.
+
+## Build system internals
+
+### General setup
+
+IBAMR is now compiled as four libraries: 2D and 3D IBTK libraries and 2D and 3D
+IBAMR libraries. Since IBAMR depends on IBTK, many features in the library are
+actually set up for IBTK and then copied into IBAMR proper. IBAMR and IBTK have
+their dependencies configured in the top-level `CMakeLists.txt` file. Source
+files for each library are listed in `src/CMakeLists.txt` and
+`ibtk/src/CMakeLists.txt`, respectively. Similarly, all test executables are
+compiled in `tests/CMakeLists.txt`.
+
+Since there is a wide variety of necessary setup for examples, IBAMR includes
+the macro `IBAMR_ADD_EXAMPLE` (defined in `examples/CMakeLists.txt`) which is
+used to set up a single example program (which may have multiple source and
+input files). New examples should use this macro as well.
+
+### Configuration headers
+
+At the current time IBAMR now generates a single configuration header:
+`ibtk/config.h`. All macros defined in this file with the prefix `IBTK_` are
+redefined in `ibamr/config.h` with the prefix `IBAMR_`. The old top-level
+configuration files `IBAMR_config.h` and `IBTK_config.h` do not have equivalents
+in the CMake build system.

--- a/doc/news/changes/major/20201019DavidWells
+++ b/doc/news/changes/major/20201019DavidWells
@@ -1,0 +1,4 @@
+New: IBAMR can now be configured, compiled, and installed with CMake instead of
+with autotools.
+<br>
+(David Wells, 2020/10/19)

--- a/examples/CIB/CMakeLists.txt
+++ b/examples/CIB/CMakeLists.txt
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir ex0 ex1 ex2 ex3 ex4)
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/CIB/ex0/CMakeLists.txt
+++ b/examples/CIB/ex0/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "CIB-ex0"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/CIB/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-CIB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d cylinder2d.vertex petsc_options.dat
+  )

--- a/examples/CIB/ex1/CMakeLists.txt
+++ b/examples/CIB/ex1/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "CIB-ex1"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/CIB/ex1"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-CIB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d shell_3d_in.vertex shell_3d_out.vertex petsc_options.dat
+  )

--- a/examples/CIB/ex2/CMakeLists.txt
+++ b/examples/CIB/ex2/CMakeLists.txt
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "CIB-ex2"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/CIB/ex2"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-CIB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.plate input2d.plate.amr petsc_options.dat plate2d.vertex
+  EXTRA_FILES
+    plate2d.m)

--- a/examples/CIB/ex3/CMakeLists.txt
+++ b/examples/CIB/ex3/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "CIB-ex3"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/CIB/ex3"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-CIB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.nozzle nozzle2d.vertex
+    )

--- a/examples/CIB/ex4/CMakeLists.txt
+++ b/examples/CIB/ex4/CMakeLists.txt
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "CIB-ex4"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/CIB/ex4"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-CIB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input3d.sphere input3d.test.long petsc_options.dat sphere_3d.vertex
+  EXTRA_FILES
+    check_sol.m)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,105 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+ADD_CUSTOM_TARGET(examples)
+
+SET(EXAMPLE_DIRECTORIES CIB ConstraintIB IB IBFE IBLevelSet IMP adv_diff
+  advect complex_fluids level_set multiphase_flow navier_stokes
+  vc_navier_stokes wave_tank)
+
+#
+# Helper macro for setting up an example. Call as, for example,
+#
+# IBAMR_ADD_EXAMPLE(
+#   TARGET_NAME
+#     "IBFE-ex0"
+#   OUTPUT_DIRECTORY
+#     "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex0"
+#   OUTPUT_NAME
+#     main2d
+#   EXAMPLE_GROUP
+#     examples-IBFE
+#   SOURCES
+#     "example.cpp"
+#   REQUIRES
+#     IBAMR_HAVE_LIBMESH
+#   LINK_TARGETS
+#     EXECUTABLE2d
+#   INPUT_FILES
+#     input2d cylinder2d.vertex petsc_options.dat
+#   )
+#
+# Here the target name is the name used by CMake to identify what needs to be
+# compiled. The actual executable will be named (in this case) main2d and will
+# be placed in the specified OUTPUT_DIRECTORY.
+#
+# TARGET_NAME, OUTPUT_DIRECTORY, OUTPUT_NAME, EXAMPLE_GROUP, and SOURCES are all
+# mandatory arguments. The rest can be skipped.
+#
+MACRO(IBAMR_ADD_EXAMPLE)
+  SET(OPTIONS)
+
+  SET(ONE_VALUE_ARGS TARGET_NAME OUTPUT_DIRECTORY OUTPUT_NAME EXAMPLE_GROUP)
+  SET(MULTI_VALUE_ARGS SOURCES REQUIRES LINK_TARGETS INPUT_FILES EXTRA_FILES)
+
+  CMAKE_PARSE_ARGUMENTS(EX "${OPTIONS}" "${ONE_VALUE_ARGS}" "${MULTI_VALUE_ARGS}"
+    ${ARGN})
+
+  SET(_failed_requirement)
+  SET(_requirements_met TRUE)
+  FOREACH(_requirement ${EX_REQUIRES})
+    IF(NOT ${${_requirement}})
+      SET(_requirements_met FALSE)
+      SET(_failed_requirement ${_requirement})
+    ENDIF()
+  ENDFOREACH()
+
+  IF(${_requirements_met})
+    ADD_EXECUTABLE("${EX_TARGET_NAME}" EXCLUDE_FROM_ALL ${EX_SOURCES})
+    SET_TARGET_PROPERTIES("${EX_TARGET_NAME}"
+      PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY
+      "${EX_OUTPUT_DIRECTORY}"
+      OUTPUT_NAME
+      "${EX_OUTPUT_NAME}")
+    TARGET_INCLUDE_DIRECTORIES("${EX_TARGET_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+    IF(NOT "${EX_LINK_TARGETS}" STREQUAL "")
+      TARGET_LINK_LIBRARIES("${EX_TARGET_NAME}" PRIVATE ${EX_LINK_TARGETS})
+    ENDIF()
+    ADD_DEPENDENCIES("${EX_EXAMPLE_GROUP}" "${EX_TARGET_NAME}")
+
+    FOREACH(_input_file ${EX_INPUT_FILES})
+      CONFIGURE_FILE("${_input_file}" "${EX_OUTPUT_DIRECTORY}" COPYONLY)
+    ENDFOREACH()
+
+    FOREACH(_extra_file ${EX_EXTRA_FILES})
+      CONFIGURE_FILE("${_extra_file}" "${EX_OUTPUT_DIRECTORY}" COPYONLY)
+    ENDFOREACH()
+  ELSE()
+    MESSAGE(WARNING "Example ${EX_TARGET_NAME} could not be set up since the "
+      "required feature ${_failed_requirement} = FALSE")
+  ENDIF()
+ENDMACRO()
+
+#
+# Add example subdirectories:
+#
+FOREACH(_dir ${EXAMPLE_DIRECTORIES})
+  ADD_CUSTOM_TARGET("examples-${_dir}")
+  ADD_DEPENDENCIES(examples "examples-${_dir}")
+ENDFOREACH()
+
+FOREACH(_dir ${EXAMPLE_DIRECTORIES})
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/ConstraintIB/CMakeLists.txt
+++ b/examples/ConstraintIB/CMakeLists.txt
@@ -1,0 +1,19 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir eel2d eel3d falling_sphere flow_past_cylinder
+    impulsively_started_cylinder knifefish moving_plate
+    oscillating_rigid_cylinder stokes_first_problem
+    )
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/ConstraintIB/eel2d/CMakeLists.txt
+++ b/examples/ConstraintIB/eel2d/CMakeLists.txt
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "ConstraintIB-eel2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/ConstraintIB/eel2d"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-ConstraintIB
+  SOURCES
+    IBEELKinematics.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d eel2d.vertex
+  EXTRA_FILES
+    eel2d_straightswimmer.m)

--- a/examples/ConstraintIB/eel3d/CMakeLists.txt
+++ b/examples/ConstraintIB/eel3d/CMakeLists.txt
@@ -1,0 +1,47 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+# This example uses GSL to generate the eel data.
+IF(IBAMR_HAVE_GSL)
+  IBAMR_ADD_EXAMPLE(
+    TARGET_NAME
+      "ConstraintIB-eel3d"
+    OUTPUT_DIRECTORY
+      "${CMAKE_BINARY_DIR}/examples/ConstraintIB/eel3d"
+    OUTPUT_NAME
+      main3d
+    EXAMPLE_GROUP
+      examples-ConstraintIB
+    SOURCES
+      IBEELKinematics3d.cpp example.cpp
+    LINK_TARGETS
+      EXECUTABLE3d GSL::gsl
+    INPUT_FILES
+      input3d eel3d.vertex)
+
+  IBAMR_ADD_EXAMPLE(
+    TARGET_NAME
+      "ConstraintIB-eel3d-generator"
+    OUTPUT_DIRECTORY
+      "${CMAKE_BINARY_DIR}/examples/ConstraintIB/eel3d"
+    OUTPUT_NAME
+      eelgenerator3d
+    EXAMPLE_GROUP
+      examples-ConstraintIB
+    SOURCES
+      eelgenerator3d.cpp
+    LINK_TARGETS
+      GSL::gsl)
+ELSE()
+  MESSAGE(STATUS "GSL not available - disabling ConstraintIB-eel3d")
+ENDIF()

--- a/examples/ConstraintIB/falling_sphere/CMakeLists.txt
+++ b/examples/ConstraintIB/falling_sphere/CMakeLists.txt
@@ -1,0 +1,43 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "ConstraintIB-filling_sphere"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/ConstraintIB/falling_sphere"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-ConstraintIB
+  SOURCES
+    CartGridBodyForce.cpp ForceProjector.cpp RigidBodyKinematics.cpp
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d sphere3d.vertex
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "ConstraintIB-spheregen"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/ConstraintIB/falling_sphere"
+  OUTPUT_NAME
+    sphereGen3d
+  EXAMPLE_GROUP
+    examples-ConstraintIB
+  SOURCES
+    sphereGen3d.cpp
+  )

--- a/examples/ConstraintIB/flow_past_cylinder/CMakeLists.txt
+++ b/examples/ConstraintIB/flow_past_cylinder/CMakeLists.txt
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "ConstraintIB-flow_past_cylinder"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/ConstraintIB/flow_past_cylinder"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-ConstraintIB
+  SOURCES
+    RigidBodyKinematics.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d cylinder2d.vertex
+  EXTRA_FILES
+    Cylinder2d.m)

--- a/examples/ConstraintIB/impulsively_started_cylinder/CMakeLists.txt
+++ b/examples/ConstraintIB/impulsively_started_cylinder/CMakeLists.txt
@@ -1,0 +1,28 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "ConstraintIB-impulsively_started_cylinder"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/ConstraintIB/impulsively_started_cylinder"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-ConstraintIB
+  SOURCES
+    RigidBodyKinematics.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d cylinder2d.vertex)

--- a/examples/ConstraintIB/knifefish/CMakeLists.txt
+++ b/examples/ConstraintIB/knifefish/CMakeLists.txt
@@ -1,0 +1,28 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "ConstraintIB-knifefish"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/ConstraintIB/knifefish"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-ConstraintIB
+  SOURCES
+    KnifeFishKinematics.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d RadiusAmp.dat KnifeFish.vertex)

--- a/examples/ConstraintIB/moving_plate/CMakeLists.txt
+++ b/examples/ConstraintIB/moving_plate/CMakeLists.txt
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "ConstraintIB-moving_plate"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/ConstraintIB/moving_plate"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-ConstraintIB
+  SOURCES
+    RigidBodyKinematics.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d plate2d.vertex
+  EXTRA_FILES
+    generate_plate2d.m)

--- a/examples/ConstraintIB/oscillating_rigid_cylinder/CMakeLists.txt
+++ b/examples/ConstraintIB/oscillating_rigid_cylinder/CMakeLists.txt
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "ConstraintIB-oscillating_rigid_cylinder"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/ConstraintIB/oscillating_rigid_cylinder"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-ConstraintIB
+  SOURCES
+    OscillatingCylinderKinematics.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d cylinder2d.vertex
+  EXTRA_FILES
+    Cylinder2d.m)

--- a/examples/ConstraintIB/stokes_first_problem/CMakeLists.txt
+++ b/examples/ConstraintIB/stokes_first_problem/CMakeLists.txt
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "ConstraintIB-stokes_first_problem"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/ConstraintIB/stokes_first_problem"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-ConstraintIB
+  SOURCES
+    RigidBodyKinematics.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d stokes_plate.vertex
+  EXTRA_FILES
+    stokes_plate.m)

--- a/examples/IB/CMakeLists.txt
+++ b/examples/IB/CMakeLists.txt
@@ -1,0 +1,14 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+ADD_SUBDIRECTORY(explicit)

--- a/examples/IB/explicit/CMakeLists.txt
+++ b/examples/IB/explicit/CMakeLists.txt
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir ex0 ex1 ex2 ex3 ex4 ex5 ex6)
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/IB/explicit/ex0/CMakeLists.txt
+++ b/examples/IB/explicit/ex0/CMakeLists.txt
@@ -1,0 +1,28 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IB-ex0"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IB/explicit/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d input2d.shell input2d.shell_circum_fibers)

--- a/examples/IB/explicit/ex1/CMakeLists.txt
+++ b/examples/IB/explicit/ex1/CMakeLists.txt
@@ -1,0 +1,39 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IB-ex1"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IB/explicit/ex1"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d input2d.shell input2d.shell_circum_fibers
+    curve2d_64.spring curve2d_64.vertex curve2d_128.spring curve2d_128.vertex
+    curve2d_256.spring curve2d_256.vertex curve2d_512.spring curve2d_512.vertex
+    shell2d_64.spring shell2d_64.vertex shell2d_128.spring shell2d_128.vertex
+    shell2d_256.spring shell2d_256.vertex
+    shell2d_radial_64.spring shell2d_radial_64.vertex
+    shell2d_radial_128.spring shell2d_radial_128.vertex
+    shell2d_radial_256.spring shell2d_radial_256.vertex
+    sphere3d.spring sphere3d.vertex
+  EXTRA_FILES
+    generate_curve2d.m generate_shell2d.m
+    )

--- a/examples/IB/explicit/ex2/CMakeLists.txt
+++ b/examples/IB/explicit/ex2/CMakeLists.txt
@@ -1,0 +1,57 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IB-ex2-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IB/explicit/ex2"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.cylinder input2d.cylinder_stabilized
+    cylinder2d_128.spring cylinder2d_128.vertex
+    cylinder2d_256.spring cylinder2d_256.vertex
+    cylinder2d_512.spring cylinder2d_512.vertex
+    cylinder2d_1024.spring cylinder2d_1024.vertex
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IB-ex2-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IB/explicit/ex2"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-IB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d.cylinder input3d.cylinder.test
+    input3d.sphere
+    cylinder3d_128.vertex
+    cylinder3d_256.vertex
+    cylinder3d_512.vertex
+    sphere3d_32.spring sphere3d_32.vertex
+    sphere3d_64.spring sphere3d_64.vertex
+    sphere3d_128.spring sphere3d_128.vertex
+    sphere3d_256.spring sphere3d_256.vertex)

--- a/examples/IB/explicit/ex3/CMakeLists.txt
+++ b/examples/IB/explicit/ex3/CMakeLists.txt
@@ -1,0 +1,32 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IB-ex3"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IB/explicit/ex3"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    fila_256.beam fila_256.spring fila_256.target fila_256.vertex
+    fila_512.beam fila_512.spring fila_512.target fila_512.vertex
+    fila_1024.beam fila_1024.spring fila_1024.target fila_1024.vertex
+    )

--- a/examples/IB/explicit/ex4/CMakeLists.txt
+++ b/examples/IB/explicit/ex4/CMakeLists.txt
@@ -1,0 +1,32 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IB-ex4"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IB/explicit/ex4"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+    curve3d_64.director curve3d_64.rod curve3d_64.vertex
+  EXTRA_FILES
+    generate_mesh3d.m
+    )

--- a/examples/IB/explicit/ex5/CMakeLists.txt
+++ b/examples/IB/explicit/ex5/CMakeLists.txt
@@ -1,0 +1,46 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IB-ex5-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IB/explicit/ex5"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d points2d.vertex
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IB-ex5-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IB/explicit/ex5"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-IB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d points3d.vertex
+    )

--- a/examples/IB/explicit/ex6/CMakeLists.txt
+++ b/examples/IB/explicit/ex6/CMakeLists.txt
@@ -1,0 +1,35 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IB-ex6"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IB/explicit/ex6"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IB
+  SOURCES
+    example.cpp IBSimpleHierarchyIntegrator.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    curve2d_64.spring curve2d_64.vertex
+    curve2d_128.spring curve2d_128.vertex
+    curve2d_256.spring curve2d_256.vertex
+    curve2d_512.spring curve2d_512.vertex
+  EXTRA_FILES
+    generate_curve2d.m
+    )

--- a/examples/IBFE/CMakeLists.txt
+++ b/examples/IBFE/CMakeLists.txt
@@ -1,0 +1,14 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+ADD_SUBDIRECTORY(explicit)

--- a/examples/IBFE/explicit/CMakeLists.txt
+++ b/examples/IBFE/explicit/CMakeLists.txt
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir ex0 ex1 ex2 ex3 ex4 ex5 ex6 ex7 ex8 ex9 ex10 ex11)
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/IBFE/explicit/ex0/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex0/CMakeLists.txt
@@ -1,0 +1,31 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex0"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/IBFE/explicit/ex1/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex1/CMakeLists.txt
@@ -1,0 +1,31 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex1"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex1"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/IBFE/explicit/ex10/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex10/CMakeLists.txt
@@ -1,0 +1,31 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex10"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex10"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/IBFE/explicit/ex11/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex11/CMakeLists.txt
@@ -1,0 +1,33 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex11"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex11"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  EXTRA_FILES
+    compute_St.m
+    )

--- a/examples/IBFE/explicit/ex2/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex2/CMakeLists.txt
@@ -1,0 +1,50 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex2-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex2"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex2-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex2"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+    )

--- a/examples/IBFE/explicit/ex3/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex3/CMakeLists.txt
@@ -1,0 +1,48 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex3"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex3"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex3-convergence-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex3"
+  OUTPUT_NAME
+    convergence_tester2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    convergence_tester.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+    )

--- a/examples/IBFE/explicit/ex4/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex4/CMakeLists.txt
@@ -1,0 +1,84 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex4-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex4"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex4-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex4"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex4-convergence-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex4"
+  OUTPUT_NAME
+    convergence_tester2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    convergence_tester.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex4-convergence-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex4"
+  OUTPUT_NAME
+    convergence_tester3d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    convergence_tester.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE3d
+    )

--- a/examples/IBFE/explicit/ex5/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex5/CMakeLists.txt
@@ -1,0 +1,55 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex5-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex5"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  EXTRA_FILES
+    compute_St.m
+    )
+
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex5-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex5"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  EXTRA_FILES
+    compute_St.m
+    )

--- a/examples/IBFE/explicit/ex6/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex6/CMakeLists.txt
@@ -1,0 +1,31 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex6"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex6"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/IBFE/explicit/ex7/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex7/CMakeLists.txt
@@ -1,0 +1,31 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex7"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex7"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.caseC input2d.caseS2 input2d.caseSP
+    )

--- a/examples/IBFE/explicit/ex8/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex8/CMakeLists.txt
@@ -1,0 +1,31 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex8"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex8"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/IBFE/explicit/ex9/CMakeLists.txt
+++ b/examples/IBFE/explicit/ex9/CMakeLists.txt
@@ -1,0 +1,50 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex9-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex9"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBFE-ex9-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBFE/explicit/ex9"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-IBFE
+  SOURCES
+    example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+    )

--- a/examples/IBLevelSet/CMakeLists.txt
+++ b/examples/IBLevelSet/CMakeLists.txt
@@ -1,0 +1,14 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+ADD_SUBDIRECTORY(ex0)

--- a/examples/IBLevelSet/ex0/CMakeLists.txt
+++ b/examples/IBLevelSet/ex0/CMakeLists.txt
@@ -1,0 +1,34 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IBLevelSet-ex0"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IBLevelSet/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IBLevelSet
+  SOURCES
+    example.cpp FlowGravityForcing.cpp GravityForcing.cpp
+    LSLocateGasInterface.cpp SetFluidGasSolidDensity.cpp
+    SetFluidGasSolidViscosity.cpp SetLSProperties.cpp
+    TagLSRefinementCells.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d CircleMesh.msh
+    )

--- a/examples/IMP/CMakeLists.txt
+++ b/examples/IMP/CMakeLists.txt
@@ -1,0 +1,14 @@
+# ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+ADD_SUBDIRECTORY(explicit)

--- a/examples/IMP/explicit/CMakeLists.txt
+++ b/examples/IMP/explicit/CMakeLists.txt
@@ -1,0 +1,14 @@
+# ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+ADD_SUBDIRECTORY(ex0)

--- a/examples/IMP/explicit/ex0/CMakeLists.txt
+++ b/examples/IMP/explicit/ex0/CMakeLists.txt
@@ -1,0 +1,31 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IMP-ex0"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IMP/explicit/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IMP
+  SOURCES
+    main.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/adv_diff/CMakeLists.txt
+++ b/examples/adv_diff/CMakeLists.txt
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir ex0 ex1 ex2)
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/adv_diff/ex0/CMakeLists.txt
+++ b/examples/adv_diff/ex0/CMakeLists.txt
@@ -1,0 +1,46 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "adv_diff-ex0-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/adv_diff/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-adv_diff
+  SOURCES
+    example.cpp QInit.cpp UFunction.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "adv_diff-ex0-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/adv_diff/ex0"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-adv_diff
+  SOURCES
+    example.cpp QInit.cpp UFunction.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+    )

--- a/examples/adv_diff/ex1/CMakeLists.txt
+++ b/examples/adv_diff/ex1/CMakeLists.txt
@@ -1,0 +1,46 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "adv_diff-ex1-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/adv_diff/ex1"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-adv_diff
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "adv_diff-ex1-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/adv_diff/ex1"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-adv_diff
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+    )

--- a/examples/adv_diff/ex2/CMakeLists.txt
+++ b/examples/adv_diff/ex2/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "adv_diff-ex2"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/adv_diff/ex2"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-adv_diff
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/advect/CMakeLists.txt
+++ b/examples/advect/CMakeLists.txt
@@ -1,0 +1,50 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "advect-ex0-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/advect"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-advect
+  SOURCES
+    QInit.cpp UFunction.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "advect-ex0-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/advect"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-advect
+  SOURCES
+    QInit.cpp UFunction.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )

--- a/examples/complex_fluids/CMakeLists.txt
+++ b/examples/complex_fluids/CMakeLists.txt
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir ex0 ex1 ex2 ex3 ex4)
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/complex_fluids/ex0/CMakeLists.txt
+++ b/examples/complex_fluids/ex0/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "complex_fluids-ex0"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/complex_fluids/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-complex_fluids
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/complex_fluids/ex1/CMakeLists.txt
+++ b/examples/complex_fluids/ex1/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "complex_fluids-ex1"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/complex_fluids/ex1"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-complex_fluids
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/complex_fluids/ex2/CMakeLists.txt
+++ b/examples/complex_fluids/ex2/CMakeLists.txt
@@ -1,0 +1,46 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "complex_fluids-ex2"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/complex_fluids/ex2"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-complex_fluids
+  SOURCES
+    example.cpp InterpolationUtilities.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  EXTRA_FILES
+    plot_sxx.m
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "complex_fluids-ex2-convergence"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/complex_fluids/ex2"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-complex_fluids
+  SOURCES
+    convergence_tester.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+    )

--- a/examples/complex_fluids/ex3/CMakeLists.txt
+++ b/examples/complex_fluids/ex3/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "complex_fluids-ex3"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/complex_fluids/ex3"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-complex_fluids
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/complex_fluids/ex4/CMakeLists.txt
+++ b/examples/complex_fluids/ex4/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "complex_fluids-ex4"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/complex_fluids/ex4"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-complex_fluids
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+    )

--- a/examples/level_set/CMakeLists.txt
+++ b/examples/level_set/CMakeLists.txt
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir ex0 ex1)
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/level_set/ex0/CMakeLists.txt
+++ b/examples/level_set/ex0/CMakeLists.txt
@@ -1,0 +1,46 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "level_set-ex0-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/level_set/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-level_set
+  SOURCES
+    example.cpp LSLocateInterface.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "level_set-ex0-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/level_set/ex0"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-level_set
+  SOURCES
+    example.cpp LSLocateInterface.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )

--- a/examples/level_set/ex1/CMakeLists.txt
+++ b/examples/level_set/ex1/CMakeLists.txt
@@ -1,0 +1,46 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "level_set-ex1-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/level_set/ex1"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-level_set
+  SOURCES
+    example.cpp LSLocateInterface.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "level_set-ex1-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/level_set/ex1"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-level_set
+  SOURCES
+    example.cpp LSLocateInterface.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )

--- a/examples/multiphase_flow/CMakeLists.txt
+++ b/examples/multiphase_flow/CMakeLists.txt
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir ex0 ex1 ex2 ex3 ex4 ex5 ex6 ex7 ex8 ex9 ex10 ex11 ex12 ex13)
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/multiphase_flow/ex0/CMakeLists.txt
+++ b/examples/multiphase_flow/ex0/CMakeLists.txt
@@ -1,0 +1,47 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex0-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    example.cpp LSLocateCircularInterface.cpp SetFluidProperties.cpp SetLSProperties.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )
+
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex0-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex0"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    example.cpp LSLocateCircularInterface.cpp SetFluidProperties.cpp SetLSProperties.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )

--- a/examples/multiphase_flow/ex1/CMakeLists.txt
+++ b/examples/multiphase_flow/ex1/CMakeLists.txt
@@ -1,0 +1,33 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex1-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex1"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateCircularInterface.cpp LSLocateGasInterface.cpp
+    RigidBodyKinematics.cpp SetFluidGasSolidDensity.cpp
+    SetFluidGasSolidViscosity.cpp SetLSProperties.cpp TagLSRefinementCells.cpp
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.cyl input2d_free_fall.cyl cylinder2d.vertex
+    cylinder2d_free_fall.vertex
+  )

--- a/examples/multiphase_flow/ex10/CMakeLists.txt
+++ b/examples/multiphase_flow/ex10/CMakeLists.txt
@@ -1,0 +1,45 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex10"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex10"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    FlowGravityForcing.cpp GravityForcing.cpp LSLocateCircularInterface.cpp
+    LSLocateGasInterface.cpp RigidBodyKinematics.cpp SetFluidGasSolidDensity.cpp
+    SetFluidGasSolidViscosity.cpp SetLSProperties.cpp TagLSRefinementCells.cpp
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex10-cylindergen"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex10"
+  OUTPUT_NAME
+    cylinderGen
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    cylinderGen.cpp
+  )

--- a/examples/multiphase_flow/ex11/CMakeLists.txt
+++ b/examples/multiphase_flow/ex11/CMakeLists.txt
@@ -1,0 +1,48 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex11"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex11"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateGasInterface.cpp LSLocateStructureInterface.cpp
+    LevelSetSolidInitialCondition.cpp RigidBodyKinematics.cpp SetFluidGasSolidDensity.cpp
+    SetFluidGasSolidViscosity.cpp SetLSProperties.cpp TagLSRefinementCells.cpp
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  EXTRA_FILES
+    Barge2d.m
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex11-bargegen"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex11"
+  OUTPUT_NAME
+    bargeGen
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    bargeGen.cpp
+  )
+

--- a/examples/multiphase_flow/ex12/CMakeLists.txt
+++ b/examples/multiphase_flow/ex12/CMakeLists.txt
@@ -1,0 +1,69 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex12-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex12"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateGasInterface.cpp LSLocateStructureInterface.cpp
+    LevelSetSolidInitialCondition.cpp RigidBodyKinematics.cpp SetFluidGasSolidDensity.cpp
+    SetFluidGasSolidViscosity.cpp SetLSProperties.cpp TagLSRefinementCells.cpp
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  EXTRA_FILES
+    Wedge2d.m wedge2d.vertex
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex12-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex12"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateGasInterface.cpp LSLocateStructureInterface.cpp
+    LevelSetSolidInitialCondition.cpp RigidBodyKinematics.cpp SetFluidGasSolidDensity.cpp
+    SetFluidGasSolidViscosity.cpp SetLSProperties.cpp TagLSRefinementCells.cpp
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  EXTRA_FILES
+    Wedge3d.m
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex12-wedgegen"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex12"
+  OUTPUT_NAME
+    wedgeGen
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    wedgeGen.cpp
+  )

--- a/examples/multiphase_flow/ex13/CMakeLists.txt
+++ b/examples/multiphase_flow/ex13/CMakeLists.txt
@@ -1,0 +1,49 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex13"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex13"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    FlowGravityForcing.cpp GravityForcing.cpp LSLocateGasInterface.cpp
+    LSLocateStructureInterface.cpp LevelSetGasInitialCondition.cpp
+    LevelSetSolidInitialCondition.cpp RigidBodyKinematics.cpp
+    SetFluidGasSolidDensity.cpp SetFluidGasSolidViscosity.cpp
+    SetLSProperties.cpp TagLSRefinementCells.cpp
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d rectangle3d.vertex
+  EXTRA_FILES
+    Rectangle3d.m
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex13-rectanglegen"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex13"
+  OUTPUT_NAME
+    rectangleGen
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    rectangleGen.cpp
+  )

--- a/examples/multiphase_flow/ex2/CMakeLists.txt
+++ b/examples/multiphase_flow/ex2/CMakeLists.txt
@@ -1,0 +1,33 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex2"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex2"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateCircularInterface.cpp LSLocateGasInterface.cpp
+    SetFluidGasSolidDensity.cpp SetFluidGasSolidViscosity.cpp SetLSProperties.cpp
+    TagLSRefinementCells.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.cyl input2d_free_fall.cyl
+  EXTRA_FILES
+    generate_distmesh_cylinder.m
+  )

--- a/examples/multiphase_flow/ex3/CMakeLists.txt
+++ b/examples/multiphase_flow/ex3/CMakeLists.txt
@@ -1,0 +1,48 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex3-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex3"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    LSLocateCircularInterface.cpp SetFluidProperties.cpp SetLSProperties.cpp
+    TagLSRefinementCells.cpp VelocityInitialCondition.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex3-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex3"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    LSLocateCircularInterface.cpp SetFluidProperties.cpp SetLSProperties.cpp
+    TagLSRefinementCells.cpp VelocityInitialCondition.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )

--- a/examples/multiphase_flow/ex4/CMakeLists.txt
+++ b/examples/multiphase_flow/ex4/CMakeLists.txt
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex4"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex4"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateLayerInterface.cpp SetFluidProperties.cpp
+    SetLSProperties.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.filling input2d.stationary
+  )

--- a/examples/multiphase_flow/ex5/CMakeLists.txt
+++ b/examples/multiphase_flow/ex5/CMakeLists.txt
@@ -1,0 +1,50 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex5-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex5"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateColumnInterface.cpp LevelSetInitialCondition.cpp
+    SetFluidProperties.cpp SetLSProperties.cpp TagLSRefinementCells.cpp
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex5-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex5"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateColumnInterface.cpp LevelSetInitialCondition.cpp
+    SetFluidProperties.cpp SetLSProperties.cpp TagLSRefinementCells.cpp
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )

--- a/examples/multiphase_flow/ex6/CMakeLists.txt
+++ b/examples/multiphase_flow/ex6/CMakeLists.txt
@@ -1,0 +1,50 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex6-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex6"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateFluidInterface.cpp LevelSetInitialCondition.cpp
+    SetFluidProperties.cpp SetLSProperties.cpp TagLSRefinementCells.cpp
+    VelocityInitialCondition.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex6-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex6"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateFluidInterface.cpp LevelSetInitialCondition.cpp
+    SetFluidProperties.cpp SetLSProperties.cpp TagLSRefinementCells.cpp
+    VelocityInitialCondition.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )

--- a/examples/multiphase_flow/ex7/CMakeLists.txt
+++ b/examples/multiphase_flow/ex7/CMakeLists.txt
@@ -1,0 +1,31 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex7"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex7"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateCircularInterface.cpp LSLocateGasInterface.cpp
+    RigidBodyKinematics.cpp SetFluidGasSolidDensity.cpp SetFluidGasSolidViscosity.cpp
+    SetLSProperties.cpp TagLSRefinementCells.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.cyl cylinder2d.vertex
+  )

--- a/examples/multiphase_flow/ex8/CMakeLists.txt
+++ b/examples/multiphase_flow/ex8/CMakeLists.txt
@@ -1,0 +1,63 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex8-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex8"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateCircularInterface.cpp LSLocateGasInterface.cpp
+    RigidBodyKinematics.cpp SetFluidGasSolidDensity.cpp SetFluidGasSolidViscosity.cpp
+    SetLSProperties.cpp TagLSRefinementCells.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.cyl
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex8-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex8"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    GravityForcing.cpp LSLocateCircularInterface.cpp LSLocateGasInterface.cpp
+    RigidBodyKinematics.cpp SetFluidGasSolidDensity.cpp SetFluidGasSolidViscosity.cpp
+    SetLSProperties.cpp TagLSRefinementCells.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d.sphere
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex8-spheregen"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex8"
+  OUTPUT_NAME
+    sphereGen
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    sphereGen.cpp
+  )

--- a/examples/multiphase_flow/ex9/CMakeLists.txt
+++ b/examples/multiphase_flow/ex9/CMakeLists.txt
@@ -1,0 +1,45 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex9"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex9"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    FlowGravityForcing.cpp GravityForcing.cpp LSLocateCircularInterface.cpp
+    LSLocateGasInterface.cpp RigidBodyKinematics.cpp SetFluidGasSolidDensity.cpp
+    SetFluidGasSolidViscosity.cpp SetLSProperties.cpp TagLSRefinementCells.cpp
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.flow input2d.full cylinder2d.vertex
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "multiphase_flow-ex9-cylindergen"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/multiphase_flow/ex9"
+  OUTPUT_NAME
+    cylinderGen
+  EXAMPLE_GROUP
+    examples-multiphase_flow
+  SOURCES
+    cylinderGen.cpp
+  )

--- a/examples/navier_stokes/CMakeLists.txt
+++ b/examples/navier_stokes/CMakeLists.txt
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir ex0 ex1 ex2 ex3 ex4 ex5 ex6)
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/navier_stokes/ex0/CMakeLists.txt
+++ b/examples/navier_stokes/ex0/CMakeLists.txt
@@ -1,0 +1,46 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-ex0-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d input2d.forced_flow
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-ex0-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex0"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )

--- a/examples/navier_stokes/ex1/CMakeLists.txt
+++ b/examples/navier_stokes/ex1/CMakeLists.txt
@@ -1,0 +1,76 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-ex1-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex1"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-ex1-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex1"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-convergence-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex"
+  OUTPUT_NAME
+    convergence_tester2d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    convergence_tester.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-convergence-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex1"
+  OUTPUT_NAME
+    convergence_tester3d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    convergence_tester.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  )

--- a/examples/navier_stokes/ex2/CMakeLists.txt
+++ b/examples/navier_stokes/ex2/CMakeLists.txt
@@ -1,0 +1,33 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-ex2"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex2"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  EXTRA_FILES
+    L1norm.m L1normx.m L1normy.m
+    L2norm.m L2normx.m L2normy.m
+    analyzer.m
+  )

--- a/examples/navier_stokes/ex3/CMakeLists.txt
+++ b/examples/navier_stokes/ex3/CMakeLists.txt
@@ -1,0 +1,33 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-ex3"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex3"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  EXTRA_FILES
+    L1norm.m L1normx.m L1normy.m
+    L2norm.m L2normx.m L2normy.m
+    analyzer.m analyzer_256.m
+  )

--- a/examples/navier_stokes/ex4/CMakeLists.txt
+++ b/examples/navier_stokes/ex4/CMakeLists.txt
@@ -1,0 +1,46 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-ex4-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex4"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-ex4-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex4"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )

--- a/examples/navier_stokes/ex5/CMakeLists.txt
+++ b/examples/navier_stokes/ex5/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-ex5"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex5"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    BoussinesqForcing.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )

--- a/examples/navier_stokes/ex6/CMakeLists.txt
+++ b/examples/navier_stokes/ex6/CMakeLists.txt
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "navier_stokes-ex6"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/navier_stokes/ex6"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-navier_stokes
+  SOURCES
+    BoussinesqForcing.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d
+  )

--- a/examples/vc_navier_stokes/CMakeLists.txt
+++ b/examples/vc_navier_stokes/CMakeLists.txt
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir ex0 ex1 ex2)
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/vc_navier_stokes/ex0/CMakeLists.txt
+++ b/examples/vc_navier_stokes/ex0/CMakeLists.txt
@@ -1,0 +1,50 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "vc_navier_stokes-ex0-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/vc_navier_stokes/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-vc_navier_stokes
+  SOURCES
+    SetFluidProperties.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d input2d.amr input2d.bubble
+  EXTRA_FILES
+    ManufacturedSolution_2D.nb
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "vc_navier_stokes-ex0-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/vc_navier_stokes/ex0"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-vc_navier_stokes
+  SOURCES
+    SetFluidProperties.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d input3d.amr
+  EXTRA_FILES
+    ManufacturedSolution_3D.nb
+  )

--- a/examples/vc_navier_stokes/ex1/CMakeLists.txt
+++ b/examples/vc_navier_stokes/ex1/CMakeLists.txt
@@ -1,0 +1,31 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "vc_navier_stokes-ex1"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/vc_navier_stokes/ex1"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-vc_navier_stokes
+  SOURCES
+    SetFluidProperties.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d input2d.amr
+  EXTRA_FILES
+    extract_error.sh
+  )

--- a/examples/vc_navier_stokes/ex2/CMakeLists.txt
+++ b/examples/vc_navier_stokes/ex2/CMakeLists.txt
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "vc_navier_stokes-ex2"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/vc_navier_stokes/ex2"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-vc_navier_stokes
+  SOURCES
+    GravityForcing.cpp LSLocateCircularInterface.cpp SetFluidProperties.cpp
+    SetLSProperties.cpp TagLSRefinementCells.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d.cgs input2d.mks
+  )

--- a/examples/wave_tank/CMakeLists.txt
+++ b/examples/wave_tank/CMakeLists.txt
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+FOREACH(_dir ex0 ex1)
+  ADD_SUBDIRECTORY(${_dir})
+ENDFOREACH()

--- a/examples/wave_tank/ex0/CMakeLists.txt
+++ b/examples/wave_tank/ex0/CMakeLists.txt
@@ -1,0 +1,52 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "wave_tank-ex0-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/wave_tank/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-wave_tank
+  SOURCES
+    GravityForcing.cpp LSLocateColumnInterface.cpp SetFluidProperties.cpp
+    SetLSProperties.cpp TagLSRefinementCells.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d input2d_5thOrderStokes input2d_CaseA
+    input2d_CaseA_IrregularWave input2d_CaseB input2d_CaseC
+  EXTRA_FILES
+    StokesWaveLength.m compareIrregularWave.m compareStokesFifthOrder.m
+    compareStokesFirstOrder.m compareStokesSecondOrder.m
+  )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "wave_tank-ex0-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/wave_tank/ex0"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-wave_tank
+  SOURCES
+    GravityForcing.cpp LSLocateColumnInterface.cpp SetFluidProperties.cpp
+    SetLSProperties.cpp TagLSRefinementCells.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE3d
+  INPUT_FILES
+    input3d
+  )

--- a/examples/wave_tank/ex1/CMakeLists.txt
+++ b/examples/wave_tank/ex1/CMakeLists.txt
@@ -1,0 +1,35 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "wave_tank-ex1"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/wave_tank/ex1"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-wave_tank
+  SOURCES
+    FlowGravityForcing.cpp GravityForcing.cpp LSLocateGasInterface.cpp
+    LSLocateTrapezoidalInterface.cpp LevelSetSolidInitialCondition.cpp
+    RigidBodyKinematics.cpp SetFluidGasSolidDensity.cpp
+    SetFluidGasSolidViscosity.cpp SetLSProperties.cpp
+    TagLSRefinementCells.cpp example.cpp
+  LINK_TARGETS
+    EXECUTABLE2d
+  INPUT_FILES
+    input2d trapezoid2d.vertex
+  EXTRA_FILES
+    Trapezoid2D.m
+  )

--- a/ibtk/CMakeLists.txt
+++ b/ibtk/CMakeLists.txt
@@ -1,0 +1,1 @@
+ADD_SUBDIRECTORY(src)

--- a/ibtk/include/ibtk/config.h.in
+++ b/ibtk/include/ibtk/config.h.in
@@ -11,19 +11,50 @@
 //
 // ---------------------------------------------------------------------
 
-/////////////////////// INCLUDE GUARD ////////////////////////////////////
-
 #ifndef included_IBTK_config
 #define included_IBTK_config
 
-///////////////////////////// INCLUDES ///////////////////////////////////
+//
+// Version information
+//
 
-#include <IBTK_config.h>
+// Major version of IBTK and IBAMR.
+#define IBTK_VERSION_MAJOR @IBTK_VERSION_MAJOR@
 
-// This header is a stub defined to keep the CMake and autotools build systems
-// compatible. As such, headers are included in an odd order to keep things
-// working.
+// Minor version of IBTK and IBAMR.
+#define IBTK_VERSION_MINOR @IBTK_VERSION_MINOR@
 
+// Subminor version of IBTK and IBAMR.
+#define IBTK_VERSION_SUBMINOR @IBTK_VERSION_SUBMINOR@
+
+#define IBTK_VERSION_GTE(major, minor, subminor)                                          \
+    ((IBTK_VERSION_MAJOR * 10000 + IBTK_VERSION_MINOR * 100 + IBTK_VERSION_SUBMINOR) >= \
+     (major)*10000 + (minor)*100 + (subminor))
+
+//
+// Dependency information
+//
+
+// Whether or not _Pragma is available
+#cmakedefine IBTK_HAVE_PRAGMA_KEYWORD
+
+// Whether or not libMesh is available
+#cmakedefine IBTK_HAVE_LIBMESH
+
+// Whether or not Silo is available
+#cmakedefine IBTK_HAVE_SILO
+
+//
+// Utility macros
+//
+
+// Correctly mangle Fortran names
+#define IBTK_FC_FUNC(name, NAME) @IBTK_FC_FUNC@
+
+// Like IBTK_FC_FUNC, but for names containing underscores
+#define IBTK_FC_FUNC_(name, NAME) @IBTK_FC_FUNC_@
+
+// Macro for disabling warnings
 #ifdef IBTK_HAVE_PRAGMA_KEYWORD
 // Prevent clang-format from doing strange things to this very long macro:
 // clang-format off
@@ -57,8 +88,4 @@ _Pragma("GCC diagnostic ignored \"-Wunneeded-internal-declaration\"")
 
 #endif // #ifdef IBTK_HAVE_PRAGMA_KEYWORD
 
-#include <ibtk/IBTK_CHKERRQ.h>
-#include <ibtk/compiler_hints.h>
-#include <ibtk/ibtk_utilities.h>
-
-#endif //#ifndef included_IBTK_config
+#endif // included_IBTK_config

--- a/ibtk/include/ibtk/ibtk_macros.h
+++ b/ibtk/include/ibtk/ibtk_macros.h
@@ -16,37 +16,6 @@
 
 #include <ibtk/config.h>
 
-#ifdef IBTK_HAVE_PRAGMA_KEYWORD
-// Prevent clang-format from doing strange things to this very long macro:
-// clang-format off
-
-// The first four warnings here should be left in that order: new warnings
-// should be placed at the end.
-#define IBTK_DISABLE_EXTRA_WARNINGS                             \
-_Pragma("GCC diagnostic push")                                  \
-_Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")         \
-_Pragma("GCC diagnostic ignored \"-Wpragmas\"")                 \
-_Pragma("GCC diagnostic ignored \"-Wunknown-warning-option\"")  \
-_Pragma("GCC diagnostic ignored \"-Wunknown-warning\"")         \
-_Pragma("GCC diagnostic ignored \"-Wunused-variable\"")         \
-_Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")      \
-_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"") \
-_Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")  \
-_Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")     \
-_Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")     \
-_Pragma("GCC diagnostic ignored \"-Wunused-local-typedefs\"")   \
-_Pragma("GCC diagnostic ignored \"-Wdeprecated-copy\"")         \
-_Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")        \
-_Pragma("GCC diagnostic ignored \"-Wunneeded-internal-declaration\"")
-
-#define IBTK_ENABLE_EXTRA_WARNINGS _Pragma("GCC diagnostic pop")
-
-// clang-format on
-#else
-
-#define IBTK_DISABLE_EXTRA_WARNINGS
-#define IBTK_ENABLE_EXTRA_WARNINGS
-
-#endif // #ifdef IBTK_HAVE_PRAGMA_KEYWORD
+#pragma message("This file has been deprecated: use ibtk/config.h directly instead")
 
 #endif // #ifndef included_IBTK_ibtk_macros

--- a/ibtk/src/CMakeLists.txt
+++ b/ibtk/src/CMakeLists.txt
@@ -1,0 +1,239 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+ADD_LIBRARY(IBTK2d SHARED)
+ADD_LIBRARY(IBTK3d SHARED)
+
+# 'base' names (without, 2d.f.m4 or 3d.f.m4) for all the fortran that is
+# explicitly compiled
+SET(FORTRAN_SRC_BASE
+  boundary/cf_interface/fortran/linearcfinterpolation
+  boundary/cf_interface/fortran/quadcfinterpolation
+  boundary/physical_boundary/fortran/cartphysbdryop
+
+  coarsen_ops/fortran/cubiccoarsen
+  coarsen_ops/fortran/rt0coarsen
+  lagrangian/fortran/lagrangian_interaction
+
+  math/fortran/curl
+  math/fortran/div
+  math/fortran/flux
+  math/fortran/grad
+  math/fortran/graddetect
+  math/fortran/interp
+  math/fortran/laplace
+  math/fortran/miscmath
+  math/fortran/rot
+  math/fortran/strain
+  math/fortran/vclaplace
+
+  refine_ops/fortran/divpreservingrefine
+  refine_ops/fortran/cart_side_refine
+
+  solvers/impls/fortran/patchsmoothers
+  )
+
+FOREACH(_d ${IBAMR_DIMENSIONS})
+  FOREACH(_fortran_root_name ${FORTRAN_SRC_BASE})
+    IBAMR_PROCESS_M4(NAME ${_fortran_root_name}${_d}d.f)
+  ENDFOREACH()
+
+  SET("FORTRAN_GENERATED_SRC${_d}D" "")
+  FOREACH(_fortran_root_name ${FORTRAN_SRC_BASE})
+    LIST(APPEND "FORTRAN_GENERATED_SRC${_d}D" "${CMAKE_CURRENT_BINARY_DIR}/${_fortran_root_name}${_d}d.f")
+  ENDFOREACH()
+ENDFOREACH()
+
+#
+# set up C++:
+#
+SET(CXX_SRC
+  # boundary
+  boundary/HierarchyGhostCellInterpolation.cpp
+  boundary/cf_interface/CartCellDoubleLinearCFInterpolation.cpp
+  boundary/cf_interface/CartSideDoubleQuadraticCFInterpolation.cpp
+  boundary/cf_interface/CartCellDoubleQuadraticCFInterpolation.cpp
+  boundary/physical_boundary/CartCellRobinPhysBdryOp.cpp
+  boundary/physical_boundary/StaggeredPhysicalBoundaryHelper.cpp
+  boundary/physical_boundary/CartExtrapPhysBdryOp.cpp
+  boundary/physical_boundary/CartSideRobinPhysBdryOp.cpp
+  boundary/physical_boundary/PhysicalBoundaryUtilities.cpp
+  boundary/physical_boundary/muParserRobinBcCoefs.cpp
+  boundary/physical_boundary/ExtendedRobinBcCoefStrategy.cpp
+  boundary/physical_boundary/RobinPhysBdryPatchStrategy.cpp
+
+  # coarsen ops
+  coarsen_ops/CartCellDoubleCubicCoarsen.cpp
+  coarsen_ops/CartSideDoubleRT0Coarsen.cpp
+  coarsen_ops/LMarkerCoarsen.cpp
+  coarsen_ops/CartSideDoubleCubicCoarsen.cpp
+
+  # lagrangian
+  lagrangian/LDataManager.cpp
+  lagrangian/LNode.cpp
+  lagrangian/LTransaction.cpp
+  lagrangian/LEInteractor.cpp
+  lagrangian/LNodeIndex.cpp
+  lagrangian/LIndexSetData.cpp
+  lagrangian/LSet.cpp
+  lagrangian/LIndexSetDataFactory.cpp
+  lagrangian/LSetData.cpp
+  lagrangian/LIndexSetVariable.cpp
+  lagrangian/LSetDataFactory.cpp
+  lagrangian/LInitStrategy.cpp
+  lagrangian/LSetDataIterator.cpp
+  lagrangian/LMarker.cpp
+  lagrangian/LSetVariable.cpp
+  lagrangian/LData.cpp
+  lagrangian/LMesh.cpp
+  lagrangian/LSiloDataWriter.cpp
+
+  # math
+  math/PETScVecUtilities.cpp
+  math/HierarchyMathOps.cpp
+  math/PoissonUtilities.cpp
+  math/SAMRAIGhostDataAccumulator.cpp
+  math/PETScMatUtilities.cpp
+  math/PatchMathOps.cpp
+
+  # refine ops
+  refine_ops/CartCellDoubleQuadraticRefine.cpp
+  refine_ops/LMarkerRefine.cpp
+  refine_ops/CartSideDoubleSpecializedLinearRefine.cpp
+  refine_ops/CartCellDoubleBoundsPreservingConservativeLinearRefine.cpp
+  refine_ops/CartSideDoubleDivPreservingRefine.cpp
+  refine_ops/CartSideDoubleRT0Refine.cpp
+
+  # solvers
+  solvers/interfaces/FACPreconditionerStrategy.cpp
+  solvers/interfaces/LinearOperator.cpp
+  solvers/interfaces/JacobianOperator.cpp
+  solvers/interfaces/GeneralOperator.cpp
+  solvers/interfaces/GeneralSolver.cpp
+  solvers/interfaces/KrylovLinearSolver.cpp
+  solvers/interfaces/NewtonKrylovSolver.cpp
+  solvers/interfaces/LinearSolver.cpp
+  solvers/wrappers/PETScSNESFunctionGOWrapper.cpp
+  solvers/wrappers/PETScSAMRAIVectorReal.cpp
+  solvers/wrappers/PETScMatLOWrapper.cpp
+  solvers/wrappers/PETScSNESJacobianJOWrapper.cpp
+  solvers/wrappers/PETScPCLSWrapper.cpp
+  solvers/impls/CCPoissonPETScLevelSolver.cpp
+  solvers/impls/PoissonSolver.cpp
+  solvers/impls/NewtonKrylovSolverManager.cpp
+  solvers/impls/VCSCViscousPETScLevelSolver.cpp
+  solvers/impls/PETScLevelSolver.cpp
+  solvers/impls/CCPoissonSolverManager.cpp
+  solvers/impls/PoissonFACPreconditionerStrategy.cpp
+  solvers/impls/BGaussSeidelPreconditioner.cpp
+  solvers/impls/BJacobiPreconditioner.cpp
+  solvers/impls/SCPoissonPointRelaxationFACOperator.cpp
+  solvers/impls/KrylovLinearSolverPoissonSolverInterface.cpp
+  solvers/impls/VCSCViscousOperator.cpp
+  solvers/impls/FACPreconditioner.cpp
+  solvers/impls/PETScMFFDJacobianOperator.cpp
+  solvers/impls/VCSCViscousOpPointRelaxationFACOperator.cpp
+  solvers/impls/CCLaplaceOperator.cpp
+  solvers/impls/PETScNewtonKrylovSolver.cpp
+  solvers/impls/CCPoissonBoxRelaxationFACOperator.cpp
+  solvers/impls/CCPoissonHypreLevelSolver.cpp
+  solvers/impls/PoissonFACPreconditioner.cpp
+  solvers/impls/CCPoissonLevelRelaxationFACOperator.cpp
+  solvers/impls/PETScKrylovLinearSolver.cpp
+  solvers/impls/KrylovLinearSolverManager.cpp
+  solvers/impls/SCPoissonPETScLevelSolver.cpp
+  solvers/impls/SCPoissonSolverManager.cpp
+  solvers/impls/LaplaceOperator.cpp
+  solvers/impls/SCLaplaceOperator.cpp
+  solvers/impls/SCPoissonHypreLevelSolver.cpp
+  solvers/impls/PETScKrylovPoissonSolver.cpp
+  solvers/impls/CCPoissonPointRelaxationFACOperator.cpp
+
+  # utilities
+  utilities/RefinePatchStrategySet.cpp
+  utilities/NodeSynchCopyFillPattern.cpp
+  utilities/ParallelEdgeMap.cpp
+  utilities/DebuggingUtilities.cpp
+  utilities/CellNoCornersFillPattern.cpp
+  utilities/CoarsenPatchStrategySet.cpp
+  utilities/SideDataSynchronization.cpp
+  utilities/StandardTagAndInitStrategySet.cpp
+  utilities/IndexUtilities.cpp
+  utilities/ParallelSet.cpp
+  utilities/FaceDataSynchronization.cpp
+  utilities/HierarchyIntegrator.cpp
+  utilities/MergingLoadBalancer.cpp
+  utilities/CopyToRootSchedule.cpp
+  utilities/AppInitializer.cpp
+  utilities/IBTKInit.cpp
+  utilities/SAMRAIDataCache.cpp
+  utilities/FixedSizedStream.cpp
+  utilities/muParserCartGridFunction.cpp
+  utilities/IBTK_MPI.cpp
+  utilities/FaceSynchCopyFillPattern.cpp
+  utilities/CartGridFunctionSet.cpp
+  utilities/EdgeDataSynchronization.cpp
+  utilities/NodeDataSynchronization.cpp
+  utilities/ParallelMap.cpp
+  utilities/SideNoCornersFillPattern.cpp
+  utilities/box_utilities.cpp
+  utilities/Streamable.cpp
+  utilities/CopyToRootTransaction.cpp
+  utilities/SideSynchCopyFillPattern.cpp
+  utilities/CartGridFunction.cpp
+  utilities/NormOps.cpp
+  utilities/EdgeSynchCopyFillPattern.cpp
+  utilities/StreamableManager.cpp
+  utilities/LMarkerUtilities.cpp
+  utilities/PartitioningBox.cpp
+  )
+
+IF(IBAMR_HAVE_LIBMESH)
+  LIST(APPEND CXX_SRC
+    # lagrangian
+    lagrangian/BoxPartitioner.cpp
+    lagrangian/FEDataInterpolation.cpp
+    lagrangian/FEDataManager.cpp
+    lagrangian/FEMapping.cpp
+    lagrangian/FEProjector.cpp
+    lagrangian/FEValues.cpp
+    lagrangian/StableCentroidPartitioner.cpp
+
+    # utilities
+    utilities/LibMeshSystemVectors.cpp
+    utilities/LibMeshSystemIBVectors.cpp
+    utilities/libmesh_utilities.cpp
+    )
+ENDIF()
+
+# TARGET_SOURCES needs to use private - if we used public then dependencies on
+# this target will also compile the source files
+TARGET_SOURCES(IBTK2d PRIVATE ${FORTRAN_GENERATED_SRC2D} ${CXX_SRC})
+TARGET_SOURCES(IBTK3d PRIVATE ${FORTRAN_GENERATED_SRC3D} ${CXX_SRC})
+
+# Include path to ibtk/config.h
+TARGET_INCLUDE_DIRECTORIES(IBTK2d PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ibtk/include/>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ibtk/>)
+TARGET_INCLUDE_DIRECTORIES(IBTK3d PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ibtk/include/>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>)
+
+TARGET_LINK_LIBRARIES(IBTK2d PUBLIC IBTKHeaders)
+TARGET_LINK_LIBRARIES(IBTK3d PUBLIC IBTKHeaders)
+
+IBAMR_SETUP_TARGET_LIBRARY(IBTK2d)
+IBAMR_SETUP_TARGET_LIBRARY(IBTK3d)
+
+INSTALL(TARGETS IBTK2d EXPORT IBAMRTargets COMPONENT library)
+INSTALL(TARGETS IBTK3d EXPORT IBAMRTargets COMPONENT library)

--- a/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
+++ b/ibtk/src/lagrangian/fortran/lagrangian_interaction2d.f.m4
@@ -74,7 +74,7 @@ define(SPREAD_2D_SPECIALIZE_FIXED_WIDTH,
          endif')dnl
 include(SAMRAI_FORTDIR/pdat_m4arrdim2d.i)dnl
 
-c     this is a Fortran include, not an m4 include
+c     this is an m4 include, not a Fortran include
 include(CURRENT_SRCDIR/lagrangian_delta.f.m4)
 
 c

--- a/ibtk/src/refine_ops/fortran/cart_side_helpers.f.m4
+++ b/ibtk/src/refine_ops/fortran/cart_side_helpers.f.m4
@@ -11,8 +11,13 @@ c COPYRIGHT at the top level directory of IBAMR.
 c
 c ---------------------------------------------------------------------
 
-define(REAL,`double precision')dnl
-define(INTEGER,`integer')dnl
+dnl This file only exists to be included into
+dnl cart_side_refine2d.f and cart_side_refine3d.f: i.e., it is
+dnl never explicitly compiled on its own so that the delta function kernels
+dnl can be inlined. This is necessary since Fortran compilers will (unless
+dnl we use something fancy like LTO) only do inlining of functions and
+dnl subroutines defined in the same translation unit.
+
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c

--- a/ibtk/src/refine_ops/fortran/cart_side_refine2d.f.m4
+++ b/ibtk/src/refine_ops/fortran/cart_side_refine2d.f.m4
@@ -40,8 +40,8 @@ minmod3(
      & 2.d0*d_dx1_L($1,$2,$3),
      & 2.d0*d_dx1_R($1,$2,$3))')dnl'
 
-c     this is a Fortran include, not an m4 include
-      include 'cart_side_helpers.f'
+c     this is an m4 include, not a Fortran include
+include(CURRENT_SRCDIR/cart_side_helpers.f.m4)
 
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/ibtk/src/refine_ops/fortran/cart_side_refine3d.f.m4
+++ b/ibtk/src/refine_ops/fortran/cart_side_refine3d.f.m4
@@ -48,8 +48,8 @@ minmod3(
      & 2.d0*d_dx2_L($1,$2,$3,$4),
      & 2.d0*d_dx2_R($1,$2,$3,$4))')dnl'
 
-c     this is a Fortran include, not an m4 include
-      include 'cart_side_helpers.f'
+c     this is an m4 include, not a Fortran include
+include(CURRENT_SRCDIR/cart_side_helpers.f.m4)
 
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/include/ibamr/config.h
+++ b/include/ibamr/config.h
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2020 - 2020 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#ifndef included_IBAMR_config
+#define included_IBAMR_config
+
+#include <ibtk/config.h>
+
+// Same as the IBTK include file - for compatibility we simply redefine all
+// macros with IBAMR
+
+#define IBAMR_VERSION_MAJOR IBTK_VERSION_MAJOR
+
+#define IBAMR_VERSION_MINOR IBTK_VERSION_MINOR
+
+#define IBAMR_VERSION_SUBMINOR IBTK_VERSION_SUBMINOR
+
+#define IBAMR_VERSION_GTE(major, minor, subminor) IBTK_VERSION_GTE(major, minor, subminor)
+
+#define IBAMR_HAVE_PRAGMA_KEYWORD IBTK_HAVE_PRAGMA_KEYWORD
+
+#define IBAMR_HAVE_LIBMESH IBTK_HAVE_LIBMESH
+
+#define IBAMR_HAVE_SILO IBTK_HAVE_SILO
+
+#define IBAMR_FC_FUNC(name, NAME) IBTK_FC_FUNC(name, NAME)
+
+#define IBAMR_FC_FUNC_(name, NAME) IBTK_FC_FUNC_(name, NAME)
+
+#define IBAMR_DISABLE_EXTRA_WARNINGS IBTK_DISABLE_EXTRA_WARNINGS
+
+#define IBAMR_ENABLE_EXTRA_WARNINGS IBTK_ENABLE_EXTRA_WARNINGS
+
+#endif // included_IBAMR_config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,239 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+ADD_LIBRARY(IBAMR2d SHARED)
+ADD_LIBRARY(IBAMR3d SHARED)
+
+# 'base' names (without, 2d.f.m4 or 3d.f.m4) for all the fortran that is
+# explicitly compiled
+SET(FORTRAN_SRC_BASE
+  adv_diff/fortran/adv_diff_consdiff
+  adv_diff/fortran/adv_diff_wp_convective_op
+  advect/fortran/advect_centered_derivatives
+  advect/fortran/advect_detect
+  advect/fortran/advect_diff
+  advect/fortran/advect_helpers
+  advect/fortran/advect_predictors
+  advect/fortran/advect_stable
+  complex_fluids/fortran/div_tensor
+  complex_fluids/fortran/log_upper_convective_op
+  complex_fluids/fortran/sqrt_upper_convective_op
+  complex_fluids/fortran/upper_convective_op
+  level_set/fortran/levelsetops
+  navier_stokes/fortran/navier_stokes_bdryop
+  navier_stokes/fortran/navier_stokes_divsource
+  navier_stokes/fortran/navier_stokes_stabledt
+  navier_stokes/fortran/navier_stokes_staggered_derivatives
+  navier_stokes/fortran/navier_stokes_staggered_helpers
+  navier_stokes/fortran/navier_stokes_stochastic_forcing
+  navier_stokes/fortran/navier_stokes_surface_tension_forcing
+  )
+
+FOREACH(_d ${IBAMR_DIMENSIONS})
+  FOREACH(_fortran_root_name ${FORTRAN_SRC_BASE})
+    IBAMR_PROCESS_M4(NAME ${_fortran_root_name}${_d}d.f)
+  ENDFOREACH()
+
+  SET("FORTRAN_GENERATED_SRC${_d}D" "")
+  FOREACH(_fortran_root_name ${FORTRAN_SRC_BASE})
+    LIST(APPEND "FORTRAN_GENERATED_SRC${_d}D" "${CMAKE_CURRENT_BINARY_DIR}/${_fortran_root_name}${_d}d.f")
+  ENDFOREACH()
+ENDFOREACH()
+
+#
+# set up C++:
+#
+SET(CXX_SRC
+  # adv diff
+  adv_diff/AdvDiffPredictorCorrectorHyperbolicPatchOps.cpp
+  adv_diff/AdvDiffConvectiveOperatorManager.cpp
+  adv_diff/AdvDiffCUIConvectiveOperator.cpp
+  adv_diff/AdvDiffCenteredConvectiveOperator.cpp
+  adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
+  adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
+  adv_diff/AdvDiffHierarchyIntegrator.cpp
+  adv_diff/AdvDiffPhysicalBoundaryUtilities.cpp
+  adv_diff/AdvDiffWavePropConvectiveOperator.cpp
+  adv_diff/AdvDiffStochasticForcing.cpp
+  adv_diff/AdvDiffPPMConvectiveOperator.cpp
+
+  # wave generation
+  wave_generation/StokesFirstOrderWaveBcCoef.cpp
+  wave_generation/StokesSecondOrderWaveBcCoef.cpp
+  wave_generation/StokesFifthOrderWaveBcCoef.cpp
+  wave_generation/StokesWaveGeneratorStrategy.cpp
+  wave_generation/WaveGenerationFunctions.cpp
+  wave_generation/WaveDampingFunctions.cpp
+  wave_generation/IrregularWaveGenerator.cpp
+  wave_generation/FifthOrderStokesWaveGenerator.cpp
+  wave_generation/FirstOrderStokesWaveGenerator.cpp
+  wave_generation/IrregularWaveBcCoef.cpp
+
+  # navier stokes
+  navier_stokes/INSIntermediateVelocityBcCoef.cpp
+  navier_stokes/INSStaggeredCenteredConvectiveOperator.cpp
+  navier_stokes/StaggeredStokesPETScMatUtilities.cpp
+  navier_stokes/PETScKrylovStaggeredStokesSolver.cpp
+  navier_stokes/StokesSpecifications.cpp
+  navier_stokes/INSStaggeredStochasticForcing.cpp
+  navier_stokes/VCStaggeredStokesProjectionPreconditioner.cpp
+  navier_stokes/StaggeredStokesSolverManager.cpp
+  navier_stokes/INSStaggeredUpwindConvectiveOperator.cpp
+  navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+  navier_stokes/VCStaggeredStokesOperator.cpp
+  navier_stokes/StaggeredStokesPETScVecUtilities.cpp
+  navier_stokes/INSCollocatedVelocityBcCoef.cpp
+  navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
+  navier_stokes/StaggeredStokesPhysicalBoundaryHelper.cpp
+  navier_stokes/INSStaggeredVelocityBcCoef.cpp
+  navier_stokes/INSStaggeredCUIConvectiveOperator.cpp
+  navier_stokes/INSCollocatedPPMConvectiveOperator.cpp
+  navier_stokes/INSStaggeredWavePropConvectiveOperator.cpp
+  navier_stokes/INSCollocatedConvectiveOperatorManager.cpp
+  navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+  navier_stokes/INSProjectionBcCoef.cpp
+  navier_stokes/INSHierarchyIntegrator.cpp
+  navier_stokes/StaggeredStokesPETScLevelSolver.cpp
+  navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
+  navier_stokes/StaggeredStokesBoxRelaxationFACOperator.cpp
+  navier_stokes/INSStaggeredConvectiveOperatorManager.cpp
+  navier_stokes/INSStaggeredStabilizedPPMConvectiveOperator.cpp
+  navier_stokes/INSCollocatedWavePropConvectiveOperator.cpp
+  navier_stokes/SpongeLayerForceFunction.cpp
+  navier_stokes/INSVCStaggeredVelocityBcCoef.cpp
+  navier_stokes/KrylovLinearSolverStaggeredStokesSolverInterface.cpp
+  navier_stokes/StaggeredStokesFACPreconditioner.cpp
+  navier_stokes/INSStaggeredPPMConvectiveOperator.cpp
+  navier_stokes/INSStaggeredPressureBcCoef.cpp
+  navier_stokes/StokesBcCoefStrategy.cpp
+  navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
+  navier_stokes/SurfaceTensionForceFunction.cpp
+  navier_stokes/StaggeredStokesLevelRelaxationFACOperator.cpp
+  navier_stokes/INSVCStaggeredPressureBcCoef.cpp
+  navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
+  navier_stokes/StaggeredStokesFACPreconditionerStrategy.cpp
+  navier_stokes/INSVCStaggeredConservativeMassMomentumIntegrator.cpp
+  navier_stokes/StaggeredStokesOpenBoundaryStabilizer.cpp
+  navier_stokes/StaggeredStokesBlockPreconditioner.cpp
+  navier_stokes/StaggeredStokesOperator.cpp
+  navier_stokes/INSCollocatedCenteredConvectiveOperator.cpp
+  navier_stokes/StaggeredStokesSolver.cpp
+  navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+
+  # IB
+  IB/IBInstrumentPanel.cpp
+  IB/BrinkmanPenalizationStrategy.cpp
+  IB/PenaltyIBMethod.cpp
+  IB/GeneralizedIBMethod.cpp
+  IB/IBLagrangianForceStrategy.cpp
+  IB/KrylovMobilitySolver.cpp
+  IB/IBHydrodynamicForceEvaluator.cpp
+  IB/DirectMobilitySolver.cpp
+  IB/IBHydrodynamicSurfaceForceEvaluator.cpp
+  IB/IBRodForceSpecFactory.cpp
+  IB/IBExplicitHierarchyIntegrator.cpp
+  IB/CIBStaggeredStokesSolver.cpp
+  IB/IBKirchhoffRodForceGen.cpp
+  IB/IBAnchorPointSpec.cpp
+  IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+  IB/IBFECentroidPostProcessor.cpp
+  IB/IBRedundantInitializer.cpp
+  IB/IBAnchorPointSpecFactory.cpp
+  IB/CIBStrategy.cpp
+  IB/IBInterpolantHierarchyIntegrator.cpp
+  IB/IBFESurfaceMethod.cpp
+  IB/IBInstrumentationSpecFactory.cpp
+  # This file is not yet finished
+  # IB/IBFEPatchRecoveryPostProcessor.cpp
+  IB/IBFEPostProcessor.cpp
+  IB/BrinkmanPenalizationRigidBodyDynamics.cpp
+  IB/CIBMobilitySolver.cpp
+  IB/IBStrategy.cpp
+  IB/IBTargetPointForceSpec.cpp
+  IB/IBStrategySet.cpp
+  IB/IBHierarchyIntegrator.cpp
+  IB/MaterialPointSpecFactory.cpp
+  IB/IBInstrumentationSpec.cpp
+  IB/IBFEMethod.cpp
+  IB/ConstraintIBMethod.cpp
+  IB/IBEulerianSourceFunction.cpp
+  IB/IBBeamForceSpecFactory.cpp
+  IB/MobilityFunctions.cpp
+  IB/IMPMethod.cpp
+  IB/IMPInitializer.cpp
+  IB/IBStandardForceGen.cpp
+  IB/CIBStaggeredStokesOperator.cpp
+  IB/Wall.cpp
+  IB/IBStandardInitializer.cpp
+  IB/IBInterpolantMethod.cpp
+  IB/IBEulerianForceFunction.cpp
+  IB/NonbondedForceEvaluator.cpp
+  IB/IBFEInstrumentPanel.cpp
+  IB/StaggeredStokesIBLevelRelaxationFACOperator.cpp
+  IB/MaterialPointSpec.cpp
+  IB/KrylovFreeBodyMobilitySolver.cpp
+  IB/IBSpringForceSpecFactory.cpp
+  IB/ConstraintIBKinematics.cpp
+  IB/IBLevelSetMethod.cpp
+  IB/IBLagrangianForceStrategySet.cpp
+  IB/IBRodForceSpec.cpp
+  IB/FEMechanicsBase.cpp
+  IB/IBSourceSpec.cpp
+  IB/IBSourceSpecFactory.cpp
+  IB/CIBSaddlePointSolver.cpp
+  IB/WallForceEvaluator.cpp
+  IB/IBTargetPointForceSpecFactory.cpp
+  IB/IBMethod.cpp
+  IB/IBFEDirectForcingKinematics.cpp
+  IB/IBBeamForceSpec.cpp
+  IB/IBSpringForceSpec.cpp
+  IB/CIBMethod.cpp
+  IB/IBLagrangianSourceStrategy.cpp
+  IB/IBStandardSourceGen.cpp
+
+  # complex fluids
+  complex_fluids/CFRoliePolyRelaxation.cpp
+  complex_fluids/CFGiesekusRelaxation.cpp
+  complex_fluids/CFRelaxationOperator.cpp
+  complex_fluids/CFINSForcing.cpp
+  complex_fluids/CFOldroydBRelaxation.cpp
+  complex_fluids/CFUpperConvectiveOperator.cpp
+
+  # advect
+  advect/AdvectorExplicitPredictorPatchOps.cpp
+  advect/AdvectorPredictorCorrectorHyperbolicPatchOps.cpp
+
+  # level set
+  level_set/FESurfaceDistanceEvaluator.cpp
+  level_set/LSInitStrategy.cpp
+  level_set/FastSweepingLSMethod.cpp
+  level_set/RelaxationLSBcCoefs.cpp
+  level_set/RelaxationLSMethod.cpp
+  utilities/RNG.cpp
+  utilities/ConvectiveOperator.cpp
+  )
+
+TARGET_SOURCES(IBAMR2d PRIVATE ${FORTRAN_GENERATED_SRC2D} ${CXX_SRC})
+TARGET_SOURCES(IBAMR3d PRIVATE ${FORTRAN_GENERATED_SRC3D} ${CXX_SRC})
+
+TARGET_LINK_LIBRARIES(IBAMR2d PUBLIC IBAMRHeaders IBTKHeaders)
+TARGET_LINK_LIBRARIES(IBAMR3d PUBLIC IBAMRHeaders IBTKHeaders)
+
+IBAMR_SETUP_TARGET_LIBRARY(IBAMR2d)
+IBAMR_SETUP_TARGET_LIBRARY(IBAMR3d)
+
+TARGET_LINK_LIBRARIES(IBAMR2d PUBLIC IBTK2d)
+TARGET_LINK_LIBRARIES(IBAMR3d PUBLIC IBTK3d)
+
+INSTALL(TARGETS IBAMR2d EXPORT IBAMRTargets COMPONENT library)
+INSTALL(TARGETS IBAMR3d EXPORT IBAMRTargets COMPONENT library)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,270 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+ADD_CUSTOM_TARGET(tests)
+
+# We use the list of test directories in two ways:
+# 1. each test is added to a target tests-dir so that, e.g., 'make tests-IBFE'
+#    only compiles the IBFE tests.
+# 2. all input and output files in these source directories are symlinked into
+#    their corresponding build directories.
+SET(TEST_DIRECTORIES CIB IB IBFE IBTK adv_diff advect complex_fluids interpolate
+  level_set multiphase_flow navier_stokes physical_boundary refine spread
+  vc_navier_stokes wave_tank)
+
+FOREACH(_dir ${TEST_DIRECTORIES})
+  ADD_CUSTOM_TARGET("tests-${_dir}")
+  ADD_DEPENDENCIES(tests "tests-${_dir}")
+ENDFOREACH()
+
+# TODO - we should clean up these macros so we don't have 3 macros that do
+# basically the same thing
+
+# Convenience macro that sets up an executable target which links against
+# _target_link. For example, if the inputs are Foo, bar.cpp, and quux then we
+# create a target Foo_bar in directory Foo which depends on quux.
+MACRO(SETUP _dir _src _target_link)
+  GET_FILENAME_COMPONENT(_out_name "${_src}" NAME_WE)
+  SET(_target "tests-${_dir}_${_out_name}")
+  ADD_EXECUTABLE(${_target} EXCLUDE_FROM_ALL "${_dir}/${_src}")
+  SET_TARGET_PROPERTIES(${_target}
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/tests/${_dir}"
+    OUTPUT_NAME
+    ${_out_name}
+    )
+  TARGET_COMPILE_OPTIONS(${_target} PUBLIC -DSOURCE_DIR="${CMAKE_SOURCE_DIR}/tests/${_dir}/")
+  TARGET_LINK_LIBRARIES(${_target} PRIVATE "${_target_link}")
+  ADD_DEPENDENCIES("tests-${_dir}" ${_target})
+ENDMACRO()
+
+# Like the last one, but for 2d targets. For example, if the inputs are Foo and
+# bar.cpp then we create a target Foo_bar_2d in directory Foo which depends on
+# IBAMR2d.
+MACRO(SETUP_2D _dir _src)
+  GET_FILENAME_COMPONENT(_dest "${_src}" NAME_WE)
+  SET(_out_name "${_dest}_2d")
+  SET(_target "tests-${_dir}_${_out_name}")
+  ADD_EXECUTABLE(${_target} EXCLUDE_FROM_ALL "${_dir}/${_src}")
+  SET_TARGET_PROPERTIES(${_target}
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/tests/${_dir}"
+    OUTPUT_NAME
+    ${_out_name}
+    )
+  TARGET_COMPILE_OPTIONS(${_target} PUBLIC -DSOURCE_DIR="${CMAKE_SOURCE_DIR}/tests/${_dir}/")
+  TARGET_LINK_LIBRARIES(${_target} PRIVATE IBAMR2d)
+  ADD_DEPENDENCIES("tests-${_dir}" ${_target})
+ENDMACRO()
+
+# Like the last one, but for 3d targets. For example, if the inputs are Foo and
+# bar.cpp then we create a target Foo_bar_3d in directory Foo which depends on
+# IBAMR3d.
+MACRO(SETUP_3D _dir _src)
+  GET_FILENAME_COMPONENT(_dest "${_src}" NAME_WE)
+  SET(_out_name "${_dest}_3d")
+  SET(_target "tests-${_dir}_${_out_name}")
+  ADD_EXECUTABLE(${_target} EXCLUDE_FROM_ALL "${_dir}/${_src}")
+  SET_TARGET_PROPERTIES(${_target}
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/tests/${_dir}"
+    OUTPUT_NAME
+    ${_out_name}
+    )
+  TARGET_COMPILE_OPTIONS(${_target} PUBLIC -DSOURCE_DIR="${CMAKE_SOURCE_DIR}/tests/${_dir}/")
+  TARGET_LINK_LIBRARIES(${_target} PRIVATE IBAMR3d)
+  ADD_DEPENDENCIES(tests-${_dir} ${_target})
+ENDMACRO()
+
+# adv_diff:
+SETUP_2D(adv_diff adv_diff_02.cpp)
+SETUP_2D(adv_diff adv_diff_03.cpp)
+SETUP_2D(adv_diff adv_diff_convec_opers.cpp)
+
+SETUP_3D(adv_diff adv_diff_01.cpp)
+SETUP_3D(adv_diff adv_diff_02.cpp)
+SETUP_3D(adv_diff adv_diff_convec_opers.cpp)
+
+# advect:
+SETUP_2D(advect advect_01.cpp)
+SETUP_3D(advect advect_01.cpp)
+
+# complex_fluids:
+SETUP(complex_fluids cf_four_roll_mill.cpp IBAMR2d)
+SETUP_2D(complex_fluids cf_relaxation_op_01.cpp)
+SETUP_2D(complex_fluids cf_forcing_op_01.cpp)
+
+SETUP_3D(complex_fluids cf_relaxation_op_01.cpp)
+SETUP_3D(complex_fluids cf_forcing_op_01.cpp)
+
+# interpolate:
+SETUP_2D(interpolate interpolate_01.cpp)
+SETUP_3D(interpolate interpolate_01.cpp)
+
+# level_set:
+SETUP_2D(level_set fe_surface_distance.cpp)
+SETUP_3D(level_set fe_surface_distance.cpp)
+
+# multiphase_flow:
+SETUP(multiphase_flow free_falling_cyl_cib.cpp IBAMR2d)
+SETUP(multiphase_flow rotating_barge_cib.cpp IBAMR2d)
+SETUP(multiphase_flow check_hydro_force.cpp IBAMR2d)
+SETUP(multiphase_flow high_density_droplet.cpp IBAMR2d)
+
+# navier_stokes:
+SETUP_2D(navier_stokes navier_stokes_01.cpp)
+SETUP_3D(navier_stokes navier_stokes_01.cpp)
+
+# physical_boundary:
+SETUP(physical_boundary extrapolation_01.cpp IBAMR2d)
+SETUP_2D(physical_boundary 01.cpp)
+SETUP_3D(physical_boundary 01.cpp)
+
+# refine:
+SETUP_2D(refine rt0_refine_01.cpp)
+SETUP_3D(refine rt0_refine_01.cpp)
+
+# spread:
+IF(IBAMR_HAVE_LIBMESH)
+  SETUP_2D(spread spread_01.cpp)
+  SETUP_3D(spread spread_01.cpp)
+  SETUP_2D(spread spread_02.cpp)
+  SETUP_3D(spread spread_02.cpp)
+ENDIF()
+
+# vc_navier_stokes:
+SETUP_2D(vc_navier_stokes vc_navier_stokes_01.cpp)
+SETUP_3D(vc_navier_stokes vc_navier_stokes_01.cpp)
+
+# wave_tank:
+SETUP(wave_tank nwt_cylinder.cpp IBAMR2d)
+SETUP(wave_tank nwt.cpp IBAMR2d)
+
+# CIB:
+SETUP(CIB cib_plate.cpp IBAMR2d)
+SETUP(CIB cib_double_shell.cpp IBAMR3d)
+
+# IB:
+SETUP(IB explicit_ex0 IBAMR2d)
+SETUP(IB explicit_ex1 IBAMR2d)
+
+# IBFE:
+IF(IBAMR_HAVE_LIBMESH)
+  SETUP(IBFE interpolate_velocity_02.cpp IBAMR2d)
+
+  SETUP_2D(IBFE explicit_ex0.cpp)
+  SETUP_2D(IBFE explicit_ex1.cpp)
+  SETUP_2D(IBFE explicit_ex4.cpp)
+  SETUP_2D(IBFE explicit_ex5.cpp)
+  SETUP_2D(IBFE explicit_ex8.cpp)
+  SETUP_2D(IBFE interpolate_velocity_01.cpp)
+  SETUP_2D(IBFE ib_partitioning_01.cpp)
+  SETUP_2D(IBFE ib_partitioning_02.cpp)
+  SETUP_2D(IBFE zero_exterior_values.cpp)
+
+  SETUP_3D(IBFE explicit_ex2.cpp)
+  SETUP_3D(IBFE explicit_ex4.cpp)
+  SETUP_3D(IBFE explicit_ex5.cpp)
+  SETUP_3D(IBFE ib_partitioning_01.cpp)
+  SETUP_3D(IBFE ib_partitioning_02.cpp)
+  SETUP_3D(IBFE interpolate_velocity_01.cpp)
+  SETUP_3D(IBFE zero_exterior_values.cpp)
+ENDIF()
+
+# IBTK:
+SETUP(IBTK hierarchy_callbacks IBAMR2d)
+SETUP(IBTK ibtk_init.cpp IBAMR2d)
+SETUP(IBTK ibtk_mpi.cpp IBAMR2d)
+SETUP(IBTK ldata_01.cpp IBAMR2d)
+SETUP(IBTK mpi_type_wrappers.cpp IBAMR2d)
+
+IF(IBAMR_HAVE_LIBMESH)
+  SETUP(IBTK elem_hmax_01.cpp IBAMR2d)
+  SETUP(IBTK elem_hmax_02.cpp IBAMR3d)
+  SETUP(IBTK fe_values_01.cpp IBAMR2d)
+  SETUP(IBTK fe_values_02.cpp IBAMR2d)
+  SETUP(IBTK jacobian_calc_01.cpp IBAMR2d)
+  SETUP(IBTK mapping_01.cpp IBAMR2d)
+  SETUP(IBTK subdomain_level_translation_01.cpp IBAMR2d)
+
+  SETUP_2D(IBTK bounding_boxes_01.cpp)
+  SETUP_2D(IBTK multilevel_fe_01.cpp)
+ENDIF()
+SETUP_2D(IBTK box_utilities_01.cpp)
+SETUP_2D(IBTK ghost_accumulation_01.cpp)
+SETUP_2D(IBTK ghost_indices_01.cpp)
+SETUP_2D(IBTK laplace_01.cpp)
+SETUP_2D(IBTK laplace_02.cpp)
+SETUP_2D(IBTK laplace_03.cpp)
+SETUP_2D(IBTK phys_boundary_ops.cpp)
+SETUP_2D(IBTK poisson_01.cpp)
+SETUP_2D(IBTK prolongation_mat.cpp)
+SETUP_2D(IBTK samraidatacache_01.cpp)
+SETUP_2D(IBTK vc_viscous_solver.cpp)
+
+IF(IBAMR_HAVE_LIBMESH)
+  SETUP_3D(IBTK bounding_boxes_01.cpp)
+  SETUP_3D(IBTK multilevel_fe_01.cpp)
+ENDIF()
+SETUP_3D(IBTK box_utilities_01.cpp)
+SETUP_3D(IBTK ghost_accumulation_01.cpp)
+SETUP_3D(IBTK ghost_indices_01.cpp)
+SETUP_3D(IBTK laplace_01.cpp)
+SETUP_3D(IBTK laplace_02.cpp)
+SETUP_3D(IBTK laplace_03.cpp)
+SETUP_3D(IBTK phys_boundary_ops.cpp)
+SETUP_3D(IBTK poisson_01.cpp)
+SETUP_3D(IBTK prolongation_mat.cpp)
+SETUP_3D(IBTK samraidatacache_01.cpp)
+SETUP_3D(IBTK vc_viscous_solver.cpp)
+
+ADD_CUSTOM_COMMAND(TARGET tests
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_SOURCE_DIR}/attest ${CMAKE_BINARY_DIR}/attest)
+
+# Set up the input and output files. Since the input and output files aren't
+# really used by the build system we use a shell script to find them every time
+# 'make test' is run rather than evaluating the glob when cmake generates the
+# build system.
+SET(TEST_DIRECTORIES CIB IB IBFE IBTK adv_diff advect complex_fluids interpolate
+  level_set multiphase_flow navier_stokes physical_boundary refine spread
+  vc_navier_stokes wave_tank)
+
+FOREACH(_dir ${TEST_DIRECTORIES})
+  ADD_CUSTOM_COMMAND(TARGET "tests-${_dir}"
+    POST_BUILD
+    COMMAND bash ${CMAKE_SOURCE_DIR}/tests/link-test-files.sh
+    ${CMAKE_SOURCE_DIR}/tests/${_dir} ${CMAKE_BINARY_DIR}/tests/${_dir}
+    VERBATIM)
+ENDFOREACH()
+
+# Find numdiff, if possible (we only need it for tests so its not essential that
+# we find it now)
+FIND_PROGRAM(NUMDIFF_EXECUTABLE NAMES numdiff HINTS ${NUMDIFF_ROOT} PATH_SUFFIXES bin)
+
+IF ("${NUMDIFF_EXECUTABLE}" STREQUAL "NUMDIFF_EXECUTABLE-NOTFOUND")
+  MESSAGE(WARNING "\
+The configuration script was not able to locate numdiff. If you want to run \
+the test suite you will need to either edit attest.conf, specify the path to \
+numdiff to attest, or rerun CMake with the argument NUMDIFF_ROOT specifying \
+numdiff's root installation directory.")
+  # clear the value so that attest.conf doesn't contain an invalid path
+  SET(NUMDIFF_EXECUTABLE "")
+ENDIF()
+
+# Set up the default attest configuration file:
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/attest.conf.in
+  ${CMAKE_BINARY_DIR}/attest.conf)

--- a/tests/attest.conf.in
+++ b/tests/attest.conf.in
@@ -1,0 +1,10 @@
+# attest default configuration file
+[attest]
+jobs = 1
+keep_work_directories = False
+mpiexec = @MPIEXEC_EXECUTABLE@
+numdiff = @NUMDIFF_EXECUTABLE@
+show_only = False
+test_directory = /tests/
+include_regex = .*
+exclude_regex = ^$

--- a/tests/link-test-files.sh
+++ b/tests/link-test-files.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+# Replacement for cmake -E create_symlink that is much faster.
+#
+# $1 is the source test directory
+# $2 is the build test directory
+
+INPUT_DIR="$1"
+OUTPUT_DIR="$2"
+
+# We have to avoid using loops or other such things to work with weird file
+# names (e.g., paths that include spaces)
+find "$INPUT_DIR" \( -name '*.input' -o -name '*.output' \) -exec ln -f -s {} "$OUTPUT_DIR" \;


### PR DESCRIPTION
I deleted the template since its not really applicable.

I have spent enough time working on the new build system that its in pretty good shape (though it only really works on my desktop at the moment). Major benefits of CMake:
- We can handle dependencies cleanly instead of accumulating a giant list of LIBS.
- `make install` works correctly.
- We will be able to use CPack to generate real packages (e.g., `.dmg` files)
- Much better interop with external tools like clang-tidy and XCode
- Optimized executables are about ~half as large~ 90% smaller, debug executables are not 700 MB each
- The whole build system is much smaller. We only need about ~300~ 600 lines of code, the rest of the CMake code just enumerates source files, sets up examples, etc.

 We are at the point where I can enumerate the major known remaining problems:
- [x] We need to correctly export targets. We can cleanly set up targets in the test suite, but in principle we should be able to set up user codes with just three lines, e.g.,
```cmake
FIND_PACKAGE(IBAMR 0.7.0 REQUIRED)
ADD_EXECUTABLE(main3d "main.cpp")
TARGET_LINK_LIBRARIES(main3d IBAMR::IBAMR2d)
```
- [x] We need real configuration options instead of hardcoding `SAMRAI_DIR` et al to paths on my desktop
- [x] Handle bundled muParser
- [x] Compile examples. This is a nice place to show how to use a CMake module in an example (GSL)
- [x] Fix the 25 or so test programs that are compiled in weird ways to be more regular
- [x] Support silo
- [x] Write a shell script to link test input/output files to replace `cmake -E create_symlink` since we want globs evaluated when we call `make test` and not when we run CMake to generate the build system
- [x] Generate better configuration headers (see also #802)
- [x] Explicitly manage hypre as a dependency
- [x] get consistent Fortran symbol mangling set up (this is done by macros that should be in #802)
- [x] Split up the tests target into subtargets so that experts can write `make tests-IBTK` to only compile a subset of tests (see #555)
- [x] document our conventions and some basic CMake conventions (e.g., all find modules look in `PACKAGENAME_ROOT`)
- [x] Add consistency checks - e.g., that libMesh uses the same version of PETSc that is specified by `PETSC_ROOT`.

Some serious caveats of the current approach:
- We need a very new version of CMake (3.15) because I want modern CMake features (please no `INCLUDE_DIRECTORIES`)
- ~We currently use pkg-config to set up muParser, libMesh, and PETSc, which is not ideal (i.e., we require it as a build dependency)~ This is now fixed with something more portable but also more ad-hoc (parsing `petscvariables`).
- ~The configuration dependencies mean that we only work with the current development version of libMesh (I need to write a few more patches for them too to fix some additional outstanding problems)~ This has also been fixed by removing the dependency on pkg-config.

New TODO list:
- [x] Check that PETSc, HDF5, and SAMRAI are all using the same MPI implementation.
- [ ] Expose `IBAMR_DIMENSIONS` to let people compile in only 2D or only 3D. (this isn't in the current build system - lets handle it in a follow-up PR)
- [ ] Check the cross-compiling situation. I'm not sure I can verify this without access to a machine with a very different architecture.
- [ ] Look into how we can generate our own `pkg-config` files (even though we don't use `pkg-config` ourselves) (let's handle this in a follow-up PR)