### PR TITLE
Cmake mac fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,7 +507,6 @@ ENDIF()
 #
 FUNCTION(IBAMR_CHECK_COMPILATION_WITH_MPI _dependency_name _src _dependency_libraries
     _dependency_includes)
-  MESSAGE(STATUS "Verifying that ${_dependency_name} is configured with the same version of MPI as IBAMR is:")
   SET(CMAKE_REQUIRED_INCLUDES)
   LIST(APPEND CMAKE_REQUIRED_INCLUDES "${_dependency_includes}")
   LIST(APPEND CMAKE_REQUIRED_INCLUDES "${PETSC_INCLUDE_DIRS}")
@@ -522,17 +521,19 @@ FUNCTION(IBAMR_CHECK_COMPILATION_WITH_MPI _dependency_name _src _dependency_libr
   CHECK_CXX_SOURCE_COMPILES("${_src}" ${_test_name})
   IF(NOT "${${_test_name}}")
     MESSAGE(FATAL_ERROR "\
-Unable to compile a test program dependent on ${_dependency} that links against
-MPI. This usually means that the dependency is misconfigured or is using a
-different version of MPI than the one supplied to IBAMR.")
+Unable to compile a test program dependent on ${_dependency} that links \
+against MPI. This usually means that the dependency is misconfigured or is \
+using a different version of MPI than the one supplied to IBAMR.")
   ENDIF()
   SET(CMAKE_REQUIRED_INCLUDES)
   SET(CMAKE_REQUIRED_LIBRARIES)
 
-  MESSAGE(STATUS "Checking that we do not link against a different MPI library - ")
   FIND_PROGRAM(_ldd "ldd")
   FIND_PROGRAM(_readlink "readlink")
-  IF(NOT ${_ldd} STREQUAL "ldd-NOTFOUND" AND NOT ${_readlink} STREQUAL "readlink-NOTFOUND")
+  IF(NOT "${_ldd}" STREQUAL "_ldd-NOTFOUND" AND NOT "${_readlink}" STREQUAL "_readlink-NOTFOUND")
+    MESSAGE(STATUS "\
+Verifying that ${_dependency_name} is configured with the same version of MPI \
+as IBAMR is")
     FOREACH(_lib ${_dependency_libraries})
       IF(EXISTS ${_lib})
         EXECUTE_PROCESS(COMMAND "${_ldd}" "${_lib}"
@@ -568,8 +569,10 @@ Please recompile ${_dependency} to link against the same version of MPI.")
         ENDFOREACH()
       ENDIF()
     ENDFOREACH()
+    MESSAGE(STATUS "\
+Verifying that ${_dependency_name} is configured with the same version of MPI \
+as IBAMR is - library resolution check succeeded")
   ENDIF()
-  MESSAGE(STATUS "Checking that we do not link against a different MPI library - Success")
 ENDFUNCTION()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,8 +354,8 @@ IF(NOT "${LIBMESH_ROOT}" STREQUAL "")
   FIND_PROGRAM(_libmesh_config "libmesh-config" HINTS ${LIBMESH_ROOT}/bin/)
   IF("${_libmesh_config}" STREQUAL "_libmesh_config-NOTFOUND")
     MESSAGE(FATAL_ERROR "\
-libMesh (an optional dependency) was specified with LIBMESH_ROOT=${LIBMESH_ROOT}
-but a valid libmesh-config script could not be found in ${LIBMESH_ROOT}/bin/.
+libMesh (an optional dependency) was specified with LIBMESH_ROOT=${LIBMESH_ROOT} \
+but a valid libmesh-config script could not be found in ${LIBMESH_ROOT}/bin/. \
 Please check the value of LIBMESH_ROOT and rerun CMake.")
   ELSE()
     SET(IBAMR_HAVE_LIBMESH TRUE)
@@ -448,7 +448,7 @@ CMake.")
       )
     IF(NOT "${LIBMESH_WITH_SAME_PETSC}")
       MESSAGE(FATAL_ERROR "\
-The version of PETSc detected by libMesh differs from the version of PETSc
+The version of PETSc detected by libMesh differs from the version of PETSc \
 detected by IBAMR. This is not allowed.")
     ENDIF()
 
@@ -475,8 +475,8 @@ IF(NOT "${LIBMESH_ROOT}" STREQUAL "")
     FIND_PACKAGE(ZLIB REQUIRED)
   ELSE()
     MESSAGE(FATAL_ERROR "\
-Silo (an optional dependency) was specified with SILO_ROOT=${SILO_ROOT} but a
-silo installation could not be found in that location. Please check the value
+Silo (an optional dependency) was specified with SILO_ROOT=${SILO_ROOT} but a \
+silo installation could not be found in that location. Please check the value \
 of SILO_ROOT and rerun CMake.")
   ENDIF()
 ELSE()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,9 +229,14 @@ TARGET_SOURCES(IBAMR3d PRIVATE ${FORTRAN_GENERATED_SRC3D} ${CXX_SRC})
 TARGET_LINK_LIBRARIES(IBAMR2d PUBLIC IBAMRHeaders IBTKHeaders)
 TARGET_LINK_LIBRARIES(IBAMR3d PUBLIC IBAMRHeaders IBTKHeaders)
 
-IBAMR_SETUP_TARGET_LIBRARY(IBAMR2d)
-IBAMR_SETUP_TARGET_LIBRARY(IBAMR3d)
-
+# Since libIBAMR and libIBTK have the same dependencies (and libIBAMR always
+# depends on libIBTK), satisfy the dependencies (and NDIM definition) for
+# libIBAMR by linking against libIBTK.
+#
+# The order we resolve libIBAMR's dependencies in is important since SAMRAI is
+# usually staticly linked - if we do SAMRAI then IBTK we will end up with
+# duplicate symbols, so it has to be the other way around (so that we pick up
+# any SAMRAI symbols in libIBTK rather than adding them to libIBAMR).
 TARGET_LINK_LIBRARIES(IBAMR2d PUBLIC IBTK2d)
 TARGET_LINK_LIBRARIES(IBAMR3d PUBLIC IBTK3d)
 


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

Fixes #1172 - the link order resulted in both `libIBTK.so` and `libIBAMR.so` having copies of the same SAMRAI symbols, which lead to very strange results (like a file handle being set for IBTK but not IBAMR). I'm surprised this isn't a problem on Linux - good thing we test with multiple platforms. I cleaned up a few other things while I was around.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?