### PR TITLE
Fix an ABI problem in some Fortran code.

### DIFF
--- a/include/ibamr/AdvectorExplicitPredictorPatchOps.h
+++ b/include/ibamr/AdvectorExplicitPredictorPatchOps.h
@@ -374,11 +374,12 @@ private:
      *    d_limiter_type ........ specifies the type of slope limiting type used in
      *                            computing numerical fluxes
      *    d_using_full_ctu ...... specifies whether full corner transport
-     *                            upwinding is used for 3D computations
+     *                            upwinding is used for 3D computations. Set to 1 to
+     *                            enable it.
      */
     LimiterType d_limiter_type = MC_LIMITED;
 #if (NDIM == 3)
-    bool d_using_full_ctu = true;
+    int d_using_full_ctu = 1;
 #endif
 };
 } // namespace IBAMR

--- a/src/advect/AdvectorExplicitPredictorPatchOps.cpp
+++ b/src/advect/AdvectorExplicitPredictorPatchOps.cpp
@@ -226,7 +226,7 @@ extern "C"
                            const double&,
                            const int&,
 #if (NDIM == 3)
-                           const unsigned int&,
+                           const int&,
 #endif
 #if (NDIM == 2)
                            const int&,
@@ -283,7 +283,7 @@ extern "C"
                                        const double&,
                                        const int&,
 #if (NDIM == 3)
-                                       const unsigned int&,
+                                       const int&,
 #endif
 #if (NDIM == 2)
                                        const int&,
@@ -349,7 +349,7 @@ extern "C"
                                const double&,
                                const int&,
 #if (NDIM == 3)
-                               const unsigned int&,
+                               const int&,
 #endif
 #if (NDIM == 2)
                                const int&,
@@ -412,7 +412,7 @@ extern "C"
                                            const double&,
                                            const int&,
 #if (NDIM == 3)
-                                           const unsigned int&,
+                                           const int&,
 #endif
 #if (NDIM == 2)
                                            const int&,
@@ -997,7 +997,7 @@ AdvectorExplicitPredictorPatchOps::predict(FaceData<NDIM, double>& q_half,
             ADVECT_PREDICT_FC(dx,
                               dt,
                               d_limiter_type,
-                              static_cast<unsigned int>(d_using_full_ctu),
+                              d_using_full_ctu,
                               ilower(0),
                               iupper(0),
                               ilower(1),
@@ -1059,7 +1059,7 @@ AdvectorExplicitPredictorPatchOps::predict(FaceData<NDIM, double>& q_half,
             ADVECT_PREDICT_PPM_FC(dx,
                                   dt,
                                   d_limiter_type,
-                                  static_cast<unsigned int>(d_using_full_ctu),
+                                  d_using_full_ctu,
                                   ilower(0),
                                   iupper(0),
                                   ilower(1),
@@ -1186,7 +1186,7 @@ AdvectorExplicitPredictorPatchOps::predictWithSourceTerm(FaceData<NDIM, double>&
             ADVECT_PREDICT_WITH_SOURCE_FC(dx,
                                           dt,
                                           d_limiter_type,
-                                          static_cast<unsigned int>(d_using_full_ctu),
+                                          d_using_full_ctu,
                                           ilower(0),
                                           iupper(0),
                                           ilower(1),
@@ -1258,7 +1258,7 @@ AdvectorExplicitPredictorPatchOps::predictWithSourceTerm(FaceData<NDIM, double>&
             ADVECT_PREDICT_PPM_WITH_SOURCE_FC(dx,
                                               dt,
                                               d_limiter_type,
-                                              static_cast<unsigned int>(d_using_full_ctu),
+                                              d_using_full_ctu,
                                               ilower(0),
                                               iupper(0),
                                               ilower(1),
@@ -1319,7 +1319,7 @@ AdvectorExplicitPredictorPatchOps::getFromInput(Pointer<Database> db, bool /*is_
         TBOX_ASSERT(d_limiter_type != UNKNOWN_LIMITER_TYPE);
     }
 #if (NDIM == 3)
-    if (db->keyExists("using_full_ctu")) d_using_full_ctu = db->getBool("using_full_ctu");
+    if (db->keyExists("using_full_ctu")) d_using_full_ctu = db->getBool("using_full_ctu") ? 1 : 0;
 #endif
     return;
 } // getFromInput
@@ -1351,7 +1351,7 @@ AdvectorExplicitPredictorPatchOps::getFromRestart()
                                  << "  Restart file version different than class version.");
     }
 #if (NDIM == 3)
-    d_using_full_ctu = db->getBool("d_using_full_ctu");
+    d_using_full_ctu = db->getBool("d_using_full_ctu") ? 1 : 0;
 #endif
     return;
 } // getFromRestart

--- a/src/advect/fortran/advect_predictors3d.f.m4
+++ b/src/advect/fortran/advect_predictors3d.f.m4
@@ -186,7 +186,9 @@ c
 
       INTEGER limiter
 
-      LOGICAL usefullctu
+c     It would make more sense to pass a LOGICAL but its not clear which
+c     C type that corresponds to, so use an integer
+      INTEGER usefullctu
 
       REAL dx(0:NDIM-1), dt
 
@@ -274,7 +276,8 @@ c     differences of the "temporary" predicted values.  Full corner
 c     transport upwinding (increasing the largest stable timestep but
 c     not order of accuracy) is somewhat expensive and optional.
 c
-      if ( usefullctu ) then
+
+      if ( usefullctu .eq. 1 ) then
 c
 c     Include full corner transport upwinding.
 c
@@ -384,7 +387,9 @@ c
       INTEGER nugc0,nugc1,nugc2
       INTEGER nqhalfgc0,nqhalfgc1,nqhalfgc2
 
-      LOGICAL usefullctu
+c     It would make more sense to pass a LOGICAL but its not clear which
+c     C type that corresponds to, so use an integer
+      INTEGER usefullctu
 
       INTEGER limiter
 
@@ -497,7 +502,7 @@ c     differences of the "temporary" predicted values.  Full corner
 c     transport upwinding (increasing the largest stable timestep but
 c     not order of accuracy) is somewhat expensive and optional.
 c
-      if ( usefullctu ) then
+      if ( usefullctu .eq. 1 ) then
 c
 c     Include full corner transport upwinding.
 c
@@ -603,7 +608,9 @@ c
       INTEGER nugc0,nugc1,nugc2
       INTEGER nqhalfgc0,nqhalfgc1,nqhalfgc2
 
-      LOGICAL usefullctu
+c     It would make more sense to pass a LOGICAL but its not clear which
+c     C type that corresponds to, so use an integer
+      INTEGER usefullctu
 
       INTEGER limiter
 
@@ -727,7 +734,7 @@ c     differences of the "temporary" predicted values.  Full corner
 c     transport upwinding (increasing the largest stable timestep but
 c     not order of accuracy) is somewhat expensive and optional.
 c
-      if ( usefullctu ) then
+      if ( usefullctu .eq. 1 ) then
 c
 c     Include full corner transport upwinding.
 c
@@ -837,7 +844,9 @@ c
       INTEGER nugc0,nugc1,nugc2
       INTEGER nqhalfgc0,nqhalfgc1,nqhalfgc2
 
-      LOGICAL usefullctu
+c     It would make more sense to pass a LOGICAL but its not clear which
+c     C type that corresponds to, so use an integer
+      INTEGER usefullctu
 
       INTEGER limiter
 
@@ -989,7 +998,7 @@ c     differences of the "temporary" predicted values.  Full corner
 c     transport upwinding (increasing the largest stable timestep but
 c     not order of accuracy) is somewhat expensive and optional.
 c
-      if ( usefullctu ) then
+      if ( usefullctu .eq. 1 ) then
 c
 c     Include full corner transport upwinding.
 c


### PR DESCRIPTION
Enabling link-time optimization with GCC has the interesting side effect of enabling type-checking of our Fortran interfaces. In particular, it looks like LOGICAL is not the same as unsigned int: some FORTRAN compilers make logical true equal to -1 so this is not the right choice.

After reading through some gfortran documentation I'm not sure at all what integral type LOGICAL is supposed to be, so lets completely avoid the issue and use an integer set to 1 if we want the corner code on.

Here is one of the four GCC warnings:
```
/home/drwells/Documents/Code/CPP/ibamr/src/advect/AdvectorExplicitPredictorPatchOps.cpp:411:10:
warning: type of 'advect_predict_ppm_with_source3d_' does not match original declaration
  411 |     void ADVECT_PREDICT_PPM_WITH_SOURCE_FC(const double*,
      |          ^
/home/drwells/Documents/Code/CPP/ibamr/build/src/advect/fortran/advect_predictors3d.f:984:
note: 'advect_predict_ppm_with_source3d' was previously declared here
  984 |       subroutine advect_predict_PPM_with_source3d(
      |
```
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?