### PR TITLE
Fix the ghost cell size given to SAMRAIGhostDataAccumulator.

### DIFF
--- a/doc/news/changes/minor/2020713DavidWells
+++ b/doc/news/changes/minor/2020713DavidWells
@@ -1,0 +1,4 @@
+Fix: Fixed a problem with IBFEMethod when the ghost data size required by
+IBFEMethod is not equal to that required by another class.
+<br>
+(David Wells, 2020/07/13)

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -928,10 +928,19 @@ IBFEMethod::spreadForce(const int f_data_idx,
     }
 
     {
-        auto hierarchy = d_use_scratch_hierarchy ? d_scratch_hierarchy : d_hierarchy;
         if (!d_ghost_data_accumulator)
+        {
+            // If we have multiple IBMethod objects we may end up with a wider
+            // ghost region than the one required by this class. Hence, set the
+            // ghost width by just picking whatever the data actually has at the
+            // moment.
+            const Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(ln);
+            const IntVector<NDIM> gcw =
+                level->getPatchDescriptor()->getPatchDataFactory(f_scratch_data_idx)->getGhostCellWidth();
+
             d_ghost_data_accumulator.reset(new SAMRAIGhostDataAccumulator(
-                hierarchy, f_var, d_ghosts, d_hierarchy->getFinestLevelNumber(), d_hierarchy->getFinestLevelNumber()));
+                hierarchy, f_var, gcw, d_hierarchy->getFinestLevelNumber(), d_hierarchy->getFinestLevelNumber()));
+        }
         d_ghost_data_accumulator->accumulateGhostData(f_scratch_data_idx);
     }
 


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

Thanks to @jabrown893 for pointing this out.

IBFEMethod can determine the ghost cell width required by itself and by FEDataManager, but it doesn't know about ghost cell with requirements of other classes. Hence we should not use its own ghost width for setting up force spreading accumulation data structures - instead we can just read it from the input data.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?