### PR TITLE
Remove a note on std::function.

### DIFF
--- a/include/ibamr/ConstraintIBMethod.h
+++ b/include/ibamr/ConstraintIBMethod.h
@@ -631,8 +631,6 @@ private:
 
     /*!
      * Pre and post fluid solve call back functions and contexts.
-     *
-     * TODO: Update these to use std::function.
      */
     std::vector<void (*)(const double, const double, const int, void*)> d_prefluidsolve_callback_fns,
         d_postfluidsolve_callback_fns;


### PR DESCRIPTION
Fixes #1110.

We decided to not switch to std::function since
1. We already pass context pointers as part of the API, so we don't really need to support binding to member functions, storing data with std::bind(), etc.
2. std::function usually requires an additional function call when it is bound to a function pointer defined in another compilation unit. Since we call these functions a lot (every quadrature point in IBFE) we should avoid that extra overhead.
3. Its better to use one way of passing functions around and not convert half the library to std::function.


This commit just removes a comment so I am not going to bother with the normal checklist.