### PR TITLE
Revert attest to require Python 3.5.

### DIFF
--- a/attest
+++ b/attest
@@ -294,7 +294,8 @@ class Test:
             try:
                 run_result = subprocess.run(
                     run_args,
-                    capture_output=True,
+                    stderr=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
                     cwd=temporary_directory,
                     timeout=self._parameters.test_timeout)
                 if self._expect_error:
@@ -307,7 +308,8 @@ class Test:
                     if self.do_restart():
                         run_args += ["./restart/", str(self.restart_n())]
                         run_result = subprocess.run(run_args,
-                                                    capture_output=True,
+                                                    stderr=subprocess.PIPE,
+                                                    stdout=subprocess.PIPE,
                                                     cwd=temporary_directory)
                         run_succeeded = run_result.returncode == 0
                 test_timed_out = False
@@ -325,7 +327,8 @@ class Test:
                         [self._parameters.numdiff] + numdiff_flags +
                         [self.output_file, temporary_directory + os.sep
                          + "output"],
-                        capture_output=True,
+                        stderr=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
                         # allow the test runner to crash if numdiff somehow
                         # times out
                         timeout=self._parameters.test_timeout)

--- a/src/IB/ConstraintIBMethod.cpp
+++ b/src/IB/ConstraintIBMethod.cpp
@@ -964,7 +964,7 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
                     const int local_idx = node_idx->getLocalPETScIndex();
-                    const Vector& displacement = node_idx->getPeriodicDisplacement();
+                    const IBTK::Vector& displacement = node_idx->getPeriodicDisplacement();
                     const double* const X_current = &X_data_current[local_idx][0];
                     const double* const X_new = &X_data_new[local_idx][0];
                     for (unsigned int d = 0; d < NDIM; ++d)
@@ -1098,7 +1098,7 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
                     const int local_idx = node_idx->getLocalPETScIndex();
-                    const Vector& displacement = node_idx->getPeriodicDisplacement();
+                    const IBTK::Vector& displacement = node_idx->getPeriodicDisplacement();
                     const double* const X_current = &X_data_current[local_idx][0];
                     const double* const X_new = &X_data_new[local_idx][0];
 #if (NDIM == 2)
@@ -1333,7 +1333,7 @@ ConstraintIBMethod::calculateMomentumOfKinematicsVelocity(const int position_han
                 {
                     const int local_idx = node_idx->getLocalPETScIndex();
                     const double* const X = &X_data[local_idx][0];
-                    const Vector& displacement = node_idx->getPeriodicDisplacement();
+                    const IBTK::Vector& displacement = node_idx->getPeriodicDisplacement();
 #if (NDIM == 2)
                     double x = displacement[0] + X[0] - d_center_of_mass_unshifted_new[position_handle][0];
                     double y = displacement[1] + X[1] - d_center_of_mass_unshifted_new[position_handle][1];
@@ -1662,7 +1662,7 @@ ConstraintIBMethod::calculateRigidRotationalMomentum()
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
                     const int local_idx = node_idx->getLocalPETScIndex();
-                    const Vector& displacement = node_idx->getPeriodicDisplacement();
+                    const IBTK::Vector& displacement = node_idx->getPeriodicDisplacement();
                     const double* const U = &U_interp_data[local_idx][0];
                     const double* const X = &X_data[local_idx][0];
 #if (NDIM == 2)
@@ -1787,7 +1787,7 @@ ConstraintIBMethod::calculateCurrentLagrangianVelocity()
                     }
 
                     // Rotational velocity
-                    const Vector& displacement = node_idx->getPeriodicDisplacement();
+                    const IBTK::Vector& displacement = node_idx->getPeriodicDisplacement();
                     if (struct_param.getStructureIsSelfRotating())
                     {
                         for (int d = 0; d < NDIM; ++d)
@@ -1892,7 +1892,7 @@ ConstraintIBMethod::correctVelocityOnLagrangianMesh()
                     }
 
                     // Rotational velocity
-                    const Vector& displacement = node_idx->getPeriodicDisplacement();
+                    const IBTK::Vector& displacement = node_idx->getPeriodicDisplacement();
                     if (struct_param.getStructureIsSelfRotating())
                     {
                         for (int d = 0; d < NDIM; ++d)
@@ -2602,7 +2602,7 @@ ConstraintIBMethod::calculateTorque()
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
                     const int local_idx = node_idx->getLocalPETScIndex();
-                    const Vector& displacement = node_idx->getPeriodicDisplacement();
+                    const IBTK::Vector& displacement = node_idx->getPeriodicDisplacement();
                     const double* const U_new = &U_new_data[local_idx][0];
                     const double* const U_current = &U_current_data[local_idx][0];
                     const double* const U_correction = &U_correction_data[local_idx][0];
@@ -2847,7 +2847,7 @@ ConstraintIBMethod::calculateStructureRotationalMomentum()
                 if (lag_idx_range.first <= lag_idx && lag_idx < lag_idx_range.second)
                 {
                     const int local_idx = node_idx->getLocalPETScIndex();
-                    const Vector& displacement = node_idx->getPeriodicDisplacement();
+                    const IBTK::Vector& displacement = node_idx->getPeriodicDisplacement();
                     const double* const U_new = &U_new_data[local_idx][0];
                     const double* const X = &X_data[local_idx][0];
 #if (NDIM == 2)

--- a/tests/IBFE/explicit_ex8.cpp
+++ b/tests/IBFE/explicit_ex8.cpp
@@ -256,7 +256,7 @@ compute_inflow_flux(const Pointer<PatchHierarchy<NDIM> > hierarchy, const int U_
                 static const int side = 0;
                 if (pgeom->getTouchesRegularBoundary(axis, side))
                 {
-                    Vector n;
+                    IBTK::Vector n;
                     for (int d = 0; d < NDIM; ++d)
                     {
                         n[d] = axis == d ? +1.0 : 0.0;


### PR DESCRIPTION
In #1289 we obtained an implicit dependence on Python 3.7. This reverts that change.

I've also included a few needed `Vector` namespace changes.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
