### PR TITLE
Improve kernel selection

### DIFF
--- a/doc/news/changes/minor/20211018DavidWells
+++ b/doc/news/changes/minor/20211018DavidWells
@@ -1,0 +1,7 @@
+Improved: Classes inheriting from IBStrategy now check, in their constructors,
+that they are using supported kernels instead of the internal functions checking
+kernel names every time they are called. This greatly improves performance for
+applications that call the spread or interpolate functions in loops (e.g., over
+elements).
+<br>
+(David Wells, 2021/10/18)

--- a/ibtk/include/ibtk/LEInteractor.h
+++ b/ibtk/include/ibtk/LEInteractor.h
@@ -95,6 +95,12 @@ public:
     static int getStencilSize(const std::string& kernel_fcn);
 
     /*!
+     * \brief Return whether or not the provided string corresponds to a known
+     * kernel function.
+     */
+    static bool isKnownKernel(const std::string& kernel_fcn);
+
+    /*!
      * \brief Returns the minimum ghost width size corresponding to the
      * specified kernel function.
      *

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -2836,6 +2836,10 @@ FEDataManager::FEDataManager(std::string object_name,
 {
     TBOX_ASSERT(!d_object_name.empty());
 
+    // Validate the kernel choices.
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_default_interp_spec.kernel_fcn));
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_default_spread_spec.kernel_fcn));
+
     if (d_registered_for_restart)
     {
         RestartManager::getManager()->registerRestartItem(d_object_name, this);

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -176,6 +176,9 @@ LDataManager::getManager(const std::string& name,
                          const IntVector<NDIM>& min_ghost_width,
                          bool register_for_restart)
 {
+    // Validate the kernel choices.
+    TBOX_ASSERT(LEInteractor::isKnownKernel(default_interp_kernel_fcn));
+    TBOX_ASSERT(LEInteractor::isKnownKernel(default_spread_kernel_fcn));
     if (s_data_manager_instances.find(name) == s_data_manager_instances.end())
     {
         const IntVector<NDIM> ghost_width = IntVector<NDIM>::max(
@@ -410,6 +413,9 @@ LDataManager::spread(const int f_data_idx,
                      const int finest_ln_in)
 {
     IBTK_TIMER_START(t_spread);
+#ifndef NDEBUG
+    TBOX_ASSERT(LEInteractor::isKnownKernel(spread_kernel_fcn));
+#endif
 
     const int coarsest_ln = (coarsest_ln_in == -1 ? 0 : coarsest_ln_in);
     const int finest_ln = (finest_ln_in == -1 ? d_hierarchy->getFinestLevelNumber() : finest_ln_in);

--- a/ibtk/src/lagrangian/LEInteractor.cpp
+++ b/ibtk/src/lagrangian/LEInteractor.cpp
@@ -1440,14 +1440,6 @@ LEInteractor::isKnownKernel(const std::string& kernel_fcn)
 int
 LEInteractor::getStencilSize(const std::string& kernel_fcn)
 {
-    // Some IBAMR applications want to call this function *a lot*, e.g., ideally
-    // we would call this on every element in a finite element mesh instead of
-    // batching with huge temporary arrays. Hence doing all these string
-    // comparisons can get surprisingly expensive. Chop them up first with a
-    // switch statement.
-    //
-    // For readability, the old and not hacky version is included at the end of
-    // the function.
     switch (string_to_kernel(kernel_fcn))
     {
     case BSPLINE_3:

--- a/ibtk/src/lagrangian/LEInteractor.cpp
+++ b/ibtk/src/lagrangian/LEInteractor.cpp
@@ -1311,6 +1311,102 @@ spread_data(const int stencil_sz,
     }
 #endif
 } // spread_data
+
+// For internal use - convert to an enumeration. This may make it into the
+// public interface one day but for backwards compatibility we accept only
+// strings for now.
+enum KernelType
+{
+    BSPLINE_3,
+    BSPLINE_4,
+    BSPLINE_5,
+    BSPLINE_6,
+    DISCONTINUOUS_LINEAR,
+    PIECEWISE_CONSTANT,
+    PIECEWISE_LINEAR,
+    PIECEWISE_CUBIC,
+    IB_3,
+    IB_4,
+    IB_4_W8,
+    IB_5,
+    IB_6,
+    USER_DEFINED,
+    INVALID
+};
+
+KernelType
+string_to_kernel(const std::string& kernel_fcn)
+{
+    // Some IBAMR applications want to call this function *a lot*, e.g., ideally
+    // we would call this on every element in a finite element mesh instead of
+    // batching with huge temporary arrays. Hence doing all these string
+    // comparisons can get surprisingly expensive. Chop them up first with a
+    // switch statement.
+#ifndef NDEBUG
+    if (!LEInteractor::isKnownKernel(kernel_fcn))
+    {
+        TBOX_ERROR("Unknown kernel function " << kernel_fcn << std::endl);
+        return INVALID;
+    }
+#endif
+    switch (kernel_fcn.front())
+    {
+    // BSPLINE family
+    case 'B':
+    {
+        switch (kernel_fcn.back())
+        {
+        case '3':
+            return BSPLINE_3;
+        case '4':
+            return BSPLINE_4;
+        case '5':
+            return BSPLINE_5;
+        case '6':
+            return BSPLINE_6;
+        }
+    }
+    // DISCONTINUOUS family
+    case 'D':
+    {
+        return DISCONTINUOUS_LINEAR;
+    }
+    // PIECEWISE family
+    case 'P':
+    {
+        switch (kernel_fcn[11])
+        {
+        case 'O':
+            return PIECEWISE_CONSTANT;
+        case 'I':
+            return PIECEWISE_LINEAR;
+        case 'U':
+            return PIECEWISE_CUBIC;
+        }
+    }
+    // classic IB family
+    case 'I':
+    {
+        switch (kernel_fcn[3])
+        {
+        case '3':
+            return IB_3;
+        case '4':
+            return kernel_fcn.size() == 4 ? IB_4 : IB_4_W8;
+        case '5':
+            return IB_5;
+        case '6':
+            return IB_6;
+        }
+    }
+    // user defined
+    case 'U':
+        return USER_DEFINED;
+    }
+
+    TBOX_ERROR("Unknown kernel function " << kernel_fcn << std::endl);
+    return INVALID;
+}
 } // namespace
 
 double (*LEInteractor::s_kernel_fcn)(double r) = &ib4_kernel_fcn;
@@ -1331,25 +1427,63 @@ LEInteractor::printClassData(std::ostream& os)
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
+bool
+LEInteractor::isKnownKernel(const std::string& kernel_fcn)
+{
+    return kernel_fcn == "BSPLINE_3" || kernel_fcn == "BSPLINE_4" || kernel_fcn == "BSPLINE_5" ||
+           kernel_fcn == "BSPLINE_6" || kernel_fcn == "DISCONTINUOUS_LINEAR" || kernel_fcn == "PIECEWISE_CONSTANT" ||
+           kernel_fcn == "PIECEWISE_LINEAR" || kernel_fcn == "PIECEWISE_CUBIC" || kernel_fcn == "IB_3" ||
+           kernel_fcn == "IB_4" || kernel_fcn == "IB_4_W8" || kernel_fcn == "IB_5" || kernel_fcn == "IB_6" ||
+           kernel_fcn == "USER_DEFINED";
+}
+
 int
 LEInteractor::getStencilSize(const std::string& kernel_fcn)
 {
-    if (kernel_fcn == "PIECEWISE_CONSTANT") return 1;
-    if (kernel_fcn == "DISCONTINUOUS_LINEAR") return 2;
-    if (kernel_fcn == "PIECEWISE_LINEAR") return 2;
-    if (kernel_fcn == "PIECEWISE_CUBIC") return 4;
-    if (kernel_fcn == "IB_3") return 4;
-    if (kernel_fcn == "IB_4") return 4;
-    if (kernel_fcn == "IB_4_W8") return 8;
-    if (kernel_fcn == "IB_5") return 6;
-    if (kernel_fcn == "IB_6") return 6;
-    if (kernel_fcn == "BSPLINE_3") return 4;
-    if (kernel_fcn == "BSPLINE_4") return 4;
-    if (kernel_fcn == "BSPLINE_5") return 6;
-    if (kernel_fcn == "BSPLINE_6") return 6;
-    if (kernel_fcn == "USER_DEFINED") return s_kernel_fcn_stencil_size;
-    TBOX_ERROR("LEInteractor::getStencilSize()\n"
-               << "  Unknown kernel function " << kernel_fcn << std::endl);
+    // Some IBAMR applications want to call this function *a lot*, e.g., ideally
+    // we would call this on every element in a finite element mesh instead of
+    // batching with huge temporary arrays. Hence doing all these string
+    // comparisons can get surprisingly expensive. Chop them up first with a
+    // switch statement.
+    //
+    // For readability, the old and not hacky version is included at the end of
+    // the function.
+    switch (string_to_kernel(kernel_fcn))
+    {
+    case BSPLINE_3:
+        return 4;
+    case BSPLINE_4:
+        return 4;
+    case BSPLINE_5:
+        return 6;
+    case BSPLINE_6:
+        return 6;
+    case DISCONTINUOUS_LINEAR:
+        return 2;
+    case PIECEWISE_CONSTANT:
+        return 1;
+    case PIECEWISE_LINEAR:
+        return 2;
+    case PIECEWISE_CUBIC:
+        return 4;
+    case IB_3:
+        return 4;
+    case IB_4:
+        return 4;
+    case IB_4_W8:
+        return 8;
+    case IB_5:
+        return 6;
+    case IB_6:
+        return 6;
+    case USER_DEFINED:
+        return s_kernel_fcn_stencil_size;
+    case INVALID:
+    default:
+        TBOX_ERROR("LEInteractor::getStencilSize()\n"
+                   << "  Unknown kernel function " << kernel_fcn << std::endl);
+    }
+
     return -1;
 }
 
@@ -3713,7 +3847,9 @@ LEInteractor::interpolate(double* const Q_data,
     const int local_indices_size = static_cast<int>(local_indices.size());
     const IntVector<NDIM>& ilower = q_data_box.lower();
     const IntVector<NDIM>& iupper = q_data_box.upper();
-    if (interp_fcn == "PIECEWISE_CONSTANT")
+    switch (string_to_kernel(interp_fcn))
+    {
+    case PIECEWISE_CONSTANT:
     {
         LAGRANGIAN_PIECEWISE_CONSTANT_INTERP_FC(dx,
                                                 x_lower,
@@ -3744,8 +3880,9 @@ LEInteractor::interpolate(double* const Q_data,
                                                 local_indices_size,
                                                 X_data,
                                                 Q_data);
+        break;
     }
-    else if (interp_fcn == "DISCONTINUOUS_LINEAR")
+    case DISCONTINUOUS_LINEAR:
     {
         LAGRANGIAN_DISCONTINUOUS_LINEAR_INTERP_FC(dx,
                                                   x_lower,
@@ -3777,8 +3914,9 @@ LEInteractor::interpolate(double* const Q_data,
                                                   local_indices_size,
                                                   X_data,
                                                   Q_data);
+        break;
     }
-    else if (interp_fcn == "PIECEWISE_LINEAR")
+    case PIECEWISE_LINEAR:
     {
         LAGRANGIAN_PIECEWISE_LINEAR_INTERP_FC(dx,
                                               x_lower,
@@ -3809,8 +3947,9 @@ LEInteractor::interpolate(double* const Q_data,
                                               local_indices_size,
                                               X_data,
                                               Q_data);
+        break;
     }
-    else if (interp_fcn == "PIECEWISE_CUBIC")
+    case PIECEWISE_CUBIC:
     {
         LAGRANGIAN_PIECEWISE_CUBIC_INTERP_FC(dx,
                                              x_lower,
@@ -3841,8 +3980,9 @@ LEInteractor::interpolate(double* const Q_data,
                                              local_indices_size,
                                              X_data,
                                              Q_data);
+        break;
     }
-    else if (interp_fcn == "IB_3")
+    case IB_3:
     {
         LAGRANGIAN_IB_3_INTERP_FC(dx,
                                   x_lower,
@@ -3873,8 +4013,9 @@ LEInteractor::interpolate(double* const Q_data,
                                   local_indices_size,
                                   X_data,
                                   Q_data);
+        break;
     }
-    else if (interp_fcn == "IB_4")
+    case IB_4:
     {
         LAGRANGIAN_IB_4_INTERP_FC(dx,
                                   x_lower,
@@ -3905,8 +4046,9 @@ LEInteractor::interpolate(double* const Q_data,
                                   local_indices_size,
                                   X_data,
                                   Q_data);
+        break;
     }
-    else if (interp_fcn == "IB_4_W8")
+    case IB_4_W8:
     {
         LAGRANGIAN_IB_4_W8_INTERP_FC(dx,
                                      x_lower,
@@ -3937,8 +4079,9 @@ LEInteractor::interpolate(double* const Q_data,
                                      local_indices_size,
                                      X_data,
                                      Q_data);
+        break;
     }
-    else if (interp_fcn == "IB_5")
+    case IB_5:
     {
         LAGRANGIAN_IB_5_INTERP_FC(dx,
                                   x_lower,
@@ -3969,8 +4112,9 @@ LEInteractor::interpolate(double* const Q_data,
                                   local_indices_size,
                                   X_data,
                                   Q_data);
+        break;
     }
-    else if (interp_fcn == "IB_6")
+    case IB_6:
     {
         LAGRANGIAN_IB_6_INTERP_FC(dx,
                                   x_lower,
@@ -4001,8 +4145,9 @@ LEInteractor::interpolate(double* const Q_data,
                                   local_indices_size,
                                   X_data,
                                   Q_data);
+        break;
     }
-    else if (interp_fcn == "BSPLINE_3")
+    case BSPLINE_3:
     {
         LAGRANGIAN_BSPLINE_3_INTERP_FC(dx,
                                        x_lower,
@@ -4033,8 +4178,9 @@ LEInteractor::interpolate(double* const Q_data,
                                        local_indices_size,
                                        X_data,
                                        Q_data);
+        break;
     }
-    else if (interp_fcn == "BSPLINE_4")
+    case BSPLINE_4:
     {
         LAGRANGIAN_BSPLINE_4_INTERP_FC(dx,
                                        x_lower,
@@ -4065,8 +4211,9 @@ LEInteractor::interpolate(double* const Q_data,
                                        local_indices_size,
                                        X_data,
                                        Q_data);
+        break;
     }
-    else if (interp_fcn == "BSPLINE_5")
+    case BSPLINE_5:
     {
         LAGRANGIAN_BSPLINE_5_INTERP_FC(dx,
                                        x_lower,
@@ -4097,8 +4244,9 @@ LEInteractor::interpolate(double* const Q_data,
                                        local_indices_size,
                                        X_data,
                                        Q_data);
+        break;
     }
-    else if (interp_fcn == "BSPLINE_6")
+    case BSPLINE_6:
     {
         LAGRANGIAN_BSPLINE_6_INTERP_FC(dx,
                                        x_lower,
@@ -4129,8 +4277,9 @@ LEInteractor::interpolate(double* const Q_data,
                                        local_indices_size,
                                        X_data,
                                        Q_data);
+        break;
     }
-    else if (interp_fcn == "USER_DEFINED")
+    case USER_DEFINED:
     {
         userDefinedInterpolate(Q_data,
                                Q_depth,
@@ -4145,9 +4294,10 @@ LEInteractor::interpolate(double* const Q_data,
                                &local_indices[0],
                                &periodic_shifts[0],
                                local_indices_size);
+        break;
     }
-    else
-    {
+    case INVALID:
+    default:
         TBOX_ERROR("LEInteractor::interpolate()\n"
                    << "  Unknown interpolation kernel function " << interp_fcn << std::endl);
     }
@@ -4193,7 +4343,9 @@ LEInteractor::spread(double* const q_data,
     const int local_indices_size = static_cast<int>(local_indices.size());
     const IntVector<NDIM>& ilower = q_data_box.lower();
     const IntVector<NDIM>& iupper = q_data_box.upper();
-    if (spread_fcn == "PIECEWISE_CONSTANT")
+    switch (string_to_kernel(spread_fcn))
+    {
+    case PIECEWISE_CONSTANT:
     {
         LAGRANGIAN_PIECEWISE_CONSTANT_SPREAD_FC(dx,
                                                 x_lower,
@@ -4224,8 +4376,9 @@ LEInteractor::spread(double* const q_data,
                                                 q_gcw(2),
 #endif
                                                 q_data);
+        break;
     }
-    else if (spread_fcn == "DISCONTINUOUS_LINEAR")
+    case DISCONTINUOUS_LINEAR:
     {
         LAGRANGIAN_DISCONTINUOUS_LINEAR_SPREAD_FC(dx,
                                                   x_lower,
@@ -4257,8 +4410,9 @@ LEInteractor::spread(double* const q_data,
                                                   q_gcw(2),
 #endif
                                                   q_data);
+        break;
     }
-    else if (spread_fcn == "PIECEWISE_LINEAR")
+    case PIECEWISE_LINEAR:
     {
         LAGRANGIAN_PIECEWISE_LINEAR_SPREAD_FC(dx,
                                               x_lower,
@@ -4289,8 +4443,9 @@ LEInteractor::spread(double* const q_data,
                                               q_gcw(2),
 #endif
                                               q_data);
+        break;
     }
-    else if (spread_fcn == "PIECEWISE_CUBIC")
+    case PIECEWISE_CUBIC:
     {
         LAGRANGIAN_PIECEWISE_CUBIC_SPREAD_FC(dx,
                                              x_lower,
@@ -4321,8 +4476,9 @@ LEInteractor::spread(double* const q_data,
                                              q_gcw(2),
 #endif
                                              q_data);
+        break;
     }
-    else if (spread_fcn == "IB_3")
+    case IB_3:
     {
         LAGRANGIAN_IB_3_SPREAD_FC(dx,
                                   x_lower,
@@ -4353,8 +4509,9 @@ LEInteractor::spread(double* const q_data,
                                   q_gcw(2),
 #endif
                                   q_data);
+        break;
     }
-    else if (spread_fcn == "IB_4")
+    case IB_4:
     {
         LAGRANGIAN_IB_4_SPREAD_FC(dx,
                                   x_lower,
@@ -4385,8 +4542,9 @@ LEInteractor::spread(double* const q_data,
                                   q_gcw(2),
 #endif
                                   q_data);
+        break;
     }
-    else if (spread_fcn == "IB_4_W8")
+    case IB_4_W8:
     {
         LAGRANGIAN_IB_4_W8_SPREAD_FC(dx,
                                      x_lower,
@@ -4417,8 +4575,9 @@ LEInteractor::spread(double* const q_data,
                                      q_gcw(2),
 #endif
                                      q_data);
+        break;
     }
-    else if (spread_fcn == "IB_5")
+    case IB_5:
     {
         LAGRANGIAN_IB_5_SPREAD_FC(dx,
                                   x_lower,
@@ -4449,8 +4608,9 @@ LEInteractor::spread(double* const q_data,
                                   q_gcw(2),
 #endif
                                   q_data);
+        break;
     }
-    else if (spread_fcn == "IB_6")
+    case IB_6:
     {
         LAGRANGIAN_IB_6_SPREAD_FC(dx,
                                   x_lower,
@@ -4481,8 +4641,9 @@ LEInteractor::spread(double* const q_data,
                                   q_gcw(2),
 #endif
                                   q_data);
+        break;
     }
-    else if (spread_fcn == "BSPLINE_3")
+    case BSPLINE_3:
     {
         LAGRANGIAN_BSPLINE_3_SPREAD_FC(dx,
                                        x_lower,
@@ -4513,8 +4674,9 @@ LEInteractor::spread(double* const q_data,
                                        q_gcw(2),
 #endif
                                        q_data);
+        break;
     }
-    else if (spread_fcn == "BSPLINE_4")
+    case BSPLINE_4:
     {
         LAGRANGIAN_BSPLINE_4_SPREAD_FC(dx,
                                        x_lower,
@@ -4545,8 +4707,9 @@ LEInteractor::spread(double* const q_data,
                                        q_gcw(2),
 #endif
                                        q_data);
+        break;
     }
-    else if (spread_fcn == "BSPLINE_5")
+    case BSPLINE_5:
     {
         LAGRANGIAN_BSPLINE_5_SPREAD_FC(dx,
                                        x_lower,
@@ -4577,8 +4740,9 @@ LEInteractor::spread(double* const q_data,
                                        q_gcw(2),
 #endif
                                        q_data);
+        break;
     }
-    else if (spread_fcn == "BSPLINE_6")
+    case BSPLINE_6:
     {
         LAGRANGIAN_BSPLINE_6_SPREAD_FC(dx,
                                        x_lower,
@@ -4609,8 +4773,9 @@ LEInteractor::spread(double* const q_data,
                                        q_gcw(2),
 #endif
                                        q_data);
+        break;
     }
-    else if (spread_fcn == "USER_DEFINED")
+    case USER_DEFINED:
     {
         userDefinedSpread(q_data,
                           q_data_box,
@@ -4625,11 +4790,14 @@ LEInteractor::spread(double* const q_data,
                           &local_indices[0],
                           &periodic_shifts[0],
                           local_indices_size);
+        break;
     }
-    else
+    case INVALID:
+    default:
     {
         TBOX_ERROR("LEInteractor::spread()\n"
                    << "  Unknown spreading kernel function " << spread_fcn << std::endl);
+    }
     }
     return;
 }

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1243,7 +1243,9 @@ IBFEMethod::setInterpSpec(const FEDataManager::InterpSpec& interp_spec, const un
 {
     TBOX_ASSERT(!d_fe_equation_systems_initialized);
     TBOX_ASSERT(part < d_meshes.size());
+    TBOX_ASSERT(LEInteractor::isKnownKernel(interp_spec.kernel_fcn));
     d_interp_spec[part] = interp_spec;
+
     return;
 }
 
@@ -1252,6 +1254,7 @@ IBFEMethod::setSpreadSpec(const FEDataManager::SpreadSpec& spread_spec, const un
 {
     TBOX_ASSERT(!d_fe_equation_systems_initialized);
     TBOX_ASSERT(part < d_meshes.size());
+    TBOX_ASSERT(LEInteractor::isKnownKernel(spread_spec.kernel_fcn));
     d_spread_spec[part] = spread_spec;
     return;
 }
@@ -2920,6 +2923,10 @@ IBFEMethod::getFromInput(const Pointer<Database>& db, bool /*is_from_restart*/)
         d_default_spread_spec.kernel_fcn = db->getString("spread_kernel_fcn");
     else if (db->isString("IB_kernel_fcn"))
         d_default_spread_spec.kernel_fcn = db->getString("IB_kernel_fcn");
+
+    // Validate the kernel choices.
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_default_interp_spec.kernel_fcn));
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_default_spread_spec.kernel_fcn));
 
     if (db->isBool("spread_use_nodal_quadrature"))
         d_default_spread_spec.use_nodal_quadrature = db->getBool("spread_use_nodal_quadrature");

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -1038,6 +1038,7 @@ IBFESurfaceMethod::setInterpSpec(const FEDataManager::InterpSpec& interp_spec, c
 {
     TBOX_ASSERT(!d_fe_equation_systems_initialized);
     TBOX_ASSERT(part < d_num_parts);
+    TBOX_ASSERT(LEInteractor::isKnownKernel(interp_spec.kernel_fcn));
     d_interp_spec[part] = interp_spec;
     return;
 }
@@ -1047,6 +1048,7 @@ IBFESurfaceMethod::setSpreadSpec(const FEDataManager::SpreadSpec& spread_spec, c
 {
     TBOX_ASSERT(!d_fe_equation_systems_initialized);
     TBOX_ASSERT(part < d_num_parts);
+    TBOX_ASSERT(LEInteractor::isKnownKernel(spread_spec.kernel_fcn));
     d_spread_spec[part] = spread_spec;
     return;
 }
@@ -2038,6 +2040,10 @@ IBFESurfaceMethod::getFromInput(Pointer<Database> db, bool /*is_from_restart*/)
         d_default_spread_spec.kernel_fcn = db->getString("spread_kernel_fcn");
     else if (db->isString("IB_kernel_fcn"))
         d_default_spread_spec.kernel_fcn = db->getString("IB_kernel_fcn");
+
+    // Validate the kernel choices.
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_default_interp_spec.kernel_fcn));
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_default_spread_spec.kernel_fcn));
 
     if (db->isString("spread_quad_type"))
         d_default_spread_spec.quad_type = Utility::string_to_enum<QuadratureType>(db->getString("spread_quad_type"));

--- a/src/IB/IBInterpolantMethod.cpp
+++ b/src/IB/IBInterpolantMethod.cpp
@@ -1024,6 +1024,8 @@ IBInterpolantMethod::getFromInput(Pointer<Database> db, bool is_from_restart)
             d_ghosts = static_cast<int>(std::ceil(db->getDouble("min_ghost_cell_width")));
         }
     }
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_interp_kernel_fcn));
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_spread_kernel_fcn));
     if (db->keyExists("error_if_points_leave_domain"))
         d_error_if_points_leave_domain = db->getBool("error_if_points_leave_domain");
     if (db->keyExists("do_log"))
@@ -1060,6 +1062,8 @@ IBInterpolantMethod::getFromRestart()
         d_spread_kernel_fcn = db->getString("d_spread_kernel_fcn");
     else if (db->keyExists("d_spread_delta_fcn"))
         d_spread_kernel_fcn = db->getString("d_spread_delta_fcn");
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_interp_kernel_fcn));
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_spread_kernel_fcn));
     db->getIntegerArray("d_ghosts", d_ghosts, NDIM);
 
     for (unsigned int struct_no = 0; struct_no < d_num_rigid_parts; ++struct_no)

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -2027,6 +2027,8 @@ IBMethod::getFromInput(Pointer<Database> db, bool is_from_restart)
         if (db->isBool("normalize_source_strength"))
             d_normalize_source_strength = db->getBool("normalize_source_strength");
     }
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_interp_kernel_fcn));
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_spread_kernel_fcn));
     if (db->keyExists("error_if_points_leave_domain"))
         d_error_if_points_leave_domain = db->getBool("error_if_points_leave_domain");
     if (db->keyExists("force_jac_mffd")) d_force_jac_mffd = db->getBool("force_jac_mffd");
@@ -2064,6 +2066,8 @@ IBMethod::getFromRestart()
         d_spread_kernel_fcn = db->getString("d_spread_kernel_fcn");
     else if (db->keyExists("d_spread_delta_fcn"))
         d_spread_kernel_fcn = db->getString("d_spread_delta_fcn");
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_interp_kernel_fcn));
+    TBOX_ASSERT(LEInteractor::isKnownKernel(d_spread_kernel_fcn));
     db->getIntegerArray("d_ghosts", d_ghosts, NDIM);
     if (db->keyExists("instrument_names"))
     {


### PR DESCRIPTION
Incredibly, `fdl::IFEDMethod` spends about 6-7% of its time doing string comparisons inside `LEInteractor`. This patch rewrites those string comparison functions to check the minimal number of characters and instead moves the 'verify the kernel' checks to debug mode and also object constructors.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
