### PR TITLE
Move a Fortran function used in IBTK into IBTK.

### DIFF
--- a/ibtk/src/refine_ops/fortran/Makefile.am
+++ b/ibtk/src/refine_ops/fortran/Makefile.am
@@ -14,10 +14,10 @@
 ## Process this file with automake to produce Makefile.in
 include $(top_srcdir)/config/Make-rules
 
-EXTRA_DIST =                                            \
+EXTRA_DIST = cart_side_helpers.f.m4                     \
   cart_side_refine2d.f.m4    cart_side_refine3d.f.m4    \
   divpreservingrefine2d.f.m4 divpreservingrefine3d.f.m4
-BUILT_SOURCES =                                   \
+BUILT_SOURCES = cart_side_helpers.f               \
   cart_side_refine2d.f    cart_side_refine3d.f    \
   divpreservingrefine2d.f divpreservingrefine3d.f
 CLEANFILES = ${BUILT_SOURCES}

--- a/ibtk/src/refine_ops/fortran/Makefile.in
+++ b/ibtk/src/refine_ops/fortran/Makefile.in
@@ -410,11 +410,11 @@ IBTK2d_LIBS = ${top_builddir}/lib/libIBTK2d.a
 IBTK3d_LIBS = ${top_builddir}/lib/libIBTK3d.a
 pkg_includedir = $(includedir)/@PACKAGE@
 SUFFIXES = .f.m4
-EXTRA_DIST = \
+EXTRA_DIST = cart_side_helpers.f.m4                     \
   cart_side_refine2d.f.m4    cart_side_refine3d.f.m4    \
   divpreservingrefine2d.f.m4 divpreservingrefine3d.f.m4
 
-BUILT_SOURCES = \
+BUILT_SOURCES = cart_side_helpers.f               \
   cart_side_refine2d.f    cart_side_refine3d.f    \
   divpreservingrefine2d.f divpreservingrefine3d.f
 

--- a/ibtk/src/refine_ops/fortran/cart_side_helpers.f.m4
+++ b/ibtk/src/refine_ops/fortran/cart_side_helpers.f.m4
@@ -1,0 +1,46 @@
+c ---------------------------------------------------------------------
+c
+c Copyright (c) 2011 - 2019 by the IBAMR developers
+c All rights reserved.
+c
+c This file is part of IBAMR.
+c
+c IBAMR is free software and is distributed under the 3-clause BSD
+c license. The full text of the license can be found in the file
+c COPYRIGHT at the top level directory of IBAMR.
+c
+c ---------------------------------------------------------------------
+
+define(REAL,`double precision')dnl
+define(INTEGER,`integer')dnl
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+c     The minmod function of three arguments.
+c
+c     The minmod function is a function of two or more arguments that
+c     takes the value of the argument with the smallest modulus if all
+c     arguments have the same sign.  Otherwise it takes the value zero.
+c
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c
+      REAL function minmod3(a,b,c)
+c
+      implicit none
+c
+c     Input.
+c
+      REAL a,b,c
+c
+c     minmod(a,b,c)
+c
+      if     ( (a.ge.0.0d0).and.(b.ge.0.0d0).and.(c.ge.0.0d0) ) then
+         minmod3 = dmin1(a,b,c)
+      elseif ( (a.le.0.0d0).and.(b.le.0.0d0).and.(c.le.0.0d0) ) then
+         minmod3 = dmax1(a,b,c)
+      else
+         minmod3 = 0.d0
+      endif
+c
+      return
+      end

--- a/ibtk/src/refine_ops/fortran/cart_side_refine2d.f.m4
+++ b/ibtk/src/refine_ops/fortran/cart_side_refine2d.f.m4
@@ -39,6 +39,10 @@ minmod3(
      & d_dx1_C($1,$2,$3),
      & 2.d0*d_dx1_L($1,$2,$3),
      & 2.d0*d_dx1_R($1,$2,$3))')dnl'
+
+c     this is a Fortran include, not an m4 include
+      include 'cart_side_helpers.f'
+
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c

--- a/ibtk/src/refine_ops/fortran/cart_side_refine3d.f.m4
+++ b/ibtk/src/refine_ops/fortran/cart_side_refine3d.f.m4
@@ -47,6 +47,10 @@ minmod3(
      & d_dx2_C($1,$2,$3,$4),
      & 2.d0*d_dx2_L($1,$2,$3,$4),
      & 2.d0*d_dx2_R($1,$2,$3,$4))')dnl'
+
+c     this is a Fortran include, not an m4 include
+      include 'cart_side_helpers.f'
+
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c

--- a/src/advect/fortran/advect_helpers.f.m4
+++ b/src/advect/fortran/advect_helpers.f.m4
@@ -106,37 +106,6 @@ c
 c
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c
-c     The minmod function of three arguments.
-c
-c     The minmod function is a function of two or more arguments that
-c     takes the value of the argument with the smallest modulus if all
-c     arguments have the same sign.  Otherwise it takes the value zero.
-c
-ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-c
-      REAL function minmod3(a,b,c)
-c
-      implicit none
-c
-c     Input.
-c
-      REAL a,b,c
-c
-c     minmod(a,b,c)
-c
-      if     ( (a.ge.0.0d0).and.(b.ge.0.0d0).and.(c.ge.0.0d0) ) then
-         minmod3 = dmin1(a,b,c)
-      elseif ( (a.le.0.0d0).and.(b.le.0.0d0).and.(c.le.0.0d0) ) then
-         minmod3 = dmax1(a,b,c)
-      else
-         minmod3 = 0.d0
-      endif
-c
-      return
-      end
-c
-ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-c
 c     The maxmod function of two arguments.
 c
 c     The maxmod function is a function of two or more arguments that


### PR DESCRIPTION
We need to do this in the CMake build so that there are no undefined symbols in libIBTK2d and libIBTK3d. With static libraries this is not a problem but it is with shared libraries on mac (the linker fails if any symbols are undefined).

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?