### PR TITLE
Computing cell-center and cell index based on grid lower

### DIFF
--- a/doc/news/changes/minor/20210621RamakrishnanThirumalaisamy
+++ b/doc/news/changes/minor/20210621RamakrishnanThirumalaisamy
@@ -1,0 +1,5 @@
+Bug Fix: Computing cell-center locations and cell index using grid_lower_X rather than patch_lower_X in all Brinkman adv diff examples and tests to avoid processor dependent results.
+
+New: In IndexUtilities class, new rouine is added to get side-center coordinates using grid_lower_X.
+<br>
+(Ramakrishnan Thirumalaisamy, 2021/06/21)

--- a/examples/adv_diff/ex3/LevelSetInitialCondition.h
+++ b/examples/adv_diff/ex3/LevelSetInitialCondition.h
@@ -34,6 +34,7 @@ public:
      * \brief Class constructor.
      */
     LevelSetInitialCondition(const std::string& object_name,
+                             const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
                              const double radius,
                              const IBTK::VectorNd& origin,
                              const bool fluid_is_interior_to_cylinder);
@@ -81,6 +82,12 @@ private:
      * Name of this object.
      */
     std::string d_object_name;
+
+    /*!
+     * The Cartesian grid geometry object provides the extents of the
+     * computational domain.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 
     /*!
      * Radius of cylinder.

--- a/examples/adv_diff/ex3/example.cpp
+++ b/examples/adv_diff/ex3/example.cpp
@@ -52,33 +52,31 @@ evaluate_brinkman_bc_callback_fcn(int B_idx,
 #endif
 
     Pointer<PatchHierarchy<NDIM> > patch_hierarchy = hier_math_ops->getPatchHierarchy();
-    const int coarsest_ln = 0;
     const int finest_ln = patch_hierarchy->getFinestLevelNumber();
 
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    Pointer<PatchLevel<NDIM> > finest_level = patch_hierarchy->getPatchLevel(finest_ln);
+    IntVector<NDIM> ratio = finest_level->getRatio();
+    for (PatchLevel<NDIM>::Iterator p(finest_level); p; p++)
     {
-        Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
-        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        Pointer<Patch<NDIM> > patch = finest_level->getPatch(p());
+        const Box<NDIM>& patch_box = patch->getBox();
+        const Pointer<CartesianGridGeometry<NDIM> > grid_geom = patch_hierarchy->getGridGeometry();
+        Pointer<SideData<NDIM, double> > B_data = patch->getPatchData(B_idx);
+
+        for (unsigned int axis = 0; axis < NDIM; ++axis)
         {
-            Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& patch_box = patch->getBox();
-            Pointer<SideData<NDIM, double> > B_data = patch->getPatchData(B_idx);
-
-            for (unsigned int axis = 0; axis < NDIM; ++axis)
+            for (Box<NDIM>::Iterator it(SideGeometry<NDIM>::toSideBox(patch_box, axis)); it; it++)
             {
-                for (Box<NDIM>::Iterator it(SideGeometry<NDIM>::toSideBox(patch_box, axis)); it; it++)
-                {
-                    SideIndex<NDIM> si(it(), axis, SideIndex<NDIM>::Lower);
-                    IBTK::Vector coord = IndexUtilities::getSideCenter(*patch, si);
+                SideIndex<NDIM> si(it(), axis, SideIndex<NDIM>::Lower);
+                IBTK::Vector coord = IndexUtilities::getSideCenter(grid_geom, ratio, si);
 
-                    if (axis == 0)
-                    {
-                        (*B_data)(si) = cos(coord[0]) * sin(coord[1]);
-                    }
-                    else if (axis == 1)
-                    {
-                        (*B_data)(si) = sin(coord[0]) * cos(coord[1]);
-                    }
+                if (axis == 0)
+                {
+                    (*B_data)(si) = cos(coord[0]) * sin(coord[1]);
+                }
+                else if (axis == 1)
+                {
+                    (*B_data)(si) = sin(coord[0]) * cos(coord[1]);
                 }
             }
         }
@@ -169,7 +167,7 @@ main(int argc, char* argv[])
         IBTK::Vector2d origin(M_PI, M_PI);
         const bool fluid_is_interior_to_cylinder = input_db->getBool("FLUID_IS_INTERIOR_TO_CYLINDER");
         Pointer<CartGridFunction> phi_solid_init =
-            new LevelSetInitialCondition("ls_init", radius, origin, fluid_is_interior_to_cylinder);
+            new LevelSetInitialCondition("ls_init", grid_geometry, radius, origin, fluid_is_interior_to_cylinder);
         time_integrator->setInitialConditions(phi_solid_var, phi_solid_init);
 
         const IntVector<NDIM>& periodic_shift = grid_geometry->getPeriodicShift();

--- a/examples/adv_diff/ex3/input2d
+++ b/examples/adv_diff/ex3/input2d
@@ -103,6 +103,11 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator {
    enable_logging                = ENABLE_LOGGING
    max_integrator_steps          = MAX_INTEGRATOR_STEPS
    brinkman_time_independent     = BRINKMAN_TIME_INDEPENDENT
+   solver_type = "PETSC_KRYLOV_SOLVER"
+   solver_db
+   {
+      rel_residual_tol = 1.0e-12
+   }
 }
 
 Main {

--- a/examples/adv_diff/ex4/LevelSetInitialConditionCircle.cpp
+++ b/examples/adv_diff/ex4/LevelSetInitialConditionCircle.cpp
@@ -21,11 +21,14 @@
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
-LevelSetInitialConditionCircle::LevelSetInitialConditionCircle(const std::string& object_name,
-                                                               const double radius,
-                                                               const IBTK::VectorNd& origin,
-                                                               const bool fluid_is_interior_to_cylinder)
+LevelSetInitialConditionCircle::LevelSetInitialConditionCircle(
+    const std::string& object_name,
+    const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
+    const double radius,
+    const IBTK::VectorNd& origin,
+    const bool fluid_is_interior_to_cylinder)
     : d_object_name(object_name),
+      d_grid_geom(grid_geom),
       d_radius(radius),
       d_origin(origin),
       d_fluid_is_interior_to_cylinder(fluid_is_interior_to_cylinder)
@@ -46,7 +49,7 @@ LevelSetInitialConditionCircle::setDataOnPatch(const int data_idx,
                                                Pointer<Patch<NDIM> > patch,
                                                const double /*data_time*/,
                                                const bool initial_time,
-                                               Pointer<PatchLevel<NDIM> > /*patch_level*/)
+                                               Pointer<PatchLevel<NDIM> > patch_level)
 {
     // Set the level set function throughout the domain
     if (initial_time)
@@ -57,15 +60,18 @@ LevelSetInitialConditionCircle::setDataOnPatch(const int data_idx,
         {
             CellIndex<NDIM> ci(it());
             Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const double* patch_X_lower = patch_geom->getXLower();
-            const hier::Index<NDIM>& patch_lower_idx = patch_box.lower();
             const double* const patch_dx = patch_geom->getDx();
+            const double* const grid_x_lower = d_grid_geom->getXLower();
+            IntVector<NDIM> ratio = patch_level->getRatio();
+            const SAMRAI::hier::Box<NDIM> domain_box =
+                SAMRAI::hier::Box<NDIM>::refine(d_grid_geom->getPhysicalDomain()[0], ratio);
+            const hier::Index<NDIM>& grid_lower_idx = domain_box.lower();
+
             // Get physical coordinates
             IBTK::Vector coord = IBTK::Vector::Zero();
             for (int d = 0; d < NDIM; ++d)
-            {
-                coord[d] = patch_X_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
-            }
+                coord[d] = grid_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - grid_lower_idx(d)) + 0.5);
+
             double distance = std::numeric_limits<double>::quiet_NaN();
 #if (NDIM == 2)
             distance = std::sqrt((coord[0] - d_origin[0]) * (coord[0] - d_origin[0]) +

--- a/examples/adv_diff/ex4/LevelSetInitialConditionCircle.h
+++ b/examples/adv_diff/ex4/LevelSetInitialConditionCircle.h
@@ -34,6 +34,7 @@ public:
      * \brief Class constructor.
      */
     LevelSetInitialConditionCircle(const std::string& object_name,
+                                   const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
                                    const double radius,
                                    const IBTK::VectorNd& origin,
                                    const bool fluid_is_interior_to_cylinder = false);
@@ -81,6 +82,12 @@ private:
      * Name of this object.
      */
     std::string d_object_name;
+
+    /*!
+     * The Cartesian grid geometry object provides the extents of the
+     * computational domain.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 
     /*!
      * Radius of cylinder.

--- a/examples/adv_diff/ex4/LevelSetInitialConditionHexagram.cpp
+++ b/examples/adv_diff/ex4/LevelSetInitialConditionHexagram.cpp
@@ -21,9 +21,11 @@
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
-LevelSetInitialConditionHexagram::LevelSetInitialConditionHexagram(const std::string& object_name,
-                                                                   const IBTK::VectorNd& origin)
-    : d_object_name(object_name), d_origin(origin)
+LevelSetInitialConditionHexagram::LevelSetInitialConditionHexagram(
+    const std::string& object_name,
+    const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
+    const IBTK::VectorNd& origin)
+    : d_object_name(object_name), d_grid_geom(grid_geom), d_origin(origin)
 {
     // intentionally blank
     return;
@@ -41,13 +43,22 @@ LevelSetInitialConditionHexagram::setDataOnPatch(const int data_idx,
                                                  Pointer<Patch<NDIM> > patch,
                                                  const double /*data_time*/,
                                                  const bool initial_time,
-                                                 Pointer<PatchLevel<NDIM> > /*patch_level*/)
+                                                 Pointer<PatchLevel<NDIM> > patch_level)
 {
     // Set the level set function throughout the domain
     if (initial_time)
     {
         const Box<NDIM>& patch_box = patch->getBox();
         Pointer<CellData<NDIM, double> > D_data = patch->getPatchData(data_idx);
+
+        Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
+        const double* const patch_dx = patch_geom->getDx();
+        const double* const grid_x_lower = d_grid_geom->getXLower();
+        IntVector<NDIM> ratio = patch_level->getRatio();
+        const SAMRAI::hier::Box<NDIM> domain_box =
+            SAMRAI::hier::Box<NDIM>::refine(d_grid_geom->getPhysicalDomain()[0], ratio);
+        const hier::Index<NDIM>& grid_lower_idx = domain_box.lower();
+
         std::vector<double> k{ -0.5, 0.8660254038, 0.5773502692, 1.7320508076 };
         IBTK::VectorNd kxy{ k[0], k[1] };
         IBTK::VectorNd kyx{ k[1], k[0] };
@@ -55,18 +66,14 @@ LevelSetInitialConditionHexagram::setDataOnPatch(const int data_idx,
         IBTK::VectorNd coord = IBTK::Vector::Zero();
         IBTK::VectorNd p = IBTK::Vector::Zero();
         IBTK::VectorNd q = IBTK::Vector::Zero();
+
         for (Box<NDIM>::Iterator it(patch_box); it; it++)
         {
             CellIndex<NDIM> ci(it());
-            Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const double* patch_X_lower = patch_geom->getXLower();
-            const hier::Index<NDIM>& patch_lower_idx = patch_box.lower();
-            const double* const patch_dx = patch_geom->getDx();
 
             for (int d = 0; d < NDIM; ++d)
-            {
-                coord[d] = patch_X_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
-            }
+                coord[d] = grid_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - grid_lower_idx(d)) + 0.5);
+
             p = coord - d_origin;
             q = p.cwiseAbs();
             q -= 2.0 * std::min(kxy.dot(q), 0.0) * kxy;

--- a/examples/adv_diff/ex4/LevelSetInitialConditionHexagram.h
+++ b/examples/adv_diff/ex4/LevelSetInitialConditionHexagram.h
@@ -33,7 +33,9 @@ public:
     /*!
      * \brief Class constructor.
      */
-    LevelSetInitialConditionHexagram(const std::string& object_name, const IBTK::VectorNd& origin);
+    LevelSetInitialConditionHexagram(const std::string& object_name,
+                                     const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
+                                     const IBTK::VectorNd& origin);
 
     /*!
      * \brief Empty destructor.
@@ -89,6 +91,12 @@ private:
      * Name of this object.
      */
     std::string d_object_name;
+
+    /*!
+     * The Cartesian grid geometry object provides the extents of the
+     * computational domain.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 
     /*!
      * Origin of the geometry.

--- a/examples/adv_diff/ex4/input2d
+++ b/examples/adv_diff/ex4/input2d
@@ -103,6 +103,11 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator {
    enable_logging                = ENABLE_LOGGING
    max_integrator_steps          = MAX_INTEGRATOR_STEPS
    brinkman_time_independent     = BRINKMAN_TIME_INDEPENDENT
+   solver_type = "PETSC_KRYLOV_SOLVER"
+   solver_db
+   {
+      rel_residual_tol = 1.0e-12
+   }
 }
 
 Main {

--- a/examples/adv_diff/ex5/LevelSetInitialCondition.cpp
+++ b/examples/adv_diff/ex5/LevelSetInitialCondition.cpp
@@ -22,9 +22,10 @@
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
 LevelSetInitialCondition::LevelSetInitialCondition(const std::string& object_name,
+                                                   const Pointer<CartesianGridGeometry<NDIM> > grid_geom,
                                                    const IBTK::VectorNd& interface_loc,
                                                    const bool left_side)
-    : d_object_name(object_name), d_interface_loc(interface_loc), d_left_side(left_side)
+    : d_object_name(object_name), d_grid_geom(grid_geom), d_interface_loc(interface_loc), d_left_side(left_side)
 {
     // intentionally blank
     return;
@@ -42,26 +43,31 @@ LevelSetInitialCondition::setDataOnPatch(const int data_idx,
                                          Pointer<Patch<NDIM> > patch,
                                          const double /*data_time*/,
                                          const bool initial_time,
-                                         Pointer<PatchLevel<NDIM> > /*patch_level*/)
+                                         Pointer<PatchLevel<NDIM> > patch_level)
 {
     // Set the level set function throughout the domain
     if (initial_time)
     {
         const Box<NDIM>& patch_box = patch->getBox();
         Pointer<CellData<NDIM, double> > D_data = patch->getPatchData(data_idx);
+
+        Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
+        const double* const patch_dx = patch_geom->getDx();
+        const double* const grid_x_lower = d_grid_geom->getXLower();
+        IntVector<NDIM> ratio = patch_level->getRatio();
+        const SAMRAI::hier::Box<NDIM> domain_box =
+            SAMRAI::hier::Box<NDIM>::refine(d_grid_geom->getPhysicalDomain()[0], ratio);
+        const hier::Index<NDIM>& grid_lower_idx = domain_box.lower();
+
         for (Box<NDIM>::Iterator it(patch_box); it; it++)
         {
             CellIndex<NDIM> ci(it());
-            Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const double* patch_X_lower = patch_geom->getXLower();
-            const hier::Index<NDIM>& patch_lower_idx = patch_box.lower();
-            const double* const patch_dx = patch_geom->getDx();
+
             // Get physical coordinates
             IBTK::Vector coord = IBTK::Vector::Zero();
             for (int d = 0; d < NDIM; ++d)
-            {
-                coord[d] = patch_X_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
-            }
+                coord[d] = grid_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - grid_lower_idx(d)) + 0.5);
+
             double distance = std::numeric_limits<double>::quiet_NaN();
             distance = d_interface_loc[0] - coord[0];
             double sign = 0.0;

--- a/examples/adv_diff/ex5/LevelSetInitialCondition.h
+++ b/examples/adv_diff/ex5/LevelSetInitialCondition.h
@@ -34,6 +34,7 @@ public:
      * \brief Class constructor.
      */
     LevelSetInitialCondition(const std::string& object_name,
+                             const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
                              const IBTK::VectorNd& interface_loc,
                              const bool left_side = false);
 
@@ -80,6 +81,12 @@ private:
      * Name of this object.
      */
     std::string d_object_name;
+
+    /*!
+     * The Cartesian grid geometry object provides the extents of the
+     * computational domain.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 
     /*!
      * Interface location.

--- a/examples/adv_diff/ex5/input2d
+++ b/examples/adv_diff/ex5/input2d
@@ -108,6 +108,11 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator {
    enable_logging                = ENABLE_LOGGING
    max_integrator_steps          = MAX_INTEGRATOR_STEPS
    brinkman_time_independent     = BRINKMAN_TIME_INDEPENDENT
+   solver_type = "PETSC_KRYLOV_SOLVER"
+   solver_db
+   {
+      rel_residual_tol = 1.0e-12
+   }
 }
 
 Main {

--- a/examples/adv_diff/ex6/LevelSetInitialConditionEgg.h
+++ b/examples/adv_diff/ex6/LevelSetInitialConditionEgg.h
@@ -33,7 +33,9 @@ public:
     /*!
      * \brief Class constructor.
      */
-    LevelSetInitialConditionEgg(const std::string& object_name, const IBTK::VectorNd& origin);
+    LevelSetInitialConditionEgg(const std::string& object_name,
+                                const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
+                                const IBTK::VectorNd& origin);
 
     /*!
      * \brief Empty destructor.
@@ -84,6 +86,12 @@ private:
      * Name of this object.
      */
     std::string d_object_name;
+
+    /*!
+     * The Cartesian grid geometry object provides the extents of the
+     * computational domain.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 
     /*!
      * Origin of geometry.

--- a/examples/adv_diff/ex6/LevelSetInitialConditionTorus.cpp
+++ b/examples/adv_diff/ex6/LevelSetInitialConditionTorus.cpp
@@ -19,9 +19,10 @@
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
 LevelSetInitialConditionTorus::LevelSetInitialConditionTorus(const std::string& object_name,
+                                                             const Pointer<CartesianGridGeometry<NDIM> > grid_geom,
                                                              const IBTK::VectorNd& origin,
                                                              const IBTK::Vector2d& t)
-    : d_object_name(object_name), d_origin(origin), d_t(t)
+    : d_object_name(object_name), d_grid_geom(grid_geom), d_origin(origin), d_t(t)
 {
     // intentionally blank
     return;
@@ -39,7 +40,7 @@ LevelSetInitialConditionTorus::setDataOnPatch(const int data_idx,
                                               Pointer<Patch<NDIM> > patch,
                                               const double /*data_time*/,
                                               const bool initial_time,
-                                              Pointer<PatchLevel<NDIM> > /*patch_level*/)
+                                              Pointer<PatchLevel<NDIM> > patch_level)
 {
     // Set the level set function throughout the domain
     if (initial_time)
@@ -51,18 +52,22 @@ LevelSetInitialConditionTorus::setDataOnPatch(const int data_idx,
         IBTK::VectorNd coord = IBTK::Vector::Zero();
         IBTK::VectorNd p = IBTK::Vector::Zero();
         IBTK::Vector2d q(0.0, 0.0);
+
+        Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
+        const double* const patch_dx = patch_geom->getDx();
+        const double* const grid_x_lower = d_grid_geom->getXLower();
+        IntVector<NDIM> ratio = patch_level->getRatio();
+        const SAMRAI::hier::Box<NDIM> domain_box =
+            SAMRAI::hier::Box<NDIM>::refine(d_grid_geom->getPhysicalDomain()[0], ratio);
+        const hier::Index<NDIM>& grid_lower_idx = domain_box.lower();
+
         for (Box<NDIM>::Iterator it(patch_box); it; it++)
         {
             CellIndex<NDIM> ci(it());
-            Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const double* patch_X_lower = patch_geom->getXLower();
-            const hier::Index<NDIM>& patch_lower_idx = patch_box.lower();
-            const double* const patch_dx = patch_geom->getDx();
 
             for (int d = 0; d < NDIM; ++d)
-            {
-                coord[d] = patch_X_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
-            }
+                coord[d] = grid_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - grid_lower_idx(d)) + 0.5);
+
             p = coord - d_origin;
             IBTK::Vector2d p_xz(p[0], p[2]);
             q << p_xz.norm() - d_t[0], p[1];

--- a/examples/adv_diff/ex6/LevelSetInitialConditionTorus.h
+++ b/examples/adv_diff/ex6/LevelSetInitialConditionTorus.h
@@ -34,6 +34,7 @@ public:
      * \brief Class constructor.
      */
     LevelSetInitialConditionTorus(const std::string& object_name,
+                                  const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
                                   const IBTK::VectorNd& origin,
                                   const IBTK::Vector2d& t);
 
@@ -91,6 +92,12 @@ private:
      * Name of this object.
      */
     std::string d_object_name;
+
+    /*!
+     * The Cartesian grid geometry object provides the extents of the
+     * computational domain.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 
     /*!
      * Origin of torus.

--- a/examples/adv_diff/ex6/input2d
+++ b/examples/adv_diff/ex6/input2d
@@ -105,6 +105,11 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator {
    enable_logging                = ENABLE_LOGGING
    max_integrator_steps          = MAX_INTEGRATOR_STEPS
    brinkman_time_independent     = BRINKMAN_TIME_INDEPENDENT
+   solver_type = "PETSC_KRYLOV_SOLVER"
+   solver_db
+   {
+      rel_residual_tol = 1.0e-12
+   }
 }
 
 Main {

--- a/examples/adv_diff/ex6/input3d
+++ b/examples/adv_diff/ex6/input3d
@@ -114,6 +114,11 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator {
    enable_logging                = ENABLE_LOGGING
    max_integrator_steps          = MAX_INTEGRATOR_STEPS
    brinkman_time_independent     = BRINKMAN_TIME_INDEPENDENT
+   solver_type = "PETSC_KRYLOV_SOLVER"
+   solver_db
+   {
+      rel_residual_tol = 1.0e-12
+   }
 }
 
 Main {

--- a/examples/adv_diff/ex7/LevelSetInitialCondition.h
+++ b/examples/adv_diff/ex7/LevelSetInitialCondition.h
@@ -34,6 +34,7 @@ public:
      * \brief Class constructor.
      */
     LevelSetInitialCondition(const std::string& object_name,
+                             const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
                              const double radius,
                              const IBTK::VectorNd& origin,
                              const bool fluid_is_interior_to_cylinder = false);
@@ -81,6 +82,12 @@ private:
      * Name of this object.
      */
     std::string d_object_name;
+
+    /*!
+     * The Cartesian grid geometry object provides the extents of the
+     * computational domain.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 
     /*!
      * Radius of cylinder.

--- a/examples/adv_diff/ex7/input2d
+++ b/examples/adv_diff/ex7/input2d
@@ -105,6 +105,11 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator {
    enable_logging                = ENABLE_LOGGING
    max_integrator_steps          = MAX_INTEGRATOR_STEPS
    brinkman_time_independent     = BRINKMAN_TIME_INDEPENDENT
+   solver_type = "PETSC_KRYLOV_SOLVER"
+   solver_db
+   {
+      rel_residual_tol = 1.0e-12
+   }
 }
 
 Main {

--- a/ibtk/include/ibtk/IndexUtilities.h
+++ b/ibtk/include/ibtk/IndexUtilities.h
@@ -160,6 +160,34 @@ public:
                                         const SAMRAI::pdat::SideIndex<NDIM>& side_idx);
 
     /*!
+     * \return The spatial coordinate of the given side center.
+     *
+     * @param grid_geom The grid geometry provides the extents of the computational domain.
+     *
+     * @param ratio Refinement ratio.
+     *
+     * @param side_idx The SideIndex describing the current side.
+     */
+    template <typename Vector>
+    static Vector getSideCenter(const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> >& grid_geom,
+                                const SAMRAI::hier::IntVector<NDIM>& ratio,
+                                const SAMRAI::pdat::SideIndex<NDIM>& side_idx);
+
+    /*!
+     * \return The spatial coordinate of the given side center.
+     *
+     * @param grid_geom The grid geometry provides the extents of the computational domain.
+     *
+     * @param ratio Refinement ratio.
+     *
+     * @param side_idx The SideIndex describing the current side.
+     */
+    static IBTK::VectorNd
+    getSideCenter(const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> >& grid_geom,
+                  const SAMRAI::hier::IntVector<NDIM>& ratio,
+                  const SAMRAI::pdat::SideIndex<NDIM>& side_idx);
+
+    /*!
      * \brief Map (i,j,k,d) index for a DOF defined for a SAMRAI variable
      * on a particular patch level to a positive integer. Such a mapping can
      * be useful for creating an application ordering (AO) between SAMRAI and

--- a/ibtk/include/ibtk/private/IndexUtilities-inl.h
+++ b/ibtk/include/ibtk/private/IndexUtilities-inl.h
@@ -115,6 +115,52 @@ IndexUtilities::getSideCenter(const SAMRAI::hier::Patch<NDIM>& patch, const SAMR
     return getSideCenter<VectorNd>(patch, side_idx);
 } // getSideCenter
 
+template <typename Vector>
+inline Vector
+IndexUtilities::getSideCenter(const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> >& grid_geom,
+                              const SAMRAI::hier::IntVector<NDIM>& ratio,
+                              const SAMRAI::pdat::SideIndex<NDIM>& side_idx)
+{
+    const int axis = side_idx.getAxis();
+    const double* const dx0 = grid_geom->getDx();
+    double patch_dx[NDIM];
+    for (unsigned int d = 0; d < NDIM; ++d)
+    {
+        patch_dx[d] = dx0[d] / static_cast<double>(ratio(d));
+    }
+    const SAMRAI::hier::Box<NDIM> domain_box =
+        SAMRAI::hier::Box<NDIM>::refine(grid_geom->getPhysicalDomain()[0], ratio);
+    const double* const grid_x_lower = grid_geom->getXLower();
+    const SAMRAI::hier::Index<NDIM>& grid_lower_idx = domain_box.lower();
+
+    Vector side_coord;
+    for (int d = 0; d < NDIM; ++d)
+    {
+        if (d == axis)
+        {
+            side_coord[d] = grid_x_lower[d] + patch_dx[d] * (static_cast<double>(side_idx(d) - grid_lower_idx(d)));
+        }
+        else
+        {
+            side_coord[d] =
+                grid_x_lower[d] + patch_dx[d] * (static_cast<double>(side_idx(d) - grid_lower_idx(d)) + 0.5);
+        }
+    }
+    for (int d = NDIM; d < side_coord.size(); ++d)
+    {
+        side_coord[d] = 0.0;
+    }
+    return side_coord;
+} // getSideCenter
+
+inline VectorNd
+IndexUtilities::getSideCenter(const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> >& grid_geom,
+                              const SAMRAI::hier::IntVector<NDIM>& ratio,
+                              const SAMRAI::pdat::SideIndex<NDIM>& side_idx)
+{
+    return getSideCenter<VectorNd>(grid_geom, ratio, side_idx);
+} // getSideCenter
+
 template <class DoubleArray>
 inline SAMRAI::hier::Index<NDIM>
 IndexUtilities::getCellIndex(const DoubleArray& X,

--- a/tests/adv_diff/LevelSetInitialCondition.cpp
+++ b/tests/adv_diff/LevelSetInitialCondition.cpp
@@ -19,10 +19,12 @@
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
 LevelSetInitialCondition::LevelSetInitialCondition(const std::string& object_name,
+                                                   const Pointer<CartesianGridGeometry<NDIM> > grid_geom,
                                                    const double radius,
                                                    const IBTK::VectorNd& origin,
                                                    const bool fluid_is_interior_to_cylinder)
     : d_object_name(object_name),
+      d_grid_geom(grid_geom),
       d_radius(radius),
       d_origin(origin),
       d_fluid_is_interior_to_cylinder(fluid_is_interior_to_cylinder)
@@ -43,26 +45,31 @@ LevelSetInitialCondition::setDataOnPatch(const int data_idx,
                                          Pointer<Patch<NDIM> > patch,
                                          const double /*data_time*/,
                                          const bool initial_time,
-                                         Pointer<PatchLevel<NDIM> > /*patch_level*/)
+                                         Pointer<PatchLevel<NDIM> > patch_level)
 {
     // Set the level set function throughout the domain
     if (initial_time)
     {
         const Box<NDIM>& patch_box = patch->getBox();
         Pointer<CellData<NDIM, double> > D_data = patch->getPatchData(data_idx);
+
+        Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
+        const double* const patch_dx = patch_geom->getDx();
+        const double* const grid_x_lower = d_grid_geom->getXLower();
+        IntVector<NDIM> ratio = patch_level->getRatio();
+        const SAMRAI::hier::Box<NDIM> domain_box =
+            SAMRAI::hier::Box<NDIM>::refine(d_grid_geom->getPhysicalDomain()[0], ratio);
+        const hier::Index<NDIM>& grid_lower_idx = domain_box.lower();
+
         for (Box<NDIM>::Iterator it(patch_box); it; it++)
         {
             CellIndex<NDIM> ci(it());
-            Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const double* patch_X_lower = patch_geom->getXLower();
-            const hier::Index<NDIM>& patch_lower_idx = patch_box.lower();
-            const double* const patch_dx = patch_geom->getDx();
+
             // Get physical coordinates
             IBTK::Vector coord = IBTK::Vector::Zero();
             for (int d = 0; d < NDIM; ++d)
-            {
-                coord[d] = patch_X_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
-            }
+                coord[d] = grid_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - grid_lower_idx(d)) + 0.5);
+
             double distance = std::numeric_limits<double>::quiet_NaN();
 #if (NDIM == 2)
             distance = std::sqrt((coord[0] - d_origin[0]) * (coord[0] - d_origin[0]) +

--- a/tests/adv_diff/LevelSetInitialCondition.h
+++ b/tests/adv_diff/LevelSetInitialCondition.h
@@ -34,6 +34,7 @@ public:
      * \brief Class constructor.
      */
     LevelSetInitialCondition(const std::string& object_name,
+                             const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
                              const double radius,
                              const IBTK::VectorNd& origin,
                              const bool fluid_is_interior_to_cylinder);
@@ -81,6 +82,12 @@ private:
      * Name of this object.
      */
     std::string d_object_name;
+
+    /*!
+     * The Cartesian grid geometry object provides the extents of the
+     * computational domain.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 
     /*!
      * Radius of cylinder.

--- a/tests/adv_diff/LevelSetInitialConditionHexagram.cpp
+++ b/tests/adv_diff/LevelSetInitialConditionHexagram.cpp
@@ -14,6 +14,8 @@
 #include "LevelSetInitialConditionHexagram.h"
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
+#include "tbox/Pointer.h"
+
 #include <SAMRAI_config.h>
 
 // SAMRAI INCLUDES
@@ -21,9 +23,11 @@
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
-LevelSetInitialConditionHexagram::LevelSetInitialConditionHexagram(const std::string& object_name,
-                                                                   const IBTK::VectorNd& origin)
-    : d_object_name(object_name), d_origin(origin)
+LevelSetInitialConditionHexagram::LevelSetInitialConditionHexagram(
+    const std::string& object_name,
+    const Pointer<CartesianGridGeometry<NDIM> > grid_geom,
+    const IBTK::VectorNd& origin)
+    : d_object_name(object_name), d_grid_geom(grid_geom), d_origin(origin)
 {
     // intentionally blank
     return;
@@ -41,7 +45,7 @@ LevelSetInitialConditionHexagram::setDataOnPatch(const int data_idx,
                                                  Pointer<Patch<NDIM> > patch,
                                                  const double /*data_time*/,
                                                  const bool initial_time,
-                                                 Pointer<PatchLevel<NDIM> > /*patch_level*/)
+                                                 Pointer<PatchLevel<NDIM> > patch_level)
 {
     // Set the level set function throughout the domain
     if (initial_time)
@@ -51,22 +55,27 @@ LevelSetInitialConditionHexagram::setDataOnPatch(const int data_idx,
         std::vector<double> k{ -0.5, 0.8660254038, 0.5773502692, 1.7320508076 };
         IBTK::VectorNd kxy{ k[0], k[1] };
         IBTK::VectorNd kyx{ k[1], k[0] };
+
         // Get physical coordinates
         IBTK::VectorNd coord = IBTK::Vector::Zero();
         IBTK::VectorNd p = IBTK::Vector::Zero();
         IBTK::VectorNd q = IBTK::Vector::Zero();
+
+        Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
+        const double* const patch_dx = patch_geom->getDx();
+        const double* const grid_x_lower = d_grid_geom->getXLower();
+        IntVector<NDIM> ratio = patch_level->getRatio();
+        const SAMRAI::hier::Box<NDIM> domain_box =
+            SAMRAI::hier::Box<NDIM>::refine(d_grid_geom->getPhysicalDomain()[0], ratio);
+        const hier::Index<NDIM>& grid_lower_idx = domain_box.lower();
+
         for (Box<NDIM>::Iterator it(patch_box); it; it++)
         {
             CellIndex<NDIM> ci(it());
-            Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const double* patch_X_lower = patch_geom->getXLower();
-            const hier::Index<NDIM>& patch_lower_idx = patch_box.lower();
-            const double* const patch_dx = patch_geom->getDx();
 
             for (int d = 0; d < NDIM; ++d)
-            {
-                coord[d] = patch_X_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
-            }
+                coord[d] = grid_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - grid_lower_idx(d)) + 0.5);
+
             p = coord - d_origin;
             q = p.cwiseAbs();
             q -= 2.0 * std::min(kxy.dot(q), 0.0) * kxy;

--- a/tests/adv_diff/LevelSetInitialConditionHexagram.h
+++ b/tests/adv_diff/LevelSetInitialConditionHexagram.h
@@ -19,6 +19,8 @@
 // IBAMR INCLUDES
 #include <ibamr/AdvDiffHierarchyIntegrator.h>
 
+#include "CartesianGridGeometry.h"
+
 #include <ibamr/app_namespaces.h>
 
 /////////////////////////////// CLASS DEFINITION /////////////////////////////
@@ -33,7 +35,9 @@ public:
     /*!
      * \brief Class constructor.
      */
-    LevelSetInitialConditionHexagram(const std::string& object_name, const IBTK::VectorNd& origin);
+    LevelSetInitialConditionHexagram(const std::string& object_name,
+                                     const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > grid_geom,
+                                     const IBTK::VectorNd& origin);
 
     /*!
      * \brief Empty destructor.
@@ -78,6 +82,12 @@ private:
      * Name of this object.
      */
     std::string d_object_name;
+
+    /*!
+     * The Cartesian grid geometry object provides the extents of the
+     * computational domain.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM> > d_grid_geom;
 
     /*!
      * Origin of the geometry.

--- a/tests/adv_diff/bp_adv_diff_01_2d.input
+++ b/tests/adv_diff/bp_adv_diff_01_2d.input
@@ -104,6 +104,11 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator {
    enable_logging                = ENABLE_LOGGING
    max_integrator_steps          = MAX_INTEGRATOR_STEPS
    brinkman_time_independent     = BRINKMAN_TIME_INDEPENDENT
+   solver_type = "PETSC_KRYLOV_SOLVER"
+   solver_db
+   {
+      rel_residual_tol = 1.0e-12
+   }
 }
 
 Main {

--- a/tests/adv_diff/bp_adv_diff_01_2d.output
+++ b/tests/adv_diff/bp_adv_diff_01_2d.output
@@ -1,4 +1,4 @@
 Error in q (only in the fluid region) :
-  L1-norm:  0.0008731834945
-  L2-norm:  0.0001877609566
-  max-norm: 6.266649774e-05
+  L1-norm:  0.0008710607733
+  L2-norm:  0.0001872993309
+  max-norm: 6.224074597e-05

--- a/tests/adv_diff/bp_adv_diff_02.cpp
+++ b/tests/adv_diff/bp_adv_diff_02.cpp
@@ -80,7 +80,6 @@ evaluate_brinkman_bc_callback_fcn(int B_idx,
 {
     BrinkmanPenalizationCtx* bp_ctx = static_cast<BrinkmanPenalizationCtx*>(ctx);
     Pointer<PatchHierarchy<NDIM> > patch_hierarchy = hier_math_ops->getPatchHierarchy();
-    const int coarsest_ln = 0;
     const int finest_ln = patch_hierarchy->getFinestLevelNumber();
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -119,86 +118,86 @@ evaluate_brinkman_bc_callback_fcn(int B_idx,
     int interface_cell_patch_idx = bp_ctx->interface_cell_patch_idx;
     int prop_counter_idx = bp_ctx->prop_counter_idx;
 
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    Pointer<PatchLevel<NDIM> > finest_level = patch_hierarchy->getPatchLevel(finest_ln);
+    IntVector<NDIM> ratio = finest_level->getRatio();
+
+    const Pointer<CartesianGridGeometry<NDIM> > grid_geom = patch_hierarchy->getGridGeometry();
+    const double* const grid_x_lower = grid_geom->getXLower();
+    const SAMRAI::hier::Box<NDIM> domain_box =
+        SAMRAI::hier::Box<NDIM>::refine(grid_geom->getPhysicalDomain()[0], ratio);
+    const hier::Index<NDIM>& grid_lower_idx = domain_box.lower();
+    for (PatchLevel<NDIM>::Iterator p(finest_level); p; p++)
     {
-        Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
-        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        Pointer<Patch<NDIM> > patch = finest_level->getPatch(p());
+        const Box<NDIM>& patch_box = patch->getBox();
+        const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
+        const double* const patch_dx = patch_geom->getDx();
+
+        Pointer<CellData<NDIM, double> > grad_phi_cc_data = patch->getPatchData(grad_phi_cc_idx);
+        Pointer<CellData<NDIM, double> > ls_data = patch->getPatchData(phi_scratch_idx);
+        Pointer<CellData<NDIM, double> > g_cc_data = patch->getPatchData(g_cc_scratch_idx);
+        Pointer<CellData<NDIM, double> > interface_cell_bool_data = patch->getPatchData(interface_cell_patch_idx);
+        for (Box<NDIM>::Iterator it(patch_box); it; it++)
         {
-            Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& patch_box = patch->getBox();
-            const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const double* const patch_x_lower = patch_geom->getXLower();
-            const double* const patch_dx = patch_geom->getDx();
-            const hier::Index<NDIM>& patch_lower_idx = patch_box.lower();
-            Pointer<CellData<NDIM, double> > grad_phi_cc_data = patch->getPatchData(grad_phi_cc_idx);
-            Pointer<CellData<NDIM, double> > ls_data = patch->getPatchData(phi_scratch_idx);
-            Pointer<CellData<NDIM, double> > g_cc_data = patch->getPatchData(g_cc_scratch_idx);
-            Pointer<CellData<NDIM, double> > interface_cell_bool_data = patch->getPatchData(interface_cell_patch_idx);
-            for (Box<NDIM>::Iterator it(patch_box); it; it++)
+            CellIndex<NDIM> ci(it());
+            CellIndex<NDIM> ci_e = ci;
+            CellIndex<NDIM> ci_w = ci;
+            CellIndex<NDIM> ci_n = ci;
+            CellIndex<NDIM> ci_s = ci;
+#if (NDIM == 3)
+            CellIndex<NDIM> ci_f = ci;
+            CellIndex<NDIM> ci_b = ci;
+#endif
+            ci_e(0) += 1;
+            ci_w(0) -= 1;
+            ci_n(1) += 1;
+            ci_s(1) -= 1;
+#if (NDIM == 3)
+            ci_f(2) += 1;
+            ci_b(2) -= 1;
+#endif
+            const double ls_c_value = (*ls_data)(ci);
+            const double ls_e_value = (*ls_data)(ci_e);
+            const double ls_w_value = (*ls_data)(ci_w);
+            const double ls_n_value = (*ls_data)(ci_n);
+            const double ls_s_value = (*ls_data)(ci_s);
+#if (NDIM == 3)
+            const double ls_f_value = (*ls_data)(ci_f);
+            const double ls_b_value = (*ls_data)(ci_b);
+#endif
+
+            // Finding interface cells.
+            if ((ls_c_value * ls_e_value <= 0.0) || (ls_c_value * ls_w_value <= 0.0) ||
+                (ls_c_value * ls_n_value <= 0.0) || (ls_c_value * ls_s_value <= 0.0)
+#if (NDIM == 3)
+                || (ls_c_value * ls_f_value <= 0.0) || (ls_c_value * ls_b_value <= 0.0)
+#endif
+            )
             {
-                CellIndex<NDIM> ci(it());
-                CellIndex<NDIM> ci_e = ci;
-                CellIndex<NDIM> ci_w = ci;
-                CellIndex<NDIM> ci_n = ci;
-                CellIndex<NDIM> ci_s = ci;
-#if (NDIM == 3)
-                CellIndex<NDIM> ci_f = ci;
-                CellIndex<NDIM> ci_b = ci;
-#endif
-                ci_e(0) += 1;
-                ci_w(0) -= 1;
-                ci_n(1) += 1;
-                ci_s(1) -= 1;
-#if (NDIM == 3)
-                ci_f(2) += 1;
-                ci_b(2) -= 1;
-#endif
-                const double ls_c_value = (*ls_data)(ci);
-                const double ls_e_value = (*ls_data)(ci_e);
-                const double ls_w_value = (*ls_data)(ci_w);
-                const double ls_n_value = (*ls_data)(ci_n);
-                const double ls_s_value = (*ls_data)(ci_s);
-#if (NDIM == 3)
-                const double ls_f_value = (*ls_data)(ci_f);
-                const double ls_b_value = (*ls_data)(ci_b);
-#endif
+                IBTK::VectorNd coord = IBTK::Vector::Zero();
+                IBTK::VectorNd interface_coord = IBTK::Vector::Zero();
+                for (int d = 0; d < NDIM; ++d)
+                    coord[d] = grid_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - grid_lower_idx(d)) + 0.5);
 
-                // Finding interface cells.
-                if ((ls_c_value * ls_e_value <= 0) || (ls_c_value * ls_w_value <= 0) ||
-                    (ls_c_value * ls_n_value <= 0) || (ls_c_value * ls_s_value <= 0)
-#if (NDIM == 3)
-                    || (ls_c_value * ls_f_value <= 0) || (ls_c_value * ls_b_value <= 0)
-#endif
-                )
+                // Compute g in the interface cell.
+                double g = 0.0;
+                for (int d = 0; d < NDIM; ++d)
                 {
-                    IBTK::VectorNd coord = IBTK::Vector::Zero();
-                    IBTK::VectorNd interface_coord = IBTK::Vector::Zero();
-                    for (int d = 0; d < NDIM; ++d)
-                    {
-                        coord[d] =
-                            patch_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
-                    }
-
-                    // Compute g in the interface cell.
-                    double g = 0.0;
-                    for (int d = 0; d < NDIM; ++d)
-                    {
-                        interface_coord[d] = coord[d] + ls_c_value * (*grad_phi_cc_data)(ci, d);
-                    }
-#if (NDIM == 2)
-                    g = cos(interface_coord[0]) * sin(interface_coord[1]) * (*grad_phi_cc_data)(ci, 0) +
-                        sin(interface_coord[0]) * cos(interface_coord[1]) * (*grad_phi_cc_data)(ci, 1);
-#elif (NDIM == 3)
-                    g = cos(interface_coord[1]) * cos(interface_coord[2]) * sin(interface_coord[0]) *
-                            (*grad_phi_cc_data)(ci, 0) +
-                        cos(interface_coord[0]) * cos(interface_coord[2]) * sin(interface_coord[1]) *
-                            (*grad_phi_cc_data)(ci, 1) +
-                        cos(interface_coord[0]) * cos(interface_coord[1]) * sin(interface_coord[2]) *
-                            (*grad_phi_cc_data)(ci, 2);
-#endif
-                    (*g_cc_data)(ci) = g;
-                    (*interface_cell_bool_data)(ci) = 1.0;
+                    interface_coord[d] = coord[d] + ls_c_value * (*grad_phi_cc_data)(ci, d);
                 }
+#if (NDIM == 2)
+                g = cos(interface_coord[0]) * sin(interface_coord[1]) * (*grad_phi_cc_data)(ci, 0) +
+                    sin(interface_coord[0]) * cos(interface_coord[1]) * (*grad_phi_cc_data)(ci, 1);
+#elif (NDIM == 3)
+                g = cos(interface_coord[1]) * cos(interface_coord[2]) * sin(interface_coord[0]) *
+                        (*grad_phi_cc_data)(ci, 0) +
+                    cos(interface_coord[0]) * cos(interface_coord[2]) * sin(interface_coord[1]) *
+                        (*grad_phi_cc_data)(ci, 1) +
+                    cos(interface_coord[0]) * cos(interface_coord[1]) * sin(interface_coord[2]) *
+                        (*grad_phi_cc_data)(ci, 2);
+#endif
+                (*g_cc_data)(ci) = g;
+                (*interface_cell_bool_data)(ci) = 1.0;
             }
         }
     }
@@ -228,96 +227,84 @@ evaluate_brinkman_bc_callback_fcn(int B_idx,
     const int num_prop_cells = bp_ctx->num_prop_cells;
 
     // Propagate the interfacial g value to the neighboring cells along the normal direction.
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    for (PatchLevel<NDIM>::Iterator p(finest_level); p; p++)
     {
-        Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
-        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        Pointer<Patch<NDIM> > patch = finest_level->getPatch(p());
+        const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
+        const double* const patch_dx = patch_geom->getDx();
+        Pointer<CellData<NDIM, double> > g_cc_data = patch->getPatchData(g_cc_scratch_idx);
+        Pointer<CellData<NDIM, double> > interface_cell_data = patch->getPatchData(interface_cell_patch_idx);
+        Pointer<CellData<NDIM, double> > prop_counter_data = patch->getPatchData(prop_counter_idx);
+        Pointer<CellData<NDIM, double> > grad_phi_cc_data = patch->getPatchData(grad_phi_cc_idx);
+        const Box<NDIM>& ghost_box = g_cc_data->getGhostBox();
+        const hier::Index<NDIM>& ghost_lower_idx = ghost_box.lower();
+        const hier::Index<NDIM>& ghost_upper_idx = ghost_box.upper();
+
+        for (Box<NDIM>::Iterator it(ghost_box); it; it++)
         {
-            Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& patch_box = patch->getBox();
-            const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-            const double* const patch_x_lower = patch_geom->getXLower();
-            const double* const patch_dx = patch_geom->getDx();
-            Pointer<CellData<NDIM, double> > g_cc_data = patch->getPatchData(g_cc_scratch_idx);
-            Pointer<CellData<NDIM, double> > interface_cell_data = patch->getPatchData(interface_cell_patch_idx);
-            Pointer<CellData<NDIM, double> > prop_counter_data = patch->getPatchData(prop_counter_idx);
-            Pointer<CellData<NDIM, double> > grad_phi_cc_data = patch->getPatchData(grad_phi_cc_idx);
-            const Box<NDIM>& ghost_box = g_cc_data->getGhostBox();
-            const hier::Index<NDIM>& patch_lower_idx = patch_box.lower();
-            const hier::Index<NDIM>& ghost_lower_idx = ghost_box.lower();
-            const hier::Index<NDIM>& ghost_upper_idx = ghost_box.upper();
+            CellIndex<NDIM> ci(it());
 
-            for (Box<NDIM>::Iterator it(ghost_box); it; it++)
+            if ((*interface_cell_data)(ci) > 0.0)
             {
-                CellIndex<NDIM> ci(it());
+                std::vector<CellIndex<NDIM> > nbr_cell_normal(num_prop_cells);     // vector stores cell index of
+                                                                                   // neighbor cells in +n direction
+                std::vector<CellIndex<NDIM> > nbr_cell_neg_normal(num_prop_cells); // vector stores cell index of
+                                                                                   // neighbor cells in -n direction
+                // location of the interface cells.
+                IBTK::VectorNd coord = IBTK::Vector::Zero();
+                IBTK::VectorNd coord_nbr = IBTK::Vector::Zero();
+                const double g = (*g_cc_data)(ci);
+                for (int d = 0; d < NDIM; ++d)
+                    coord[d] = grid_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - grid_lower_idx(d)) + 0.5);
 
-                if ((*interface_cell_data)(ci) > 0.0)
+                // propagating g in +n direction.
+                int counter = 0;
+                for (auto& nbr_cell : nbr_cell_normal)
                 {
-                    std::vector<CellIndex<NDIM> > nbr_cell_normal(num_prop_cells);     // vector stores cell index of
-                                                                                       // neighbor cells in +n direction
-                    std::vector<CellIndex<NDIM> > nbr_cell_neg_normal(num_prop_cells); // vector stores cell index of
-                                                                                       // neighbor cells in -n direction
-
-                    // location of the interface cells.
-                    IBTK::VectorNd coord = IBTK::Vector::Zero();
-                    IBTK::VectorNd coord_nbr = IBTK::Vector::Zero();
-                    const double g = (*g_cc_data)(ci);
+                    counter++;
                     for (int d = 0; d < NDIM; ++d)
                     {
-                        coord[d] =
-                            patch_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
+                        coord_nbr[d] = coord[d] + counter * patch_dx[d] * (*grad_phi_cc_data)(ci, d);
                     }
+                    nbr_cell = IndexUtilities::getCellIndex(&coord_nbr[0], grid_geom, ratio);
 
-                    // propagating g in +n direction.
-                    int counter = 0;
-                    for (auto& nbr_cell : nbr_cell_normal)
-                    {
-                        counter++;
-                        for (int d = 0; d < NDIM; ++d)
-                        {
-                            coord_nbr[d] = coord[d] + counter * patch_dx[d] * (*grad_phi_cc_data)(ci, d);
-                        }
-
-                        nbr_cell = IndexUtilities::getCellIndex(&coord_nbr[0], patch_geom, patch_box);
-
-                        if (nbr_cell[0] >= ghost_lower_idx[0] && nbr_cell[0] <= ghost_upper_idx[0] &&
-                            nbr_cell[1] >= ghost_lower_idx[1] && nbr_cell[1] <= ghost_upper_idx[1]
+                    if (nbr_cell[0] >= ghost_lower_idx[0] && nbr_cell[0] <= ghost_upper_idx[0] &&
+                        nbr_cell[1] >= ghost_lower_idx[1] && nbr_cell[1] <= ghost_upper_idx[1]
 #if (NDIM == 3)
-                            && nbr_cell[2] >= ghost_lower_idx[2] && nbr_cell[2] <= ghost_upper_idx[2]
+                        && nbr_cell[2] >= ghost_lower_idx[2] && nbr_cell[2] <= ghost_upper_idx[2]
 #endif
-                        )
+                    )
+                    {
+                        (*prop_counter_data)(nbr_cell) = (*prop_counter_data)(nbr_cell) + 1.0;
+                        if (std::abs((*g_cc_data)(nbr_cell)) <= std::abs(g))
                         {
-                            (*prop_counter_data)(nbr_cell) = (*prop_counter_data)(nbr_cell) + 1.0;
-                            if (std::abs((*g_cc_data)(nbr_cell)) <= std::abs(g))
-                            {
-                                (*g_cc_data)(nbr_cell) = g;
-                            }
+                            (*g_cc_data)(nbr_cell) = g;
                         }
                     }
+                }
 
-                    // propagating g in -n direction.
-                    counter = 0;
-                    for (auto& nbr_cell : nbr_cell_neg_normal)
+                // propagating g in -n direction.
+                counter = 0;
+                for (auto& nbr_cell : nbr_cell_neg_normal)
+                {
+                    counter++;
+                    for (int d = 0; d < NDIM; ++d)
                     {
-                        counter++;
-                        for (int d = 0; d < NDIM; ++d)
-                        {
-                            coord_nbr[d] = coord[d] - counter * patch_dx[d] * (*grad_phi_cc_data)(ci, d);
-                        }
-                        nbr_cell = IndexUtilities::getCellIndex(&coord_nbr[0], patch_geom, patch_box);
+                        coord_nbr[d] = coord[d] - counter * patch_dx[d] * (*grad_phi_cc_data)(ci, d);
+                    }
+                    nbr_cell = IndexUtilities::getCellIndex(&coord_nbr[0], grid_geom, ratio);
 
-                        if (nbr_cell[0] >= ghost_lower_idx[0] && nbr_cell[0] <= ghost_upper_idx[0] &&
-                            nbr_cell[1] >= ghost_lower_idx[1] && nbr_cell[1] <= ghost_upper_idx[1]
+                    if (nbr_cell[0] >= ghost_lower_idx[0] && nbr_cell[0] <= ghost_upper_idx[0] &&
+                        nbr_cell[1] >= ghost_lower_idx[1] && nbr_cell[1] <= ghost_upper_idx[1]
 #if (NDIM == 3)
-                            && nbr_cell[2] >= ghost_lower_idx[2] && nbr_cell[2] <= ghost_upper_idx[2]
+                        && nbr_cell[2] >= ghost_lower_idx[2] && nbr_cell[2] <= ghost_upper_idx[2]
 #endif
-                        )
+                    )
+                    {
+                        (*prop_counter_data)(nbr_cell) = (*prop_counter_data)(nbr_cell) + 1.0;
+                        if (std::abs((*g_cc_data)(nbr_cell)) <= std::abs(g))
                         {
-                            (*prop_counter_data)(nbr_cell) = (*prop_counter_data)(nbr_cell) + 1.0;
-                            if (std::abs((*g_cc_data)(nbr_cell)) <= std::abs(g))
-                            {
-                                (*g_cc_data)(nbr_cell) = g;
-                            }
+                            (*g_cc_data)(nbr_cell) = g;
                         }
                     }
                 }
@@ -325,25 +312,21 @@ evaluate_brinkman_bc_callback_fcn(int B_idx,
         }
     }
 
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    for (PatchLevel<NDIM>::Iterator p(finest_level); p; p++)
     {
-        Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
-        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        Pointer<Patch<NDIM> > patch = finest_level->getPatch(p());
+        const Box<NDIM>& patch_box = patch->getBox();
+        Pointer<SideData<NDIM, double> > grad_phi_sc_data = patch->getPatchData(grad_phi_sc_idx);
+        Pointer<SideData<NDIM, double> > B_data = patch->getPatchData(B_idx);
+        Pointer<CellData<NDIM, double> > g_cc_data = patch->getPatchData(g_cc_scratch_idx);
+        for (unsigned int axis = 0; axis < NDIM; ++axis)
         {
-            Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& patch_box = patch->getBox();
-            Pointer<SideData<NDIM, double> > grad_phi_sc_data = patch->getPatchData(grad_phi_sc_idx);
-            Pointer<SideData<NDIM, double> > B_data = patch->getPatchData(B_idx);
-            Pointer<CellData<NDIM, double> > g_cc_data = patch->getPatchData(g_cc_scratch_idx);
-            for (unsigned int axis = 0; axis < NDIM; ++axis)
+            for (Box<NDIM>::Iterator it(SideGeometry<NDIM>::toSideBox(patch_box, axis)); it; it++)
             {
-                for (Box<NDIM>::Iterator it(SideGeometry<NDIM>::toSideBox(patch_box, axis)); it; it++)
-                {
-                    SideIndex<NDIM> si(it(), axis, SideIndex<NDIM>::Lower);
-                    // Interpolating g from cell to side.
-                    const double g_sc = 0.5 * ((*g_cc_data)(si.toCell(0)) + (*g_cc_data)(si.toCell(1)));
-                    (*B_data)(si) = g_sc * (*grad_phi_sc_data)(si);
-                }
+                SideIndex<NDIM> si(it(), axis, SideIndex<NDIM>::Lower);
+                // Interpolating g from cell to side.
+                const double g_sc = 0.5 * ((*g_cc_data)(si.toCell(0)) + (*g_cc_data)(si.toCell(1)));
+                (*B_data)(si) = g_sc * (*grad_phi_sc_data)(si);
             }
         }
     }
@@ -441,7 +424,8 @@ main(int argc, char* argv[])
 
         origin << M_PI, M_PI;
         // ls initial condition for Hexagram.
-        Pointer<CartGridFunction> phi_solid_init = new LevelSetInitialConditionHexagram("ls_init", origin);
+        Pointer<CartGridFunction> phi_solid_init =
+            new LevelSetInitialConditionHexagram("ls_init", grid_geometry, origin);
 
         time_integrator->setInitialConditions(phi_solid_var, phi_solid_init);
 

--- a/tests/adv_diff/bp_adv_diff_02_2d.mpirun=8.input
+++ b/tests/adv_diff/bp_adv_diff_02_2d.mpirun=8.input
@@ -7,7 +7,7 @@ RADIUS = 1.5
 
 // grid spacing parameters
 MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
-REF_RATIO  = 2                            // refinement ratio between levels
+REF_RATIO  = 1                            // refinement ratio between levels
 N = 256                                   // actual number of grid cells on coarsest grid level
 NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
 DX = 2*PI/NFINEST
@@ -105,6 +105,11 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator {
    enable_logging                = ENABLE_LOGGING
    max_integrator_steps          = MAX_INTEGRATOR_STEPS
    brinkman_time_independent     = BRINKMAN_TIME_INDEPENDENT
+   solver_type = "PETSC_KRYLOV_SOLVER"
+   solver_db
+   {
+      rel_residual_tol = 1.0e-12
+   }
 }
 
 Main {

--- a/tests/adv_diff/bp_adv_diff_02_2d.mpirun=8.output
+++ b/tests/adv_diff/bp_adv_diff_02_2d.mpirun=8.output
@@ -1,4 +1,4 @@
 Error in q (only in the fluid region) :
-  L1-norm:  0.09049706675
-  L2-norm:  0.02532477419
-  max-norm: 0.04455027832
+  L1-norm:  0.09483566835
+  L2-norm:  0.02611177469
+  max-norm: 0.04508145645


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
We compute cell-centers using grid_lower in all our Brinkman examples and tests. This fixes #1203. Please take a look.