### PR TITLE
CMake: remove a duplicate definition.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -245,10 +245,6 @@ ADD_CUSTOM_COMMAND(TARGET tests
 # really used by the build system we use a shell script to find them every time
 # 'make test' is run rather than evaluating the glob when cmake generates the
 # build system.
-SET(TEST_DIRECTORIES CIB IB IBFE IBTK adv_diff advect complex_fluids interpolate
-  level_set multiphase_flow navier_stokes physical_boundary refine spread
-  vc_navier_stokes wave_tank)
-
 FOREACH(_dir ${TEST_DIRECTORIES})
   ADD_CUSTOM_COMMAND(TARGET "tests-${_dir}"
     POST_BUILD


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->
This fixes a very silly repeated variable definition bug. The definition at the top of the file is correct.

The usual checklist isn't relevant. This makes the coarsen tests added in #1122 actually run.