### PR TITLE
Remove a debugging message.

### DIFF
--- a/cmake/IBAMRConfig.cmake.in
+++ b/cmake/IBAMRConfig.cmake.in
@@ -27,9 +27,7 @@ IF(NOT @IBAMR_USE_BUNDLED_Boost@)
   # libraries that *do* link against boost libraries
   GET_TARGET_PROPERTY(_boost_definitions Boost::headers
     INTERFACE_COMPILE_DEFINITIONS)
-  MESSAGE(STATUS "compile defs are ${_boost_definitions}")
   LIST(REMOVE_ITEM _boost_definitions "BOOST_ALL_NO_LIB")
-  MESSAGE(STATUS "compile defs are ${_boost_definitions}")
   SET_TARGET_PROPERTIES(Boost::headers PROPERTIES INTERFACE_COMPILE_DEFINITIONS
     "${_boost_definitions}")
 ENDIF()


### PR DESCRIPTION
The normal stuff doesn't apply - this only effects some messages printed in user projects configured with CMake.