### PR TITLE
Fix usage of Eigen::Index to work with older versions of Eigen.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,37 +568,32 @@ boost support or an external boost library.")
       ENDIF()
     ENDIF()
 
+    # Use slightly different error messages for bundled and non-bundled Eigen
     IF(EXISTS ${LIBMESH_ROOT}/include/Eigen)
       IF("${EIGEN3_ROOT}" STREQUAL "${LIBMESH_ROOT}/include/Eigen")
         # OK
+      ELSEIF(${IBAMR_USE_BUNDLED_EIGEN3})
+        MESSAGE(FATAL_ERROR "\
+libMesh appears to have been compiled with a bundled copy of Eigen3 (i.e., the \
+directory ${LIBMESH_ROOT}/include/Eigen exists) but IBAMR was configured to \
+use its own bundled copy of Eigen3. IBAMR does not support using multiple copies \
+of Eigen3. To fix this, we recommend deleting the current libMesh installation, \
+recompiling libMesh without Eigen support, and then reinstalling libMesh. IBAMR \
+does not support using libMesh's bundled copy of Eigen3 since that version is \
+not installed with Eigen's CMake configuration files. If you need to use Eigen \
+with libMesh then you will need to use an external installation for both \
+libMesh and IBAMR.")
       ELSE()
-        # If this happens then the provided version of Eigen3 appears to not
-        # match the one libMesh has: we don't support this. Verify it's not an
-        # odd coincidence before bailing out.
-        CHECK_CXX_SOURCE_COMPILES(
-          "
-          #include <libmesh/libmesh_config.h>
-          #ifdef LIBMESH_HAVE_EIGEN
-          // OK
-          #else
-          #error
-          #endif
-          int main() {}
-          "
-          LIBMESH_WITH_EIGEN
-          )
-        IF(${LIBMESH_WITH_EIGEN})
-          MESSAGE(FATAL_ERROR "\
+        MESSAGE(FATAL_ERROR "\
 libMesh appears to have been compiled with a bundled copy of Eigen3 (i.e., the \
 directory ${LIBMESH_ROOT}/include/Eigen exists) and this version of Eigen is \
-different from the one provided via via EIGEN3_ROOT = ${EIGEN3_ROOT}: i.e., \
+different from the one provided to CMake via EIGEN3_ROOT = ${EIGEN3_ROOT}: i.e., \
 there are two versions of Eigen3 in the configuration path, which is not \
 supported. To fix this, delete the current libMesh installation, recompile \
 libMesh without Eigen, and reinstall libMesh. If you aren't sure what to do, \
 the best option is to ensure that libMesh is compiled without support for \
 Eigen and then let IBAMR either detect an Eigen installation or use its own \
 bundled copy.")
-        ENDIF()
       ENDIF()
     ENDIF()
 

--- a/src/IB/DirectMobilitySolver.cpp
+++ b/src/IB/DirectMobilitySolver.cpp
@@ -668,7 +668,13 @@ DirectMobilitySolver::factorizeDenseMatrix(double* mat_data,
         //
         // and instead store A <- V sqrt(D)
         using MatrixType = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
-        Eigen::Map<MatrixType> mat_view(mat_data, Eigen::Index(mat_size), Eigen::Index(mat_size));
+        // Older versions of Eigen don't make Eigen::Index publicly available
+#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
+        using IndexType = Eigen::Index;
+#else
+        using IndexType = typename MatrixType::Index;
+#endif
+        Eigen::Map<MatrixType> mat_view(mat_data, IndexType(mat_size), IndexType(mat_size));
         // For compatibility with the old code, we copy the lower triangle into
         // the upper triangle, even if they aren't actually equal
         for (int i = 0; i < mat_size; ++i)


### PR DESCRIPTION
I don't really understand this problem - the `typedef` is clearly in an included Eigen header (`Meta.h`). Nevertheless relying on the type stored by the matrix works for both recent versions of Eigen and the one bundled with IBAMR.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
