### PR TITLE
Transfer data inside the SecondaryHierarchy.

### DIFF
--- a/ibtk/include/ibtk/SecondaryHierarchy.h
+++ b/ibtk/include/ibtk/SecondaryHierarchy.h
@@ -77,32 +77,30 @@ public:
                 int workload_idx);
 
     /*!
-     * Get the transfer schedule from the primary hierarchy to the secondary
-     * hierarchy associated with the given level and index. If necessary the
-     * schedule is created and stored in a map.
+     * Transfer data from the primary hierarchy to the secondary hierarchy.
      *
      * If needed, a SAMRAI::xfer::RefinePatchStrategy object can be provided
      * for filling ghost data at physical boundaries.
      */
-    SAMRAI::xfer::RefineSchedule<NDIM>&
-    getPrimaryToSecondarySchedule(int level_number,
-                                  int primary_data_idx,
-                                  int secondary_data_idx,
-                                  SAMRAI::xfer::RefinePatchStrategy<NDIM>* patch_strategy = nullptr);
+    void
+    transferPrimaryToSecondary(int level_number,
+                               int primary_data_idx,
+                               int secondary_data_idx,
+                               double data_time,
+                               SAMRAI::xfer::RefinePatchStrategy<NDIM>* patch_strategy = nullptr);
 
     /*!
-     * Get the transfer schedule from the secondary hierarchy to the primary
-     * hierarchy associated with the given level and index. If necessary the
-     * schedule is created and stored in a map.
+     * Transfer data from the secondary hierarchy to the primary hierarchy.
      *
      * If needed, a SAMRAI::xfer::RefinePatchStrategy object can be provided
      * for filling ghost data at physical boundaries.
      */
-    SAMRAI::xfer::RefineSchedule<NDIM>&
-    getSecondaryToPrimarySchedule(int level_number,
-                                  int primary_data_idx,
-                                  int secondary_data_idx,
-                                  SAMRAI::xfer::RefinePatchStrategy<NDIM>* patch_strategy = nullptr);
+    void
+    transferSecondaryToPrimary(int level_number,
+                               int primary_data_idx,
+                               int secondary_data_idx,
+                               double data_time,
+                               SAMRAI::xfer::RefinePatchStrategy<NDIM>* patch_strategy = nullptr);
 
     /*!
      * Get a copy of the pointer to the secondary scratch object.

--- a/ibtk/src/utilities/SecondaryHierarchy.cpp
+++ b/ibtk/src/utilities/SecondaryHierarchy.cpp
@@ -245,11 +245,12 @@ SecondaryHierarchy::reinit(int coarsest_patch_level_number,
     }
 }
 
-SAMRAI::xfer::RefineSchedule<NDIM>&
-SecondaryHierarchy::getPrimaryToSecondarySchedule(const int level_number,
-                                                  const int primary_data_idx,
-                                                  const int scratch_data_idx,
-                                                  SAMRAI::xfer::RefinePatchStrategy<NDIM>* patch_strategy)
+void
+SecondaryHierarchy::transferPrimaryToSecondary(const int level_number,
+                                               const int primary_data_idx,
+                                               const int scratch_data_idx,
+                                               const double data_time,
+                                               SAMRAI::xfer::RefinePatchStrategy<NDIM>* patch_strategy)
 {
     TBOX_ASSERT(d_secondary_hierarchy);
     const auto key = std::make_pair(level_number, std::make_pair(primary_data_idx, scratch_data_idx));
@@ -264,14 +265,15 @@ SecondaryHierarchy::getPrimaryToSecondarySchedule(const int level_number,
         d_transfer_forward_schedules[key] =
             refine_algorithm->createSchedule("DEFAULT_FILL", scratch_level, level, patch_strategy);
     }
-    return *d_transfer_forward_schedules[key];
+    d_transfer_forward_schedules[key]->fillData(data_time);
 } // getPrimaryToSecondarySchedule
 
-SAMRAI::xfer::RefineSchedule<NDIM>&
-SecondaryHierarchy::getSecondaryToPrimarySchedule(const int level_number,
-                                                  const int primary_data_idx,
-                                                  const int scratch_data_idx,
-                                                  SAMRAI::xfer::RefinePatchStrategy<NDIM>* patch_strategy)
+void
+SecondaryHierarchy::transferSecondaryToPrimary(const int level_number,
+                                               const int primary_data_idx,
+                                               const int scratch_data_idx,
+                                               const double data_time,
+                                               SAMRAI::xfer::RefinePatchStrategy<NDIM>* patch_strategy)
 {
     TBOX_ASSERT(d_secondary_hierarchy);
     const auto key = std::make_pair(level_number, std::make_pair(primary_data_idx, scratch_data_idx));
@@ -285,7 +287,7 @@ SecondaryHierarchy::getSecondaryToPrimarySchedule(const int level_number,
         d_transfer_backward_schedules[key] =
             refine_algorithm->createSchedule("DEFAULT_FILL", level, scratch_level, patch_strategy);
     }
-    return *d_transfer_backward_schedules[key];
+    d_transfer_backward_schedules[key]->fillData(data_time);
 } // getSecondaryToPrimarySchedule
 
 std::shared_ptr<IBTK::SAMRAIDataCache>

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -666,8 +666,7 @@ IBFEMethod::interpolateVelocity(const int u_data_idx,
         for (int ln = 0; ln <= getFinestPatchLevelNumber(); ++ln)
         {
             d_secondary_hierarchy
-                ->getPrimaryToSecondarySchedule(ln, u_data_idx, u_data_idx, d_ib_solver->getVelocityPhysBdryOp())
-                .fillData(data_time);
+                ->transferPrimaryToSecondary(ln, u_data_idx, u_data_idx, data_time, d_ib_solver->getVelocityPhysBdryOp());
         }
     }
     else
@@ -1060,8 +1059,7 @@ IBFEMethod::spreadForce(const int f_data_idx,
             f_primary_data_ops->setToScalar(f_primary_scratch_data_idx,
                                             0.0,
                                             /*interior_only*/ false);
-            d_secondary_hierarchy->getSecondaryToPrimarySchedule(ln, f_primary_scratch_data_idx, f_scratch_data_idx)
-                .fillData(data_time);
+            d_secondary_hierarchy->transferSecondaryToPrimary(ln, f_primary_scratch_data_idx, f_scratch_data_idx, data_time);
             f_primary_data_ops->add(f_data_idx, f_data_idx, f_primary_scratch_data_idx);
         }
     }
@@ -1200,8 +1198,7 @@ IBFEMethod::spreadFluidSource(const int q_data_idx,
     {
         assertStructureOnFinestLevel();
         d_secondary_hierarchy
-            ->getPrimaryToSecondarySchedule(d_hierarchy->getFinestLevelNumber(), q_data_idx, q_data_idx)
-            .fillData(data_time);
+            ->transferPrimaryToSecondary(d_hierarchy->getFinestLevelNumber(), q_data_idx, q_data_idx, data_time);
     }
 
     for (unsigned int part = 0; part < d_meshes.size(); ++part)
@@ -1222,8 +1219,7 @@ IBFEMethod::spreadFluidSource(const int q_data_idx,
     {
         assertStructureOnFinestLevel();
         d_secondary_hierarchy
-            ->getSecondaryToPrimarySchedule(d_hierarchy->getFinestLevelNumber(), q_data_idx, q_data_idx)
-            .fillData(data_time);
+            ->transferSecondaryToPrimary(d_hierarchy->getFinestLevelNumber(), q_data_idx, q_data_idx, data_time);
     }
 
     IBAMR_TIMER_STOP(t_spread_fluid_source);
@@ -1476,9 +1472,8 @@ void IBFEMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierar
         for (int ln = 0; ln <= getFinestPatchLevelNumber(); ++ln)
         {
             d_secondary_hierarchy
-                ->getSecondaryToPrimarySchedule(
-                    ln, d_lagrangian_workload_current_idx, d_lagrangian_workload_current_idx)
-                .fillData(0.0);
+                ->transferSecondaryToPrimary(
+                    ln, d_lagrangian_workload_current_idx, d_lagrangian_workload_current_idx, 0.0);
         }
     }
 


### PR DESCRIPTION
I want to put this in now so that we can go back and add more timers later -
that will make it easier to justify the choice of multiple Eulerian data
partitionings in the load balancing paper.

In particular, I want to merge this now since this is an API change and we don't
have to worry about compatibility with this class yet since it is new in 0.9.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
