### PR TITLE
Get rid of an extra warning.

### DIFF
--- a/ibtk/src/utilities/AppInitializer.cpp
+++ b/ibtk/src/utilities/AppInitializer.cpp
@@ -136,15 +136,10 @@ AppInitializer::AppInitializer(int argc, char* argv[], const std::string& defaul
     // Avoid some warnings by unconditionally creating the timer database, even if
     // we never use it:
     {
-        Pointer<Database> timer_manager_db = new NullDatabase();
+        Pointer<Database> timer_manager_db;
         if (d_input_db->isDatabase("TimerManager"))
         {
             timer_manager_db = d_input_db->getDatabase("TimerManager");
-        }
-        else
-        {
-            pout << "WARNING: AppInitializer::AppInitializer(): " << timer_dump_interval_key_name
-                 << " > 0, but `TimerManager' input entries not specifed in input file\n";
         }
         TimerManager::createManager(timer_manager_db);
     }


### PR DESCRIPTION
Fix some issues in #1073: it looks like I messed up running the test suite somehow. Fortunately its not a big deal to remedy.

This does not work as intended since if absolutely nothing is specified (like in most of the tests) then timer_dump_interval_key_name is an empty string - lets just avoid the problem by getting rid of it. The problem is obvious, anyway - if no timer information is specified the TimerManager will print things we don't want.

Furthermore - we don't want to use a null database here since that will always pass checks for whether or not a key exists (here 'null database' really means that they are using the null object pattern, not that it is an empty database).

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?