### PR TITLE
Fix a problem with overload resolution and the secondary hierarchy.

### DIFF
--- a/ibtk/src/utilities/SecondaryHierarchy.cpp
+++ b/ibtk/src/utilities/SecondaryHierarchy.cpp
@@ -204,7 +204,7 @@ SecondaryHierarchy::reinit(int coarsest_patch_level_number,
         Pointer<RefineAlgorithm<NDIM> > refine_algorithm = new RefineAlgorithm<NDIM>();
         Pointer<RefineOperator<NDIM> > refine_op = nullptr;
         refine_algorithm->registerRefine(workload_idx, workload_idx, workload_idx, refine_op);
-        auto schedule = refine_algorithm->createSchedule("DEFAULT_FILL", new_level, old_level, nullptr, false, nullptr);
+        auto schedule = refine_algorithm->createSchedule("DEFAULT_FILL", new_level, old_level);
 
         schedule->fillData(0.0);
     }
@@ -242,7 +242,7 @@ SecondaryHierarchy::reinit(int coarsest_patch_level_number,
         Pointer<RefineAlgorithm<NDIM> > refine_algorithm = new RefineAlgorithm<NDIM>();
         Pointer<RefineOperator<NDIM> > refine_op = nullptr;
         refine_algorithm->registerRefine(workload_idx, workload_idx, workload_idx, refine_op);
-        auto schedule = refine_algorithm->createSchedule("DEFAULT_FILL", new_level, old_level, nullptr, false, nullptr);
+        auto schedule = refine_algorithm->createSchedule("DEFAULT_FILL", new_level, old_level);
         schedule->fillData(0.0);
     }
 }
@@ -264,7 +264,7 @@ SecondaryHierarchy::getPrimaryToScratchSchedule(const int level_number,
         Pointer<RefineOperator<NDIM> > refine_op_f = nullptr;
         refine_algorithm->registerRefine(scratch_data_idx, primary_data_idx, scratch_data_idx, refine_op_f);
         d_transfer_forward_schedules[key] =
-            refine_algorithm->createSchedule("DEFAULT_FILL", scratch_level, level, patch_strategy, false, nullptr);
+            refine_algorithm->createSchedule("DEFAULT_FILL", scratch_level, level, patch_strategy);
     }
     return *d_transfer_forward_schedules[key];
 } // getPrimaryToScratchSchedule
@@ -285,7 +285,7 @@ SecondaryHierarchy::getScratchToPrimarySchedule(const int level_number,
         Pointer<RefineOperator<NDIM> > refine_op_b = nullptr;
         refine_algorithm->registerRefine(primary_data_idx, scratch_data_idx, primary_data_idx, refine_op_b);
         d_transfer_backward_schedules[key] =
-            refine_algorithm->createSchedule("DEFAULT_FILL", level, scratch_level, patch_strategy, false, nullptr);
+            refine_algorithm->createSchedule("DEFAULT_FILL", level, scratch_level, patch_strategy);
     }
     return *d_transfer_backward_schedules[key];
 } // getScratchToPrimarySchedule

--- a/tests/IBTK/secondary_hierarchy_01.cpp
+++ b/tests/IBTK/secondary_hierarchy_01.cpp
@@ -39,8 +39,6 @@
 
 #include <ibtk/app_namespaces.h>
 
-// test showing orders of accuracy for a cell-centered Laplace solver.
-
 int
 main(int argc, char* argv[])
 {


### PR DESCRIPTION
Since `tbox::Pointer`s can be converted to eachother all the way up through the `DescribedClass` base class we cannot specify default arguments here. I'm not sure how this works with new versions of GCC.

Regardless the fix is very easy - just delete unnecessary default arguments.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
