### PR TITLE
Fix cmake no libmesh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -960,8 +960,10 @@ FUNCTION(IBAMR_SETUP_TARGET_LIBRARY target_library)
 
   # we and our users will use these MPI functions so make the interface public:
   TARGET_LINK_LIBRARIES(${target_library} PUBLIC MPI::MPI_C)
-  # libMesh is underlinked and needs MPI's C++ library
-  IF(${IBAMR_HAVE_LIBMESH})
+  # If openMPI is built with the old C++ bindings enabled then we need to link
+  # against them, since we don't consistently define OMPI_SKIP_MPICXX. We always
+  # need this with libMesh since libMesh is underlinked.
+  IF(${MPI_MPICXX_FOUND})
     TARGET_LINK_LIBRARIES(${target_library} PUBLIC MPI::MPI_CXX)
   ENDIF()
   # Silo is underlinked and depends on HDF5, so do it first:

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -90,8 +90,7 @@ MACRO(IBAMR_ADD_EXAMPLE)
       CONFIGURE_FILE("${_extra_file}" "${EX_OUTPUT_DIRECTORY}" COPYONLY)
     ENDFOREACH()
   ELSE()
-    MESSAGE(WARNING "Example ${EX_TARGET_NAME} could not be set up since the "
-      "required feature ${_failed_requirement} = FALSE")
+    MESSAGE(STATUS "Example ${EX_TARGET_NAME} requires libMesh - skipping")
   ENDIF()
 ENDMACRO()
 

--- a/examples/IBLevelSet/ex1/example.cpp
+++ b/examples/IBLevelSet/ex1/example.cpp
@@ -227,7 +227,7 @@ main(int argc, char* argv[])
 
         navier_stokes_integrator->registerAdvDiffHierarchyIntegrator(adv_diff_integrator);
 
-        Pointer<IBFEMethod> ibfe_method_ops = nullptr;
+        Pointer<IBStrategy> ibfe_method_ops = nullptr;
         Pointer<IBInterpolantMethod> ib_interpolant_method_ops = new IBInterpolantMethod(
             "IBInterpolantMethod", app_initializer->getComponentDatabase("IBInterpolantMethod"));
         Pointer<IBLevelSetMethod> ib_level_set_method_ops =

--- a/examples/complex_fluids/ex2/CMakeLists.txt
+++ b/examples/complex_fluids/ex2/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (c) 2020 - 2020 by the IBAMR developers
+## Copyright (c) 2020 - 2021 by the IBAMR developers
 ## All rights reserved.
 ##
 ## This file is part of IBAMR.
@@ -22,6 +22,8 @@ IBAMR_ADD_EXAMPLE(
     examples-complex_fluids
   SOURCES
     example.cpp InterpolationUtilities.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
   LINK_TARGETS
     IBAMR2d
   INPUT_FILES
@@ -41,6 +43,8 @@ IBAMR_ADD_EXAMPLE(
     examples-complex_fluids
   SOURCES
     convergence_tester.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
   LINK_TARGETS
     IBAMR2d
     )

--- a/examples/complex_fluids/ex4/CMakeLists.txt
+++ b/examples/complex_fluids/ex4/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (c) 2020 - 2020 by the IBAMR developers
+## Copyright (c) 2020 - 2021 by the IBAMR developers
 ## All rights reserved.
 ##
 ## This file is part of IBAMR.
@@ -22,6 +22,8 @@ IBAMR_ADD_EXAMPLE(
     examples-complex_fluids
   SOURCES
     example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
   LINK_TARGETS
     IBAMR2d
   INPUT_FILES

--- a/examples/fe_mechanics/ex0/CMakeLists.txt
+++ b/examples/fe_mechanics/ex0/CMakeLists.txt
@@ -22,6 +22,8 @@ IBAMR_ADD_EXAMPLE(
     examples-fe_mechanics
   SOURCES
     example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
   LINK_TARGETS
     IBAMR2d
   INPUT_FILES
@@ -39,6 +41,8 @@ IBAMR_ADD_EXAMPLE(
     examples-fe_mechanics
   SOURCES
     example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
   LINK_TARGETS
     IBAMR3d
   INPUT_FILES

--- a/examples/multiphase_flow/ex2/CMakeLists.txt
+++ b/examples/multiphase_flow/ex2/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (c) 2020 - 2020 by the IBAMR developers
+## Copyright (c) 2020 - 2021 by the IBAMR developers
 ## All rights reserved.
 ##
 ## This file is part of IBAMR.
@@ -24,6 +24,8 @@ IBAMR_ADD_EXAMPLE(
     GravityForcing.cpp LSLocateCircularInterface.cpp LSLocateGasInterface.cpp
     SetFluidGasSolidDensity.cpp SetFluidGasSolidViscosity.cpp SetLSProperties.cpp
     TagLSRefinementCells.cpp example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
   LINK_TARGETS
     IBAMR2d
   INPUT_FILES

--- a/ibtk/include/ibtk/BoxPartitioner.h
+++ b/ibtk/include/ibtk/BoxPartitioner.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include <ibtk/PartitioningBox.h>
 
 #include <libmesh/mesh_base.h>
@@ -110,4 +112,5 @@ protected:
 };
 } // namespace IBTK
 //////////////////////////////////////////////////////////////////////////////
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_boxpartitioner

--- a/ibtk/include/ibtk/FECache.h
+++ b/ibtk/include/ibtk/FECache.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include <ibtk/QuadratureCache.h>
 
 #include <tbox/Utilities.h>
@@ -282,4 +284,5 @@ FECache::operator()(const FECache::key_type& quad_key, const libMesh::Elem* elem
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_FECache

--- a/ibtk/include/ibtk/FEDataInterpolation.h
+++ b/ibtk/include/ibtk/FEDataInterpolation.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include "ibtk/FEDataManager.h"
 #include "ibtk/FEValues.h"
 #include "ibtk/libmesh_utilities.h"
@@ -373,4 +375,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_FEDataInterpolation

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include "ibtk/QuadratureCache.h"
 #include "ibtk/SAMRAIDataCache.h"
 #include "ibtk/ibtk_enums.h"
@@ -1353,4 +1355,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_FEDataManager

--- a/ibtk/include/ibtk/FEMapping.h
+++ b/ibtk/include/ibtk/FEMapping.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include <ibtk/FECache.h>
 #include <ibtk/ibtk_utilities.h>
 
@@ -611,4 +613,5 @@ std::unique_ptr<FEMapping<3, 3> > FEMapping<3, 3>::build(const key_type key, con
 
 } // namespace IBTK
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_FEMapping

--- a/ibtk/include/ibtk/FEMappingCache.h
+++ b/ibtk/include/ibtk/FEMappingCache.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include <ibtk/FECache.h>
 #include <ibtk/FEMapping.h>
 #include <ibtk/libmesh_utilities.h>
@@ -136,4 +138,5 @@ FEMappingCache<dim, spacedim>::operator[](const FEMappingCache<dim, spacedim>::k
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_FEMappingCache

--- a/ibtk/include/ibtk/FEProjector.h
+++ b/ibtk/include/ibtk/FEProjector.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include <ibtk/FischerGuess.h>
 
 #include <libmesh/equation_systems.h>
@@ -210,4 +212,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_FEProjector

--- a/ibtk/include/ibtk/FEValues.h
+++ b/ibtk/include/ibtk/FEValues.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include <ibtk/FECache.h>
 #include <ibtk/FEMapping.h>
 
@@ -151,4 +153,5 @@ protected:
 };
 } // namespace IBTK
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_FEValues

--- a/ibtk/include/ibtk/FischerGuess.h
+++ b/ibtk/include/ibtk/FischerGuess.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include <libmesh/numeric_vector.h>
 
 IBTK_DISABLE_EXTRA_WARNINGS
@@ -96,4 +98,5 @@ protected:
 };
 } // namespace IBTK
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif

--- a/ibtk/include/ibtk/IBTKInit.h
+++ b/ibtk/include/ibtk/IBTKInit.h
@@ -20,15 +20,14 @@
 
 #include <ibtk/config.h>
 
-#include "SAMRAI_config.h"
-#include "tbox/SAMRAIManager.h"
-#include "tbox/SAMRAI_MPI.h"
+#include <tbox/Utilities.h>
 
-#include <petscsys.h>
 #ifdef IBTK_HAVE_LIBMESH
-#include "libmesh/libmesh.h"
-#include "libmesh/reference_counter.h"
+#include <libmesh/libmesh.h>
+#include <libmesh/reference_counter.h>
 #endif
+
+#include <mpi.h>
 
 namespace IBTK
 {

--- a/ibtk/include/ibtk/LibMeshSystemVectors.h
+++ b/ibtk/include/ibtk/LibMeshSystemVectors.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include <libmesh/equation_systems.h>
 #include <libmesh/petsc_vector.h>
 #include <libmesh/system.h>
@@ -162,4 +164,5 @@ protected:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_AppInitializer

--- a/ibtk/include/ibtk/QuadratureCache.h
+++ b/ibtk/include/ibtk/QuadratureCache.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include <ibtk/libmesh_utilities.h>
 
 #include <libmesh/enum_elem_type.h>
@@ -129,4 +131,5 @@ QuadratureCache::operator[](const QuadratureCache::key_type& quad_key)
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_QuadratureCache

--- a/ibtk/include/ibtk/StableCentroidPartitioner.h
+++ b/ibtk/include/ibtk/StableCentroidPartitioner.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include <ibtk/PartitioningBox.h>
 
 #include <libmesh/mesh_base.h>
@@ -65,4 +67,5 @@ protected:
 };
 } // namespace IBTK
 //////////////////////////////////////////////////////////////////////////////
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_ibtk_stablecentroidpartitioner

--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#ifdef IBTK_HAVE_LIBMESH
+
 #include "ibtk/IBTK_CHKERRQ.h"
 
 #include "tbox/Utilities.h"
@@ -1624,4 +1626,5 @@ std::vector<libMeshWrappers::BoundingBox> get_global_element_bounding_boxes(cons
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBTK_HAVE_LIBMESH
 #endif //#ifndef included_IBTK_libmesh_utilities

--- a/ibtk/src/utilities/IBTKInit.cpp
+++ b/ibtk/src/utilities/IBTKInit.cpp
@@ -13,10 +13,15 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
-#include "ibtk/IBTKInit.h"
-#include "ibtk/IBTK_MPI.h"
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
 
-#include "ibtk/app_namespaces.h"
+#include <tbox/SAMRAIManager.h>
+#include <tbox/SAMRAI_MPI.h>
+
+#include <petscsys.h>
+
+#include <ibtk/app_namespaces.h>
 
 namespace IBTK
 {

--- a/ibtk/src/utilities/IBTK_MPI.cpp
+++ b/ibtk/src/utilities/IBTK_MPI.cpp
@@ -13,17 +13,14 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
-#include "ibtk/IBTK_MPI.h"
+#include <ibtk/IBTK_MPI.h>
 
-#include "SAMRAI_config.h"
-#include "tbox/SAMRAI_MPI.h"
-#include "tbox/Utilities.h"
+#include <tbox/SAMRAI_MPI.h>
+#include <tbox/Utilities.h>
 
 #include <ostream>
 #include <string>
 #include <vector>
-
-#include "ibtk/app_namespaces.h" // IWYU pragma: keep
 
 namespace IBTK
 {
@@ -45,9 +42,9 @@ IBTK_MPI::comm
 IBTK_MPI::getSAMRAIWorld()
 {
 #if SAMRAI_VERSION_MAJOR == 2
-    return SAMRAI_MPI::commWorld;
+    return SAMRAI::tbox::SAMRAI_MPI::commWorld;
 #else
-    return SAMRAI_MPI::getSAMRAIWorld()
+    return SAMRAI::tbox::SAMRAI_MPI::getSAMRAIWorld()
 #endif
 }
 

--- a/include/ibamr/FEMechanicsBase.h
+++ b/include/ibamr/FEMechanicsBase.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#ifdef IBAMR_HAVE_LIBMESH
+
 #include "ibamr/ibamr_enums.h"
 
 #include "ibtk/FEDataManager.h"
@@ -738,4 +740,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBAMR_HAVE_LIBMESH
 #endif //#ifndef included_IBAMR_FEMechanicsBase

--- a/include/ibamr/FESurfaceDistanceEvaluator.h
+++ b/include/ibamr/FESurfaceDistanceEvaluator.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#ifdef IBAMR_HAVE_LIBMESH
+
 #include "ibamr/IBFEMethod.h"
 
 #include "ibtk/IndexUtilities.h"
@@ -233,4 +235,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBAMR_HAVE_LIBMESH
 #endif // #ifndef included_FESurfaceDistanceEvaluator

--- a/include/ibamr/IBFECentroidPostProcessor.h
+++ b/include/ibamr/IBFECentroidPostProcessor.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#ifdef IBAMR_HAVE_LIBMESH
+
 #include "ibamr/IBFEPostProcessor.h"
 
 #include "ibtk/libmesh_utilities.h"
@@ -133,4 +135,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBAMR_HAVE_LIBMESH
 #endif //#ifndef included_IBAMR_IBFECentroidPostProcessor

--- a/include/ibamr/IBFEInstrumentPanel.h
+++ b/include/ibamr/IBFEInstrumentPanel.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#ifdef IBAMR_HAVE_LIBMESH
+
 #include "ibamr/IBFEMethod.h"
 
 #include "ibtk/FEDataManager.h"
@@ -286,4 +288,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBAMR_HAVE_LIBMESH
 #endif //#ifndef included_IBAMR_IBFEInstrumentPanel

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#ifdef IBAMR_HAVE_LIBMESH
+
 #include "ibamr/FEMechanicsBase.h"
 #include "ibamr/IBFEDirectForcingKinematics.h"
 #include "ibamr/IBStrategy.h"
@@ -1107,4 +1109,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBAMR_HAVE_LIBMESH
 #endif //#ifndef included_IBAMR_IBFEMethod

--- a/include/ibamr/IBFEPostProcessor.h
+++ b/include/ibamr/IBFEPostProcessor.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#ifdef IBAMR_HAVE_LIBMESH
+
 #include "ibamr/IBFEMethod.h"
 
 #include "ibtk/FEDataManager.h"
@@ -379,4 +381,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBAMR_HAVE_LIBMESH
 #endif //#ifndef included_IBAMR_IBFEPostProcessor

--- a/include/ibamr/IBFESurfaceMethod.h
+++ b/include/ibamr/IBFESurfaceMethod.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#ifdef IBAMR_HAVE_LIBMESH
+
 #include "ibamr/IBStrategy.h"
 
 #include "ibtk/FEDataManager.h"
@@ -772,4 +774,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBAMR_HAVE_LIBMESH
 #endif //#ifndef included_IBAMR_IBFESurfaceMethod

--- a/include/ibamr/IMPInitializer.h
+++ b/include/ibamr/IMPInitializer.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#ifdef IBAMR_HAVE_LIBMESH
+
 #include "ibtk/LInitStrategy.h"
 #include "ibtk/LSiloDataWriter.h"
 
@@ -280,4 +282,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBAMR_HAVE_LIBMESH
 #endif //#ifndef included_IBAMR_IMPInitializer

--- a/include/ibamr/IMPMethod.h
+++ b/include/ibamr/IMPMethod.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#ifdef IBAMR_HAVE_LIBMESH
+
 #include "ibamr/IBStrategy.h"
 
 #include "ibtk/LInitStrategy.h"
@@ -448,4 +450,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBAMR_HAVE_LIBMESH
 #endif //#ifndef included_IBAMR_IMPMethod

--- a/include/ibamr/MaterialPointSpec.h
+++ b/include/ibamr/MaterialPointSpec.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#ifdef IBAMR_HAVE_LIBMESH
+
 #include "ibtk/Streamable.h"
 #include "ibtk/StreamableFactory.h"
 
@@ -253,4 +255,5 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
+#endif //#ifdef IBAMR_HAVE_LIBMESH
 #endif //#ifndef included_IBAMR_MaterialPointSpec

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,31 +148,22 @@ SET(CXX_SRC
   IB/IBKirchhoffRodForceGen.cpp
   IB/IBAnchorPointSpec.cpp
   IB/IBImplicitStaggeredHierarchyIntegrator.cpp
-  IB/IBFECentroidPostProcessor.cpp
   IB/IBRedundantInitializer.cpp
   IB/IBAnchorPointSpecFactory.cpp
   IB/CIBStrategy.cpp
   IB/IBInterpolantHierarchyIntegrator.cpp
-  IB/IBFESurfaceMethod.cpp
   IB/IBInstrumentationSpecFactory.cpp
-  # This file is not yet finished
-  # IB/IBFEPatchRecoveryPostProcessor.cpp
-  IB/IBFEPostProcessor.cpp
   IB/BrinkmanPenalizationRigidBodyDynamics.cpp
   IB/CIBMobilitySolver.cpp
   IB/IBStrategy.cpp
   IB/IBTargetPointForceSpec.cpp
   IB/IBStrategySet.cpp
   IB/IBHierarchyIntegrator.cpp
-  IB/MaterialPointSpecFactory.cpp
   IB/IBInstrumentationSpec.cpp
-  IB/IBFEMethod.cpp
   IB/ConstraintIBMethod.cpp
   IB/IBEulerianSourceFunction.cpp
   IB/IBBeamForceSpecFactory.cpp
   IB/MobilityFunctions.cpp
-  IB/IMPMethod.cpp
-  IB/IMPInitializer.cpp
   IB/IBStandardForceGen.cpp
   IB/CIBStaggeredStokesOperator.cpp
   IB/Wall.cpp
@@ -180,24 +171,19 @@ SET(CXX_SRC
   IB/IBInterpolantMethod.cpp
   IB/IBEulerianForceFunction.cpp
   IB/NonbondedForceEvaluator.cpp
-  IB/IBFEInstrumentPanel.cpp
   IB/StaggeredStokesIBLevelRelaxationFACOperator.cpp
-  IB/MaterialPointSpec.cpp
   IB/KrylovFreeBodyMobilitySolver.cpp
   IB/IBSpringForceSpecFactory.cpp
   IB/ConstraintIBKinematics.cpp
   IB/IBLevelSetMethod.cpp
   IB/IBLagrangianForceStrategySet.cpp
   IB/IBRodForceSpec.cpp
-  IB/FEMechanicsBase.cpp
-  IB/FEMechanicsExplicitIntegrator.cpp
   IB/IBSourceSpec.cpp
   IB/IBSourceSpecFactory.cpp
   IB/CIBSaddlePointSolver.cpp
   IB/WallForceEvaluator.cpp
   IB/IBTargetPointForceSpecFactory.cpp
   IB/IBMethod.cpp
-  IB/IBFEDirectForcingKinematics.cpp
   IB/IBBeamForceSpec.cpp
   IB/IBSpringForceSpec.cpp
   IB/CIBMethod.cpp
@@ -217,7 +203,6 @@ SET(CXX_SRC
   advect/AdvectorPredictorCorrectorHyperbolicPatchOps.cpp
 
   # level set
-  level_set/FESurfaceDistanceEvaluator.cpp
   level_set/LSInitStrategy.cpp
   level_set/FastSweepingLSMethod.cpp
   level_set/RelaxationLSBcCoefs.cpp
@@ -225,6 +210,27 @@ SET(CXX_SRC
   utilities/RNG.cpp
   utilities/ConvectiveOperator.cpp
   )
+
+IF(${IBAMR_HAVE_LIBMESH})
+  LIST(APPEND CXX_SRC
+    IB/FEMechanicsBase.cpp
+    IB/FEMechanicsExplicitIntegrator.cpp
+    IB/IBFECentroidPostProcessor.cpp
+    IB/IBFEDirectForcingKinematics.cpp
+    IB/IBFEInstrumentPanel.cpp
+    IB/IBFEMethod.cpp
+    # This file is not yet finished
+    # IB/IBFEPatchRecoveryPostProcessor.cpp
+    IB/IBFEPostProcessor.cpp
+    IB/IBFESurfaceMethod.cpp
+    IB/IMPInitializer.cpp
+    IB/IMPMethod.cpp
+    IB/MaterialPointSpec.cpp
+    IB/MaterialPointSpecFactory.cpp
+
+    level_set/FESurfaceDistanceEvaluator.cpp
+    )
+ENDIF()
 
 TARGET_SOURCES(IBAMR2d PRIVATE ${FORTRAN_GENERATED_SRC2D} ${CXX_SRC})
 TARGET_SOURCES(IBAMR3d PRIVATE ${FORTRAN_GENERATED_SRC3D} ${CXX_SRC})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,7 +117,7 @@ SETUP_3D(complex_fluids cf_relaxation_op_01.cpp)
 SETUP_3D(complex_fluids cf_forcing_op_01.cpp)
 
 # fe_mechanics:
-IF(IBAMR_HAVE_LIBMESH)
+IF(${IBAMR_HAVE_LIBMESH})
   SETUP_2D(fe_mechanics fe_mechanics_ex0.cpp)
   SETUP_3D(fe_mechanics fe_mechanics_ex0.cpp)
 ENDIF()
@@ -127,8 +127,10 @@ SETUP_2D(interpolate interpolate_01.cpp)
 SETUP_3D(interpolate interpolate_01.cpp)
 
 # level_set:
-SETUP_2D(level_set fe_surface_distance.cpp)
-SETUP_3D(level_set fe_surface_distance.cpp)
+IF(${IBAMR_HAVE_LIBMESH})
+  SETUP_2D(level_set fe_surface_distance.cpp)
+  SETUP_3D(level_set fe_surface_distance.cpp)
+ENDIF()
 
 # multiphase_flow:
 SETUP(multiphase_flow free_falling_cyl_cib.cpp IBAMR2d)
@@ -150,7 +152,7 @@ SETUP_2D(refine rt0_refine_01.cpp)
 SETUP_3D(refine rt0_refine_01.cpp)
 
 # spread:
-IF(IBAMR_HAVE_LIBMESH)
+IF(${IBAMR_HAVE_LIBMESH})
   SETUP_2D(spread spread_01.cpp)
   SETUP_3D(spread spread_01.cpp)
   SETUP_2D(spread spread_02.cpp)
@@ -162,8 +164,10 @@ SETUP_2D(vc_navier_stokes vc_navier_stokes_01.cpp)
 SETUP_3D(vc_navier_stokes vc_navier_stokes_01.cpp)
 
 # wave_tank:
-SETUP(wave_tank nwt_cylinder.cpp IBAMR2d)
-SETUP(wave_tank nwt.cpp IBAMR2d)
+IF(${IBAMR_HAVE_LIBMESH})
+  SETUP(wave_tank nwt_cylinder.cpp IBAMR2d)
+  SETUP(wave_tank nwt.cpp IBAMR2d)
+ENDIF()
 
 # CIB:
 SETUP(CIB cib_plate.cpp IBAMR2d)
@@ -179,7 +183,7 @@ SETUP(IB ib_body_force.cpp IBAMR2d)
 SETUP(IB ib_body_force_kirchhoff.cpp IBAMR3d)
 
 # IBFE:
-IF(IBAMR_HAVE_LIBMESH)
+IF(${IBAMR_HAVE_LIBMESH})
   SETUP(IBFE interpolate_velocity_02.cpp IBAMR2d)
 
   SETUP_2D(IBFE explicit_ex0.cpp)
@@ -210,7 +214,7 @@ SETUP(IBTK ldata_01.cpp IBAMR2d)
 SETUP(IBTK mpi_type_wrappers.cpp IBAMR2d)
 SETUP(IBTK child_integrators.cpp IBAMR2d)
 
-IF(IBAMR_HAVE_LIBMESH)
+IF(${IBAMR_HAVE_LIBMESH})
   SETUP(IBTK elem_hmax_01.cpp IBAMR2d)
   SETUP(IBTK elem_hmax_02.cpp IBAMR3d)
   SETUP(IBTK fe_values_01.cpp IBAMR2d)
@@ -237,7 +241,7 @@ SETUP_2D(IBTK secondary_hierarchy_01.cpp)
 SETUP_2D(IBTK vc_viscous_solver.cpp)
 SETUP_2D(IBTK helmholtz.cpp)
 
-IF(IBAMR_HAVE_LIBMESH)
+IF(${IBAMR_HAVE_LIBMESH})
   SETUP_3D(IBTK bounding_boxes_01.cpp)
   SETUP_3D(IBTK multilevel_fe_01.cpp)
 ENDIF()

--- a/tests/IBTK/box_utilities_01.cpp
+++ b/tests/IBTK/box_utilities_01.cpp
@@ -11,15 +11,8 @@
 //
 // ---------------------------------------------------------------------
 
-#include "ibtk/IBTK_MPI.h"
 #include <ibtk/IBTKInit.h>
 #include <ibtk/box_utilities.h>
-
-#include <tbox/SAMRAIManager.h>
-
-#include <petscsys.h>
-
-#include <SAMRAI_config.h>
 
 #include <fstream>
 #include <vector>

--- a/tests/IBTK/ibtk_init.cpp
+++ b/tests/IBTK/ibtk_init.cpp
@@ -11,18 +11,14 @@
 //
 // ---------------------------------------------------------------------
 
-// Config files
-
-#include <SAMRAI_config.h>
+// Headers for application-specific algorithm/data structure objects
+#include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
 
 // Headers for basic PETSc objects
 #include <petscsys.h>
 
-// Headers for application-specific algorithm/data structure objects
-#include <ibtk/AppInitializer.h>
-
 // Set up application namespace declarations
-#include <ibtk/IBTKInit.h>
 #include <ibtk/app_namespaces.h>
 
 /*******************************************************************************

--- a/tests/IBTK/ibtk_mpi.cpp
+++ b/tests/IBTK/ibtk_mpi.cpp
@@ -16,7 +16,9 @@
 // Set up application namespace declarations
 #include <ibtk/IBTKInit.h>
 #include <ibtk/IBTK_MPI.h>
-#include <ibtk/app_namespaces.h>
+
+#include <fstream>
+#include <limits>
 
 template <typename T>
 bool minReduction(T x, T exact, int proc);
@@ -50,48 +52,48 @@ int
 main(int argc, char* argv[])
 {
     // Initialize IBTK
-    IBTKInit ibtkInit(argc, argv, MPI_COMM_WORLD);
+    IBTK::IBTKInit ibtkInit(argc, argv, MPI_COMM_WORLD);
 
-    int num_nodes = IBTK_MPI::getNodes();
-    int rank = IBTK_MPI::getRank();
+    int num_nodes = IBTK::IBTK_MPI::getNodes();
+    int rank = IBTK::IBTK_MPI::getRank();
 
-    ofstream output_file;
+    std::ofstream output_file;
     if (!rank) output_file.open("output");
 
     // integers
-    int x = IBTK_MPI::getRank();
+    int x = IBTK::IBTK_MPI::getRank();
     bool passed = minReduction(x, 0, 0);
 
-    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    passed = IBTK::IBTK_MPI::maxReduction(passed ? 1 : 0);
     if (!rank) output_file << "Min test " << (passed ? "passed" : "failed") << ".\n";
 
-    passed = maxReduction(x, IBTK_MPI::getNodes() - 1, IBTK_MPI::getNodes() - 1);
+    passed = maxReduction(x, IBTK::IBTK_MPI::getNodes() - 1, IBTK::IBTK_MPI::getNodes() - 1);
 
-    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    passed = IBTK::IBTK_MPI::maxReduction(passed ? 1 : 0);
     if (!rank) output_file << "Max test " << (passed ? "passed" : "failed") << ".\n";
 
     passed = sumReduction(x, num_nodes * (num_nodes - 1) / 2);
 
-    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    passed = IBTK::IBTK_MPI::maxReduction(passed ? 1 : 0);
     if (!rank) output_file << "sumReduction test " << (passed ? "passed" : "failed") << ".\n";
 
     passed = allToOneSumReduction(x, num_nodes * (num_nodes - 1) / 2, 0);
 
-    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    passed = IBTK::IBTK_MPI::maxReduction(passed ? 1 : 0);
     if (!rank) output_file << "allToOneSum test " << (passed ? "passed" : "failed") << ".\n";
 
     passed = bcast(x, num_nodes - 1, num_nodes - 1);
 
-    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    passed = IBTK::IBTK_MPI::maxReduction(passed ? 1 : 0);
     if (!rank) output_file << "bcast test " << (passed ? "passed" : "failed") << ".\n";
 
     passed = sendAndRecv(x, (x - 1 + num_nodes) % num_nodes);
 
-    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    passed = IBTK::IBTK_MPI::maxReduction(passed ? 1 : 0);
     if (!rank) output_file << "send and recv test " << (passed ? "passed" : "failed") << ".\n";
     passed = allGather(x);
 
-    passed = IBTK_MPI::maxReduction(passed ? 1 : 0);
+    passed = IBTK::IBTK_MPI::maxReduction(passed ? 1 : 0);
     if (!rank) output_file << "all gather test " << (passed ? "passed" : "failed") << ".\n";
 
     if (!rank) output_file.close();
@@ -103,7 +105,7 @@ minReduction(T x, T exact, int proc)
 {
     int min_proc = std::numeric_limits<int>::max();
     // perform a min reduction
-    T val = IBTK_MPI::minReduction(x, &min_proc);
+    T val = IBTK::IBTK_MPI::minReduction(x, &min_proc);
     if (val == exact && proc == min_proc)
         return true;
     else
@@ -116,7 +118,7 @@ maxReduction(T x, T exact, int proc)
 {
     int max_proc = std::numeric_limits<int>::min();
     // perform a max reduction
-    T val = IBTK_MPI::maxReduction(x, &max_proc);
+    T val = IBTK::IBTK_MPI::maxReduction(x, &max_proc);
     if (val == exact && proc == max_proc)
         return true;
     else
@@ -127,7 +129,7 @@ template <typename T>
 bool
 sumReduction(T x, T exact)
 {
-    T val = IBTK_MPI::sumReduction(x);
+    T val = IBTK::IBTK_MPI::sumReduction(x);
     if (val == exact)
         return true;
     else
@@ -138,8 +140,8 @@ template <typename T>
 bool
 allToOneSumReduction(T x, T exact, int root)
 {
-    IBTK_MPI::allToOneSumReduction(&x, 1, root);
-    if (IBTK_MPI::getRank() == root)
+    IBTK::IBTK_MPI::allToOneSumReduction(&x, 1, root);
+    if (IBTK::IBTK_MPI::getRank() == root)
     {
         if (x == exact)
             return true;
@@ -156,7 +158,7 @@ template <typename T>
 bool
 bcast(T x, T exact, int root)
 {
-    T other = IBTK_MPI::bcast(x, root);
+    T other = IBTK::IBTK_MPI::bcast(x, root);
     if (other == exact)
         return true;
     else
@@ -168,10 +170,10 @@ bool
 sendAndRecv(T x, T exact)
 {
     T other;
-    int num_nodes = IBTK_MPI::getNodes();
+    int num_nodes = IBTK::IBTK_MPI::getNodes();
     int size = 1;
-    IBTK_MPI::send(&x, size, (IBTK_MPI::getRank() + 1) % num_nodes, false);
-    IBTK_MPI::recv(&other, size, (IBTK_MPI::getRank() - 1 + num_nodes) % num_nodes, false);
+    IBTK::IBTK_MPI::send(&x, size, (IBTK::IBTK_MPI::getRank() + 1) % num_nodes, false);
+    IBTK::IBTK_MPI::recv(&other, size, (IBTK::IBTK_MPI::getRank() - 1 + num_nodes) % num_nodes, false);
 
     if (other == exact)
         return true;
@@ -183,11 +185,11 @@ template <typename T>
 bool
 allGather(T x)
 {
-    std::vector<T> other(IBTK_MPI::getNodes());
-    IBTK_MPI::allGather(x, other.data());
+    std::vector<T> other(IBTK::IBTK_MPI::getNodes());
+    IBTK::IBTK_MPI::allGather(x, other.data());
 
     bool passed = true;
-    for (int i = 0; i < IBTK_MPI::getNodes(); ++i)
+    for (int i = 0; i < IBTK::IBTK_MPI::getNodes(); ++i)
         if (other[i] != i) passed = false;
     return passed;
 }

--- a/tests/IBTK/mpi_type_wrappers.cpp
+++ b/tests/IBTK/mpi_type_wrappers.cpp
@@ -13,23 +13,20 @@
 
 // Config files
 
-#include "ibtk/IBTK_MPI.h"
 #include <ibtk/AppInitializer.h>
 #include <ibtk/IBTKInit.h>
 #include <ibtk/IBTK_MPI.h>
 
 #include <tbox/SAMRAIManager.h>
 
-#include <SAMRAI_config.h>
-
 // Set up application namespace declarations
-#include <ibamr/app_namespaces.h>
-
 #include <boost/core/demangle.hpp>
 
 #include <fstream>
 #include <iostream>
 #include <utility>
+
+#include <ibamr/app_namespaces.h>
 
 // Verify that the correspondence between MPI and C++ types in IBTK_MPI works.
 


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

We need to fix a bunch of things to get CMake working without libMesh.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?