### PR TITLE
Prevent some code from being overoptimized.

### DIFF
--- a/doc/news/changes/minor/20200629DavidWells
+++ b/doc/news/changes/minor/20200629DavidWells
@@ -1,0 +1,5 @@
+Fix: GCC 10.1.0 generates incorrect vectorized code for the multi-variable
+overload of IBTK::get_values_for_interpolation(). Get around this by adding
+a temporary array to the function.
+<br>
+(David Wells, 2020/06/29)


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

GCC 10.1.0 got a lot better at vectorizing code, but in this case I am pretty sure it is doing something wrong: it is generating wrong code w.r.t. where the array index is placed which causes bus errors. I will ultimately report this to the GCC guys but I want to finish up a few other things first - for now this workaround seems to defeat the loop vectorization function.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
