### PR TITLE
Implement a faster bounding box intersection function.

### DIFF
--- a/doc/news/changes/minor/20200731DavidWells
+++ b/doc/news/changes/minor/20200731DavidWells
@@ -1,0 +1,5 @@
+Improved: The bounding box intersection algorithm for associating libMesh
+elements with patches has been rewritten to be about 9 times faster. This
+substantially lowers the time required in regrid operations.
+<br>
+(David Wells, 2020/07/31)


### PR DESCRIPTION
We can get much better performance by implementing a few extra things:
1. Inline the function
2. Explicit short-circuit logic in the loop over spatial dimensions
3. Skip a fourth redundant line segment check

This seems trivial, but it makes a huge difference in models with large numbers
of elements (such as the TAVR code) that regrid frequently since we presently
call this function, for N local patches and K global elements, K*N times: i.e.,
if one processor has twice as many patches it has to do twice as much work, so
making this much cheaper has a large benefit to both serial preformance and time
spent waiting in parallel.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
