### PR TITLE
Cleanup initializeFEEquationSystems

### DIFF
--- a/include/ibamr/FEMechanicsBase.h
+++ b/include/ibamr/FEMechanicsBase.h
@@ -403,11 +403,6 @@ public:
 
 protected:
     /*!
-     * Do the actual work in initializeFEEquationSystems.
-     */
-    virtual void doInitializeFEEquationSystems() = 0;
-
-    /*!
      * Do the actual work in reinitializeFEData and initializeFEData. if @p
      * use_present_data is `true` then the current content of the solution
      * vectors is used: more exactly, the coordinates and velocities (computed
@@ -546,12 +541,6 @@ protected:
      * Object managing access to libMesh system vectors for the pressure.
      */
     std::unique_ptr<IBTK::LibMeshSystemVectors> d_P_vecs;
-
-    /*!
-     * Whether or not the libMesh equation systems objects have been initialized
-     * (i.e., whether or not initializeFEEquationSystems has been called).
-     */
-    bool d_fe_equation_systems_initialized = false;
 
     /*!
      * Whether or not all finite element data (including that initialized by

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -345,12 +345,10 @@ class IBFEDirectForcingKinematics;
  * up if restart information is not available.
  *
  * This code is based on an IBFE example and assumes that the IBAMR objects
- * objects are already set up in the usual way.
+ * objects are already set up in the usual way and IBFEMethod has been
+ * constructed (but no further functions have been called).
  *
  * @code
- * // Actually create the EquationSystems objects.
- * ib_method_ops->initializeFEEquationSystems();
- *
  * // This code assumes we only have one part, so there is only one
  * // EquationSystems object.
  * libMesh::EquationSystems *equation_systems =
@@ -680,21 +678,6 @@ public:
     IBTK::FEDataManager::SpreadSpec getDefaultSpreadSpec() const;
 
     /*!
-     * Set the workload spec object used with a particular mesh part.
-     */
-    void setWorkloadSpec(const IBTK::FEDataManager::WorkloadSpec& workload_spec, unsigned int part = 0);
-
-    /*!
-     * Set the interpolation spec object used with a particular mesh part.
-     */
-    void setInterpSpec(const IBTK::FEDataManager::InterpSpec& interp_spec, unsigned int part = 0);
-
-    /*!
-     * Set the spread spec object used with a particular mesh part.
-     */
-    void setSpreadSpec(const IBTK::FEDataManager::SpreadSpec& spread_spec, unsigned int part = 0);
-
-    /*!
      * \brief Register Eulerian variables with the parent IBHierarchyIntegrator.
      */
     void registerEulerianVariables() override;
@@ -814,7 +797,7 @@ protected:
     /*!
      * Do the actual work in initializeFEEquationSystems.
      */
-    virtual void doInitializeFEEquationSystems() override;
+    void doInitializeFEEquationSystems();
 
     /*!
      * Do the actual work in reinitializeFEData and initializeFEData. if @p

--- a/src/IB/FEMechanicsBase.cpp
+++ b/src/IB/FEMechanicsBase.cpp
@@ -221,7 +221,6 @@ FEMechanicsBase::~FEMechanicsBase()
 std::shared_ptr<FEData>
 FEMechanicsBase::getFEData(const unsigned int part) const
 {
-    TBOX_ASSERT(d_fe_equation_systems_initialized);
     TBOX_ASSERT(part < d_meshes.size());
     return d_fe_data[part];
 }
@@ -323,7 +322,6 @@ FEMechanicsBase::registerStaticPressurePart(PressureProjectionType projection_ty
                                             VolumetricEnergyDerivativeFcn U_prime_fcn,
                                             unsigned int part)
 {
-    TBOX_ASSERT(d_fe_equation_systems_initialized);
     TBOX_ASSERT(part < d_meshes.size());
     if (d_static_pressure_part[part]) return;
     d_has_static_pressure_parts = true;
@@ -369,15 +367,7 @@ FEMechanicsBase::postprocessIntegrateData(double /*current_time*/, double /*new_
 void
 FEMechanicsBase::initializeFEEquationSystems()
 {
-    if (d_fe_equation_systems_initialized) return;
-
-    // Set up the coupling matrix that will be used by each system.
-    d_diagonal_system_coupling.resize(NDIM);
-    for (unsigned int i = 0; i < NDIM; ++i)
-        for (unsigned int j = 0; j < NDIM; ++j) d_diagonal_system_coupling(i, j) = i == j ? 1 : 0;
-
-    doInitializeFEEquationSystems();
-    d_fe_equation_systems_initialized = true;
+    return;
 }
 
 void
@@ -385,7 +375,6 @@ FEMechanicsBase::initializeFEData()
 {
     if (d_fe_data_initialized) return;
 
-    initializeFEEquationSystems();
     doInitializeFEData(RestartManager::getManager()->isFromRestart());
     d_fe_data_initialized = true;
 }
@@ -1232,6 +1221,11 @@ FEMechanicsBase::commonConstructor(const std::string& object_name,
             d_default_quad_order_pressure[part] = FIFTH;
         }
     }
+
+    // Set up the coupling matrix that will be used by each system.
+    d_diagonal_system_coupling.resize(NDIM);
+    for (unsigned int i = 0; i < NDIM; ++i)
+        for (unsigned int j = 0; j < NDIM; ++j) d_diagonal_system_coupling(i, j) = i == j ? 1 : 0;
 
     // Initialize object with data read from the input and restart databases.
     bool from_restart = RestartManager::getManager()->isFromRestart();


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

It turns out that we can call this function in the constructor (and hence simplify a bunch of code) in most cases - the drawback at the moment is that `IBFEMethod::setInterpSpec` at al don't work anymore with this patch (those are used in the TAVR model and also IBFE example 6).

It should be possible to work around this in two ways:
1. Rewrite those functions to pass the information along to the FEDataManager object.
2. Expand the `IBFEMethod` input database to take `FEDataManager_0`, `FEDataManager_1`, or some other naming scheme that lets us set these things up in the constructor.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [ ] Was clang-format run?
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
