### PR TITLE
Create timer manager before everything else.

### DIFF
--- a/doc/news/changes/minor/20200727AaronBarrett
+++ b/doc/news/changes/minor/20200727AaronBarrett
@@ -1,0 +1,4 @@
+Bug fix: AppInitializer now creates the TimerManager correctly using the
+database provided from the input file.
+<br>
+(Aaron Barret, 2020/06/26)

--- a/ibtk/src/utilities/AppInitializer.cpp
+++ b/ibtk/src/utilities/AppInitializer.cpp
@@ -113,6 +113,41 @@ AppInitializer::AppInitializer(int argc, char* argv[], const std::string& defaul
         }
     }
 
+    // Configure timer options.
+    std::string timer_dump_interval_key_name;
+    if (main_db->keyExists("timer_interval"))
+    {
+        timer_dump_interval_key_name = "timer_interval";
+    }
+    else if (main_db->keyExists("timer_dump_interval"))
+    {
+        timer_dump_interval_key_name = "timer_dump_interval";
+    }
+    else if (main_db->keyExists("timer_write_interval"))
+    {
+        timer_dump_interval_key_name = "timer_write_interval";
+    }
+
+    if (!timer_dump_interval_key_name.empty())
+    {
+        d_timer_dump_interval = main_db->getInteger(timer_dump_interval_key_name);
+    }
+
+    if (d_timer_dump_interval > 0)
+    {
+        Pointer<Database> timer_manager_db = new NullDatabase();
+        if (d_input_db->isDatabase("TimerManager"))
+        {
+            timer_manager_db = d_input_db->getDatabase("TimerManager");
+        }
+        else
+        {
+            pout << "WARNING: AppInitializer::AppInitializer(): " << timer_dump_interval_key_name
+                 << " > 0, but `TimerManager' input entries not specifed in input file\n";
+        }
+        TimerManager::createManager(timer_manager_db);
+    }
+
     // Configure visualization options.
     std::string viz_dump_interval_key_name;
     if (main_db->keyExists("viz_interval"))
@@ -321,41 +356,6 @@ AppInitializer::AppInitializer(int argc, char* argv[], const std::string& defaul
             pout << "WARNING: AppInitializer::AppInitializer(): " << data_dump_interval_key_name
                  << " > 0, but `data_dump_dirname' is not specified in input file\n";
         }
-    }
-
-    // Configure timer options.
-    std::string timer_dump_interval_key_name;
-    if (main_db->keyExists("timer_interval"))
-    {
-        timer_dump_interval_key_name = "timer_interval";
-    }
-    else if (main_db->keyExists("timer_dump_interval"))
-    {
-        timer_dump_interval_key_name = "timer_dump_interval";
-    }
-    else if (main_db->keyExists("timer_write_interval"))
-    {
-        timer_dump_interval_key_name = "timer_write_interval";
-    }
-
-    if (!timer_dump_interval_key_name.empty())
-    {
-        d_timer_dump_interval = main_db->getInteger(timer_dump_interval_key_name);
-    }
-
-    if (d_timer_dump_interval > 0)
-    {
-        Pointer<Database> timer_manager_db = new NullDatabase();
-        if (d_input_db->isDatabase("TimerManager"))
-        {
-            timer_manager_db = d_input_db->getDatabase("TimerManager");
-        }
-        else
-        {
-            pout << "WARNING: AppInitializer::AppInitializer(): " << timer_dump_interval_key_name
-                 << " > 0, but `TimerManager' input entries not specifed in input file\n";
-        }
-        TimerManager::createManager(timer_manager_db);
     }
     return;
 } // AppInitializer


### PR DESCRIPTION
`AppInitializer` sets up visualization, restart, and timer objects in that order. But since the SAMRAI class `VisItDataWriter` also sets up timers through the static `TimerManager` class, a default `TimerManager` class will be created. The simple fix is to create the `TimerManager` object before `VisItDataWriter`.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
