### PR TITLE
Remove a stray emacs file.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,0 @@
-((nil . ((projectile-project-compilation-dir . "../ibamr-objs-dbg")
-         (projectile-project-compilation-cmd . "make -kwj8")
-         )))


### PR DESCRIPTION
This is specific to a particular user's projectile configuration.

The usual checksheet doesn't apply since this is strictly an emacs configuration file.