### PR TITLE
Also avoid -Wparentheses warnings with autotools.

### DIFF
--- a/ibtk/config/config.h.tmp
+++ b/ibtk/config/config.h.tmp
@@ -45,6 +45,7 @@ _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")     \
 _Pragma("GCC diagnostic ignored \"-Wunused-local-typedefs\"")   \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-copy\"")         \
 _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")        \
+_Pragma("GCC diagnostic ignored \"-Wparentheses\"")             \
 _Pragma("GCC diagnostic ignored \"-Wunneeded-internal-declaration\"")
 
 #define IBTK_ENABLE_EXTRA_WARNINGS _Pragma("GCC diagnostic pop")


### PR DESCRIPTION
Same as #1315 but for autotools.

Unfortunately we do need to implement this twice. The ultimate goal is to have a single configuration header - in particular, one that is populated by CMake and is thus incompatible with autotools. Hence the autotools stub header needs to duplicate code.