### PR TITLE
Remove an exported boost preprocessor symbol.

### DIFF
--- a/cmake/IBAMRConfig.cmake.in
+++ b/cmake/IBAMRConfig.cmake.in
@@ -22,6 +22,16 @@ FIND_PACKAGE(MPI REQUIRED)
 IF(NOT @IBAMR_USE_BUNDLED_Boost@)
   SET(Boost_ROOT "@Boost_ROOT@")
   FIND_PACKAGE(Boost 1.57 REQUIRED)
+
+  # We do not want to set BOOST_ALL_NO_LIB in case IBAMR is linked to other
+  # libraries that *do* link against boost libraries
+  GET_TARGET_PROPERTY(_boost_definitions Boost::headers
+    INTERFACE_COMPILE_DEFINITIONS)
+  MESSAGE(STATUS "compile defs are ${_boost_definitions}")
+  LIST(REMOVE_ITEM _boost_definitions "BOOST_ALL_NO_LIB")
+  MESSAGE(STATUS "compile defs are ${_boost_definitions}")
+  SET_TARGET_PROPERTIES(Boost::headers PROPERTIES INTERFACE_COMPILE_DEFINITIONS
+    "${_boost_definitions}")
 ENDIF()
 
 IF(NOT @IBAMR_USE_BUNDLED_Eigen3@)


### PR DESCRIPTION
This is nice to have during compilation (since we do not officially require anything more than the boost headers) but it really should not be set when users use IBAMR since they may want to use other parts of boost.

An example: https://github.com/drwells/fiddle uses IBAMR + deal.II, and deal.II uses the boost serialization library which is not header-only. For reasons I don't fully understand things seem to work, but it doesn't make sense to define this symbol in this circumstance, so we just shouldn't define it and let users do whatever they think is appropriate.

As usual, the list doesn't apply.

@abarret it would help if you could try this one out too before merging.