### PR TITLE
Skip -Wparentheses in external headers.

### DIFF
--- a/ibtk/include/ibtk/config.h.in
+++ b/ibtk/include/ibtk/config.h.in
@@ -76,6 +76,7 @@ _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")     \
 _Pragma("GCC diagnostic ignored \"-Wunused-local-typedefs\"")   \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-copy\"")         \
 _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")        \
+_Pragma("GCC diagnostic ignored \"-Wparentheses\"")             \
 _Pragma("GCC diagnostic ignored \"-Wunneeded-internal-declaration\"")
 
 #define IBTK_ENABLE_EXTRA_WARNINGS _Pragma("GCC diagnostic pop")


### PR DESCRIPTION
Needed to work around some boost warnings.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

Fixes the annoying boost warnings @boyceg, @marshallrdavey, and myself just saw.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?