### PR TITLE
add input option controlling if negative weights are allowed in IBFE coupling

### DIFF
--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -2966,6 +2966,7 @@ IBFEMethod::getFromInput(const Pointer<Database>& db, bool /*is_from_restart*/)
         d_default_interp_spec.quad_order = FIRST;
         d_default_interp_spec.use_adaptive_quadrature = false;
         d_default_interp_spec.use_consistent_mass_matrix = false;
+        d_default_interp_spec.allow_rules_with_negative_weights = false;
         // we default to using a lumped mass matrix, but allow users to choose to use a consistent mass matrix (even
         // though it seems like a bad idea)
     }
@@ -2995,6 +2996,12 @@ IBFEMethod::getFromInput(const Pointer<Database>& db, bool /*is_from_restart*/)
     else if (db->isBool("IB_use_consistent_mass_matrix"))
         d_default_interp_spec.use_consistent_mass_matrix = db->getBool("IB_use_consistent_mass_matrix");
 
+    if (db->isBool("interp_allow_rules_with_negative_weights"))
+        d_default_interp_spec.allow_rules_with_negative_weights =
+            db->getBool("interp_allow_rules_with_negative_weights");
+    else if (db->isBool("IB_allow_rules_with_negative_weights"))
+        d_default_interp_spec.allow_rules_with_negative_weights = db->getBool("IB_allow_rules_with_negative_weights");
+
     // Spreading settings.
     if (db->isString("spread_delta_fcn"))
         d_default_spread_spec.kernel_fcn = db->getString("spread_delta_fcn");
@@ -3014,6 +3021,7 @@ IBFEMethod::getFromInput(const Pointer<Database>& db, bool /*is_from_restart*/)
         d_default_spread_spec.quad_type = QTRAP;
         d_default_spread_spec.quad_order = FIRST;
         d_default_spread_spec.use_adaptive_quadrature = false;
+        d_default_spread_spec.allow_rules_with_negative_weights = false;
     }
 
     if (db->isString("spread_quad_type"))
@@ -3035,6 +3043,12 @@ IBFEMethod::getFromInput(const Pointer<Database>& db, bool /*is_from_restart*/)
         d_default_spread_spec.point_density = db->getDouble("spread_point_density");
     else if (db->isDouble("IB_point_density"))
         d_default_spread_spec.point_density = db->getDouble("IB_point_density");
+
+    if (db->isBool("spread_allow_rules_with_negative_weights"))
+        d_default_spread_spec.allow_rules_with_negative_weights =
+            db->getBool("spread_allow_rules_with_negative_weights");
+    else if (db->isBool("IB_allow_rules_with_negative_weights"))
+        d_default_spread_spec.allow_rules_with_negative_weights = db->getBool("IB_allow_rules_with_negative_weights");
 
     // Force computation settings.
     if (db->isBool("split_normal_force"))


### PR DESCRIPTION
This option should have been included in #1188.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
