### PR TITLE
Use LibMeshSystemIBVectors in IBFESurfaceMethod, part 1.

### DIFF
--- a/include/ibamr/IBFESurfaceMethod.h
+++ b/include/ibamr/IBFESurfaceMethod.h
@@ -23,6 +23,7 @@
 #include "ibamr/IBStrategy.h"
 
 #include "ibtk/FEDataManager.h"
+#include "ibtk/LibMeshSystemIBVectors.h"
 #include "ibtk/SAMRAIGhostDataAccumulator.h"
 #include "ibtk/ibtk_utilities.h"
 #include "ibtk/libmesh_utilities.h"
@@ -561,14 +562,23 @@ protected:
     std::unique_ptr<IBTK::SAMRAIGhostDataAccumulator> d_ghost_data_accumulator;
 
     SAMRAI::hier::IntVector<NDIM> d_ghosts = 0;
+
     std::vector<libMesh::System*> d_X_systems, d_U_systems, d_U_n_systems, d_U_t_systems, d_F_systems, d_DP_systems;
-    std::vector<libMesh::PetscVector<double>*> d_X_current_vecs, d_X_new_vecs, d_X_half_vecs, d_X0_vecs,
-        d_X_IB_ghost_vecs;
+
     std::vector<libMesh::PetscVector<double>*> d_U_current_vecs, d_U_new_vecs, d_U_half_vecs;
     std::vector<libMesh::PetscVector<double>*> d_U_n_current_vecs, d_U_n_new_vecs, d_U_n_half_vecs;
     std::vector<libMesh::PetscVector<double>*> d_U_t_current_vecs, d_U_t_new_vecs, d_U_t_half_vecs;
     std::vector<libMesh::PetscVector<double>*> d_F_half_vecs, d_F_IB_ghost_vecs;
     std::vector<libMesh::PetscVector<double>*> d_DP_half_vecs, d_DP_IB_ghost_vecs;
+
+    /*!
+     * Object managing access to libMesh system vectors for the position system.
+     *
+     * @note Unlike IBAMR::IBFEMethod, this class does not inherit from
+     * FEMechanicsBase and therefore both normal and IB vectors are handled by
+     * d_X_vecs.
+     */
+    std::unique_ptr<IBTK::LibMeshSystemIBVectors> d_X_vecs;
 
     bool d_fe_equation_systems_initialized = false, d_fe_data_initialized = false;
 


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

Part of #934 - `LibMeshSystemData` ended up being added to the library and used so we should go ahead and use it in `IBFESurfaceMethod`. Using it here also lets use remove some deprecated `FEDataManager` functions which will be nice for cleaning up that class (as part of the multilevel project).

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
