### PR TITLE
Fix the CMake flags used in libMesh tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,21 +388,21 @@ CMake.")
     EXECUTE_PROCESS(COMMAND "${_libmesh_config}" "--include" OUTPUT_VARIABLE _libmesh_raw_includes)
     STRING(REGEX REPLACE "\n$" "" _libmesh_raw_includes ${_libmesh_raw_includes})
     SEPARATE_ARGUMENTS(_libmesh_raw_includes)
-    MESSAGE(STATUS "LIBMESH_INCLUDES: ${LIBMESH_INCLUDES}")
     # Get rid of preceding -Is (CMake wants just directory names):
     SET(LIBMESH_INCLUDE_DIRS)
     FOREACH(_include ${_libmesh_raw_includes})
       STRING(REGEX REPLACE "^-I" "" _directory "${_include}")
       LIST(APPEND LIBMESH_INCLUDE_DIRS ${_directory})
     ENDFOREACH()
+    MESSAGE(STATUS "LIBMESH_INCLUDE_DIRS: ${LIBMESH_INCLUDE_DIRS}")
 
     # we won't use it directly but see if libMesh expects C++14 by checking its C++ flags:
     EXECUTE_PROCESS(COMMAND "${_libmesh_config}" "--cxxflags" OUTPUT_VARIABLE _libmesh_cxxflags)
-    STRING(REGEX REPLACE "\n$" "" _libmesh_cxxflags ${_libmesh_cxxflags})
+    STRING(REGEX REPLACE "\n$" " " _libmesh_cxxflags ${_libmesh_cxxflags})
     SEPARATE_ARGUMENTS(_libmesh_cxxflags)
-
-    SET(CMAKE_REQUIRED_INCLUDES "${LIBMESH_INCLUDE_DIRS}")
-    SET(CMAKE_REQUIRED_FLAGS "${_libmesh_cxxflags}")
+    ## CXX_FLAGS is not comma-separated so pull things out again
+    STRING(REPLACE ";" " " ${_libmesh_cxxflags} CMAKE_REQUIRED_FLAGS)
+    SET(CMAKE_REQUIRED_INCLUDES ${LIBMESH_INCLUDE_DIRS})
 
     # figure out which version of C++ libMesh wants to use:
     SET(LIBMESH_CXX_VERSION 11) # we require C++11 anyway so use it as the default
@@ -530,8 +530,8 @@ The version of PETSc detected by libMesh differs from the version of PETSc \
 detected by IBAMR. This is not allowed.")
     ENDIF()
 
-    SET(CMAKE_REQUIRED_INCLUDES "")
     SET(CMAKE_REQUIRED_FLAGS "")
+    SET(CMAKE_REQUIRED_INCLUDES "")
   ENDIF()
 ELSE()
   MESSAGE(STATUS "LIBMESH_ROOT was not specified so IBAMR will be configured without it.")


### PR DESCRIPTION
These should be a string of flags, not a semicolon-separated (i.e., CMake) list. It looks CMake 3.20 is strict enough in checking error codes that it detects this mistake.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
