### PR TITLE
Fix the memory leak with the scratch hierarchy.

### DIFF
--- a/doc/release-tasks.md
+++ b/doc/release-tasks.md
@@ -41,6 +41,10 @@ GitHub.
 - [ ] Check that we don't call functions like
   `ReplicatedMesh::active_local_elements_end()` inside `for`-loop declarations
   since the end iterator is expensive to compute.
+- [ ] Check that we always get unique `HierarchyDataOps` by passing `true` as
+  the third argument to `getOperationsDouble` et al. This prevents memory leaks
+  where a statically stored `HierarchyDataOps` object keeps a patch hierarchy
+  alive that is otherwise inaccessible.
 - [ ] Run clang-format on the entire code base.
 
 ## testing

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -962,7 +962,7 @@ IBFEMethod::spreadForce(const int f_data_idx,
     // zero data.
     Pointer<hier::Variable<NDIM> > f_var;
     VariableDatabase<NDIM>::getDatabase()->mapIndexToVariable(f_data_idx, f_var);
-    auto f_active_data_ops = HierarchyDataOpsManager<NDIM>::getManager()->getOperationsDouble(f_var, hierarchy);
+    auto f_active_data_ops = HierarchyDataOpsManager<NDIM>::getManager()->getOperationsDouble(f_var, hierarchy, true);
     f_active_data_ops->resetLevels(0, getFinestPatchLevelNumber());
     f_active_data_ops->setToScalar(f_scratch_data_idx,
                                    0.0,
@@ -1045,7 +1045,7 @@ IBFEMethod::spreadForce(const int f_data_idx,
         getProlongationSchedule(coarse_ln, f_scratch_data_idx, f_prolong_scratch_data_idx).fillData(data_time);
 
         // Add the values prolonged from the coarser level onto the scratch index on the finer level.
-        auto f_data_ops = HierarchyDataOpsManager<NDIM>::getManager()->getOperationsDouble(f_var, hierarchy);
+        auto f_data_ops = HierarchyDataOpsManager<NDIM>::getManager()->getOperationsDouble(f_var, hierarchy, true);
         f_data_ops->resetLevels(coarse_ln + 1, coarse_ln + 1);
         f_data_ops->add(f_scratch_data_idx, f_scratch_data_idx, f_prolong_scratch_data_idx);
     }
@@ -1056,7 +1056,8 @@ IBFEMethod::spreadForce(const int f_data_idx,
         // no corresponding index on the primary hierarchy.
         //
         // unlike the other data ops, this is always on the primary hierarchy
-        auto f_primary_data_ops = HierarchyDataOpsManager<NDIM>::getManager()->getOperationsDouble(f_var, d_hierarchy);
+        auto f_primary_data_ops =
+            HierarchyDataOpsManager<NDIM>::getManager()->getOperationsDouble(f_var, d_hierarchy, true);
         for (int ln = 0; ln <= getFinestPatchLevelNumber(); ++ln)
         {
             f_primary_data_ops->resetLevels(ln, ln);

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -981,7 +981,7 @@ IBFESurfaceMethod::spreadForce(const int f_data_idx,
     const auto f_scratch_data_idx = d_eulerian_data_cache->getCachedPatchDataIndex(f_data_idx);
     Pointer<hier::Variable<NDIM> > f_var;
     VariableDatabase<NDIM>::getDatabase()->mapIndexToVariable(f_data_idx, f_var);
-    auto f_active_data_ops = HierarchyDataOpsManager<NDIM>::getManager()->getOperationsDouble(f_var, d_hierarchy);
+    auto f_active_data_ops = HierarchyDataOpsManager<NDIM>::getManager()->getOperationsDouble(f_var, d_hierarchy, true);
     f_active_data_ops->resetLevels(ln, ln);
     f_active_data_ops->setToScalar(f_scratch_data_idx, 0.0, /*interior_only*/ false);
 

--- a/src/complex_fluids/CFINSForcing.cpp
+++ b/src/complex_fluids/CFINSForcing.cpp
@@ -357,7 +357,7 @@ CFINSForcing::setDataOnPatchHierarchy(const int data_idx,
 
     HierarchyDataOpsManager<NDIM>* hier_data_ops_manager = HierarchyDataOpsManager<NDIM>::getManager();
     Pointer<HierarchyDataOpsReal<NDIM, double> > hier_cc_data_ops =
-        hier_data_ops_manager->getOperationsDouble(d_W_cc_var, hierarchy);
+        hier_data_ops_manager->getOperationsDouble(d_W_cc_var, hierarchy, true);
     // Convert evolved quantity including ghost cells to conformation tensor.
     switch (d_evolve_type)
     {


### PR DESCRIPTION
It turns out that unless we request a unique `HierachyDataOps` then we store a copy of that object indefinitely, and that object stores a pointer to the scratch hierarchy - i.e., we never deallocate the scratch hierarchies and we get a new one every time we regrid.

I figured this out by setting a breakpoint in `SAMRAIDataCache::setPatchHierarchy()`. At the point we are supposed to destroy the hierarchy (because its reference count is zero) we in fact have a reference count of 3. To verify that this works I rigged up a copy of an IBFE example to regrid at every time step - without this patch it more than triples in memory and with this patch the memory usage is nearly constant (in both cases I had 1000 timesteps with 1000 regrids).

Since these are not really memory leaks (we destroy the objects at exit) I don't know of a good way to test that we really fixed the problem. Hence I added an item to the release checklist to remind us to look for such problems manually.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
