### PR TITLE
Fix --with-zlib

### DIFF
--- a/config/IBAMR_config.h.tmp.in
+++ b/config/IBAMR_config.h.tmp.in
@@ -130,9 +130,6 @@
 /* Define if you have the libSAMRAI3d_xfer library. */
 #undef HAVE_LIBSAMRAI3D_XFER
 
-/* Define to 1 if you have the `z' library (-lz). */
-#undef HAVE_LIBZ
-
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 

--- a/configure
+++ b/configure
@@ -30218,15 +30218,27 @@ if test "$SILO_ENABLED" = yes; then
   fi
 
   # handle silo's dependencies:
-  LDFLAGS="$ZLIB_DIR $LDFLAGS"
+  if test "x$ZLIB_DIR" = "x" ; then
+      :
+  else
+      LDFLAGS="-L$ZLIB_DIR/lib $LDFLAGS"
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for compress2 in -lz" >&5
-$as_echo_n "checking for compress2 in -lz... " >&6; }
-if ${ac_cv_lib_z_compress2+:} false; then :
+
+
+  if test "$enable_rpath" = yes; then
+    libdir=${ZLIB_DIR}/lib
+    rpath_path=$(eval echo "$acl_cv_hardcode_libdir_flag_spec")
+    LDFLAGS=""$rpath_path" $LDFLAGS"
+
+  fi
+
+  fi
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing compress2" >&5
+$as_echo_n "checking for library containing compress2... " >&6; }
+if ${ac_cv_search_compress2+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lz  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -30253,23 +30265,35 @@ return compress2 ();
   return 0;
 }
 _ACEOF
-if ac_fn_cxx_try_link "$LINENO"; then :
-  ac_cv_lib_z_compress2=yes
-else
-  ac_cv_lib_z_compress2=no
+for ac_lib in '' z; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_cxx_try_link "$LINENO"; then :
+  ac_cv_search_compress2=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_compress2+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_z_compress2" >&5
-$as_echo "$ac_cv_lib_z_compress2" >&6; }
-if test "x$ac_cv_lib_z_compress2" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBZ 1
-_ACEOF
+done
+if ${ac_cv_search_compress2+:} false; then :
 
-  LIBS="-lz $LIBS"
+else
+  ac_cv_search_compress2=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_compress2" >&5
+$as_echo "$ac_cv_search_compress2" >&6; }
+ac_res=$ac_cv_search_compress2
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 else
   as_fn_error $? "Unable to locate a valid zlib installation, which is a dependency of Silo. Since Silo is usually statically linked this must be provided to IBAMR. If zlib is not installed in a standard location then a path to it must be provided via --with-zlib=PATH." "$LINENO" 5

--- a/doc/news/changes/minor/20200910DavidWells
+++ b/doc/news/changes/minor/20200910DavidWells
@@ -1,0 +1,3 @@
+Fixed: The configuration option <code>--with-zlib</code> now works correctly.
+<br>
+(David Wells, 2020/09/10)

--- a/ibtk/config/IBTK_config.h.tmp.in
+++ b/ibtk/config/IBTK_config.h.tmp.in
@@ -130,9 +130,6 @@
 /* Define if you have the libSAMRAI3d_xfer library. */
 #undef HAVE_LIBSAMRAI3D_XFER
 
-/* Define to 1 if you have the `z' library (-lz). */
-#undef HAVE_LIBZ
-
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -30382,15 +30382,27 @@ if test "$SILO_ENABLED" = yes; then
   fi
 
   # handle silo's dependencies:
-  LDFLAGS="$ZLIB_DIR $LDFLAGS"
+  if test "x$ZLIB_DIR" = "x" ; then
+      :
+  else
+      LDFLAGS="-L$ZLIB_DIR/lib $LDFLAGS"
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for compress2 in -lz" >&5
-$as_echo_n "checking for compress2 in -lz... " >&6; }
-if ${ac_cv_lib_z_compress2+:} false; then :
+
+
+  if test "$enable_rpath" = yes; then
+    libdir=${ZLIB_DIR}/lib
+    rpath_path=$(eval echo "$acl_cv_hardcode_libdir_flag_spec")
+    LDFLAGS=""$rpath_path" $LDFLAGS"
+
+  fi
+
+  fi
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing compress2" >&5
+$as_echo_n "checking for library containing compress2... " >&6; }
+if ${ac_cv_search_compress2+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lz  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -30417,23 +30429,35 @@ return compress2 ();
   return 0;
 }
 _ACEOF
-if ac_fn_cxx_try_link "$LINENO"; then :
-  ac_cv_lib_z_compress2=yes
-else
-  ac_cv_lib_z_compress2=no
+for ac_lib in '' z; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_cxx_try_link "$LINENO"; then :
+  ac_cv_search_compress2=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_compress2+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_z_compress2" >&5
-$as_echo "$ac_cv_lib_z_compress2" >&6; }
-if test "x$ac_cv_lib_z_compress2" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBZ 1
-_ACEOF
+done
+if ${ac_cv_search_compress2+:} false; then :
 
-  LIBS="-lz $LIBS"
+else
+  ac_cv_search_compress2=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_compress2" >&5
+$as_echo "$ac_cv_search_compress2" >&6; }
+ac_res=$ac_cv_search_compress2
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 else
   as_fn_error $? "Unable to locate a valid zlib installation, which is a dependency of Silo. Since Silo is usually statically linked this must be provided to IBAMR. If zlib is not installed in a standard location then a path to it must be provided via --with-zlib=PATH." "$LINENO" 5

--- a/m4/configure_silo.m4
+++ b/m4/configure_silo.m4
@@ -65,8 +65,14 @@ if test "$SILO_ENABLED" = yes; then
   fi
 
   # handle silo's dependencies:
-  LDFLAGS_PREPEND($ZLIB_DIR)
-  AC_CHECK_LIB(z, compress2, [], [AC_MSG_ERROR([Unable to locate a valid zlib installation, which is a dependency of Silo. Since Silo is usually statically linked this must be provided to IBAMR. If zlib is not installed in a standard location then a path to it must be provided via --with-zlib=PATH.])])
+  if test "x$ZLIB_DIR" = "x" ; then
+      :
+  else
+      LDFLAGS_PREPEND(-L$ZLIB_DIR/lib)
+      ADD_RPATH_LDFLAG(${ZLIB_DIR}/lib)
+  fi
+  AC_SEARCH_LIBS([compress2], [z], [],
+                 [AC_MSG_ERROR([Unable to locate a valid zlib installation, which is a dependency of Silo. Since Silo is usually statically linked this must be provided to IBAMR. If zlib is not installed in a standard location then a path to it must be provided via --with-zlib=PATH.])])
 
   # now handle silo:
   CPPFLAGS_PREPEND($SILO_CPPFLAGS)


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

It looks like @cpuelz encountered this recently. Coincidentally I found some publicly-available notes from Michael Waldron which also contained a workaround.

Almost every Unix machine has zlib installed in a standard location so this flag is basically never necessary. This patch fixes the link flags so that it actually works correctly in the very unlikely case that it is explicitly needed.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?