### PR TITLE
Cleanup GitHub ci

### DIFF
--- a/.github/cmake/github_ci.cmake
+++ b/.github/cmake/github_ci.cmake
@@ -56,5 +56,5 @@ elseif ("$ENV{GITHUB_EVENT_NAME}" STREQUAL "push")
   # Put all branch tests in a track named the same as the branch.
   # Currently, only master is tested, but eventually branch names
   # such as "release-0.9" may exist and should have their own tracks.
-  string(REGEX_REPLACE "refs\\/heads\\/" "" ctest_track "$ENV{GITHUB_REF}")
+  string(REGEX REPLACE "refs\\/heads\\/" "" ctest_track "$ENV{GITHUB_REF}")
 endif ()

--- a/.github/cmake/github_ci.cmake
+++ b/.github/cmake/github_ci.cmake
@@ -11,50 +11,50 @@
 ##
 ## ---------------------------------------------------------------------
 
-if (NOT DEFINED "ENV{CI}")
-  message(FATAL_ERROR "This script assumes it is run inside a Github CI action.")
-endif()
+IF(NOT DEFINED "ENV{CI}")
+  MESSAGE(FATAL_ERROR "This script assumes it is run inside a Github CI action.")
+ENDIF()
 
 # Set the build metadata.
-set(CTEST_BUILD_NAME "$ENV{GITHUB_REPOSITORY}-$ENV{CMAKE_CONFIGURATION}")
-set(CTEST_SITE "github-ci")
+SET(CTEST_BUILD_NAME "$ENV{GITHUB_REPOSITORY}-$ENV{CMAKE_CONFIGURATION}")
+SET(CTEST_SITE "github-ci")
 
 # Set up the source and build directories
-set(CTEST_SOURCE_DIRECTORY "$ENV{GITHUB_WORKSPACE}")
-set(CTEST_BINARY_DIRECTORY "/build/ibamr")
+SET(CTEST_SOURCE_DIRECTORY "$ENV{GITHUB_WORKSPACE}")
+SET(CTEST_BINARY_DIRECTORY "/build/ibamr")
 
 # On fedora, MPI must be loaded using environment modules:
-if ("$ENV{CMAKE_CONFIGURATION}" MATCHES "fedora")
-  find_package(EnvModules REQUIRED)
-  env_module(purge)
-  env_module(load modules)
-  env_module(load mpi)
+IF("$ENV{CMAKE_CONFIGURATION}" MATCHES "fedora")
+  FIND_PACKAGE(EnvModules REQUIRED)
+  ENV_MODULE(purge)
+  ENV_MODULE(load modules)
+  ENV_MODULE(load mpi)
 endif()
 
 # Default to Release builds.
-if (NOT "$ENV{CMAKE_BUILD_TYPE}" STREQUAL "")
-  set(CTEST_BUILD_CONFIGURATION "$ENV{CMAKE_BUILD_TYPE}")
-endif ()
-if (NOT CTEST_BUILD_CONFIGURATION)
-  set(CTEST_BUILD_CONFIGURATION "Release")
-endif ()
+IF(NOT "$ENV{CMAKE_BUILD_TYPE}" STREQUAL "")
+  SET(CTEST_BUILD_CONFIGURATION "$ENV{CMAKE_BUILD_TYPE}")
+ENDIF()
+IF(NOT CTEST_BUILD_CONFIGURATION)
+  SET(CTEST_BUILD_CONFIGURATION "Release")
+ENDIF()
 
 # Default to using Ninja.
-if (NOT "$ENV{CMAKE_GENERATOR}" STREQUAL "")
-  set(CTEST_CMAKE_GENERATOR "$ENV{CMAKE_GENERATOR}")
-endif ()
-if (NOT CTEST_CMAKE_GENERATOR)
-  set(CTEST_CMAKE_GENERATOR "Ninja")
-endif ()
+IF(NOT "$ENV{CMAKE_GENERATOR}" STREQUAL "")
+  SET(CTEST_CMAKE_GENERATOR "$ENV{CMAKE_GENERATOR}")
+ENDIF()
+IF(NOT CTEST_CMAKE_GENERATOR)
+  SET(CTEST_CMAKE_GENERATOR "Ninja")
+ENDIF()
 
 # Determine which track to submit to.
-set(ctest_track "experimental")
-if ("$ENV{GITHUB_EVENT_NAME}" STREQUAL "pull_request")
+SET(ctest_track "experimental")
+IF("$ENV{GITHUB_EVENT_NAME}" STREQUAL "pull_request")
   # Put pull request testing in the "merge requests" track
-  set(ctest_track "merge-requests")
-elseif ("$ENV{GITHUB_EVENT_NAME}" STREQUAL "push")
+  SET(ctest_track "merge-requests")
+ELSEIF("$ENV{GITHUB_EVENT_NAME}" STREQUAL "push")
   # Put all branch tests in a track named the same as the branch.
   # Currently, only master is tested, but eventually branch names
   # such as "release-0.9" may exist and should have their own tracks.
-  string(REGEX REPLACE "refs\\/heads\\/" "" ctest_track "$ENV{GITHUB_REF}")
-endif ()
+  STRING(REGEX REPLACE "refs\\/heads\\/" "" ctest_track "$ENV{GITHUB_REF}")
+ENDIF()


### PR DESCRIPTION
This only effects the CI, so the usual checklist doesn't apply.

This PR fixes two things:
- We wrote `REGEX_REPLACE` when we should have written `REGEX REPLACE`
- Our convention is to put CMake keywords in ALL CAPS to make them conspicuous