### PR TITLE
Check that PETSc does not use 64bit indices.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,19 +352,38 @@ ENDFOREACH()
 #
 MESSAGE(STATUS "")
 MESSAGE(STATUS "Setting up PETSc")
-FIND_FILE(PETSC_VARIABLES_FILE petscvariables HINTS ${PETSC_ROOT} PATH_SUFFIXES conf lib/petsc/conf)
+FIND_FILE(PETSC_VARIABLES_FILE petscvariables HINTS ${PETSC_ROOT}
+  PATH_SUFFIXES conf lib/petsc/conf)
 IF(${PETSC_VARIABLES_FILE} STREQUAL "PETSC_VARIABLES_FILE-NOTFOUND")
   MESSAGE(FATAL_ERROR "unable to find the petscvariables configuration file")
 ELSE()
   FILE(STRINGS ${PETSC_VARIABLES_FILE} _petsc_raw_includes REGEX "^PETSC_CC_INCLUDES =.*")
   IF ("${_petsc_raw_includes}" STREQUAL "")
     MESSAGE(FATAL_ERROR
-      "The configuration script was unable to find the list of                       \
+      "The configuration script was unable to find the list of                 \
 PETSc include directories in the file ${PETSC_VARIABLES_FILE}. This usually    \
 indicates that PETSC_ROOT was set to PETSC_DIR when it should be set to        \
 PETSC_DIR/PETSC_ARCH (i.e., PETSC_ROOT must be set to the complete path to the \
 PETSc installation).")
   ENDIF()
+
+  # We do not yet support PETSc with 64-bit integers
+  #
+  # TODO - we can use REQUIRED in FIND_FILE in CMake 3.18 and newer
+  FIND_FILE(PETSC_CONF_FILE petscconf.h HINTS ${PETSC_ROOT}
+    PATH_SUFFIXES petsc include include/petsc)
+  IF(${PETSC_VARIABLES_FILE} STREQUAL "PETSC_CONF_FILE-NOTFOUND")
+    MESSAGE(FATAL_ERROR "unable to find the petscconf.h configuration file")
+  ELSE()
+    FILE(STRINGS ${PETSC_CONF_FILE} _petsc_have_64bit_indices REGEX
+      "^ *# *define.*PETSC_USE_64BIT_INDICES *1")
+    IF(NOT ${_petsc_have_64bit_indices} STREQUAL "")
+      MESSAGE(FATAL_ERROR "IBAMR does not support using 64 bit indices with \
+PETSc at this time. Please recompile PETSc (and any dependencies, such as   \
+libMesh, it may have) to NOT use 64 bit indices.")
+    ENDIF()
+  ENDIF()
+
   STRING(REGEX REPLACE "^PETSC_CC_INCLUDES =(.*)" "\\1" _petsc_raw_includes ${_petsc_raw_includes})
   SEPARATE_ARGUMENTS(_petsc_raw_includes)
   # Get rid of preceding -Is (CMake wants just directory names):

--- a/configure
+++ b/configure
@@ -26985,6 +26985,46 @@ if test "$PETSC_VERSION_VALID" = no; then
   as_fn_error $? "invalid PETSc version detected: please use PETSc 3.7 or newer" "$LINENO" 5
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for 64 bit PetscInt" >&5
+$as_echo_n "checking for 64 bit PetscInt... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <petscconf.h>
+#ifdef PETSC_USE_64BIT_INDICES
+/* OK */
+#else
+#error
+#endif
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  PETSC_HAVE_64BIT_INDICES=yes
+else
+  PETSC_HAVE_64BIT_INDICES=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: ${PETSC_HAVE_64BIT_INDICES}" >&5
+$as_echo "${PETSC_HAVE_64BIT_INDICES}" >&6; }
+if test "$PETSC_HAVE_64BIT_INDICES" = yes; then
+  as_fn_error $? "invalid PETSc version detected: IBAMR does not support 64bit indices in PETSc. Compile PETSc without 64bit indices (i.e., use --with-64-bit-indices=off)" "$LINENO" 5
+fi
+
 PETSC_LDFLAGS=""
 if test -d "${PETSC_DIR}/${PETSC_ARCH}/lib" ; then
   PETSC_LDFLAGS="-L${PETSC_DIR}/${PETSC_ARCH}/lib"

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -27149,6 +27149,46 @@ if test "$PETSC_VERSION_VALID" = no; then
   as_fn_error $? "invalid PETSc version detected: please use PETSc 3.7 or newer" "$LINENO" 5
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for 64 bit PetscInt" >&5
+$as_echo_n "checking for 64 bit PetscInt... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <petscconf.h>
+#ifdef PETSC_USE_64BIT_INDICES
+/* OK */
+#else
+#error
+#endif
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  PETSC_HAVE_64BIT_INDICES=yes
+else
+  PETSC_HAVE_64BIT_INDICES=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: ${PETSC_HAVE_64BIT_INDICES}" >&5
+$as_echo "${PETSC_HAVE_64BIT_INDICES}" >&6; }
+if test "$PETSC_HAVE_64BIT_INDICES" = yes; then
+  as_fn_error $? "invalid PETSc version detected: IBAMR does not support 64bit indices in PETSc. Compile PETSc without 64bit indices (i.e., use --with-64-bit-indices=off)" "$LINENO" 5
+fi
+
 PETSC_LDFLAGS=""
 if test -d "${PETSC_DIR}/${PETSC_ARCH}/lib" ; then
   PETSC_LDFLAGS="-L${PETSC_DIR}/${PETSC_ARCH}/lib"

--- a/m4/configure_petsc.m4
+++ b/m4/configure_petsc.m4
@@ -51,6 +51,20 @@ if test "$PETSC_VERSION_VALID" = no; then
   AC_MSG_ERROR([invalid PETSc version detected: please use PETSc 3.7 or newer])
 fi
 
+AC_MSG_CHECKING([for 64 bit PetscInt])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <petscconf.h>
+#ifdef PETSC_USE_64BIT_INDICES
+/* OK */
+#else
+#error
+#endif
+]])],[PETSC_HAVE_64BIT_INDICES=yes],[PETSC_HAVE_64BIT_INDICES=no])
+AC_MSG_RESULT([${PETSC_HAVE_64BIT_INDICES}])
+if test "$PETSC_HAVE_64BIT_INDICES" = yes; then
+  AC_MSG_ERROR([invalid PETSc version detected: IBAMR does not support 64bit indices in PETSc. Compile PETSc without 64bit indices (i.e., use --with-64-bit-indices=off)])
+fi
+
 PETSC_LDFLAGS=""
 if test -d "${PETSC_DIR}/${PETSC_ARCH}/lib" ; then
   PETSC_LDFLAGS="-L${PETSC_DIR}/${PETSC_ARCH}/lib"


### PR DESCRIPTION
The usual checklist doesn't apply since this doesn't change the library.