### PR TITLE
Fix FEMapping with QNODAL.

### DIFF
--- a/doc/news/changes/minor/20210122DavidWells
+++ b/doc/news/changes/minor/20210122DavidWells
@@ -1,0 +1,4 @@
+Fixed: IBTK::FEMapping (and, consequently, the rest of the IB stack) now works
+correctly with QNODAL.
+<br>
+(David Wells, 2021/01/22)

--- a/ibtk/include/ibtk/FEMapping.h
+++ b/ibtk/include/ibtk/FEMapping.h
@@ -220,8 +220,19 @@ public:
 
     /*!
      * Constructor.
+     *
+     * @param[in] quad_key The quadrature key (i.e., a complete description of
+     * the quadrature rule).
+     * @param[in] mapping_element_type The element type used to compute the
+     * mapping from the reference element to the physical element. This may be
+     * different from the element type in the quadrature rule - for example,
+     * one could provide TRI6 in the quadrature rule and TRI3 here.
+     * @param[in] update_flags An enum describing which values need to be
+     * computed on each element.
      */
-    FENodalMapping(const key_type quad_key, const FEUpdateFlags update_flags);
+    FENodalMapping(const key_type quad_key,
+                   const libMesh::ElemType mapping_element_type,
+                   const FEUpdateFlags update_flags);
 
     /*!
      * Recalculate relevant quantities for the provided element.
@@ -344,10 +355,21 @@ public:
      */
     using key_type = quadrature_key_type;
 
-    /**
+    /*!
      * Constructor.
+     *
+     * @param[in] quad_key The quadrature key (i.e., a complete description of
+     * the quadrature rule).
+     * @param[in] mapping_element_type The element type used to compute the
+     * mapping from the reference element to the physical element. This may be
+     * different from the element type in the quadrature rule - for example,
+     * one could provide TRI6 in the quadrature rule and TRI3 here.
+     * @param[in] update_flags An enum describing which values need to be
+     * computed on each element.
      */
-    FELagrangeMapping(const key_type quad_key, const FEUpdateFlags update_flags);
+    FELagrangeMapping(const key_type quad_key,
+                      const libMesh::ElemType mapping_element_type,
+                      const FEUpdateFlags update_flags);
 
 protected:
     virtual void fillTransforms(const libMesh::Elem* elem) override;
@@ -372,11 +394,16 @@ protected:
 class Tri3Mapping : public FENodalMapping<2, 2, 3>
 {
 public:
-    /**
-     * Explicitly use the base class' constructor (this class does not require
-     * any additional setup).
+    /*!
+     * Key type. Completely describes (excepting p-refinement) a libMesh
+     * quadrature rule.
      */
-    using FENodalMapping<2, 2, 3>::FENodalMapping;
+    using key_type = quadrature_key_type;
+
+    /*!
+     * Constructor.
+     */
+    Tri3Mapping(const key_type quad_key, const FEUpdateFlags update_flags);
 
 protected:
     virtual void fillTransforms(const libMesh::Elem* elem) override;
@@ -392,11 +419,16 @@ protected:
 class Quad4Mapping : public FENodalMapping<2, 2, 4>
 {
 public:
-    /**
-     * Explicitly use the base class' constructor (this class does not require
-     * any additional setup).
+    /*!
+     * Key type. Completely describes (excepting p-refinement) a libMesh
+     * quadrature rule.
      */
-    using FENodalMapping<2, 2, 4>::FENodalMapping;
+    using key_type = quadrature_key_type;
+
+    /*!
+     * Constructor.
+     */
+    Quad4Mapping(const key_type quad_key, const FEUpdateFlags update_flags);
 
 protected:
     virtual void fillTransforms(const libMesh::Elem* elem) override;
@@ -479,11 +511,16 @@ protected:
 class Tet4Mapping : public FENodalMapping<3, 3, 4>
 {
 public:
-    /**
-     * Explicitly use the base class' constructor (this class does not require
-     * any additional setup).
+    /*!
+     * Key type. Completely describes (excepting p-refinement) a libMesh
+     * quadrature rule.
      */
-    using FENodalMapping<3, 3, 4>::FENodalMapping;
+    using key_type = quadrature_key_type;
+
+    /**
+     * Constructor.
+     */
+    Tet4Mapping(const key_type quad_key, const FEUpdateFlags update_flags);
 
 protected:
     virtual void fillTransforms(const libMesh::Elem* elem) override;

--- a/ibtk/src/lagrangian/FEMapping.cpp
+++ b/ibtk/src/lagrangian/FEMapping.cpp
@@ -137,7 +137,7 @@ FEMapping<2, 2>::build(const key_type key, const FEUpdateFlags update_flags)
     case libMesh::ElemType::QUAD9:
         return std::unique_ptr<FEMapping<2, 2> >(new Quad9Mapping(key, update_flags));
     default:
-        return std::unique_ptr<FEMapping<2, 2> >(new FELagrangeMapping<2, 2>(key, update_flags));
+        return std::unique_ptr<FEMapping<2, 2> >(new FELagrangeMapping<2, 2>(key, std::get<0>(key), update_flags));
     }
 
     return {};
@@ -154,11 +154,12 @@ FEMapping<3, 3>::build(const key_type key, const FEUpdateFlags update_flags)
     case libMesh::ElemType::TET10:
         return std::unique_ptr<FEMapping<3, 3> >(new Tet10Mapping(key, update_flags));
     case libMesh::ElemType::HEX8:
-        return std::unique_ptr<FEMapping<3, 3> >(new FELagrangeMapping<3, 3, 8>(key, update_flags));
+        return std::unique_ptr<FEMapping<3, 3> >(
+            new FELagrangeMapping<3, 3, 8>(key, libMesh::ElemType::HEX8, update_flags));
     case libMesh::ElemType::HEX27:
         return std::unique_ptr<FEMapping<3, 3> >(new Hex27Mapping(key, update_flags));
     default:
-        return std::unique_ptr<FEMapping<3, 3> >(new FELagrangeMapping<3, 3>(key, update_flags));
+        return std::unique_ptr<FEMapping<3, 3> >(new FELagrangeMapping<3, 3>(key, std::get<0>(key), update_flags));
     }
 
     return {};
@@ -168,7 +169,8 @@ template <int dim, int spacedim>
 std::unique_ptr<FEMapping<dim, spacedim> >
 FEMapping<dim, spacedim>::build(const key_type key, const FEUpdateFlags update_flags)
 {
-    return std::unique_ptr<FEMapping<dim, spacedim> >(new FELagrangeMapping<dim, spacedim>(key, update_flags));
+    return std::unique_ptr<FEMapping<dim, spacedim> >(
+        new FELagrangeMapping<dim, spacedim>(key, std::get<0>(key), update_flags));
 }
 
 //
@@ -178,8 +180,9 @@ FEMapping<dim, spacedim>::build(const key_type key, const FEUpdateFlags update_f
 template <int dim, int spacedim, int n_nodes>
 FENodalMapping<dim, spacedim, n_nodes>::FENodalMapping(
     const typename FENodalMapping<dim, spacedim, n_nodes>::key_type quad_key,
+    const libMesh::ElemType element_mapping_type,
     const FEUpdateFlags update_flags)
-    : d_quadrature_data(quad_key), d_point_map(std::get<0>(quad_key), d_quadrature_data.d_points)
+    : d_quadrature_data(quad_key), d_point_map(element_mapping_type, d_quadrature_data.d_points)
 {
     d_update_flags = update_flags;
 
@@ -281,8 +284,9 @@ FENodalMapping<dim, spacedim, n_nodes>::fillQuadraturePoints(const libMesh::Elem
 template <int dim, int spacedim, int n_nodes>
 FELagrangeMapping<dim, spacedim, n_nodes>::FELagrangeMapping(
     const typename FELagrangeMapping<dim, spacedim, n_nodes>::key_type quad_key,
+    const libMesh::ElemType element_mapping_type,
     const FEUpdateFlags update_flags)
-    : FENodalMapping<dim, spacedim, n_nodes>(quad_key, update_flags),
+    : FENodalMapping<dim, spacedim, n_nodes>(quad_key, element_mapping_type, update_flags),
       d_n_nodes(n_nodes == -1 ? get_n_nodes(std::get<0>(quad_key)) : n_nodes)
 {
     if (n_nodes != -1) TBOX_ASSERT(d_n_nodes == n_nodes);
@@ -291,8 +295,6 @@ FELagrangeMapping<dim, spacedim, n_nodes>::FELagrangeMapping(
 #else
     TBOX_ASSERT(d_n_nodes <= static_cast<int>(libMesh::Elem::max_n_nodes));
 #endif
-    const libMesh::ElemType elem_type = std::get<0>(this->d_quadrature_data.d_key);
-
     typename decltype(d_dphi)::extent_gen extents;
     d_dphi.resize(extents[d_n_nodes][this->d_quadrature_data.size()]);
 
@@ -301,8 +303,12 @@ FELagrangeMapping<dim, spacedim, n_nodes>::FELagrangeMapping(
         for (unsigned int q = 0; q < this->d_quadrature_data.size(); ++q)
         {
             for (unsigned int d = 0; d < dim; ++d)
-                d_dphi[node_n][q][d] = libMesh::FE<dim, libMesh::LAGRANGE>::shape_deriv(
-                    elem_type, get_default_order(elem_type), node_n, d, this->d_quadrature_data.d_points[q]);
+                d_dphi[node_n][q][d] =
+                    libMesh::FE<dim, libMesh::LAGRANGE>::shape_deriv(element_mapping_type,
+                                                                     get_default_order(element_mapping_type),
+                                                                     node_n,
+                                                                     d,
+                                                                     this->d_quadrature_data.d_points[q]);
         }
     }
 }
@@ -359,6 +365,12 @@ FELagrangeMapping<dim, spacedim, n_nodes>::fillTransforms(const libMesh::Elem* e
 // Tri3Mapping
 //
 
+Tri3Mapping::Tri3Mapping(const key_type quad_key, const FEUpdateFlags update_flags)
+
+    : FENodalMapping<2, 2, 3>(quad_key, libMesh::TRI3, update_flags)
+{
+}
+
 void
 Tri3Mapping::fillTransforms(const libMesh::Elem* elem)
 {
@@ -398,9 +410,7 @@ Tri3Mapping::isAffine() const
 //
 
 Tri6Mapping::Tri6Mapping(const key_type quad_key, const FEUpdateFlags update_flags)
-    : FELagrangeMapping<2, 2, 6>(quad_key, update_flags),
-      tri3_mapping(std::make_tuple(libMesh::TRI3, std::get<1>(quad_key), std::get<2>(quad_key), std::get<3>(quad_key)),
-                   update_flags)
+    : FELagrangeMapping<2, 2, 6>(quad_key, libMesh::ElemType::TRI6, update_flags), tri3_mapping(quad_key, update_flags)
 {
 }
 
@@ -445,6 +455,12 @@ Tri6Mapping::elem_is_affine(const libMesh::Elem* elem)
 //
 // Quad4Mapping
 //
+
+Quad4Mapping::Quad4Mapping(const key_type quad_key, const FEUpdateFlags update_flags)
+
+    : FENodalMapping<2, 2, 4>(quad_key, libMesh::QUAD4, update_flags)
+{
+}
 
 void
 Quad4Mapping::fillTransforms(const libMesh::Elem* elem)
@@ -495,7 +511,7 @@ Quad4Mapping::fillTransforms(const libMesh::Elem* elem)
 //
 
 Quad9Mapping::Quad9Mapping(const Quad9Mapping::key_type quad_key, FEUpdateFlags update_flags)
-    : FENodalMapping<2, 2, 9>(quad_key, update_flags)
+    : FENodalMapping<2, 2, 9>(quad_key, std::get<0>(quad_key), update_flags)
 {
     // This code utilizes an implementation detail of
     // QBase::tensor_product_quad where the x coordinate increases fastest to
@@ -617,6 +633,12 @@ Quad9Mapping::fillTransforms(const libMesh::Elem* elem)
 // Tet4Mapping
 //
 
+Tet4Mapping::Tet4Mapping(const key_type quad_key, const FEUpdateFlags update_flags)
+
+    : FENodalMapping<3, 3, 4>(quad_key, libMesh::TET4, update_flags)
+{
+}
+
 void
 Tet4Mapping::fillTransforms(const libMesh::Elem* elem)
 {
@@ -663,9 +685,8 @@ Tet4Mapping::isAffine() const
 //
 
 Tet10Mapping::Tet10Mapping(const key_type quad_key, const FEUpdateFlags update_flags)
-    : FELagrangeMapping<3, 3, 10>(quad_key, update_flags),
-      tet4_mapping(std::make_tuple(libMesh::TET4, std::get<1>(quad_key), std::get<2>(quad_key), std::get<3>(quad_key)),
-                   update_flags)
+    : FELagrangeMapping<3, 3, 10>(quad_key, libMesh::ElemType::TET10, update_flags),
+      tet4_mapping(quad_key, update_flags)
 {
 }
 
@@ -715,9 +736,8 @@ Tet10Mapping::elem_is_affine(const libMesh::Elem* elem)
 //
 
 Hex27Mapping::Hex27Mapping(const key_type quad_key, const FEUpdateFlags update_flags)
-    : FELagrangeMapping<3, 3, 27>(quad_key, update_flags),
-      hex8_mapping(std::make_tuple(libMesh::HEX8, std::get<1>(quad_key), std::get<2>(quad_key), std::get<3>(quad_key)),
-                   update_flags)
+    : FELagrangeMapping<3, 3, 27>(quad_key, libMesh::HEX27, update_flags),
+      hex8_mapping(quad_key, libMesh::HEX8, update_flags)
 {
 }
 

--- a/tests/IBTK/jacobian_calc_01.cpp
+++ b/tests/IBTK/jacobian_calc_01.cpp
@@ -30,9 +30,9 @@
 #include <ibtk/libmesh_utilities.h>
 
 // Set up application namespace declarations
-#include <ibamr/app_namespaces.h>
-
 #include <boost/multi_array.hpp>
+
+#include <ibamr/app_namespaces.h>
 
 #include "../tests.h"
 
@@ -240,9 +240,9 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": TRI3 square" << std::endl;
             const key_type key(TRI3, QGAUSS, THIRD, true);
             Tri3Mapping jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<2> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(EDGE2, QGAUSS, THIRD, true);
-            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, key);
             ++test_n;
         }
@@ -251,9 +251,9 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": TRI3 square" << std::endl;
             const key_type key(TRI3, QGAUSS, THIRD, true);
             Tri3Mapping jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<2> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(EDGE2, QGAUSS, THIRD, true);
-            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, key);
             ++test_n;
         }
@@ -262,9 +262,9 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": TRI6 square" << std::endl;
             const key_type key(TRI6, QGAUSS, FIFTH, true);
             Tri6Mapping jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<2> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(EDGE2, QGAUSS, FIFTH, true);
-            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, key);
             ++test_n;
         }
@@ -273,9 +273,9 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": TRI6 square" << std::endl;
             const key_type key(TRI6, QGAUSS, FIFTH, true);
             Tri6Mapping jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<2> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(EDGE2, QGAUSS, FIFTH, true);
-            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, key);
             ++test_n;
         }
@@ -284,9 +284,9 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": Quad4 square" << std::endl;
             const key_type key(QUAD4, QGAUSS, THIRD, true);
             Quad4Mapping jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<2> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(EDGE2, QGAUSS, THIRD, true);
-            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, key);
             ++test_n;
         }
@@ -295,9 +295,9 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": Quad4 circle" << std::endl;
             const key_type key(QUAD4, QGAUSS, THIRD, true);
             Quad4Mapping jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<2> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(EDGE2, QGAUSS, THIRD, true);
-            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_circle(init, jac_calc_1, jac_calc_2, jac_calc_b, 5, key);
             ++test_n;
         }
@@ -306,9 +306,9 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": Quad9 square" << std::endl;
             const key_type key(QUAD9, QGAUSS, FOURTH, true);
             Quad9Mapping jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<2> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(EDGE3, QGAUSS, FOURTH, true);
-            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, key);
             ++test_n;
         }
@@ -317,9 +317,9 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": Quad9 circle" << std::endl;
             const key_type key(QUAD9, QGAUSS, FOURTH, true);
             Quad9Mapping jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<2> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(EDGE3, QGAUSS, FOURTH, true);
-            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<1, 2> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_circle(init, jac_calc_1, jac_calc_2, jac_calc_b, 4, key);
             ++test_n;
         }
@@ -328,9 +328,9 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": TET4 cube" << std::endl;
             const key_type key(TET4, QGAUSS, THIRD, true);
             Tet4Mapping jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<3> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<3> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(TRI3, QGAUSS, THIRD, true);
-            FELagrangeMapping<2, 3> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2, 3> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, key);
             ++test_n;
         }
@@ -339,10 +339,10 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": HEX8 square" << std::endl;
             const key_type key(HEX8, QGAUSS, THIRD, true);
             // HEX8 doesn't have a custom calculator yet
-            FELagrangeMapping<3> jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<3> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<3> jac_calc_1(key, std::get<0>(key), FEUpdateFlags::update_JxW);
+            FELagrangeMapping<3> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(QUAD4, QGAUSS, THIRD, true);
-            FELagrangeMapping<2, 3> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2, 3> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, key);
             ++test_n;
         }
@@ -351,10 +351,10 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": HEX8 circle" << std::endl;
             const key_type key(HEX8, QGAUSS, THIRD, true);
             // HEX8 doesn't have a custom calculator yet
-            FELagrangeMapping<3> jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<3> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<3> jac_calc_1(key, std::get<0>(key), FEUpdateFlags::update_JxW);
+            FELagrangeMapping<3> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(QUAD4, QGAUSS, THIRD, true);
-            FELagrangeMapping<2, 3> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2, 3> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_circle(init, jac_calc_1, jac_calc_2, jac_calc_b, 4, key);
             ++test_n;
         }
@@ -363,10 +363,10 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": HEX27 square" << std::endl;
             const key_type key(HEX27, QGAUSS, FOURTH, true);
             // HEX27 doesn't have a custom calculator yet
-            FELagrangeMapping<3> jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<3> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<3> jac_calc_1(key, std::get<0>(key), FEUpdateFlags::update_JxW);
+            FELagrangeMapping<3> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(QUAD9, QGAUSS, FOURTH, true);
-            FELagrangeMapping<2, 3> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2, 3> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_cube(init, jac_calc_1, jac_calc_2, jac_calc_b, key);
             ++test_n;
         }
@@ -375,10 +375,10 @@ main(int argc, char** argv)
             plog << "Test " << test_n << ": HEX27 circle" << std::endl;
             const key_type key(HEX27, QGAUSS, FOURTH, true);
             // HEX27 doesn't have a custom calculator yet
-            FELagrangeMapping<3> jac_calc_1(key, FEUpdateFlags::update_JxW);
-            FELagrangeMapping<3> jac_calc_2(key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<3> jac_calc_1(key, std::get<0>(key), FEUpdateFlags::update_JxW);
+            FELagrangeMapping<3> jac_calc_2(key, std::get<0>(key), FEUpdateFlags::update_JxW);
             const key_type boundary_key(QUAD9, QGAUSS, FOURTH, true);
-            FELagrangeMapping<2, 3> jac_calc_b(boundary_key, FEUpdateFlags::update_JxW);
+            FELagrangeMapping<2, 3> jac_calc_b(boundary_key, std::get<0>(boundary_key), FEUpdateFlags::update_JxW);
             test_circle(init, jac_calc_1, jac_calc_2, jac_calc_b, 2, key);
             ++test_n;
         }

--- a/tests/IBTK/mapping_01.cpp
+++ b/tests/IBTK/mapping_01.cpp
@@ -60,37 +60,47 @@ test(LibMeshInit& init)
         TBOX_ASSERT(false);
     }
 
-    std::unique_ptr<QBase> quad = QBase::build(QGAUSS, dim, THIRD);
-    quad->init(elem_type);
-    FEType fe_type(order, fe_family);
-    std::unique_ptr<FEBase> libmesh_fe = FEBase::build(dim, fe_type);
-    libmesh_fe->attach_quadrature_rule(quad.get());
-    libmesh_fe->get_xyz();
-    libmesh_fe->get_JxW();
+    std::vector<libMesh::QuadratureType> quad_types;
+    quad_types.push_back(QGAUSS);
+    quad_types.push_back(QGRID);
+#if !LIBMESH_VERSION_LESS_THAN(1, 5, 0)
+    quad_types.push_back(QNODAL);
+#endif
 
-    const quadrature_key_type key{ elem_type, QGAUSS, THIRD, true };
-    std::unique_ptr<FEMapping<dim> > mapping =
-        FEMapping<dim>::build(key, FEUpdateFlags::update_JxW | FEUpdateFlags::update_quadrature_points);
-
-    for (auto elem_iter = mesh.active_local_elements_begin(); elem_iter != mesh.active_local_elements_end();
-         ++elem_iter)
+    for (const libMesh::QuadratureType quad_type : quad_types)
     {
-        libmesh_fe->reinit(*elem_iter);
-        mapping->reinit(*elem_iter);
+        std::unique_ptr<QBase> quad = QBase::build(quad_type, dim, THIRD);
+        quad->init(elem_type);
+        FEType fe_type(order, fe_family);
+        std::unique_ptr<FEBase> libmesh_fe = FEBase::build(dim, fe_type);
+        libmesh_fe->attach_quadrature_rule(quad.get());
+        libmesh_fe->get_xyz();
+        libmesh_fe->get_JxW();
 
-        const std::vector<double>& JxW = libmesh_fe->get_JxW();
-        const std::vector<double>& JxW_2 = mapping->getJxW();
-        for (unsigned int i = 0; i < JxW.size(); ++i)
+        const quadrature_key_type key{ elem_type, quad_type, THIRD, true };
+        std::unique_ptr<FEMapping<dim> > mapping =
+            FEMapping<dim>::build(key, FEUpdateFlags::update_JxW | FEUpdateFlags::update_quadrature_points);
+
+        for (auto elem_iter = mesh.active_local_elements_begin(); elem_iter != mesh.active_local_elements_end();
+             ++elem_iter)
         {
-            TBOX_ASSERT(std::abs(JxW[i] - JxW_2[i]) < 1e-14 * std::max(1.0, std::abs(JxW[i])));
-        }
+            libmesh_fe->reinit(*elem_iter);
+            mapping->reinit(*elem_iter);
 
-        const std::vector<libMesh::Point>& q = libmesh_fe->get_xyz();
-        const std::vector<libMesh::Point>& q_2 = mapping->getQuadraturePoints();
+            const std::vector<double>& JxW = libmesh_fe->get_JxW();
+            const std::vector<double>& JxW_2 = mapping->getJxW();
+            for (unsigned int i = 0; i < JxW.size(); ++i)
+            {
+                TBOX_ASSERT(std::abs(JxW[i] - JxW_2[i]) < 1e-14 * std::max(1.0, std::abs(JxW[i])));
+            }
 
-        for (unsigned int i = 0; i < q.size(); ++i)
-        {
-            TBOX_ASSERT(q[i].relative_fuzzy_equals(q_2[i], 1e-15));
+            const std::vector<libMesh::Point>& q = libmesh_fe->get_xyz();
+            const std::vector<libMesh::Point>& q_2 = mapping->getQuadraturePoints();
+
+            for (unsigned int i = 0; i < q.size(); ++i)
+            {
+                TBOX_ASSERT(q[i].relative_fuzzy_equals(q_2[i], 1e-14));
+            }
         }
     }
 }


### PR DESCRIPTION
We need to specify the element used for both the quadrature rule (since QNODAL depends on that) and also the mapping itself (which libMesh assumes is always a Lagrange-type mapping based on the nodes of the mesh).

Fixes #1209.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
