### PR TITLE
Add compatibility headers for CMake.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -119,7 +119,7 @@ am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
  configure.lineno config.status.lineno
 mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/config/IBAMR_config.h.tmp
-CONFIG_CLEAN_FILES = config/make.inc
+CONFIG_CLEAN_FILES = config/make.inc config/ibamr/config.h
 CONFIG_CLEAN_VPATH_FILES =
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)

--- a/config/config.h.tmp
+++ b/config/config.h.tmp
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2020 - 2020 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+/////////////////////// INCLUDE GUARD ////////////////////////////////////
+
+#ifndef included_IBAMR_config
+#define included_IBAMR_config
+
+///////////////////////////// INCLUDES ///////////////////////////////////
+
+#include <IBAMR_config.h>
+
+#include <ibtk/config.h>
+#include <ibtk/ibtk_macros.h>
+
+#include <ibamr/ibamr_macros.h>
+
+// This header is a stub defined to improve compatibility with the new CMake
+// build system
+
+#endif //#ifndef included_IBAMR_config

--- a/configure
+++ b/configure
@@ -2730,6 +2730,9 @@ ac_config_headers="$ac_config_headers config/IBAMR_config.h.tmp"
 
 ac_config_commands="$ac_config_commands config/IBAMR_config.h"
 
+# Also copy our own CMake compatibility shim header:
+ac_config_links="$ac_config_links config/ibamr/config.h:$srcdir/config/config.h.tmp"
+
 am__api_version='1.16'
 
 # Find a good install program.  We prefer a C program (faster),
@@ -41812,6 +41815,7 @@ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
 # Files that config.status was made for.
 config_files="$ac_config_files"
 config_headers="$ac_config_headers"
+config_links="$ac_config_links"
 config_commands="$ac_config_commands"
 
 _ACEOF
@@ -41841,6 +41845,9 @@ $config_files
 
 Configuration headers:
 $config_headers
+
+Configuration links:
+$config_links
 
 Configuration commands:
 $config_commands
@@ -42451,6 +42458,7 @@ do
   case $ac_config_target in
     "config/IBAMR_config.h.tmp") CONFIG_HEADERS="$CONFIG_HEADERS config/IBAMR_config.h.tmp" ;;
     "config/IBAMR_config.h") CONFIG_COMMANDS="$CONFIG_COMMANDS config/IBAMR_config.h" ;;
+    "config/ibamr/config.h") CONFIG_LINKS="$CONFIG_LINKS config/ibamr/config.h:$srcdir/config/config.h.tmp" ;;
     "depfiles") CONFIG_COMMANDS="$CONFIG_COMMANDS depfiles" ;;
     "libtool") CONFIG_COMMANDS="$CONFIG_COMMANDS libtool" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
@@ -42590,6 +42598,7 @@ done
 if $ac_need_defaults; then
   test "${CONFIG_FILES+set}" = set || CONFIG_FILES=$config_files
   test "${CONFIG_HEADERS+set}" = set || CONFIG_HEADERS=$config_headers
+  test "${CONFIG_LINKS+set}" = set || CONFIG_LINKS=$config_links
   test "${CONFIG_COMMANDS+set}" = set || CONFIG_COMMANDS=$config_commands
 fi
 
@@ -42887,7 +42896,7 @@ cat >>$CONFIG_STATUS <<\_ACEOF || ac_write_fail=1
 fi # test -n "$CONFIG_HEADERS"
 
 
-eval set X "  :F $CONFIG_FILES  :H $CONFIG_HEADERS    :C $CONFIG_COMMANDS"
+eval set X "  :F $CONFIG_FILES  :H $CONFIG_HEADERS  :L $CONFIG_LINKS  :C $CONFIG_COMMANDS"
 shift
 for ac_tag
 do
@@ -43164,7 +43173,38 @@ $as_echo X"$_am_arg" |
 	  }
 	  s/.*/./; q'`/stamp-h$_am_stamp_count
  ;;
+  :L)
+  #
+  # CONFIG_LINK
+  #
 
+  if test "$ac_source" = "$ac_file" && test "$srcdir" = '.'; then
+    :
+  else
+    # Prefer the file from the source tree if names are identical.
+    if test "$ac_source" = "$ac_file" || test ! -r "$ac_source"; then
+      ac_source=$srcdir/$ac_source
+    fi
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: linking $ac_source to $ac_file" >&5
+$as_echo "$as_me: linking $ac_source to $ac_file" >&6;}
+
+    if test ! -r "$ac_source"; then
+      as_fn_error $? "$ac_source: file not found" "$LINENO" 5
+    fi
+    rm -f "$ac_file"
+
+    # Try a relative symlink, then a hard link, then a copy.
+    case $ac_source in
+    [\\/$]* | ?:[\\/]* ) ac_rel_source=$ac_source ;;
+	*) ac_rel_source=$ac_top_build_prefix$ac_source ;;
+    esac
+    ln -s "$ac_rel_source" "$ac_file" 2>/dev/null ||
+      ln "$ac_source" "$ac_file" 2>/dev/null ||
+      cp -p "$ac_source" "$ac_file" ||
+      as_fn_error $? "cannot link or copy $ac_source to $ac_file" "$LINENO" 5
+  fi
+ ;;
   :C)  { $as_echo "$as_me:${as_lineno-$LINENO}: executing $ac_file commands" >&5
 $as_echo "$as_me: executing $ac_file commands" >&6;}
  ;;

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,8 @@ AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADER([config/IBAMR_config.h.tmp])
 AX_PREFIX_CONFIG_H([config/IBAMR_config.h],[IBAMR],[config/IBAMR_config.h.tmp])
+# Also copy our own CMake compatibility shim header:
+AC_CONFIG_LINKS([config/ibamr/config.h:$srcdir/config/config.h.tmp])
 AM_INIT_AUTOMAKE([1.12 -Wall -Werror dist-bzip2 foreign -Wno-extra-portability subdir-objects])
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE([disable])

--- a/ibtk/Makefile.in
+++ b/ibtk/Makefile.in
@@ -121,7 +121,7 @@ am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
  configure.lineno config.status.lineno
 mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/config/IBTK_config.h.tmp
-CONFIG_CLEAN_FILES =
+CONFIG_CLEAN_FILES = config/ibtk/config.h
 CONFIG_CLEAN_VPATH_FILES =
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)

--- a/ibtk/config/config.h.tmp
+++ b/ibtk/config/config.h.tmp
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2020 - 2020 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+/////////////////////// INCLUDE GUARD ////////////////////////////////////
+
+#ifndef included_IBTK_config
+#define included_IBTK_config
+
+///////////////////////////// INCLUDES ///////////////////////////////////
+
+#include <IBTK_config.h>
+
+#include <ibtk/IBTK_CHKERRQ.h>
+#include <ibtk/ibtk_macros.h>
+
+// This header is a stub defined to improve compatibility with the new CMake
+// build system
+
+#endif //#ifndef included_IBTK_config

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -2738,6 +2738,9 @@ ac_config_headers="$ac_config_headers config/IBTK_config.h.tmp"
 
 ac_config_commands="$ac_config_commands config/IBTK_config.h"
 
+# Also copy our own CMake compatibility shim header:
+ac_config_links="$ac_config_links config/ibtk/config.h:$srcdir/config/config.h.tmp"
+
 am__api_version='1.16'
 
 # Find a good install program.  We prefer a C program (faster),
@@ -41954,6 +41957,7 @@ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
 # Files that config.status was made for.
 config_files="$ac_config_files"
 config_headers="$ac_config_headers"
+config_links="$ac_config_links"
 config_commands="$ac_config_commands"
 
 _ACEOF
@@ -41983,6 +41987,9 @@ $config_files
 
 Configuration headers:
 $config_headers
+
+Configuration links:
+$config_links
 
 Configuration commands:
 $config_commands
@@ -42593,6 +42600,7 @@ do
   case $ac_config_target in
     "config/IBTK_config.h.tmp") CONFIG_HEADERS="$CONFIG_HEADERS config/IBTK_config.h.tmp" ;;
     "config/IBTK_config.h") CONFIG_COMMANDS="$CONFIG_COMMANDS config/IBTK_config.h" ;;
+    "config/ibtk/config.h") CONFIG_LINKS="$CONFIG_LINKS config/ibtk/config.h:$srcdir/config/config.h.tmp" ;;
     "depfiles") CONFIG_COMMANDS="$CONFIG_COMMANDS depfiles" ;;
     "libtool") CONFIG_COMMANDS="$CONFIG_COMMANDS libtool" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
@@ -42646,6 +42654,7 @@ done
 if $ac_need_defaults; then
   test "${CONFIG_FILES+set}" = set || CONFIG_FILES=$config_files
   test "${CONFIG_HEADERS+set}" = set || CONFIG_HEADERS=$config_headers
+  test "${CONFIG_LINKS+set}" = set || CONFIG_LINKS=$config_links
   test "${CONFIG_COMMANDS+set}" = set || CONFIG_COMMANDS=$config_commands
 fi
 
@@ -42943,7 +42952,7 @@ cat >>$CONFIG_STATUS <<\_ACEOF || ac_write_fail=1
 fi # test -n "$CONFIG_HEADERS"
 
 
-eval set X "  :F $CONFIG_FILES  :H $CONFIG_HEADERS    :C $CONFIG_COMMANDS"
+eval set X "  :F $CONFIG_FILES  :H $CONFIG_HEADERS  :L $CONFIG_LINKS  :C $CONFIG_COMMANDS"
 shift
 for ac_tag
 do
@@ -43220,7 +43229,38 @@ $as_echo X"$_am_arg" |
 	  }
 	  s/.*/./; q'`/stamp-h$_am_stamp_count
  ;;
+  :L)
+  #
+  # CONFIG_LINK
+  #
 
+  if test "$ac_source" = "$ac_file" && test "$srcdir" = '.'; then
+    :
+  else
+    # Prefer the file from the source tree if names are identical.
+    if test "$ac_source" = "$ac_file" || test ! -r "$ac_source"; then
+      ac_source=$srcdir/$ac_source
+    fi
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: linking $ac_source to $ac_file" >&5
+$as_echo "$as_me: linking $ac_source to $ac_file" >&6;}
+
+    if test ! -r "$ac_source"; then
+      as_fn_error $? "$ac_source: file not found" "$LINENO" 5
+    fi
+    rm -f "$ac_file"
+
+    # Try a relative symlink, then a hard link, then a copy.
+    case $ac_source in
+    [\\/$]* | ?:[\\/]* ) ac_rel_source=$ac_source ;;
+	*) ac_rel_source=$ac_top_build_prefix$ac_source ;;
+    esac
+    ln -s "$ac_rel_source" "$ac_file" 2>/dev/null ||
+      ln "$ac_source" "$ac_file" 2>/dev/null ||
+      cp -p "$ac_source" "$ac_file" ||
+      as_fn_error $? "cannot link or copy $ac_source to $ac_file" "$LINENO" 5
+  fi
+ ;;
   :C)  { $as_echo "$as_me:${as_lineno-$LINENO}: executing $ac_file commands" >&5
 $as_echo "$as_me: executing $ac_file commands" >&6;}
  ;;

--- a/ibtk/configure.ac
+++ b/ibtk/configure.ac
@@ -20,6 +20,8 @@ AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADER([config/IBTK_config.h.tmp])
 AX_PREFIX_CONFIG_H([config/IBTK_config.h],[IBTK],[config/IBTK_config.h.tmp])
+# Also copy our own CMake compatibility shim header:
+AC_CONFIG_LINKS([config/ibtk/config.h:$srcdir/config/config.h.tmp])
 AM_INIT_AUTOMAKE([1.12 -Wall -Werror dist-bzip2 foreign -Wno-extra-portability subdir-objects])
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE([disable])


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

Part of #1020: We need to ultimately get rid of `IBTK_config.h` and `IBAMR_config.h` since they are top-level files. This PR adds shims that are compatible with both the new CMake build system (which doesn't have top level files) to ease the transition. Upcoming PRs will remove direct `IBTK_config.h` and `IBAMR_config.h` inclusions from the library.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
