### PR TITLE
Combine evaluation of PK1 stress functions.

### DIFF
--- a/doc/news/changes/minor/20210706DavidWells
+++ b/doc/news/changes/minor/20210706DavidWells
@@ -1,0 +1,7 @@
+Improved: FEMechanicsBase (and therefore IBFEMethod) will evaluate all PK1
+functions corresponding to the same registered libMesh systems and quadrature
+rules inside a single loop, rather than independently looping over each PK1
+function independently. This essentially eliminates the overhead of using
+multiple PK1 stress functions.
+<br>
+(David Wells, 2021/07/06)

--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -196,6 +196,12 @@ struct SystemData
     std::string system_name;
     std::vector<int> vars, grad_vars;
     libMesh::NumericVector<double>* system_vec;
+
+    bool operator==(const SystemData& other) const
+    {
+        return system_name == other.system_name && vars == other.vars && grad_vars == other.grad_vars &&
+               system_vec == other.system_vec;
+    }
 };
 
 using ScalarMeshFcnPtr =


### PR DESCRIPTION
There is a lot of overhead in this loop since we need to do the same things (find FF, possibly evaluate position and velocity values, etc) for each PK1 stress function. We can essentially eliminate all the overhead by just combining together sufficiently similar PK1 stress functions - i.e., we do the same stuff if we have the same libMesh systems and quadrature rules.

Fixes #996.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?