### PR TITLE
Convert libMesh::DenseMatrix to Eigen::Matrix.

### DIFF
--- a/ibtk/include/ibtk/FEMapping.h
+++ b/ibtk/include/ibtk/FEMapping.h
@@ -25,7 +25,6 @@
 
 #include "tbox/Utilities.h"
 
-#include <libmesh/dense_matrix.h>
 #include <libmesh/elem.h>
 #include <libmesh/enum_elem_type.h>
 #include <libmesh/enum_order.h>
@@ -35,6 +34,10 @@
 
 IBTK_DISABLE_EXTRA_WARNINGS
 #include <boost/multi_array.hpp>
+IBTK_ENABLE_EXTRA_WARNINGS
+
+IBTK_DISABLE_EXTRA_WARNINGS
+#include <Eigen/Core>
 IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <array>
@@ -88,7 +91,7 @@ protected:
      * Table containing the values of 1D shape functions (which, with a tensor
      * product, define the mapping) at reference quadrature points.
      */
-    libMesh::DenseMatrix<double> d_phi;
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> d_phi;
 };
 
 /*!
@@ -464,13 +467,13 @@ protected:
      * Table containing the values of 1D shape functions (which, with a tensor
      * product, define the mapping) at reference quadrature points.
      */
-    libMesh::DenseMatrix<double> d_phi;
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> d_phi;
 
     /**
      * Table containing the derivatives of 1D shape functions (which, with a
      * tensor product, define the mapping) at reference quadrature points.
      */
-    libMesh::DenseMatrix<double> d_dphi;
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> d_dphi;
 };
 
 /*!

--- a/ibtk/include/ibtk/FischerGuess.h
+++ b/ibtk/include/ibtk/FischerGuess.h
@@ -20,8 +20,11 @@
 
 #include <ibtk/config.h>
 
-#include <libmesh/dense_matrix.h>
 #include <libmesh/numeric_vector.h>
+
+IBTK_DISABLE_EXTRA_WARNINGS
+#include <Eigen/Core>
+IBTK_ENABLE_EXTRA_WARNINGS
 
 namespace IBTK
 {
@@ -86,7 +89,7 @@ protected:
 
     int d_n_stored_vectors = 0;
 
-    libMesh::DenseMatrix<double> d_correlation_matrix;
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> d_correlation_matrix;
 
     std::vector<std::unique_ptr<libMesh::NumericVector<double> > > d_solutions;
     std::vector<std::unique_ptr<libMesh::NumericVector<double> > > d_rhs;

--- a/ibtk/src/lagrangian/FEMapping.cpp
+++ b/ibtk/src/lagrangian/FEMapping.cpp
@@ -85,7 +85,7 @@ PointMap<dim, spacedim, n_nodes>::getMappedQuadraturePoints(const libMesh::Point
     if (n_nodes != -1) TBOX_ASSERT(nodes_end - nodes == n_nodes);
     const int n_nodes_ = n_nodes == -1 ? nodes_end - nodes : n_nodes;
     TBOX_ASSERT(d_reference_q_points.size() == physical_q_points.size());
-    TBOX_ASSERT(static_cast<std::size_t>(n_nodes_) == d_phi.m());
+    TBOX_ASSERT(n_nodes_ == d_phi.rows());
     // assumes same node ordering in the input node array as is stored in d_phi
     for (unsigned int q = 0; q < d_reference_q_points.size(); ++q)
     {


### PR DESCRIPTION
Thes solves a few problems:
1. We assume (in FischerGuess) that libMesh links against LAPACK - this might not be true so we shouldn't use its SVD solve.
2. Even in OPT mode, libMesh still does some bounds checking that shows up in profiling (e.g., in IBTK::PointMap). We check the bounds outside the loop anyway so switching to Eigen (which won't bounds-check) is safe and more efficient.
3. Eigen offers a cleaner API.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
