### PR TITLE
clean up FEProjector

### DIFF
--- a/ibtk/include/ibtk/FEProjector.h
+++ b/ibtk/include/ibtk/FEProjector.h
@@ -136,11 +136,11 @@ protected:
     /// in the absence of constraints, the matrix is diagonal.
     ///
     /// Here we refer to the unconstrained matrix (which is always diagonal) as
-    /// proj_matrix_diag and the constrained (should there be contraints) matrix
+    /// proj_matrix_diag and the constrained (should there be constraints) matrix
     /// as lumped_L2_proj_matrix.
     std::map<std::string, std::unique_ptr<libMesh::PetscMatrix<double> > > d_lumped_L2_proj_matrix;
     std::map<std::string, std::unique_ptr<libMesh::PetscLinearSolver<double> > > d_lumped_L2_proj_solver;
-    std::map<std::string, std::unique_ptr<libMesh::PetscVector<double> > > d_L2_proj_matrix_diag;
+    std::map<std::string, std::unique_ptr<libMesh::PetscVector<double> > > d_diag_L2_proj_matrix;
 
 private:
     /*!


### PR DESCRIPTION
This is mostly just moving some code around in the implementation file to keep things synched with the header.

I also update some variable names to use "`L2`" consistently (since L^2 and l^2 are different), and make some member variable names more consistent.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
