### PR TITLE
Child integrators are now traversed correctly in regridHierarchy().

### DIFF
--- a/doc/news/changes/minor/20210527AaronBarrett
+++ b/doc/news/changes/minor/20210527AaronBarrett
@@ -1,0 +1,4 @@
+Fixed: IBTK::HierarchyIntegrator now properly traverses child integrators
+during regridHierarchy().
+<br>
+(Aaron Barrett, 2021/05/27)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -206,6 +206,7 @@ SETUP(IBTK ibtk_init.cpp IBAMR2d)
 SETUP(IBTK ibtk_mpi.cpp IBAMR2d)
 SETUP(IBTK ldata_01.cpp IBAMR2d)
 SETUP(IBTK mpi_type_wrappers.cpp IBAMR2d)
+SETUP(IBTK child_integrators.cpp IBAMR2d)
 
 IF(IBAMR_HAVE_LIBMESH)
   SETUP(IBTK elem_hmax_01.cpp IBAMR2d)

--- a/tests/IBTK/Makefile.am
+++ b/tests/IBTK/Makefile.am
@@ -20,7 +20,7 @@ prolongation_mat_2d prolongation_mat_3d phys_boundary_ops_2d phys_boundary_ops_3
 vc_viscous_solver_2d vc_viscous_solver_3d box_utilities_01_2d box_utilities_01_3d \
 ghost_accumulation_01_2d ghost_accumulation_01_3d ghost_indices_01_2d \
 ghost_indices_01_3d ibtk_init hierarchy_callbacks ibtk_mpi equal_eps helmholtz_2d \
-helmholtz_3d secondary_hierarchy_01_2d
+helmholtz_3d secondary_hierarchy_01_2d child_integrators_2d
 
 if LIBMESH_ENABLED
 EXTRA_PROGRAMS += elem_hmax_01 elem_hmax_02 jacobian_calc_01 bounding_boxes_01_2d \
@@ -223,6 +223,10 @@ helmholtz_3d_SOURCES = helmholtz.cpp
 secondary_hierarchy_01_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 secondary_hierarchy_01_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 secondary_hierarchy_01_2d_SOURCES = secondary_hierarchy_01.cpp
+
+child_integrators_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
+child_integrators_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+child_integrators_2d_SOURCES = child_integrators.cpp
 
 tests: $(EXTRA_PROGRAMS)
 	if test "$(top_srcdir)" != "$(top_builddir)" ; then \

--- a/tests/IBTK/Makefile.in
+++ b/tests/IBTK/Makefile.in
@@ -102,7 +102,8 @@ EXTRA_PROGRAMS = mpi_type_wrappers$(EXEEXT) poisson_01_2d$(EXEEXT) \
 	ghost_indices_01_3d$(EXEEXT) ibtk_init$(EXEEXT) \
 	hierarchy_callbacks$(EXEEXT) ibtk_mpi$(EXEEXT) \
 	equal_eps$(EXEEXT) helmholtz_2d$(EXEEXT) helmholtz_3d$(EXEEXT) \
-	secondary_hierarchy_01_2d$(EXEEXT) $(am__EXEEXT_1)
+	secondary_hierarchy_01_2d$(EXEEXT) \
+	child_integrators_2d$(EXEEXT) $(am__EXEEXT_1)
 @LIBMESH_ENABLED_TRUE@am__append_1 = elem_hmax_01 elem_hmax_02 jacobian_calc_01 bounding_boxes_01_2d \
 @LIBMESH_ENABLED_TRUE@bounding_boxes_01_3d mapping_01 fe_values_01 fe_values_02 \
 @LIBMESH_ENABLED_TRUE@multilevel_fe_01_2d multilevel_fe_01_3d subdomain_level_translation_01 \
@@ -188,6 +189,14 @@ box_utilities_01_3d_DEPENDENCIES = $(IBAMR3d_LIBS) $(IBAMR_LIBS)
 box_utilities_01_3d_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(box_utilities_01_3d_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
+	$(LDFLAGS) -o $@
+am_child_integrators_2d_OBJECTS =  \
+	child_integrators_2d-child_integrators.$(OBJEXT)
+child_integrators_2d_OBJECTS = $(am_child_integrators_2d_OBJECTS)
+child_integrators_2d_DEPENDENCIES = $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+child_integrators_2d_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
+	$(child_integrators_2d_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__elem_hmax_01_SOURCES_DIST = elem_hmax_01.cpp
 @LIBMESH_ENABLED_TRUE@am_elem_hmax_01_OBJECTS =  \
@@ -516,6 +525,7 @@ am__depfiles_remade =  \
 	./$(DEPDIR)/bounding_boxes_01_3d-bounding_boxes_01.Po \
 	./$(DEPDIR)/box_utilities_01_2d-box_utilities_01.Po \
 	./$(DEPDIR)/box_utilities_01_3d-box_utilities_01.Po \
+	./$(DEPDIR)/child_integrators_2d-child_integrators.Po \
 	./$(DEPDIR)/elem_hmax_01-elem_hmax_01.Po \
 	./$(DEPDIR)/elem_hmax_02-elem_hmax_02.Po \
 	./$(DEPDIR)/equal_eps-equal_eps.Po \
@@ -576,10 +586,10 @@ am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
 SOURCES = $(bounding_boxes_01_2d_SOURCES) \
 	$(bounding_boxes_01_3d_SOURCES) $(box_utilities_01_2d_SOURCES) \
-	$(box_utilities_01_3d_SOURCES) $(elem_hmax_01_SOURCES) \
-	$(elem_hmax_02_SOURCES) $(equal_eps_SOURCES) \
-	$(fe_values_01_SOURCES) $(fe_values_02_SOURCES) \
-	$(fischer_guess_01_SOURCES) \
+	$(box_utilities_01_3d_SOURCES) $(child_integrators_2d_SOURCES) \
+	$(elem_hmax_01_SOURCES) $(elem_hmax_02_SOURCES) \
+	$(equal_eps_SOURCES) $(fe_values_01_SOURCES) \
+	$(fe_values_02_SOURCES) $(fischer_guess_01_SOURCES) \
 	$(ghost_accumulation_01_2d_SOURCES) \
 	$(ghost_accumulation_01_3d_SOURCES) \
 	$(ghost_indices_01_2d_SOURCES) $(ghost_indices_01_3d_SOURCES) \
@@ -604,6 +614,7 @@ SOURCES = $(bounding_boxes_01_2d_SOURCES) \
 DIST_SOURCES = $(am__bounding_boxes_01_2d_SOURCES_DIST) \
 	$(am__bounding_boxes_01_3d_SOURCES_DIST) \
 	$(box_utilities_01_2d_SOURCES) $(box_utilities_01_3d_SOURCES) \
+	$(child_integrators_2d_SOURCES) \
 	$(am__elem_hmax_01_SOURCES_DIST) \
 	$(am__elem_hmax_02_SOURCES_DIST) $(equal_eps_SOURCES) \
 	$(am__fe_values_01_SOURCES_DIST) \
@@ -1056,6 +1067,9 @@ helmholtz_3d_SOURCES = helmholtz.cpp
 secondary_hierarchy_01_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 secondary_hierarchy_01_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 secondary_hierarchy_01_2d_SOURCES = secondary_hierarchy_01.cpp
+child_integrators_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
+child_integrators_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+child_integrators_2d_SOURCES = child_integrators.cpp
 all: all-am
 
 .SUFFIXES:
@@ -1106,6 +1120,10 @@ box_utilities_01_2d$(EXEEXT): $(box_utilities_01_2d_OBJECTS) $(box_utilities_01_
 box_utilities_01_3d$(EXEEXT): $(box_utilities_01_3d_OBJECTS) $(box_utilities_01_3d_DEPENDENCIES) $(EXTRA_box_utilities_01_3d_DEPENDENCIES) 
 	@rm -f box_utilities_01_3d$(EXEEXT)
 	$(AM_V_CXXLD)$(box_utilities_01_3d_LINK) $(box_utilities_01_3d_OBJECTS) $(box_utilities_01_3d_LDADD) $(LIBS)
+
+child_integrators_2d$(EXEEXT): $(child_integrators_2d_OBJECTS) $(child_integrators_2d_DEPENDENCIES) $(EXTRA_child_integrators_2d_DEPENDENCIES) 
+	@rm -f child_integrators_2d$(EXEEXT)
+	$(AM_V_CXXLD)$(child_integrators_2d_LINK) $(child_integrators_2d_OBJECTS) $(child_integrators_2d_LDADD) $(LIBS)
 
 elem_hmax_01$(EXEEXT): $(elem_hmax_01_OBJECTS) $(elem_hmax_01_DEPENDENCIES) $(EXTRA_elem_hmax_01_DEPENDENCIES) 
 	@rm -f elem_hmax_01$(EXEEXT)
@@ -1273,6 +1291,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/bounding_boxes_01_3d-bounding_boxes_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/box_utilities_01_2d-box_utilities_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/box_utilities_01_3d-box_utilities_01.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/child_integrators_2d-child_integrators.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elem_hmax_01-elem_hmax_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elem_hmax_02-elem_hmax_02.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/equal_eps-equal_eps.Po@am__quote@ # am--include-marker
@@ -1398,6 +1417,20 @@ box_utilities_01_3d-box_utilities_01.obj: box_utilities_01.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='box_utilities_01.cpp' object='box_utilities_01_3d-box_utilities_01.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(box_utilities_01_3d_CXXFLAGS) $(CXXFLAGS) -c -o box_utilities_01_3d-box_utilities_01.obj `if test -f 'box_utilities_01.cpp'; then $(CYGPATH_W) 'box_utilities_01.cpp'; else $(CYGPATH_W) '$(srcdir)/box_utilities_01.cpp'; fi`
+
+child_integrators_2d-child_integrators.o: child_integrators.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(child_integrators_2d_CXXFLAGS) $(CXXFLAGS) -MT child_integrators_2d-child_integrators.o -MD -MP -MF $(DEPDIR)/child_integrators_2d-child_integrators.Tpo -c -o child_integrators_2d-child_integrators.o `test -f 'child_integrators.cpp' || echo '$(srcdir)/'`child_integrators.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/child_integrators_2d-child_integrators.Tpo $(DEPDIR)/child_integrators_2d-child_integrators.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='child_integrators.cpp' object='child_integrators_2d-child_integrators.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(child_integrators_2d_CXXFLAGS) $(CXXFLAGS) -c -o child_integrators_2d-child_integrators.o `test -f 'child_integrators.cpp' || echo '$(srcdir)/'`child_integrators.cpp
+
+child_integrators_2d-child_integrators.obj: child_integrators.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(child_integrators_2d_CXXFLAGS) $(CXXFLAGS) -MT child_integrators_2d-child_integrators.obj -MD -MP -MF $(DEPDIR)/child_integrators_2d-child_integrators.Tpo -c -o child_integrators_2d-child_integrators.obj `if test -f 'child_integrators.cpp'; then $(CYGPATH_W) 'child_integrators.cpp'; else $(CYGPATH_W) '$(srcdir)/child_integrators.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/child_integrators_2d-child_integrators.Tpo $(DEPDIR)/child_integrators_2d-child_integrators.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='child_integrators.cpp' object='child_integrators_2d-child_integrators.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(child_integrators_2d_CXXFLAGS) $(CXXFLAGS) -c -o child_integrators_2d-child_integrators.obj `if test -f 'child_integrators.cpp'; then $(CYGPATH_W) 'child_integrators.cpp'; else $(CYGPATH_W) '$(srcdir)/child_integrators.cpp'; fi`
 
 elem_hmax_01-elem_hmax_01.o: elem_hmax_01.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(elem_hmax_01_CXXFLAGS) $(CXXFLAGS) -MT elem_hmax_01-elem_hmax_01.o -MD -MP -MF $(DEPDIR)/elem_hmax_01-elem_hmax_01.Tpo -c -o elem_hmax_01-elem_hmax_01.o `test -f 'elem_hmax_01.cpp' || echo '$(srcdir)/'`elem_hmax_01.cpp
@@ -2080,6 +2113,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/bounding_boxes_01_3d-bounding_boxes_01.Po
 	-rm -f ./$(DEPDIR)/box_utilities_01_2d-box_utilities_01.Po
 	-rm -f ./$(DEPDIR)/box_utilities_01_3d-box_utilities_01.Po
+	-rm -f ./$(DEPDIR)/child_integrators_2d-child_integrators.Po
 	-rm -f ./$(DEPDIR)/elem_hmax_01-elem_hmax_01.Po
 	-rm -f ./$(DEPDIR)/elem_hmax_02-elem_hmax_02.Po
 	-rm -f ./$(DEPDIR)/equal_eps-equal_eps.Po
@@ -2168,6 +2202,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/bounding_boxes_01_3d-bounding_boxes_01.Po
 	-rm -f ./$(DEPDIR)/box_utilities_01_2d-box_utilities_01.Po
 	-rm -f ./$(DEPDIR)/box_utilities_01_3d-box_utilities_01.Po
+	-rm -f ./$(DEPDIR)/child_integrators_2d-child_integrators.Po
 	-rm -f ./$(DEPDIR)/elem_hmax_01-elem_hmax_01.Po
 	-rm -f ./$(DEPDIR)/elem_hmax_02-elem_hmax_02.Po
 	-rm -f ./$(DEPDIR)/equal_eps-equal_eps.Po

--- a/tests/IBTK/child_integrators.cpp
+++ b/tests/IBTK/child_integrators.cpp
@@ -1,0 +1,285 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2021 - 2021 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#include <ibamr/AdvDiffHierarchyIntegrator.h>
+#include <ibamr/IBExplicitHierarchyIntegrator.h>
+#include <ibamr/IBMethod.h>
+#include <ibamr/IBRedundantInitializer.h>
+#include <ibamr/INSStaggeredHierarchyIntegrator.h>
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
+#include <ibtk/muParserCartGridFunction.h>
+
+#include <petscsys.h>
+
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <LoadBalancer.h>
+#include <LocationIndexRobinBcCoefs.h>
+#include <SAMRAI_config.h>
+#include <StandardTagAndInitialize.h>
+#include <VisItDataWriter.h>
+
+#include <ibamr/app_namespaces.h>
+
+class DummyAdvDiffIntegrator : public AdvDiffHierarchyIntegrator
+{
+public:
+    DummyAdvDiffIntegrator(std::string object_name, Pointer<Database> input_db)
+        : AdvDiffHierarchyIntegrator(std::move(object_name), input_db, true)
+    {
+    }
+    DummyAdvDiffIntegrator() = default;
+    ~DummyAdvDiffIntegrator() = default;
+    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override
+    {
+        return;
+    }
+
+protected:
+    void regridHierarchyBeginSpecialized() override
+    {
+        plog << d_object_name << ": regridHierarchyBeginSpecialized()\n";
+    }
+    void regridHierarchyEndSpecialized() override
+    {
+        plog << d_object_name << ": regridHierarchyEndSpecialized()\n";
+    }
+    double getMinimumTimeStepSizeSpecialized() override
+    {
+        plog << d_object_name << ": getMinimumTimeStepSizeSpecialized()\n";
+        return std::numeric_limits<double>::min();
+    }
+    double getMaximumTimeStepSizeSpecialized() override
+    {
+        plog << d_object_name << ": getMaximumTimeStepSizeSpecialized()\n";
+        return std::numeric_limits<double>::max();
+    }
+    void synchronizeHierarchyDataSpecialized(VariableContextType /*ctx_type*/) override
+    {
+        plog << d_object_name << ": synchronizeHierarchyDataSpecialized()\n";
+    }
+    void resetTimeDependentHierarchyDataSpecialized(const double new_time) override
+    {
+        plog << d_object_name << ": resetTimeDependentHierarchyDataSpecialized()\n";
+    }
+    void resetIntegratorToPreadvanceStateSpecialized() override
+    {
+        plog << d_object_name << ": resetIntegratorToPreadvanceStateSpecialized()\n";
+    }
+    bool atRegridPointSpecialized() const override
+    {
+        plog << d_object_name << ": atRegridPointSpecialized()\n";
+        return false;
+    }
+    void setupPlotDataSpecialized() override
+    {
+        plog << d_object_name << ": setupPlotDataSpecialized()\n";
+    }
+    void initializeCompositeHierarchyDataSpecialized(double /*init_data_time*/, bool /*initial_time*/) override
+    {
+        plog << d_object_name << ": initializeCompositeHierarchyDataSpecialized()\n";
+    }
+    void initializeLevelDataSpecialized(Pointer<BasePatchHierarchy<NDIM> > /*hierarchy*/,
+                                        int /*level_number*/,
+                                        double /*init_data_time*/,
+                                        bool /*can_be_refined*/,
+                                        bool /*initial_time*/,
+                                        Pointer<BasePatchLevel<NDIM> > /*old_level*/,
+                                        bool /*allocate_data*/) override
+    {
+        plog << d_object_name << ": initializeLevelDataSpecialized()\n";
+    }
+    void resetHierarchyConfigurationSpecialized(Pointer<BasePatchHierarchy<NDIM> > /*hierarchy*/,
+                                                int /*coarsest_level*/,
+                                                int /*finest_level*/) override
+    {
+        plog << d_object_name << ": resetHierarchyConfigurationSpecialized()\n";
+    }
+    void putToDatabaseSpecialized(Pointer<Database> /*db*/) override
+    {
+        plog << d_object_name << ": putToDatabaseSpecialized()\n";
+    }
+    void addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/, const int /*workload_data_idx*/) override
+    {
+        plog << d_object_name << ": addWorkloadEstimate()\n";
+    }
+    void executePreprocessIntegrateHierarchyCallbackFcns(double /*current_time*/,
+                                                         double /*new_time*/,
+                                                         int /*num_cycles*/) override
+    {
+        plog << d_object_name << ": executePreprocessIntegrateHierarchyCallbackFcns()\n";
+    }
+};
+
+void
+generate_structure(const unsigned int& /*strct_num*/,
+                   const int& /*ln*/,
+                   int& num_vertices,
+                   std::vector<IBTK::Point>& vertex_posn)
+{
+    num_vertices = 1;
+    vertex_posn.resize(num_vertices);
+    vertex_posn[0] = Point(0.5, 0.5);
+}
+
+/*******************************************************************************
+ * For each run, the input filename and restart information (if needed) must   *
+ * be given on the command line.  For non-restarted case, command line is:     *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ * For restarted run, command line is:                                         *
+ *                                                                             *
+ *    executable <input file name> <restart directory> <restart number>        *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+
+    { // cleanup dynamically allocated objects prior to shutdown
+      // prevent a warning about timer initialization
+        TimerManager::createManager(nullptr);
+
+        // Parse command line options, set some standard options from the input
+        // file, initialize the restart database (if this is a restarted run),
+        // and enable file logging.
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "adv_diff.log");
+        Pointer<Database> input_db = app_initializer->getInputDatabase();
+        Pointer<Database> main_db = app_initializer->getComponentDatabase("Main");
+
+        // Get various standard options set in the input file.
+        const bool dump_viz_data = app_initializer->dumpVizData();
+        const int viz_dump_interval = app_initializer->getVizDumpInterval();
+        const bool uses_visit = dump_viz_data && app_initializer->getVisItDataWriter();
+
+        const bool dump_restart_data = app_initializer->dumpRestartData();
+        const int restart_dump_interval = app_initializer->getRestartDumpInterval();
+        const string restart_dump_dirname = app_initializer->getRestartDumpDirectory();
+
+        const bool dump_timer_data = app_initializer->dumpTimerData();
+        const int timer_dump_interval = app_initializer->getTimerDumpInterval();
+
+        // Create major algorithm and data objects that comprise the
+        // application.  These objects are configured from the input database
+        // and, if this is a restarted run, from the restart database.
+        Pointer<AdvDiffHierarchyIntegrator> adv_diff_integrator =
+            new DummyAdvDiffIntegrator("DummyAdvDiff", app_initializer->getComponentDatabase("DummyAdvDiff"));
+        Pointer<INSStaggeredHierarchyIntegrator> navier_stokes_integrator = new INSStaggeredHierarchyIntegrator(
+            "INSStaggeredHierarchyIntegrator",
+            app_initializer->getComponentDatabase("INSStaggeredHierarchyIntegrator"));
+        navier_stokes_integrator->registerAdvDiffHierarchyIntegrator(adv_diff_integrator);
+        Pointer<IBMethod> ib_method_ops = new IBMethod("IBMethod", app_initializer->getComponentDatabase("IBMethod"));
+        Pointer<IBHierarchyIntegrator> time_integrator =
+            new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                              app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                              ib_method_ops,
+                                              navier_stokes_integrator);
+        Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<StandardTagAndInitialize<NDIM> > error_detector =
+            new StandardTagAndInitialize<NDIM>("StandardTagAndInitialize",
+                                               time_integrator,
+                                               app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<BergerRigoutsos<NDIM> > box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM> > load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM> > gridding_algorithm =
+            new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                        app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                        error_detector,
+                                        box_generator,
+                                        load_balancer);
+        // Configure the IB solver.
+        Pointer<IBRedundantInitializer> ib_initializer = new IBRedundantInitializer(
+            "IBRedundantInitializer", app_initializer->getComponentDatabase("IBRedundantInitializer"));
+        std::vector<std::string> struct_list_vec = { "dummy" };
+        ib_initializer->setStructureNamesOnLevel(input_db->getInteger("MAX_LEVELS") - 1, struct_list_vec);
+        ib_initializer->registerInitStructureFunction(generate_structure);
+        ib_method_ops->registerLInitStrategy(ib_initializer);
+
+        // Set up visualization plot file writer.
+        Pointer<VisItDataWriter<NDIM> > visit_data_writer = app_initializer->getVisItDataWriter();
+        if (uses_visit)
+        {
+            time_integrator->registerVisItDataWriter(visit_data_writer);
+        }
+
+        // Initialize hierarchy configuration and data on all patches.
+        time_integrator->initializePatchHierarchy(patch_hierarchy, gridding_algorithm);
+
+        // Close the restart manager.
+        RestartManager::getManager()->closeRestartFile();
+
+        // Write out initial visualization data.
+        int iteration_num = time_integrator->getIntegratorStep();
+        double loop_time = time_integrator->getIntegratorTime();
+        if (dump_viz_data && uses_visit)
+        {
+            pout << "\n\nWriting visualization files...\n\n";
+            time_integrator->setupPlotData();
+        }
+
+        // Main time step loop.
+        double loop_time_end = time_integrator->getEndTime();
+        double dt = 0.0;
+        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        {
+            iteration_num = time_integrator->getIntegratorStep();
+            loop_time = time_integrator->getIntegratorTime();
+
+            pout << "\n";
+            pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+            pout << "At beginning of timestep # " << iteration_num << "\n";
+            pout << "Simulation time is " << loop_time << "\n";
+
+            dt = time_integrator->getMaximumTimeStepSize();
+            time_integrator->advanceHierarchy(dt);
+            loop_time += dt;
+
+            pout << "\n";
+            pout << "At end       of timestep # " << iteration_num << "\n";
+            pout << "Simulation time is " << loop_time << "\n";
+            pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+            pout << "\n";
+
+            // At specified intervals, write visualization and restart files,
+            // and print out timer data.
+            iteration_num += 1;
+            const bool last_step = !time_integrator->stepsRemaining();
+            if (dump_viz_data && uses_visit && (iteration_num % viz_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting visualization files...\n\n";
+                time_integrator->setupPlotData();
+            }
+            if (dump_restart_data && (iteration_num % restart_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting restart files...\n\n";
+                RestartManager::getManager()->writeRestartFile(restart_dump_dirname, iteration_num);
+            }
+            if (dump_timer_data && (iteration_num % timer_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting timer data...\n\n";
+                TimerManager::getManager()->print(plog);
+            }
+        }
+
+    } // cleanup dynamically allocated objects prior to shutdown
+
+} // main

--- a/tests/IBTK/child_integrators_2d.input
+++ b/tests/IBTK/child_integrators_2d.input
@@ -1,0 +1,213 @@
+// constants
+PI = 3.14159265358979
+
+// physical parameters
+L   = 1.0
+MU  = 1.0e-2
+RHO = 1.0
+K   = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 1                                 // maximum number of levels in locally refined grid
+REF_RATIO  = 4                                 // refinement ratio between levels
+N = 64                                         // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N       // effective number of grid cells on finest   grid level
+DX_FINEST = L/NFINEST
+
+// solver parameters
+DELTA_FUNCTION      = "IB_4"
+START_TIME          = 0.0e0                    // initial simulation time
+GROW_DT             = 2.0e0                    // growth factor for timesteps
+NUM_CYCLES          = 2                        // number of cycles of fixed-point iteration
+CONVECTIVE_TS_TYPE  = "MIDPOINT_RULE"        // convective time stepping type
+CONVECTIVE_OP_TYPE  = "PPM"                    // convective differencing discretization type
+CONVECTIVE_FORM     = "ADVECTIVE"              // how to compute the convective terms
+NORMALIZE_PRESSURE  = TRUE                     // whether to explicitly force the pressure to have mean zero
+CFL_MAX             = 0.3                      // maximum CFL number
+DT                  = (1.0/K)*1.6e-2*DX_FINEST // maximum timestep size
+END_TIME            = 2 * DT
+ERROR_ON_DT_CHANGE  = TRUE                     // whether to emit an error message if the time step size changes
+VORTICITY_TAGGING   = FALSE                    // whether to tag cells for refinement based on vorticity thresholds
+TAG_BUFFER          = 1                        // size of tag buffer used by grid generation algorithm
+REGRID_CFL_INTERVAL = 0.5                      // regrid whenever any material point could have moved 0.5 meshwidths since previous regrid
+OUTPUT_U            = TRUE
+OUTPUT_P            = TRUE
+OUTPUT_F            = FALSE
+OUTPUT_OMEGA        = TRUE
+OUTPUT_DIV_U        = TRUE
+ENABLE_LOGGING      = TRUE
+
+// collocated solver parameters
+PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
+SECOND_ORDER_PRESSURE_UPDATE = TRUE
+
+VelocityInitialConditions {
+   function_0 = "0.0"
+   function_1 = "0.0"
+}
+
+VelocityBcCoefs_0 {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+VelocityBcCoefs_1 {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+PressureInitialConditions {
+   R = 0.25
+   mu = K
+   function = "(X_0-0.5)^2 + (X_1-0.5)^2 <= R^2 ? mu*(1/R - pi*R) : -mu*pi*R"
+}
+
+IBHierarchyIntegrator {
+   start_time          = START_TIME
+   end_time            = END_TIME
+   grow_dt             = GROW_DT
+   num_cycles          = NUM_CYCLES
+   regrid_cfl_interval = REGRID_CFL_INTERVAL
+   dt_max              = DT
+   error_on_dt_change  = ERROR_ON_DT_CHANGE
+   tag_buffer          = TAG_BUFFER
+   enable_logging      = FALSE
+}
+
+IBMethod {
+   delta_fcn      = DELTA_FUNCTION
+   enable_logging = ENABLE_LOGGING
+}
+
+IBRedundantInitializer {
+   max_levels      = MAX_LEVELS
+   base_filenames_0 = "x"
+}
+
+INSStaggeredHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT
+   num_cycles                    = NUM_CYCLES
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_rel_thresh          = 0.25,0.125
+   tag_buffer                    = TAG_BUFFER
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+   enable_logging_solver_iterations = FALSE
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt","Silo"
+   viz_dump_interval           = 1
+   viz_dump_dirname            = "viz_IB2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 1
+   restart_dump_dirname        = "restart"
+
+// hierarchy data dump parameters
+   data_dump_interval          = int(END_TIME/(100*DT))
+   data_dump_dirname           = "hier_data_IB2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+      level_4 = REF_RATIO,REF_RATIO
+      level_5 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "GRADIENT_DETECTOR"
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+
+DummyAdvDiff {
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   num_cycles                    = NUM_CYCLES
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   cfl                           = CFL_MAX
+   dt_max                        = DT
+   tag_buffer                    = TAG_BUFFER
+   enable_logging                = ENABLE_LOGGING
+}

--- a/tests/IBTK/child_integrators_2d.output
+++ b/tests/IBTK/child_integrators_2d.output
@@ -1,0 +1,72 @@
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+DummyAdvDiff: initializeLevelDataSpecialized()
+DummyAdvDiff: resetHierarchyConfigurationSpecialized()
+INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
+  projecting the interpolated velocity field
+INSStaggeredHierarchyIntegrator::regridProjection(): regrid projection solve residual norm        = 0
+DummyAdvDiff: synchronizeHierarchyDataSpecialized()
+DummyAdvDiff: initializeCompositeHierarchyDataSpecialized()
+DummyAdvDiff: synchronizeHierarchyDataSpecialized()
+
+
+Writing visualization files...
+
+DummyAdvDiff: setupPlotDataSpecialized()
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 0
+Simulation time is 0
+DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
+DummyAdvDiff: getMinimumTimeStepSizeSpecialized()
+DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
+DummyAdvDiff: regridHierarchyBeginSpecialized()
+DummyAdvDiff: regridHierarchyEndSpecialized()
+DummyAdvDiff: initializeCompositeHierarchyDataSpecialized()
+DummyAdvDiff: synchronizeHierarchyDataSpecialized()
+INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
+INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
+INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver
+INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing incompressible Stokes solver
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
+DummyAdvDiff: synchronizeHierarchyDataSpecialized()
+DummyAdvDiff: resetTimeDependentHierarchyDataSpecialized()
+
+At end       of timestep # 0
+Simulation time is 0.00025
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+DummyAdvDiff: setupPlotDataSpecialized()
+
+Writing restart files...
+
+DummyAdvDiff: putToDatabaseSpecialized()
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 1
+Simulation time is 0.00025
+DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
+DummyAdvDiff: getMinimumTimeStepSizeSpecialized()
+DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
+DummyAdvDiff: atRegridPointSpecialized()
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
+DummyAdvDiff: synchronizeHierarchyDataSpecialized()
+DummyAdvDiff: resetTimeDependentHierarchyDataSpecialized()
+
+At end       of timestep # 1
+Simulation time is 0.0005
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+DummyAdvDiff: setupPlotDataSpecialized()
+
+Writing restart files...
+
+DummyAdvDiff: putToDatabaseSpecialized()
+IBRedundantInitializer:  Deallocating initialization data.


### PR DESCRIPTION
Fixes #1260. This fixes `HierarchyIntegrator` so that it properly traverses the tree of child integrators during `regridHierarchy`. I still need to add a test.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
