### PR TITLE
Fix the merging load balancer.

### DIFF
--- a/ibtk/src/utilities/box_utilities.cpp
+++ b/ibtk/src/utilities/box_utilities.cpp
@@ -95,6 +95,9 @@ struct BoxLexical
 std::vector<SAMRAI::hier::Box<NDIM> >
 merge_boxes_by_longest_edge(const std::vector<SAMRAI::hier::Box<NDIM> >& input_boxes)
 {
+    // Naught to do with no boxes
+    if (input_boxes.size() == 0) return input_boxes;
+
     std::set<hier::Box<NDIM>, BoxLexical> boxes;
     // In this function we interpret the boxes as partitioning boxes
     // rather than bounding boxes: i.e., the upper bounds in each
@@ -225,7 +228,6 @@ merge_boxes_by_longest_edge(const std::vector<SAMRAI::hier::Box<NDIM> >& input_b
         }
         ++round_n;
     }
-    boxes.insert(*boxes.begin());
 
     // convert back to the usual box format by undoing the box expansion
     // above.

--- a/tests/IBTK/box_utilities_01.cpp
+++ b/tests/IBTK/box_utilities_01.cpp
@@ -101,6 +101,12 @@ main(int argc, char** argv)
             for (const auto& box : result) out << box << '\n';
             for (const auto& box : boxes) check_box_contained(result, box);
         }
+
+        {
+            // We should successfully do nothing with an empty vector of boxes
+            const auto result_2 = IBTK::merge_boxes_by_longest_edge({});
+            TBOX_ASSERT(result_2.size() == 0);
+        }
     }
     if (NDIM == 3)
     {
@@ -145,6 +151,12 @@ main(int argc, char** argv)
             {
                 TBOX_ASSERT(check_box_contained(result, box));
             }
+        }
+
+        {
+            // We should successfully do nothing with an empty vector of boxes
+            const auto result_2 = IBTK::merge_boxes_by_longest_edge({});
+            TBOX_ASSERT(result_2.size() == 0);
         }
     }
 }


### PR DESCRIPTION
The extra insert statement doesn't make any sense: its a set so it already contains its first element, and if it is an empty set then this creates an invalid object (we read whatever happens to be at `begin()` and turn it into an object). In particular, since some processors can end up with zero boxes in very strange situations, this causes nonsense boxes to be created in the output as a result.

I think this bug only shows up in test problems since it is really rare, in practice, for a process to end up with no patches. This also only effects the scratch hierarchy.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
