### PR TITLE
Check for nodes that are inside the domain but outside a patch.

### DIFF
--- a/doc/news/changes/minor/20200826DavidWells
+++ b/doc/news/changes/minor/20200826DavidWells
@@ -1,0 +1,4 @@
+Improved: IBTK::FEDataManager now executes a check that, after associating
+patches with elements, that all mesh nodes are assigned to at least one patch.
+<br>
+(David Wells, 2020/06/29)

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -22,6 +22,7 @@
 
 #include "ibtk/QuadratureCache.h"
 #include "ibtk/SAMRAIDataCache.h"
+#include "ibtk/ibtk_enums.h"
 #include "ibtk/ibtk_utilities.h"
 
 #include "BasePatchLevel.h"
@@ -274,7 +275,24 @@ protected:
  * element data while this class stores additional data dependent on the
  * Eulerian grid.
  *
- * <h3>Parameters effecting workload estimate calculations</h3>
+ * <h2>Parameters read from the input database</h2>
+ *
+ * At the present time the only parameter read from the input database is
+ * <code>node_outside_patch_check</code>, which controls how this class responds
+ * to mesh nodes outside the finest patch level. In all cases, for backwards
+ * compatibility, nodes that are outside the computational domain are permitted
+ * and are ignored by this check. Possible values are:
+ * <ol>
+ *   <li><code>node_outside_permit</code>: Permit nodes to be outside the finest
+ *   patch level.</li>
+ *   <li><code>node_outside_warn</code>: Permit nodes to be outside the finest
+ *   patch level, but log a warning whenever this is detected.
+ *   <li><code>node_outside_error</code>: Abort the program when nodes are detected
+ *   outside the finest patch level.
+ * </ol>
+ * The default value is <code>node_outside_error</code>.
+ *
+ * <h2>Parameters effecting workload estimate calculations</h2>
  * FEDataManager can estimate the amount of work done in IBFE calculations
  * (such as FEDataManager::spread). Since most calculations use a variable
  * number of quadrature points on each libMesh element this estimate can vary
@@ -1254,6 +1272,15 @@ private:
      */
     const InterpSpec d_default_interp_spec;
     const SpreadSpec d_default_spread_spec;
+
+    /*!
+     * after reassociating patches with elements a node may still lie
+     * outside all patches on the finest level in unusual circumstances
+     * (like when the parent integrator class does not regrid sufficiently
+     * frequently and has more than one patch level). This enum controls
+     * what we do when this problem is detected.
+     */
+    NodeOutsidePatchCheckType d_node_patch_check = NODE_OUTSIDE_ERROR;
 
     /*!
      * SAMRAI::hier::IntVector object which determines the required ghost cell

--- a/ibtk/include/ibtk/ibtk_enums.h
+++ b/ibtk/include/ibtk/ibtk_enums.h
@@ -179,6 +179,34 @@ enum_to_string<VCInterpType>(VCInterpType val)
     return "UNKNOWN_VC_INTERP_TYPE";
 } // enum_to_string
 
+enum NodeOutsidePatchCheckType
+{
+    NODE_OUTSIDE_PERMIT = 1,
+    NODE_OUTSIDE_WARN = 2,
+    NODE_OUTSIDE_ERROR = 3,
+    UNKNOWN_NODE_OUTSIDE_PATCH_CHECK_TYPE = -1
+};
+
+template <>
+inline NodeOutsidePatchCheckType
+string_to_enum<NodeOutsidePatchCheckType>(const std::string& val)
+{
+    if (strcasecmp(val.c_str(), "NODE_OUTSIDE_PERMIT") == 0) return NODE_OUTSIDE_PERMIT;
+    if (strcasecmp(val.c_str(), "NODE_OUTSIDE_WARN") == 0) return NODE_OUTSIDE_WARN;
+    if (strcasecmp(val.c_str(), "NODE_OUTSIDE_ERROR") == 0) return NODE_OUTSIDE_ERROR;
+    return UNKNOWN_NODE_OUTSIDE_PATCH_CHECK_TYPE;
+} // string_to_enum
+
+template <>
+inline std::string
+enum_to_string<NodeOutsidePatchCheckType>(NodeOutsidePatchCheckType val)
+{
+    if (val == NODE_OUTSIDE_PERMIT) return "NODE_OUTSIDE_PERMIT";
+    if (val == NODE_OUTSIDE_WARN) return "NODE_OUTSIDE_WARN";
+    if (val == NODE_OUTSIDE_ERROR) return "NODE_OUTSIDE_ERROR";
+    return "UNKNOWN_NODE_OUTSIDE_PATCH_CHECK_TYPE";
+} // enum_to_string
+
 } // namespace IBTK
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -392,6 +392,15 @@ class IBFEDirectForcingKinematics;
  * }
  * @endcode
  *
+ * <h2>Passing Data to the FEDataManager class</h2>
+ * IBFEMethod uses IBTK::FEDataManager to actually perform IB calculations with
+ * the finite element mesh. IBTK::FEDataManager objects are configured by
+ * setting spreading and interpolation parameters in the usual way (i.e., by
+ * providing the parameters described above in the input database). Options
+ * specific to the behavior of FEDataManager can be set by defining a database
+ * named <code>FEDataManager</code> inside the database provided to this class -
+ * see the documentation of FEDataManager for more information.
+ *
  * <h2>Handling Restart Data</h2>
  * The caching of the IBFE restart data is not managed by SAMRAI's
  * SAMRAI::tbox::RestartManager. It is instead handled by
@@ -1071,6 +1080,13 @@ protected:
     SAMRAI::tbox::Pointer<SAMRAI::mesh::GriddingAlgorithm<NDIM> > d_scratch_gridding_algorithm;
 
 private:
+    /*!
+     * The input database. This is explicitly stored (and used outside the
+     * constructor) since the FEDataManager instances created by this class
+     * will also read part of it.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> d_input_db;
+
     /*!
      * Implementation of class constructor.
      */


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

Part of #1085 - this is just the last patch from #1086.

We could have saved a lot of time trying to diagnose #1085 if we had a way to detect that IBFEMethod was not working correctly. This PR adds a check to ensure that all mesh nodes are actually inside a patch or outside the domain.

To get around a problem with SAMRAI we use bounding boxes for patches that are slightly larger than the patch itself. Similarly, to determine if a point is outside the domain, we use a bounding box slightly smaller than the domain itself. In either case the node is OK.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?