### PR TITLE
Fix a displacement test.

### DIFF
--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -577,7 +577,7 @@ IBFEMethod::preprocessIntegrateData(double current_time, double new_time, int nu
         {
             plog << d_object_name << "::preprocessIntegrateData(): "
                  << "Maximum structure node displacement is " << max_distance
-                 << ". Reinitializing element to patch mappings.\n";
+                 << " - reinitializing element to patch mappings\n";
             do_reinit_element_mappings = true;
             break;
         }

--- a/tests/IBFE/explicit_ex4_2d.displace.mpirun=4.output
+++ b/tests/IBFE/explicit_ex4_2d.displace.mpirun=4.output
@@ -2875,7 +2875,7 @@ Simulation time is 0.0890625
 At beginning of timestep # 114
 Simulation time is 0.0890625
 IBHierarchyIntegrator::advanceHierarchy(): time interval = [0.089062500000,0.089843750000], dt = 0.000781250000
-IBFEMethod::preprocessIntegrateData(): Maximum structure node displacement is 0.002501697679. Reinitializing element to patch mappings.
+IBFEMethod::preprocessIntegrateData(): Maximum structure node displacement is 0.002501698048 - reinitializing element to patch mappings
 IBHierarchyIntegrator::preprocessIntegrateHierarchy(): performing Lagrangian forward Euler step
 IBHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian force
@@ -4401,7 +4401,7 @@ Simulation time is 0.136719
 At beginning of timestep # 175
 Simulation time is 0.136719
 IBHierarchyIntegrator::advanceHierarchy(): time interval = [0.136718750000,0.137500000000], dt = 0.000781250000
-IBFEMethod::preprocessIntegrateData(): Maximum structure node displacement is 0.002533934041. Reinitializing element to patch mappings.
+IBFEMethod::preprocessIntegrateData(): Maximum structure node displacement is 0.002533934630 - reinitializing element to patch mappings
 IBHierarchyIntegrator::preprocessIntegrateHierarchy(): performing Lagrangian forward Euler step
 IBHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian force


### PR DESCRIPTION
This gets around a bug in numdiff where a number followed by a period isn't treated the same way as a number followed by a space. Thanks @jabrown893 for pointing out that this test is failing!

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
