### PR TITLE
Avoid printing the initial workload.

### DIFF
--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1528,7 +1528,14 @@ void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarch
         d_F_IB_vecs->reinit();
         if (d_Q_IB_vecs) d_Q_IB_vecs->reinit();
 
-        if (d_use_scratch_hierarchy && d_do_log)
+        // This condition is complex - we only want to log the workload if we are
+        // - logging
+        // - using the scratch hierarchy
+        //
+        // but not before the first timestep should d_skip_initial_workload_log
+        // be true.
+        if (d_use_scratch_hierarchy && d_do_log &&
+            (d_started_time_integration || (!d_started_time_integration && !d_skip_initial_workload_log)))
         {
             plog << "IBFEMethod::scratch hierarchy workload" << std::endl;
             const int n_processes = IBTK_MPI::getNodes();

--- a/tests/IBFE/explicit_ex4_2d.postprocessor.scratch_hier.mpirun=4.output
+++ b/tests/IBFE/explicit_ex4_2d.postprocessor.scratch_hier.mpirun=4.output
@@ -18,12 +18,6 @@ IBHierarchyIntegrator::regridHierarchy(): regridding the patch hierarchy
 IBHierarchyIntegrator::regridHierarchy(): finishing Lagrangian data movement
 IBFEMethod: starting scratch hierarchy regrid
 IBFEMethod: finished scratch hierarchy regrid
-IBFEMethod::scratch hierarchy workload
-workload estimate on processor 0 = 1250
-workload estimate on processor 1 = 1389
-workload estimate on processor 2 = 1257
-workload estimate on processor 3 = 1279
-IBFEMethod:: end scratch hierarchy workload
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver

--- a/tests/IBFE/explicit_ex4_2d.scratch_hier.levels=1.mpirun=4.output
+++ b/tests/IBFE/explicit_ex4_2d.scratch_hier.levels=1.mpirun=4.output
@@ -18,12 +18,6 @@ IBHierarchyIntegrator::regridHierarchy(): regridding the patch hierarchy
 IBHierarchyIntegrator::regridHierarchy(): finishing Lagrangian data movement
 IBFEMethod: starting scratch hierarchy regrid
 IBFEMethod: finished scratch hierarchy regrid
-IBFEMethod::scratch hierarchy workload
-workload estimate on processor 0 = 3565
-workload estimate on processor 1 = 2584
-workload estimate on processor 2 = 3985
-workload estimate on processor 3 = 3392
-IBFEMethod:: end scratch hierarchy workload
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver

--- a/tests/IBFE/explicit_ex4_2d.scratch_hier.levels=4.mpirun=4.output
+++ b/tests/IBFE/explicit_ex4_2d.scratch_hier.levels=4.mpirun=4.output
@@ -18,12 +18,6 @@ IBHierarchyIntegrator::regridHierarchy(): regridding the patch hierarchy
 IBHierarchyIntegrator::regridHierarchy(): finishing Lagrangian data movement
 IBFEMethod: starting scratch hierarchy regrid
 IBFEMethod: finished scratch hierarchy regrid
-IBFEMethod::scratch hierarchy workload
-workload estimate on processor 0 = 3391
-workload estimate on processor 1 = 3176
-workload estimate on processor 2 = 3425
-workload estimate on processor 3 = 3534
-IBFEMethod:: end scratch hierarchy workload
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver

--- a/tests/IBFE/explicit_ex4_2d.scratch_hier.merge.mpirun=4.output
+++ b/tests/IBFE/explicit_ex4_2d.scratch_hier.merge.mpirun=4.output
@@ -18,12 +18,6 @@ IBHierarchyIntegrator::regridHierarchy(): regridding the patch hierarchy
 IBHierarchyIntegrator::regridHierarchy(): finishing Lagrangian data movement
 IBFEMethod: starting scratch hierarchy regrid
 IBFEMethod: finished scratch hierarchy regrid
-IBFEMethod::scratch hierarchy workload
-workload estimate on processor 0 = 1250
-workload estimate on processor 1 = 1389
-workload estimate on processor 2 = 1257
-workload estimate on processor 3 = 1279
-IBFEMethod:: end scratch hierarchy workload
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver

--- a/tests/IBFE/explicit_ex4_2d.scratch_hier.mpirun=4.output
+++ b/tests/IBFE/explicit_ex4_2d.scratch_hier.mpirun=4.output
@@ -18,12 +18,6 @@ IBHierarchyIntegrator::regridHierarchy(): regridding the patch hierarchy
 IBHierarchyIntegrator::regridHierarchy(): finishing Lagrangian data movement
 IBFEMethod: starting scratch hierarchy regrid
 IBFEMethod: finished scratch hierarchy regrid
-IBFEMethod::scratch hierarchy workload
-workload estimate on processor 0 = 1250
-workload estimate on processor 1 = 1389
-workload estimate on processor 2 = 1257
-workload estimate on processor 3 = 1279
-IBFEMethod:: end scratch hierarchy workload
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver

--- a/tests/IBFE/explicit_ex4_2d.scratch_hier.multilevel.b.mpirun=4.output
+++ b/tests/IBFE/explicit_ex4_2d.scratch_hier.multilevel.b.mpirun=4.output
@@ -18,12 +18,6 @@ IBHierarchyIntegrator::regridHierarchy(): regridding the patch hierarchy
 IBHierarchyIntegrator::regridHierarchy(): finishing Lagrangian data movement
 IBFEMethod: starting scratch hierarchy regrid
 IBFEMethod: finished scratch hierarchy regrid
-IBFEMethod::scratch hierarchy workload
-workload estimate on processor 0 = 1477
-workload estimate on processor 1 = 289
-workload estimate on processor 2 = 285
-workload estimate on processor 3 = 300
-IBFEMethod:: end scratch hierarchy workload
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver

--- a/tests/IBFE/explicit_ex4_2d.scratch_hier.multilevel.b.output
+++ b/tests/IBFE/explicit_ex4_2d.scratch_hier.multilevel.b.output
@@ -18,9 +18,6 @@ IBHierarchyIntegrator::regridHierarchy(): regridding the patch hierarchy
 IBHierarchyIntegrator::regridHierarchy(): finishing Lagrangian data movement
 IBFEMethod: starting scratch hierarchy regrid
 IBFEMethod: finished scratch hierarchy regrid
-IBFEMethod::scratch hierarchy workload
-workload estimate on processor 0 = 2351
-IBFEMethod:: end scratch hierarchy workload
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver

--- a/tests/IBFE/explicit_ex4_2d.scratch_hier.nodeweight.mpirun=4.output
+++ b/tests/IBFE/explicit_ex4_2d.scratch_hier.nodeweight.mpirun=4.output
@@ -18,12 +18,6 @@ IBHierarchyIntegrator::regridHierarchy(): regridding the patch hierarchy
 IBHierarchyIntegrator::regridHierarchy(): finishing Lagrangian data movement
 IBFEMethod: starting scratch hierarchy regrid
 IBFEMethod: finished scratch hierarchy regrid
-IBFEMethod::scratch hierarchy workload
-workload estimate on processor 0 = 86
-workload estimate on processor 1 = 86
-workload estimate on processor 2 = 89
-workload estimate on processor 3 = 105
-IBFEMethod:: end scratch hierarchy workload
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver

--- a/tests/IBFE/explicit_ex4_3d.scratch_hier.merge.mpirun=4.output
+++ b/tests/IBFE/explicit_ex4_3d.scratch_hier.merge.mpirun=4.output
@@ -19,12 +19,6 @@ IBHierarchyIntegrator::regridHierarchy(): regridding the patch hierarchy
 IBHierarchyIntegrator::regridHierarchy(): finishing Lagrangian data movement
 IBFEMethod: starting scratch hierarchy regrid
 IBFEMethod: finished scratch hierarchy regrid
-IBFEMethod::scratch hierarchy workload
-workload estimate on processor 0 = 235
-workload estimate on processor 1 = 235
-workload estimate on processor 2 = 217
-workload estimate on processor 3 = 217
-IBFEMethod:: end scratch hierarchy workload
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver

--- a/tests/IBFE/explicit_ex4_3d.scratch_hier.mpirun=4.output
+++ b/tests/IBFE/explicit_ex4_3d.scratch_hier.mpirun=4.output
@@ -19,12 +19,6 @@ IBHierarchyIntegrator::regridHierarchy(): regridding the patch hierarchy
 IBHierarchyIntegrator::regridHierarchy(): finishing Lagrangian data movement
 IBFEMethod: starting scratch hierarchy regrid
 IBFEMethod: finished scratch hierarchy regrid
-IBFEMethod::scratch hierarchy workload
-workload estimate on processor 0 = 235
-workload estimate on processor 1 = 235
-workload estimate on processor 2 = 217
-workload estimate on processor 3 = 217
-IBFEMethod:: end scratch hierarchy workload
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver


### PR DESCRIPTION
For reasons already documented this isn't portable before timestepping.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?

Followup to #1256 - I forgot that printing out the initial workload isn't portable, so we need an extra check for that.

@abarret thanks again for finding this. Could you please double-check that all these tests pass?