### PR TITLE
Remove some deprecated libMesh code.

### DIFF
--- a/ibtk/src/lagrangian/FEProjector.cpp
+++ b/ibtk/src/lagrangian/FEProjector.cpp
@@ -279,7 +279,7 @@ FEProjector::buildL2ProjectionSolver(const std::string& system_name)
                     FEDataManager::ZERO_DISPLACEMENT_Z_BDRY_ID
                 };
                 std::vector<boundary_id_type> bdry_ids;
-                mesh.boundary_info->boundary_ids(elem, side, bdry_ids);
+                mesh.get_boundary_info().boundary_ids(elem, side, bdry_ids);
                 const boundary_id_type dirichlet_bdry_ids = get_dirichlet_bdry_ids(bdry_ids);
                 if (!dirichlet_bdry_ids) continue;
                 fe->reinit(elem);
@@ -528,7 +528,7 @@ FEProjector::buildStabilizedL2ProjectionSolver(const std::string& system_name, c
                     FEDataManager::ZERO_DISPLACEMENT_Z_BDRY_ID
                 };
                 std::vector<boundary_id_type> bdry_ids;
-                mesh.boundary_info->boundary_ids(elem, side, bdry_ids);
+                mesh.get_boundary_info().boundary_ids(elem, side, bdry_ids);
                 const boundary_id_type dirichlet_bdry_ids = get_dirichlet_bdry_ids(bdry_ids);
                 if (!dirichlet_bdry_ids) continue;
                 fe->reinit(elem);

--- a/src/IB/FEMechanicsBase.cpp
+++ b/src/IB/FEMechanicsBase.cpp
@@ -579,7 +579,7 @@ FEMechanicsBase::doInitializeFEData(const bool use_present_data)
         // Set up boundary conditions.  Specifically, add appropriate boundary
         // IDs to the BoundaryInfo object associated with the mesh, and add DOF
         // constraints for the nodal forces and velocities.
-        const MeshBase& mesh = equation_systems.get_mesh();
+        MeshBase& mesh = equation_systems.get_mesh();
 
         DofMap& F_dof_map = F_system.get_dof_map();
         DofMap& U_dof_map = U_system.get_dof_map();
@@ -601,7 +601,7 @@ FEMechanicsBase::doInitializeFEData(const bool use_present_data)
                     FEDataManager::ZERO_DISPLACEMENT_Z_BDRY_ID
                 };
                 std::vector<boundary_id_type> bdry_ids;
-                mesh.boundary_info->boundary_ids(elem, side, bdry_ids);
+                mesh.get_boundary_info().boundary_ids(elem, side, bdry_ids);
                 const boundary_id_type dirichlet_bdry_ids = get_dirichlet_bdry_ids(bdry_ids);
                 if (!dirichlet_bdry_ids) continue;
 
@@ -610,7 +610,8 @@ FEMechanicsBase::doInitializeFEData(const bool use_present_data)
                     if (!elem->is_node_on_side(n, side)) continue;
 
                     const Node* const node = elem->node_ptr(n);
-                    mesh.boundary_info->add_node(node, dirichlet_bdry_ids);
+                    BoundaryInfo& boundary_info = mesh.get_boundary_info();
+                    boundary_info.add_node(node, dirichlet_bdry_ids);
                     for (unsigned int d = 0; d < NDIM; ++d)
                     {
                         if (!(dirichlet_bdry_ids & dirichlet_bdry_id_set[d])) continue;
@@ -862,7 +863,7 @@ FEMechanicsBase::assembleInteriorForceDensityRHS(PetscVector<double>& F_rhs_vec,
     // Extract the mesh.
     EquationSystems& equation_systems = *d_equation_systems[part];
     const MeshBase& mesh = equation_systems.get_mesh();
-    const BoundaryInfo& boundary_info = *mesh.boundary_info;
+    const BoundaryInfo& boundary_info = mesh.get_boundary_info();
     const unsigned int dim = mesh.mesh_dimension();
 
     // Setup global and elemental right-hand-side vectors.

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -313,9 +313,9 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
     // get relevant things for corresponding part
     const FEDataManager* fe_data_manager = ib_method_ops->getFEDataManager(d_part);
     const EquationSystems* equation_systems = fe_data_manager->getEquationSystems();
-    const MeshBase* mesh = &equation_systems->get_mesh();
-    const BoundaryInfo& boundary_info = *mesh->boundary_info;
-    const libMesh::Parallel::Communicator& comm_in = mesh->comm();
+    const MeshBase& mesh = equation_systems->get_mesh();
+    const BoundaryInfo& boundary_info = mesh.get_boundary_info();
+    const libMesh::Parallel::Communicator& comm_in = mesh.comm();
 
     // get equation systems from the mesh we will need.
     const System& dX_system = equation_systems->get_system(IBFEMethod::COORD_MAPPING_SYSTEM_NAME);
@@ -384,7 +384,7 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
         for (const auto& node_id : temp_node_dof_ID_sets[jj])
         {
             temp_node_dof_IDs[jj].push_back(node_id);
-            const Node* node = &mesh->node_ref(node_id);
+            const Node* node = &mesh.node_ref(node_id);
             temp_nodes[jj].push_back(*node);
             meter_centroids[jj] += *node;
         }
@@ -495,7 +495,7 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* ib_method_op
     {
         for (unsigned int ii = 0; ii < d_num_nodes[jj]; ++ii)
         {
-            const Node* node = &mesh->node_ref(d_node_dof_IDs[jj][ii]);
+            const Node* node = &mesh.node_ref(d_node_dof_IDs[jj][ii]);
             std::vector<dof_id_type> dX_dof_index;
             std::vector<dof_id_type> U_dof_index;
             for (unsigned int d = 0; d < NDIM; ++d)

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -265,7 +265,7 @@ void
 assemble_poisson(EquationSystems& es, const std::string& /*system_name*/)
 {
     const MeshBase& mesh = es.get_mesh();
-    const BoundaryInfo& boundary_info = *mesh.boundary_info;
+    const BoundaryInfo& boundary_info = mesh.get_boundary_info();
     const unsigned int dim = mesh.mesh_dimension();
     auto& system = es.get_system<LinearImplicitSystem>(IBFEMethod::PRESSURE_SYSTEM_NAME);
     const DofMap& dof_map = system.get_dof_map();
@@ -1842,7 +1842,7 @@ IBFEMethod::computeStressNormalization(PetscVector<double>& Phi_vec,
     // Extract the mesh.
     EquationSystems& equation_systems = *d_primary_fe_data_managers[part]->getEquationSystems();
     const MeshBase& mesh = equation_systems.get_mesh();
-    const BoundaryInfo& boundary_info = *mesh.boundary_info;
+    const BoundaryInfo& boundary_info = mesh.get_boundary_info();
     const unsigned int dim = mesh.mesh_dimension();
 
     // Setup extra data needed to compute stresses/forces.
@@ -2073,7 +2073,7 @@ IBFEMethod::spreadTransmissionForceDensity(const int f_data_idx,
     // Extract the mesh.
     EquationSystems& equation_systems = *d_primary_fe_data_managers[part]->getEquationSystems();
     const MeshBase& mesh = equation_systems.get_mesh();
-    const BoundaryInfo& boundary_info = *mesh.boundary_info;
+    const BoundaryInfo& boundary_info = mesh.get_boundary_info();
     const unsigned int dim = mesh.mesh_dimension();
 
     // Extract the FE systems and DOF maps, and setup the FE object.
@@ -2361,7 +2361,7 @@ IBFEMethod::imposeJumpConditions(const int f_data_idx,
     // Extract the mesh.
     EquationSystems& equation_systems = *d_primary_fe_data_managers[part]->getEquationSystems();
     const MeshBase& mesh = equation_systems.get_mesh();
-    const BoundaryInfo& boundary_info = *mesh.boundary_info;
+    const BoundaryInfo& boundary_info = mesh.get_boundary_info();
     const unsigned int dim = mesh.mesh_dimension();
     TBOX_ASSERT(dim == NDIM);
 

--- a/tests/IBFE/explicit_ex2.cpp
+++ b/tests/IBFE/explicit_ex2.cpp
@@ -224,18 +224,17 @@ main(int argc, char* argv[])
                 const bool at_mesh_bdry = !elem->neighbor_ptr(side);
                 if (at_mesh_bdry)
                 {
-                    BoundaryInfo* boundary_info = mesh.boundary_info.get();
+                    BoundaryInfo& boundary_info = mesh.get_boundary_info();
 #if (NDIM == 2)
-                    if (boundary_info->has_boundary_id(elem, side, 0) || boundary_info->has_boundary_id(elem, side, 2))
+                    if (boundary_info.has_boundary_id(elem, side, 0) || boundary_info.has_boundary_id(elem, side, 2))
                     {
-                        boundary_info->add_side(elem, side, FEDataManager::ZERO_DISPLACEMENT_XY_BDRY_ID);
+                        boundary_info.add_side(elem, side, FEDataManager::ZERO_DISPLACEMENT_XY_BDRY_ID);
                     }
 #endif
 #if (NDIM == 3)
-                    if (!(boundary_info->has_boundary_id(elem, side, 2) ||
-                          boundary_info->has_boundary_id(elem, side, 4)))
+                    if (!(boundary_info.has_boundary_id(elem, side, 2) || boundary_info.has_boundary_id(elem, side, 4)))
                     {
-                        boundary_info->add_side(elem, side, FEDataManager::ZERO_DISPLACEMENT_XYZ_BDRY_ID);
+                        boundary_info.add_side(elem, side, FEDataManager::ZERO_DISPLACEMENT_XYZ_BDRY_ID);
                     }
 #endif
                 }

--- a/tests/IBFE/explicit_ex5.cpp
+++ b/tests/IBFE/explicit_ex5.cpp
@@ -334,7 +334,8 @@ main(int argc, char* argv[])
         solid_mesh.prepare_for_use();
 
         BoundaryMesh boundary_mesh(solid_mesh.comm(), solid_mesh.mesh_dimension() - 1);
-        solid_mesh.boundary_info->sync(boundary_mesh);
+        BoundaryInfo& boundary_info = solid_mesh.get_boundary_info();
+        boundary_info.sync(boundary_mesh);
         boundary_mesh.prepare_for_use();
 
         bool use_boundary_mesh = input_db->getBoolWithDefault("USE_BOUNDARY_MESH", false);

--- a/tests/IBFE/ib_partitioning_02.cpp
+++ b/tests/IBFE/ib_partitioning_02.cpp
@@ -16,7 +16,6 @@
 #include <ibamr/IBFESurfaceMethod.h>
 #include <ibamr/INSCollocatedHierarchyIntegrator.h>
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
-#include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/IBTKInit.h>
@@ -50,6 +49,8 @@
 
 #include <string>
 #include <vector>
+
+#include <ibamr/app_namespaces.h>
 
 // This file is the main driver for parallel IB element partitioning for surface meshes.
 
@@ -130,7 +131,8 @@ main(int argc, char** argv)
         }
 
         BoundaryMesh boundary_mesh(solid_mesh.comm(), solid_mesh.mesh_dimension() - 1);
-        solid_mesh.boundary_info->sync(boundary_mesh);
+        BoundaryInfo& boundary_info = solid_mesh.get_boundary_info();
+        boundary_info.sync(boundary_mesh);
         boundary_mesh.prepare_for_use();
 
         bool use_boundary_mesh = input_db->getBoolWithDefault("USE_BOUNDARY_MESH", false);

--- a/tests/IBTK/fe_values_02.cpp
+++ b/tests/IBTK/fe_values_02.cpp
@@ -95,7 +95,8 @@ test(LibMeshInit& init, const MeshType mesh_type = MeshType::libmesh)
 
     // set up boundary mesh:
     BoundaryMesh boundary_mesh(solid_mesh.comm(), solid_mesh.mesh_dimension() - 1);
-    solid_mesh.boundary_info->sync(boundary_mesh);
+    BoundaryInfo& boundary_info = solid_mesh.get_boundary_info();
+    boundary_info.sync(boundary_mesh);
     boundary_mesh.prepare_for_use();
     Mesh& mesh = boundary_mesh;
     // the rest is the same as fe_values_01 (with the small exception of using

--- a/tests/IBTK/jacobian_calc_01.cpp
+++ b/tests/IBTK/jacobian_calc_01.cpp
@@ -93,7 +93,8 @@ test_cube(LibMeshInit& init,
     // also test the surface mesh:
     {
         BoundaryMesh boundary_mesh(mesh.comm(), mesh.mesh_dimension() - 1);
-        mesh.boundary_info->sync(boundary_mesh);
+        BoundaryInfo& boundary_info = mesh.get_boundary_info();
+        boundary_info.sync(boundary_mesh);
         boundary_mesh.prepare_for_use();
         TBOX_ASSERT(boundary_mesh.spatial_dimension() == mesh.mesh_dimension());
         TBOX_ASSERT(boundary_mesh.mesh_dimension() == mesh.mesh_dimension() - 1);
@@ -193,7 +194,8 @@ test_circle(LibMeshInit& init,
     // also test the surface mesh:
     {
         BoundaryMesh boundary_mesh(mesh.comm(), mesh.mesh_dimension() - 1);
-        mesh.boundary_info->sync(boundary_mesh);
+        BoundaryInfo& boundary_info = mesh.get_boundary_info();
+        boundary_info.sync(boundary_mesh);
         boundary_mesh.prepare_for_use();
         TBOX_ASSERT(boundary_mesh.spatial_dimension() == mesh.mesh_dimension());
         TBOX_ASSERT(boundary_mesh.mesh_dimension() == mesh.mesh_dimension() - 1);

--- a/tests/level_set/fe_surface_distance.cpp
+++ b/tests/level_set/fe_surface_distance.cpp
@@ -289,7 +289,8 @@ main(int argc, char* argv[])
 
         // Create boundary mesh
         BoundaryMesh boundary_mesh(solid_mesh.comm(), solid_mesh.mesh_dimension() - 1);
-        solid_mesh.boundary_info->sync(boundary_mesh);
+        BoundaryInfo& boundary_info = solid_mesh.get_boundary_info();
+        boundary_info.sync(boundary_mesh);
         boundary_mesh.prepare_for_use();
 #if (NDIM == 3)
         // Convert the QUAD4 at the boundaries to TRI3

--- a/tests/wave_tank/nwt_cylinder.cpp
+++ b/tests/wave_tank/nwt_cylinder.cpp
@@ -53,7 +53,6 @@
 #include <ibamr/StokesSecondOrderWaveBcCoef.h>
 #include <ibamr/SurfaceTensionForceFunction.h>
 #include <ibamr/WaveDampingFunctions.h>
-#include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartGridFunctionSet.h>
@@ -62,6 +61,8 @@
 #include <ibtk/IBTK_MPI.h>
 #include <ibtk/muParserCartGridFunction.h>
 #include <ibtk/muParserRobinBcCoefs.h>
+
+#include <ibamr/app_namespaces.h>
 
 // Application specific includes.
 #include "FlowGravityForcing.h"
@@ -560,7 +561,8 @@ main(int argc, char* argv[])
 
         // Create boundary mesh
         BoundaryMesh boundary_mesh(solid_mesh.comm(), solid_mesh.mesh_dimension() - 1);
-        solid_mesh.boundary_info->sync(boundary_mesh);
+        BoundaryInfo& boundary_info = solid_mesh.get_boundary_info();
+        boundary_info.sync(boundary_mesh);
         boundary_mesh.prepare_for_use();
 
         Mesh& mesh = solid_mesh;


### PR DESCRIPTION
`boundary_info` is now protected and thus IBAMR won't compile unless deprecated code is turned back on in libMesh.

We are currently incompatible with libMesh's development branch - see https://github.com/libMesh/libmesh/issues/2883.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?