### PR TITLE
Make ExodusII optional in the tests.

### DIFF
--- a/tests/fe_mechanics/fe_mechanics_ex0.cpp
+++ b/tests/fe_mechanics/fe_mechanics_ex0.cpp
@@ -223,7 +223,16 @@ main(int argc, char* argv[])
         // Get various standard options set in the input file.
         const bool dump_viz_data = app_initializer->dumpVizData();
         const int viz_dump_interval = app_initializer->getVizDumpInterval();
+#ifdef LIBMESH_HAVE_EXODUS_API
         const bool uses_exodus = dump_viz_data && !app_initializer->getExodusIIFilename().empty();
+#else
+        const bool uses_exodus = false;
+        if (!app_initializer->getExodusIIFilename().empty())
+        {
+            plog << "WARNING: libMesh was compiled without Exodus support, so no "
+                 << "Exodus output will be written in this program.\n";
+        }
+#endif
         const string exodus_filename = app_initializer->getExodusIIFilename();
 
         const bool dump_restart_data = app_initializer->dumpRestartData();

--- a/tests/spread/spread_02.cpp
+++ b/tests/spread/spread_02.cpp
@@ -367,11 +367,13 @@ main(int argc, char** argv)
 
         visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
 
+#ifdef LIBMESH_HAVE_EXODUS_API
         {
             std::unique_ptr<ExodusII_IO> exodus_io(new ExodusII_IO(*meshes[0]));
             EquationSystems* equation_systems = ib_method_ops->getFEDataManager()->getEquationSystems();
             exodus_io->write_timestep("out.ex2", *equation_systems, 1, 0.0);
         }
+#endif
 
         {
             const int ln = patch_hierarchy->getFinestLevelNumber();


### PR DESCRIPTION
I still have ExodusII installed with libMesh but I checked every file that writes exodus output and all of them now check that we have it installed.

We only use ExodusII for plotting in applications - its not actually used inside the library itself.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
