### PR TITLE
Use Mapping::build() directly in JacobianCalculatorCache.

### DIFF
--- a/ibtk/include/ibtk/JacobianCalculatorCache.h
+++ b/ibtk/include/ibtk/JacobianCalculatorCache.h
@@ -109,6 +109,24 @@ inline JacobianCalculatorCache::JacobianCalculatorCache(const int spatial_dimens
     TBOX_ASSERT(0 < spatial_dimension && spatial_dimension <= 3);
 }
 
+// Helper function that downcasts a unique_ptr. We need this below since
+// Mapping::build returns a mapping that always happens to be a NodalMapping
+// and a NodalMapping is a JacobianCalculator (we need to ultimately remove this
+// backwards-compatible interface and just use Mapping everywhere)
+template <typename B, typename A>
+std::unique_ptr<B>
+dynamic_unique_cast(std::unique_ptr<A>&& p)
+{
+    if (B* cast = dynamic_cast<B*>(p.get()))
+    {
+        std::unique_ptr<B> result(cast);
+        p.release();
+        return result;
+    }
+    else
+        throw std::bad_cast();
+}
+
 inline JacobianCalculatorCache::value_type&
 JacobianCalculatorCache::operator[](const JacobianCalculatorCache::key_type& quad_key)
 {
@@ -119,48 +137,50 @@ JacobianCalculatorCache::operator[](const JacobianCalculatorCache::key_type& qua
         const int dim = get_dim(elem_type);
 
         std::unique_ptr<JacobianCalculator> jac_calc;
-        switch (d_spatial_dimension)
+        const auto flag = FEUpdateFlags::update_JxW;
+        switch (dim)
         {
         case 1:
-            jac_calc.reset(new LagrangeMapping<1>(quad_key, FEUpdateFlags::update_JxW));
-            break;
-        case 2:
-            switch (elem_type)
+            switch (d_spatial_dimension)
             {
-            case libMesh::EDGE2:
-            case libMesh::EDGE3:
-            case libMesh::EDGE4:
-                jac_calc.reset(new LagrangeMapping<1, 2>(quad_key, FEUpdateFlags::update_JxW));
+            case 1:
+                jac_calc = dynamic_unique_cast<JacobianCalculator>(Mapping<1, 1>::build(quad_key, flag));
                 break;
-            case libMesh::TRI3:
-                jac_calc.reset(new Tri3Mapping(quad_key, FEUpdateFlags::update_JxW));
+            case 2:
+                jac_calc = dynamic_unique_cast<JacobianCalculator>(Mapping<1, 2>::build(quad_key, flag));
                 break;
-            case libMesh::QUAD4:
-                jac_calc.reset(new Quad4Mapping(quad_key, FEUpdateFlags::update_JxW));
-                break;
-            case libMesh::TRI6:
-            case libMesh::QUAD8:
-                jac_calc.reset(new LagrangeMapping<2, 2>(quad_key, FEUpdateFlags::update_JxW));
-                break;
-            case libMesh::QUAD9:
-                jac_calc.reset(new Quad9Mapping(quad_key, FEUpdateFlags::update_JxW));
+            case 3:
+                jac_calc = dynamic_unique_cast<JacobianCalculator>(Mapping<1, 3>::build(quad_key, flag));
                 break;
             default:
-                TBOX_ERROR("unimplemented element type");
+                TBOX_ERROR("unimplemented spatial dimension");
+            }
+            break;
+        case 2:
+            switch (d_spatial_dimension)
+            {
+            case 2:
+                jac_calc = dynamic_unique_cast<JacobianCalculator>(Mapping<2, 2>::build(quad_key, flag));
+                break;
+            case 3:
+                jac_calc = dynamic_unique_cast<JacobianCalculator>(Mapping<2, 3>::build(quad_key, flag));
+                break;
+            default:
+                TBOX_ERROR("unimplemented spatial dimension");
             }
             break;
         case 3:
-            if (dim == 1)
-                jac_calc.reset(new LagrangeMapping<1, 3>(quad_key, FEUpdateFlags::update_JxW));
-            else if (dim == 2)
-                jac_calc.reset(new LagrangeMapping<2, 3>(quad_key, FEUpdateFlags::update_JxW));
-            else if (elem_type == libMesh::TET4)
-                jac_calc.reset(new Tet4Mapping(quad_key, FEUpdateFlags::update_JxW));
-            else
-                jac_calc.reset(new LagrangeMapping<3, 3>(quad_key, FEUpdateFlags::update_JxW));
+            switch (d_spatial_dimension)
+            {
+            case 3:
+                jac_calc = dynamic_unique_cast<JacobianCalculator>(Mapping<3, 3>::build(quad_key, flag));
+                break;
+            default:
+                TBOX_ERROR("unimplemented spatial dimension");
+            }
             break;
         default:
-            TBOX_ERROR("unimplemented spatial dimension");
+            TBOX_ERROR("unimplemented dimension");
         }
 
         JacobianCalculator& new_jacob = *(*d_jacobian_calculators.emplace(quad_key, std::move(jac_calc)).first).second;


### PR DESCRIPTION
At some point we need to get rid of this class in favor of our own homebrew Mapping class but we aren't there yet. In the mean time we can simplify things by using Mapping::build() instead of a custom switch statement.

Including a few more custom element sizes makes HEX8 meshes faster - in particular this makes IBFE/explicit/ex4 about 1% faster in 3D.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?