### PR TITLE
Bug fixes to compute time steps in parallel.

### DIFF
--- a/doc/news/changes/minor/20200626AaronBarrett
+++ b/doc/news/changes/minor/20200626AaronBarrett
@@ -1,0 +1,3 @@
+Bug fix: AdvDiffHierarchyIntegrator correctly computes maximum timesteps consistent across all timesteps.
+<br>
+(Aaron Barret, 2020/06/26)

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -699,7 +699,8 @@ protected:
 
     /*!
      * Virtual method to compute an implementation-specific minimum stable time
-     * step size.
+     * step size. Implementations should ensure that the returned time step is
+     * consistent across all processors.
      *
      * A default implementation is provided that returns
      * min(dt_max,dt_growth_factor*dt_current).  The growth condition prevents
@@ -709,7 +710,8 @@ protected:
 
     /*!
      * Virtual method to compute an implementation-specific maximum stable time
-     * step size.
+     * step size. Implementations should ensure that the returned time step is
+     * consistent across all processors.
      *
      * A default implementation is provided that returns
      * min(dt_max,dt_growth_factor*dt_current).  The growth condition prevents

--- a/src/adv_diff/AdvDiffHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffHierarchyIntegrator.cpp
@@ -978,7 +978,7 @@ AdvDiffHierarchyIntegrator::getMaximumTimeStepSizeSpecialized()
             }
         }
     }
-    return dt;
+    return SAMRAI_MPI::minReduction(dt);
 } // getMaximumTimeStepSizeSpecialized
 
 void


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?

Fixes #1022. `AdvDiffHierarchyIntegrator` did not compute timestep sizes consistent across all processors. I've updated the documentation in `HierarchyIntegrator` to note that time step sizes should be consistent in implementations of `getMinimumTimeStepSizeSpecialized` and `getMaximumTimeStepSizeSpecialized`. ~~This is also fixes a minor bug in `HierarchyIntegrator` to select the smallest of all timesteps in computing the minimum timestep.~~