### PR TITLE
Fixed test suite compilation when libmesh is not present.

### DIFF
--- a/tests/IBTK/samraidatacache_01.cpp
+++ b/tests/IBTK/samraidatacache_01.cpp
@@ -67,7 +67,6 @@ main(int argc, char* argv[])
 {
     // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
     IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
-    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     // prevent a warning about timer initializations
     TimerManager::createManager(nullptr);


### PR DESCRIPTION
This is a copy-paste bug from #976.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
