### PR TITLE
Multilevel ibfe 6

### DIFF
--- a/doc/news/changes/incompatibilities/20200917DavidWells
+++ b/doc/news/changes/incompatibilities/20200917DavidWells
@@ -1,0 +1,9 @@
+Changed: The functions IBTK::FEDataManager::setPatchLevels(),
+IBTK::FEDataManager::getPatchLevels(), and IBTK::FEDataManager::getLevelNumber()
+have been removed. The first function was previously never used since the class
+assumed the structure interacted with the finest patch level. The other two
+functions have been replaced by
+IBTK::FEDataManager::getCoarsestPatchLevelNumber() and
+IBTK::FEDataManager::getFinestPatchLevelNumber().
+<br>
+(David Wells, 2020/09/17)

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -619,27 +619,14 @@ public:
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > getPatchHierarchy() const;
 
     /*!
-     * \brief Reset range of patch levels over which operations occur.
-     *
-     * The levels must exist in the hierarchy or an assertion failure will
-     * result.
+     * Get the coarsest patch level number on which elements are assigned.
      */
-    void setPatchLevels(int coarsest_ln, int finest_ln);
+    int getCoarsestPatchLevelNumber() const;
 
     /*!
-     * \brief Get the range of patch levels used by this object.
-     *
-     * \note Returns [coarsest_ln,finest_ln+1).
+     * Get the finest patch level number on which elements are assigned.
      */
-    std::pair<int, int> getPatchLevels() const;
-
-    //\}
-
-    /*!
-     * \return The level number to which the equations system object managed by
-     * the FEDataManager is assigned.
-     */
-    int getLevelNumber() const;
+    int getFinestPatchLevelNumber() const;
 
     /*!
      * \return The ghost cell width used for quantities that are to be
@@ -1243,7 +1230,6 @@ private:
      * Grid hierarchy information.
      */
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > d_hierarchy;
-    int d_coarsest_ln = IBTK::invalid_level_number, d_finest_ln = IBTK::invalid_level_number;
 
     /*!
      * Maximum possible level number in the patch hierarchy.

--- a/src/IB/IBFEPostProcessor.cpp
+++ b/src/IB/IBFEPostProcessor.cpp
@@ -220,9 +220,8 @@ void
 IBFEPostProcessor::interpolateVariables(const double data_time)
 {
     Pointer<PatchHierarchy<NDIM> > hierarchy = d_fe_data_manager->getPatchHierarchy();
-    const std::pair<int, int> patch_level_range = d_fe_data_manager->getPatchLevels();
-    const int coarsest_ln = patch_level_range.first;
-    const int finest_ln = patch_level_range.second - 1;
+    const int coarsest_ln = d_fe_data_manager->getCoarsestPatchLevelNumber();
+    const int finest_ln = d_fe_data_manager->getFinestPatchLevelNumber();
 
     const size_t num_eulerian_vars = d_scalar_interp_var_systems.size();
 

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -275,7 +275,9 @@ IBFESurfaceMethod::setupTagBuffer(Array<int>& tag_buffer, Pointer<GriddingAlgori
     for (unsigned int part = 0; part < d_num_parts; ++part)
     {
         const int gcw = d_fe_data_managers[part]->getGhostCellWidth().max();
-        const int tag_ln = d_fe_data_managers[part]->getLevelNumber() - 1;
+        // We need to refine cells up to, but not including, those on
+        // FEDataManager's finest patch level used for interaction
+        const int tag_ln = d_fe_data_managers[part]->getFinestPatchLevelNumber() - 1;
         if (tag_ln >= 0 && tag_ln < finest_hier_ln)
         {
             tag_buffer[tag_ln] = std::max(tag_buffer[tag_ln], gcw);
@@ -422,7 +424,8 @@ IBFESurfaceMethod::interpolateVelocity(const int u_data_idx,
         std::array<VectorValue<double>, 2> dX_dxi, dx_dxi;
 
         std::vector<libMesh::dof_id_type> dof_id_scratch;
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(d_fe_data_managers[part]->getLevelNumber());
+        Pointer<PatchLevel<NDIM> > level =
+            d_hierarchy->getPatchLevel(d_fe_data_managers[part]->getFinestPatchLevelNumber());
         int local_patch_num = 0;
         for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++local_patch_num)
         {
@@ -1256,6 +1259,20 @@ IBFESurfaceMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hiera
         d_fe_data_managers[part]->reinitElementMappings();
     }
 
+    // Set up the Eulerian data caches.
+    int coarsest_fe_level_num = std::numeric_limits<int>::max();
+    int finest_fe_level_num = std::numeric_limits<int>::min();
+    for (unsigned int part = 0; part < d_meshes.size(); ++part)
+    {
+        coarsest_fe_level_num =
+            std::min(coarsest_fe_level_num, d_fe_data_managers[part]->getCoarsestPatchLevelNumber());
+        finest_fe_level_num = std::max(finest_fe_level_num, d_fe_data_managers[part]->getFinestPatchLevelNumber());
+    }
+
+    // Set up the scratch data cache to work on levels that actually have elements.
+    d_eulerian_data_cache->setPatchHierarchy(hierarchy);
+    d_eulerian_data_cache->resetLevels(coarsest_fe_level_num, finest_fe_level_num);
+
     d_is_initialized = true;
     return;
 } // initializePatchHierarchy
@@ -1317,11 +1334,9 @@ IBFESurfaceMethod::initializeLevelData(Pointer<BasePatchHierarchy<NDIM> > hierar
                                        Pointer<BasePatchLevel<NDIM> > /*old_level*/,
                                        bool /*allocate_data*/)
 {
-    const int finest_hier_level = hierarchy->getFinestLevelNumber();
     for (unsigned int part = 0; part < d_num_parts; ++part)
     {
         d_fe_data_managers[part]->setPatchHierarchy(hierarchy);
-        d_fe_data_managers[part]->setPatchLevels(0, finest_hier_level);
     }
     return;
 } // initializeLevelData
@@ -1335,7 +1350,6 @@ IBFESurfaceMethod::resetHierarchyConfiguration(Pointer<BasePatchHierarchy<NDIM> 
     for (unsigned int part = 0; part < d_num_parts; ++part)
     {
         d_fe_data_managers[part]->setPatchHierarchy(hierarchy);
-        d_fe_data_managers[part]->setPatchLevels(0, hierarchy->getFinestLevelNumber());
     }
     return;
 } // resetHierarchyConfiguration
@@ -1447,7 +1461,7 @@ IBFESurfaceMethod::imposeJumpConditions(const int f_data_idx,
     // Loop over the patches to impose jump conditions on the Eulerian grid.
     const std::vector<std::vector<Elem*> >& active_patch_element_map =
         d_fe_data_managers[part]->getActivePatchElementMap();
-    const int level_num = d_fe_data_managers[part]->getLevelNumber();
+    const int level_num = d_fe_data_managers[part]->getFinestPatchLevelNumber();
     boost::multi_array<double, 1> DP_node;
     boost::multi_array<double, 2> x_node;
     std::array<VectorValue<double>, 2> dx_dxi;

--- a/tests/IBFE/explicit_ex4.cpp
+++ b/tests/IBFE/explicit_ex4.cpp
@@ -489,11 +489,6 @@ main(int argc, char** argv)
 
         if (ib_post_processor)
         {
-            if (other_manager != fe_data_manager)
-            {
-                other_manager->setPatchLevels(fe_data_manager->getPatchLevels().first,
-                                              fe_data_manager->getPatchLevels().second - 1);
-            }
             ib_post_processor->initializeFEData();
         }
 


### PR DESCRIPTION
This PR is mostly a cleanup of a bunch of different FEDataManager functions - it no longer makes sense to ask for the level on which the patch hierarchy resides, nor does it make sense to assign this with a function call (its set up in the constructor by the input database).

I removed a bunch of functions so this isn't backwards compatible but since this feature didn't exist in the past I think it's not a big deal to break it.

Part of #1112.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
