### PR TITLE
Improve our CMake-based configuration of libMesh.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,9 +403,13 @@ CMake.")
 
     SET(CMAKE_REQUIRED_INCLUDES "${LIBMESH_INCLUDE_DIRS}")
     SET(CMAKE_REQUIRED_FLAGS "${_libmesh_cxxflags}")
+
+    # figure out which version of C++ libMesh wants to use:
+    SET(LIBMESH_CXX_VERSION 11) # we require C++11 anyway so use it as the default
     CHECK_CXX_SOURCE_COMPILES(
       "
       #include <libmesh/libmesh_config.h>
+      // older versions do not define LIBMESH_HAVE_CXX14
       #ifdef LIBMESH_HAVE_CXX14_MAKE_UNIQUE
       // OK
       #else
@@ -415,6 +419,24 @@ CMake.")
       "
       LIBMESH_WITH_CXX14
       )
+    CHECK_CXX_SOURCE_COMPILES(
+      "
+      #include <libmesh/libmesh_config.h>
+      #ifdef LIBMESH_HAVE_CXX17
+      // OK
+      #else
+      #error
+      #endif
+      int main() {}
+      "
+      LIBMESH_WITH_CXX17
+      )
+
+    IF(${LIBMESH_WITH_CXX17})
+      SET(LIBMESH_CXX_VERSION 17)
+    ELSEIF(${LIBMESH_WITH_CXX14})
+      SET(LIBMESH_CXX_VERSION 14)
+    ENDIF()
     CHECK_CXX_SOURCE_COMPILES(
       "
       #include <libmesh/libmesh_config.h>
@@ -647,9 +669,9 @@ IBAMR_CHECK_COMPILATION_WITH_MPI(LIBMESH
       "\
 #include <mpi.h>
 #include <petscsys.h>
-// This test is a little different: since libMesh may use C++11 or C++14 but we
-// have not yet configured that flag yet, we instead use libMesh's petsc dependency
-// to check that we have the same MPI version.
+// This test is a little different: since libMesh may use C++11 C++14, or C++17,
+// but we but have not yet configured that flag yet, we instead use libMesh's
+// petsc dependency to check that we have the same MPI version.
 int main(int argc, char **argv)
 {
     PetscInitialize(&argc, &argv, NULL, NULL);
@@ -764,14 +786,16 @@ FUNCTION(IBAMR_SETUP_TARGET_LIBRARY target_library)
 
   MESSAGE(STATUS "Adding flag -DNDIM=${_d} to target ${target_library}")
   TARGET_COMPILE_OPTIONS(${target_library} PUBLIC -DNDIM=${_d})
-  IF(${IBAMR_HAVE_LIBMESH} AND "${LIBMESH_WITH_CXX14}")
-    MESSAGE(STATUS "libMesh expects C++14, so ${target_library} will be built with C++14 as a requirement.")
-    SET_PROPERTY(TARGET ${target_library} PROPERTY CXX_STANDARD 14)
-    TARGET_COMPILE_FEATURES(${target_library} PUBLIC cxx_std_14)
+
+  IF(${IBAMR_HAVE_LIBMESH})
+    MESSAGE(STATUS "libMesh expects C++${LIBMESH_CXX_VERSION}, so ${target_library} will be built with C++${LIBMESH_CXX_VERSION} as a requirement.")
+    SET_PROPERTY(TARGET ${target_library} PROPERTY CXX_STANDARD ${LIBMESH_CXX_VERSION})
+    TARGET_COMPILE_FEATURES(${target_library} PUBLIC "cxx_std_${LIBMESH_CXX_VERSION}")
   ELSE()
     SET_PROPERTY(TARGET ${target_library} PROPERTY CXX_STANDARD 11)
-    TARGET_COMPILE_FEATURES(${target_library} PUBLIC cxx_std_11)
+    TARGET_COMPILE_FEATURES(${target_library} PUBLIC "cxx_std_11")
   ENDIF()
+
   # we and our users will use these MPI functions so make the interface public:
   TARGET_LINK_LIBRARIES(${target_library} PUBLIC MPI::MPI_C)
   # libMesh is underlinked and needs MPI's C++ library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,62 @@ CMake.")
     ELSEIF(${LIBMESH_WITH_CXX14})
       SET(LIBMESH_CXX_VERSION 14)
     ENDIF()
+
+    # We are not compatible with libMesh's bundled version of boost, so make
+    # sure that doesn't happen:
+    IF(EXISTS ${LIBMESH_ROOT}/include/boost/)
+      IF(EXISTS ${LIBMESH_ROOT}/include/boost/multi_array.hpp)
+        # this is OK: perhaps libMesh was installed in /usr/
+      ELSE()
+        MESSAGE(FATAL_ERROR "\
+The directory ${LIBMESH_ROOT}/include/boost/ exists and contains a boost \
+installation that does not provide all the headers that IBAMR needs. This can \
+happen when either libMesh is installed with its own bundled version of boost \
+(which is not compatible with IBAMR) or when libMesh is installed into a \
+directory which happens to contain a copy of boost (e.g., when libMesh is \
+recompiled without boost and installed into the same location as a previous \
+copy of libMesh). If you want to use libMesh with boost then both libMesh and \
+IBAMR must use the same external copy of boost. The best way to fix this \
+problem is to delete ${LIBMESH_ROOT} and reinstall libMesh with either no \
+boost support or an external boost library.")
+      ENDIF()
+    ENDIF()
+
+    IF(EXISTS ${LIBMESH_ROOT}/include/Eigen)
+      IF("${Eigen3_ROOT}" STREQUAL "${LIBMESH_ROOT}/include/Eigen")
+        # OK
+      ELSE()
+        # If this happens then the provided version of Eigen appears to not
+        # match the one libMesh has: we don't support this. Verify it's not an
+        # odd coincidence before bailing out.
+        CHECK_CXX_SOURCE_COMPILES(
+          "
+          #include <libmesh/libmesh_config.h>
+          #ifdef LIBMESH_HAVE_EIGEN
+          // OK
+          #else
+          #error
+          #endif
+          int main() {}
+          "
+          LIBMESH_WITH_EIGEN
+          )
+        IF(${LIBMESH_WITH_EIGEN})
+          MESSAGE(FATAL_ERROR "\
+libMesh appears to have been compiled with a bundled copy of Eigen3 (i.e., the \
+directory ${LIBMESH_ROOT}/include/Eigen exists) and this version of Eigen is \
+different from the one provided via via Eigen3_ROOT = ${Eigen3_ROOT}: i.e., \
+there are two versions of Eigen3 in the configuration path, which is not \
+supported. To fix this, delete the current libMesh installation, recompile \
+libMesh without Eigen, and reinstall libMesh. If you aren't sure what to do, \
+the best option is to ensure that libMesh is compiled without support for \
+Eigen and then let IBAMR either detect an Eigen installation or use its own \
+bundled copy.")
+        ENDIF()
+      ENDIF()
+    ENDIF()
+
+    # Verify that libMesh uses the same PETSc that we do:
     CHECK_CXX_SOURCE_COMPILES(
       "
       #include <libmesh/libmesh_config.h>


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

libMesh now supports compilation with C++17, so we need to keep pace.

At the same time, we don't really support letting libMesh install its own copies of Eigen and Boost (the version of boost is insufficient and the version of Eigen doesn't use CMake) so try to detect those cases and error out appropriately.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?