### PR TITLE
Print required and optional CMake paths in different places.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,16 +89,26 @@ SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 #
 # With modern CMake, each find module uses the environment variable ending in
 # _ROOT to look for an installation.
-SET(_roots "Boost_ROOT" "Eigen3_ROOT" "GSL_ROOT" "HDF5_ROOT" "HYPRE_ROOT"
-  "LIBMESH_ROOT" "MUPARSER_ROOT" "MPI_ROOT" "NUMDIFF_ROOT" "PETSC_ROOT"
-  "SAMRAI_ROOT" "SILO_ROOT" "ZLIB_ROOT")
-FOREACH(_root ${_roots})
+SET(_required_roots "Boost_ROOT" "Eigen3_ROOT" "HDF5_ROOT" "HYPRE_ROOT"
+  "MUPARSER_ROOT" "MPI_ROOT" "PETSC_ROOT" "SAMRAI_ROOT")
+FOREACH(_root ${_required_roots})
   IF("${${_root}}" STREQUAL "")
     MESSAGE(STATUS "${_root} was not provided to CMake: default search paths will be used.")
   ELSE()
     MESSAGE(STATUS "${_root}=${${_root}}")
   ENDIF()
 ENDFOREACH()
+
+SET(_optional_roots "GSL_ROOT" "LIBMESH_ROOT" "NUMDIFF_ROOT" "SILO_ROOT" "ZLIB_ROOT")
+FOREACH(_root ${_optional_roots})
+  IF("${${_root}}" STREQUAL "")
+    MESSAGE(STATUS "${_root} was not provided to CMake: since this is an \
+optional dependency IBAMR will be configured without this package.")
+  ELSE()
+    MESSAGE(STATUS "${_root}=${${_root}}")
+  ENDIF()
+ENDFOREACH()
+
 
 # ---------------------------------------------------------------------------- #
 #                       1: manage mandatory dependencies                       #


### PR DESCRIPTION
The usual list isn't relevant.