### PR TITLE
Changed default MPI communicator for backwards compatibility

### DIFF
--- a/examples/IB/explicit/ex0/example.cpp
+++ b/examples/IB/explicit/ex0/example.cpp
@@ -241,8 +241,11 @@ generate_springs(
 int
 main(int argc, char* argv[])
 {
-    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
-    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    // Initialize PETSc, MPI, and SAMRAI.
+    PetscInitialize(&argc, &argv, NULL, NULL);
+    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
+    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
+    SAMRAIManager::startup();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -554,6 +557,9 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
+
+    SAMRAIManager::shutdown();
+    PetscFinalize();
 } // main
 
 void

--- a/examples/IBFE/explicit/ex0/example.cpp
+++ b/examples/IBFE/explicit/ex0/example.cpp
@@ -118,9 +118,11 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char* argv[])
 {
-    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
-    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
-    const LibMeshInit& init = ibtk_init.getLibMeshInit();
+    // Initialize libMesh, PETSc, MPI, and SAMRAI.
+    LibMeshInit init(argc, argv);
+    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
+    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
+    SAMRAIManager::startup();
 
     { // cleanup dynamically allocated objects prior to shutdown
 
@@ -586,6 +588,8 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
+
+    SAMRAIManager::shutdown();
 }
 
 void

--- a/ibtk/src/utilities/IBTK_MPI.cpp
+++ b/ibtk/src/utilities/IBTK_MPI.cpp
@@ -26,7 +26,7 @@
 
 namespace IBTK
 {
-IBTK_MPI::comm IBTK_MPI::s_communicator = MPI_COMM_NULL;
+IBTK_MPI::comm IBTK_MPI::s_communicator = MPI_COMM_WORLD;
 
 void
 IBTK_MPI::setCommunicator(IBTK_MPI::comm communicator)

--- a/tests/IB/explicit_ex0.cpp
+++ b/tests/IB/explicit_ex0.cpp
@@ -222,9 +222,11 @@ generate_springs(
 int
 main(int argc, char* argv[])
 {
-    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
-    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
-
+    // Initialize PETSc, MPI, and SAMRAI.
+    PetscInitialize(&argc, &argv, NULL, NULL);
+    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
+    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
+    SAMRAIManager::startup();
     std::array<double, 3> u_err;
     std::array<double, 3> p_err;
 
@@ -480,4 +482,7 @@ main(int argc, char* argv[])
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
+
+    SAMRAIManager::shutdown();
+    PetscFinalize();
 } // main

--- a/tests/IBFE/explicit_ex0.cpp
+++ b/tests/IBFE/explicit_ex0.cpp
@@ -123,9 +123,11 @@ void output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 int
 main(int argc, char** argv)
 {
-    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
-    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
-    const LibMeshInit& init = ibtk_init.getLibMeshInit();
+    // Initialize libMesh, PETSc, MPI, and SAMRAI.
+    LibMeshInit init(argc, argv);
+    SAMRAI_MPI::setCommunicator(PETSC_COMM_WORLD);
+    SAMRAI_MPI::setCallAbortInSerialInsteadOfExit();
+    SAMRAIManager::startup();
 
     PetscOptionsSetValue(nullptr, "-ksp_rtol", "1e-16");
     PetscOptionsSetValue(nullptr, "-ksp_rtol", "1e-16");
@@ -587,6 +589,8 @@ main(int argc, char** argv)
         for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
 
     } // cleanup dynamically allocated objects prior to shutdown
+
+    SAMRAIManager::shutdown();
 }
 
 void


### PR DESCRIPTION
This allows for backwards compatibility after #976. We now use a default communicator of `MPI_COMM_WORLD`. I also reverted two examples `IB/explicit/ex0` and `IBFE/explicit/ex0` (one with libMesh, one without) and tests `IB/explicit_ex0` and `IBFE/explicit_ex0` to ensure everything still works.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
