### PR TITLE
Fix ibtk mpi

### DIFF
--- a/doc/news/changes/incompatibilities/20211215DavidWells
+++ b/doc/news/changes/incompatibilities/20211215DavidWells
@@ -1,0 +1,6 @@
+Changed: IBTK_MPI's unused MPI type aliases have been removed.
+Additionally, the optional communicator arguments have been removed.
+This change was necessary to prevent a type conversion error that caused
+compilation issues with versions of MPI that use unsigned int for MPI_Comm.
+<br>
+(David Wells, 2021/12/15)

--- a/ibtk/include/ibtk/IBTK_MPI.h
+++ b/ibtk/include/ibtk/IBTK_MPI.h
@@ -20,11 +20,11 @@
 
 #include <ibtk/config.h>
 
+#include <mpi.h>
+
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#include <mpi.h>
 
 namespace IBTK
 {
@@ -122,17 +122,17 @@ struct IBTK_MPI
      * Return the processor rank (identifier) from 0 through the number of
      * processors minus one.
      */
-    static int getRank(MPI_Comm communicator = getCommunicator());
+    static int getRank();
 
     /**
      * Return the number of processors (nodes).
      */
-    static int getNodes(MPI_Comm communicator = getCommunicator());
+    static int getNodes();
 
     /**
      * Perform a global barrier across all processors.
      */
-    static void barrier(MPI_Comm communicator = getCommunicator());
+    static void barrier();
 
     //@{
     /**
@@ -141,10 +141,9 @@ struct IBTK_MPI
      * null, the rank of which processor the min is located is stored in the array.
      */
     template <typename T>
-    static T minReduction(T x, int* rank_of_min = nullptr, MPI_Comm communicator = getCommunicator());
+    static T minReduction(T x, int* rank_of_min = nullptr);
     template <typename T>
-    static void
-    minReduction(T* x, const int n = 1, int* rank_of_min = nullptr, MPI_Comm communicator = getCommunicator());
+    static void minReduction(T* x, const int n = 1, int* rank_of_min = nullptr);
 
     //@}
 
@@ -155,10 +154,9 @@ struct IBTK_MPI
      * null, the rank of which processor the max is located is stored in the array.
      */
     template <typename T>
-    static T maxReduction(T x, int* rank_of_min = nullptr, MPI_Comm communicator = getCommunicator());
+    static T maxReduction(T x, int* rank_of_min = nullptr);
     template <typename T>
-    static void
-    maxReduction(T* x, const int n = 1, int* rank_of_min = nullptr, MPI_Comm communicator = getCommunicator());
+    static void maxReduction(T* x, const int n = 1, int* rank_of_min = nullptr);
     //@}
 
     //@{
@@ -167,17 +165,16 @@ struct IBTK_MPI
      * contributes an array of values and element-wise sum is returned in the same array.
      */
     template <typename T>
-    static T sumReduction(T, MPI_Comm communicator = getCommunicator());
+    static T sumReduction(T);
     template <typename T>
-    static void sumReduction(T* x, const int n = 1, MPI_Comm communicator = getCommunicator());
+    static void sumReduction(T* x, const int n = 1);
     //@}
 
     /**
      * Perform an all-to-one sum reduction on an integer array.
      * The final result is only available on the root processor.
      */
-    static void
-    allToOneSumReduction(int* x, const int n, const int root = 0, MPI_Comm communicator = getCommunicator());
+    static void allToOneSumReduction(int* x, const int n, const int root = 0);
 
     //@{
     /**
@@ -186,9 +183,9 @@ struct IBTK_MPI
      * are treated as const.
      */
     template <typename T>
-    static T bcast(const T x, const int root, MPI_Comm communicator = getCommunicator());
+    static T bcast(const T x, const int root);
     template <typename T>
-    static void bcast(T* x, int& length, const int root, MPI_Comm communicator = getCommunicator());
+    static void bcast(T* x, int& length, const int root);
     //@}
 
     /*!
@@ -210,12 +207,8 @@ struct IBTK_MPI
      * to be sent with this message.  Default tag is 0.
      */
     template <typename T>
-    static void send(const T* buf,
-                     const int length,
-                     const int receiving_proc_number,
-                     const bool send_length = true,
-                     int tag = 0,
-                     MPI_Comm communicator = getCommunicator());
+    static void
+    send(const T* buf, const int length, const int receiving_proc_number, const bool send_length = true, int tag = 0);
 
     /*!
      * @brief This function sends an MPI message with an array of bytes
@@ -227,10 +220,7 @@ struct IBTK_MPI
      * @param number_bytes Integer number of bytes to send.
      * @param receiving_proc_number Receiving processor number.
      */
-    static void sendBytes(const void* buf,
-                          const int number_bytes,
-                          const int receiving_proc_number,
-                          MPI_Comm communicator = getCommunicator());
+    static void sendBytes(const void* buf, const int number_bytes, const int receiving_proc_number);
 
     /*!
      * @brief This function receives an MPI message with an array of
@@ -243,7 +233,7 @@ struct IBTK_MPI
      * @param buf Void pointer to a buffer of size number_bytes bytes.
      * @param number_bytes Integer number specifing size of buf in bytes.
      */
-    static int recvBytes(void* buf, int number_bytes, MPI_Comm communicator = getCommunicator());
+    static int recvBytes(void* buf, int number_bytes);
 
     /*!
      * @brief This function receives an MPI message with an array from another processer.
@@ -266,12 +256,7 @@ struct IBTK_MPI
      * tag is 0.
      */
     template <typename T>
-    static void recv(T* buf,
-                     int& length,
-                     const int sending_proc_number,
-                     const bool get_length = true,
-                     int tag = -1,
-                     MPI_Comm communicator = getCommunicator());
+    static void recv(T* buf, int& length, const int sending_proc_number, const bool get_length = true, int tag = -1);
 
     //@{
     /**
@@ -287,10 +272,9 @@ struct IBTK_MPI
      * then allocate the x_out array.
      */
     template <typename T>
-    static void
-    allGather(const T* x_in, int size_in, T* x_out, int size_out, MPI_Comm communicator = getCommunicator());
+    static void allGather(const T* x_in, int size_in, T* x_out, int size_out);
     template <typename T>
-    static void allGather(T x_in, T* x_out, MPI_Comm communicator = getCommunicator());
+    static void allGather(T x_in, T* x_out);
 
     //@}
 
@@ -298,14 +282,10 @@ private:
     /**
      * Performs common functions needed by some of the allToAll methods.
      */
-    static void allGatherSetup(int size_in,
-                               int size_out,
-                               std::vector<int>& rcounts,
-                               std::vector<int>& disps,
-                               MPI_Comm communicator = getCommunicator());
+    static void allGatherSetup(int size_in, int size_out, std::vector<int>& rcounts, std::vector<int>& disps);
 
     template <typename T>
-    static void minMaxReduction(T* x, const int n, int* rank, MPI_Op op, MPI_Comm communicator);
+    static void minMaxReduction(T* x, const int n, int* rank, MPI_Op op);
 
     static MPI_Comm s_communicator;
 };

--- a/ibtk/include/ibtk/IBTK_MPI.h
+++ b/ibtk/include/ibtk/IBTK_MPI.h
@@ -170,7 +170,7 @@ struct IBTK_MPI
      * contributes an array of values and element-wise sum is returned in the same array.
      */
     template <typename T>
-    static T sumReduction(T, MPI_Comm commiunicator = getCommunicator());
+    static T sumReduction(T, MPI_Comm communicator = getCommunicator());
     template <typename T>
     static void sumReduction(T* x, const int n = 1, MPI_Comm communicator = getCommunicator());
     //@}

--- a/ibtk/include/ibtk/IBTK_MPI.h
+++ b/ibtk/include/ibtk/IBTK_MPI.h
@@ -20,14 +20,11 @@
 
 #include <ibtk/config.h>
 
-#include "SAMRAI_config.h"
-#include "tbox/Utilities.h"
-
-#include <mpi.h>
-
 #include <type_traits>
 #include <utility>
 #include <vector>
+
+#include <mpi.h>
 
 namespace IBTK
 {
@@ -317,6 +314,6 @@ private:
 
 /////////////////////////////// INLINE ///////////////////////////////////////
 
-#include "ibtk/private/IBTK_MPI-inl.h" // IWYU pragma: keep
+#include <ibtk/private/IBTK_MPI-inl.h> // IWYU pragma: keep
 
 #endif

--- a/ibtk/include/ibtk/IBTK_MPI.h
+++ b/ibtk/include/ibtk/IBTK_MPI.h
@@ -105,45 +105,37 @@ mpi_type_id(const T&)
 struct IBTK_MPI
 {
     /**
-     * MPI Types
-     */
-    using comm = MPI_Comm;
-    using group = MPI_Group;
-    using request = MPI_Request;
-    using status = MPI_Status;
-
-    /**
      * Set the communicator that is used for the MPI communication routines.
      * The default communicator is MPI_COMM_WORLD.
      */
-    static void setCommunicator(IBTK_MPI::comm communicator);
+    static void setCommunicator(MPI_Comm communicator);
 
     /**
      * Get the current MPI communicator.  The default communicator is
      * MPI_COMM_WORLD.
      */
-    static IBTK_MPI::comm getCommunicator();
+    static MPI_Comm getCommunicator();
 
     /**
      * Get SAMRAI World communicator.
      */
-    static IBTK_MPI::comm getSAMRAIWorld();
+    static MPI_Comm getSAMRAIWorld();
 
     /**
      * Return the processor rank (identifier) from 0 through the number of
      * processors minus one.
      */
-    static int getRank(IBTK_MPI::comm communicator = getCommunicator());
+    static int getRank(MPI_Comm communicator = getCommunicator());
 
     /**
      * Return the number of processors (nodes).
      */
-    static int getNodes(IBTK_MPI::comm communicator = getCommunicator());
+    static int getNodes(MPI_Comm communicator = getCommunicator());
 
     /**
      * Perform a global barrier across all processors.
      */
-    static void barrier(IBTK_MPI::comm communicator = getCommunicator());
+    static void barrier(MPI_Comm communicator = getCommunicator());
 
     //@{
     /**
@@ -152,10 +144,10 @@ struct IBTK_MPI
      * null, the rank of which processor the min is located is stored in the array.
      */
     template <typename T>
-    static T minReduction(T x, int* rank_of_min = nullptr, IBTK_MPI::comm communicator = getCommunicator());
+    static T minReduction(T x, int* rank_of_min = nullptr, MPI_Comm communicator = getCommunicator());
     template <typename T>
     static void
-    minReduction(T* x, const int n = 1, int* rank_of_min = nullptr, IBTK_MPI::comm communicator = getCommunicator());
+    minReduction(T* x, const int n = 1, int* rank_of_min = nullptr, MPI_Comm communicator = getCommunicator());
 
     //@}
 
@@ -166,10 +158,10 @@ struct IBTK_MPI
      * null, the rank of which processor the max is located is stored in the array.
      */
     template <typename T>
-    static T maxReduction(T x, int* rank_of_min = nullptr, IBTK_MPI::comm communicator = getCommunicator());
+    static T maxReduction(T x, int* rank_of_min = nullptr, MPI_Comm communicator = getCommunicator());
     template <typename T>
     static void
-    maxReduction(T* x, const int n = 1, int* rank_of_min = nullptr, IBTK_MPI::comm communicator = getCommunicator());
+    maxReduction(T* x, const int n = 1, int* rank_of_min = nullptr, MPI_Comm communicator = getCommunicator());
     //@}
 
     //@{
@@ -178,9 +170,9 @@ struct IBTK_MPI
      * contributes an array of values and element-wise sum is returned in the same array.
      */
     template <typename T>
-    static T sumReduction(T, IBTK_MPI::comm commiunicator = getCommunicator());
+    static T sumReduction(T, MPI_Comm commiunicator = getCommunicator());
     template <typename T>
-    static void sumReduction(T* x, const int n = 1, IBTK_MPI::comm communicator = getCommunicator());
+    static void sumReduction(T* x, const int n = 1, MPI_Comm communicator = getCommunicator());
     //@}
 
     /**
@@ -188,7 +180,7 @@ struct IBTK_MPI
      * The final result is only available on the root processor.
      */
     static void
-    allToOneSumReduction(int* x, const int n, const int root = 0, IBTK_MPI::comm communicator = getCommunicator());
+    allToOneSumReduction(int* x, const int n, const int root = 0, MPI_Comm communicator = getCommunicator());
 
     //@{
     /**
@@ -197,9 +189,9 @@ struct IBTK_MPI
      * are treated as const.
      */
     template <typename T>
-    static T bcast(const T x, const int root, IBTK_MPI::comm communicator = getCommunicator());
+    static T bcast(const T x, const int root, MPI_Comm communicator = getCommunicator());
     template <typename T>
-    static void bcast(T* x, int& length, const int root, IBTK_MPI::comm communicator = getCommunicator());
+    static void bcast(T* x, int& length, const int root, MPI_Comm communicator = getCommunicator());
     //@}
 
     /*!
@@ -226,7 +218,7 @@ struct IBTK_MPI
                      const int receiving_proc_number,
                      const bool send_length = true,
                      int tag = 0,
-                     IBTK_MPI::comm communicator = getCommunicator());
+                     MPI_Comm communicator = getCommunicator());
 
     /*!
      * @brief This function sends an MPI message with an array of bytes
@@ -241,7 +233,7 @@ struct IBTK_MPI
     static void sendBytes(const void* buf,
                           const int number_bytes,
                           const int receiving_proc_number,
-                          IBTK_MPI::comm communicator = getCommunicator());
+                          MPI_Comm communicator = getCommunicator());
 
     /*!
      * @brief This function receives an MPI message with an array of
@@ -254,7 +246,7 @@ struct IBTK_MPI
      * @param buf Void pointer to a buffer of size number_bytes bytes.
      * @param number_bytes Integer number specifing size of buf in bytes.
      */
-    static int recvBytes(void* buf, int number_bytes, IBTK_MPI::comm communicator = getCommunicator());
+    static int recvBytes(void* buf, int number_bytes, MPI_Comm communicator = getCommunicator());
 
     /*!
      * @brief This function receives an MPI message with an array from another processer.
@@ -282,7 +274,7 @@ struct IBTK_MPI
                      const int sending_proc_number,
                      const bool get_length = true,
                      int tag = -1,
-                     IBTK_MPI::comm communicator = getCommunicator());
+                     MPI_Comm communicator = getCommunicator());
 
     //@{
     /**
@@ -299,9 +291,9 @@ struct IBTK_MPI
      */
     template <typename T>
     static void
-    allGather(const T* x_in, int size_in, T* x_out, int size_out, IBTK_MPI::comm communicator = getCommunicator());
+    allGather(const T* x_in, int size_in, T* x_out, int size_out, MPI_Comm communicator = getCommunicator());
     template <typename T>
-    static void allGather(T x_in, T* x_out, IBTK_MPI::comm communicator = getCommunicator());
+    static void allGather(T x_in, T* x_out, MPI_Comm communicator = getCommunicator());
 
     //@}
 
@@ -313,12 +305,12 @@ private:
                                int size_out,
                                std::vector<int>& rcounts,
                                std::vector<int>& disps,
-                               IBTK_MPI::comm communicator = getCommunicator());
+                               MPI_Comm communicator = getCommunicator());
 
     template <typename T>
-    static void minMaxReduction(T* x, const int n, int* rank, MPI_Op op, IBTK_MPI::comm communicator);
+    static void minMaxReduction(T* x, const int n, int* rank, MPI_Op op, MPI_Comm communicator);
 
-    static IBTK_MPI::comm s_communicator;
+    static MPI_Comm s_communicator;
 };
 
 } // namespace IBTK

--- a/ibtk/include/ibtk/private/IBTK_MPI-inl.h
+++ b/ibtk/include/ibtk/private/IBTK_MPI-inl.h
@@ -23,7 +23,7 @@ namespace IBTK
 {
 template <typename T>
 inline T
-IBTK_MPI::minReduction(T x, int* rank_of_min, IBTK_MPI::comm communicator)
+IBTK_MPI::minReduction(T x, int* rank_of_min, MPI_Comm communicator)
 {
     minReduction(&x, 1, rank_of_min, communicator);
     return x;
@@ -31,7 +31,7 @@ IBTK_MPI::minReduction(T x, int* rank_of_min, IBTK_MPI::comm communicator)
 
 template <typename T>
 inline void
-IBTK_MPI::minReduction(T* x, const int n, int* rank_of_min, IBTK_MPI::comm communicator)
+IBTK_MPI::minReduction(T* x, const int n, int* rank_of_min, MPI_Comm communicator)
 {
     if (n == 0) return;
     if (rank_of_min == nullptr)
@@ -46,7 +46,7 @@ IBTK_MPI::minReduction(T* x, const int n, int* rank_of_min, IBTK_MPI::comm commu
 
 template <typename T>
 inline T
-IBTK_MPI::maxReduction(T x, int* rank_of_max, IBTK_MPI::comm communicator)
+IBTK_MPI::maxReduction(T x, int* rank_of_max, MPI_Comm communicator)
 {
     maxReduction(&x, 1, rank_of_max, communicator);
     return x;
@@ -54,7 +54,7 @@ IBTK_MPI::maxReduction(T x, int* rank_of_max, IBTK_MPI::comm communicator)
 
 template <typename T>
 inline void
-IBTK_MPI::maxReduction(T* x, const int n, int* rank_of_max, IBTK_MPI::comm communicator)
+IBTK_MPI::maxReduction(T* x, const int n, int* rank_of_max, MPI_Comm communicator)
 {
     if (n == 0) return;
     if (rank_of_max == nullptr)
@@ -69,7 +69,7 @@ IBTK_MPI::maxReduction(T* x, const int n, int* rank_of_max, IBTK_MPI::comm commu
 
 template <typename T>
 inline T
-IBTK_MPI::sumReduction(T x, IBTK_MPI::comm communicator)
+IBTK_MPI::sumReduction(T x, MPI_Comm communicator)
 {
     // This check is useful since it occurs earlier than the mpi_type_id() base
     // case failure (and it has a clearer error message)
@@ -82,7 +82,7 @@ IBTK_MPI::sumReduction(T x, IBTK_MPI::comm communicator)
 
 template <typename T>
 inline void
-IBTK_MPI::sumReduction(T* x, const int n, IBTK_MPI::comm communicator)
+IBTK_MPI::sumReduction(T* x, const int n, MPI_Comm communicator)
 {
     if (n == 0 || getNodes(communicator) < 2) return;
     MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_SUM, communicator);
@@ -90,7 +90,7 @@ IBTK_MPI::sumReduction(T* x, const int n, IBTK_MPI::comm communicator)
 
 template <typename T>
 inline T
-IBTK_MPI::bcast(const T x, const int root, IBTK_MPI::comm communicator)
+IBTK_MPI::bcast(const T x, const int root, MPI_Comm communicator)
 {
     int size = 1;
     T temp_copy = x;
@@ -100,7 +100,7 @@ IBTK_MPI::bcast(const T x, const int root, IBTK_MPI::comm communicator)
 
 template <typename T>
 inline void
-IBTK_MPI::bcast(T* x, int& length, const int root, IBTK_MPI::comm communicator)
+IBTK_MPI::bcast(T* x, int& length, const int root, MPI_Comm communicator)
 {
     if (getNodes(communicator) > 1)
     {
@@ -115,7 +115,7 @@ IBTK_MPI::send(const T* buf,
                const int receiving_proc_number,
                const bool send_length,
                int tag,
-               IBTK_MPI::comm communicator)
+               MPI_Comm communicator)
 {
     tag = (tag >= 0) ? tag : 0;
     int size = length;
@@ -133,7 +133,7 @@ IBTK_MPI::recv(T* buf,
                const int sending_proc_number,
                const bool get_length,
                int tag,
-               IBTK_MPI::comm communicator)
+               MPI_Comm communicator)
 {
     MPI_Status status;
     tag = (tag >= 0) ? tag : 0;
@@ -146,7 +146,7 @@ IBTK_MPI::recv(T* buf,
 
 template <typename T>
 inline void
-IBTK_MPI::allGather(const T* x_in, int size_in, T* x_out, int size_out, IBTK_MPI::comm communicator)
+IBTK_MPI::allGather(const T* x_in, int size_in, T* x_out, int size_out, MPI_Comm communicator)
 {
     std::vector<int> rcounts, disps;
     allGatherSetup(size_in, size_out, rcounts, disps, communicator);
@@ -157,7 +157,7 @@ IBTK_MPI::allGather(const T* x_in, int size_in, T* x_out, int size_out, IBTK_MPI
 
 template <typename T>
 inline void
-IBTK_MPI::allGather(T x_in, T* x_out, IBTK_MPI::comm communicator)
+IBTK_MPI::allGather(T x_in, T* x_out, MPI_Comm communicator)
 {
     MPI_Allgather(&x_in, 1, mpi_type_id(x_in), x_out, 1, mpi_type_id(x_in), communicator);
 } // allGather
@@ -165,7 +165,7 @@ IBTK_MPI::allGather(T x_in, T* x_out, IBTK_MPI::comm communicator)
 //////////////////////////////////////  PRIVATE  ///////////////////////////////////////////////////
 template <typename T>
 inline void
-IBTK_MPI::minMaxReduction(T* x, const int n, int* rank, MPI_Op op, IBTK_MPI::comm communicator)
+IBTK_MPI::minMaxReduction(T* x, const int n, int* rank, MPI_Op op, MPI_Comm communicator)
 {
     std::vector<std::pair<T, int> > recv(n);
     std::vector<std::pair<T, int> > send(n);

--- a/ibtk/include/ibtk/private/IBTK_MPI-inl.h
+++ b/ibtk/include/ibtk/private/IBTK_MPI-inl.h
@@ -17,164 +17,161 @@
 #define included_IBTK_MPI_inc
 
 #include <ibtk/config.h>
+
 #include <ibtk/IBTK_MPI.h>
 
 namespace IBTK
 {
 template <typename T>
 inline T
-IBTK_MPI::minReduction(T x, int* rank_of_min, MPI_Comm communicator)
+IBTK_MPI::minReduction(T x, int* rank_of_min)
 {
-    minReduction(&x, 1, rank_of_min, communicator);
+    minReduction(&x, 1, rank_of_min);
     return x;
 } // minReduction
 
 template <typename T>
 inline void
-IBTK_MPI::minReduction(T* x, const int n, int* rank_of_min, MPI_Comm communicator)
+IBTK_MPI::minReduction(T* x, const int n, int* rank_of_min)
 {
     if (n == 0) return;
     if (rank_of_min == nullptr)
     {
-        MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_MIN, communicator);
+        MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_MIN, IBTK_MPI::getCommunicator());
     }
     else
     {
-        minMaxReduction(x, n, rank_of_min, MPI_MINLOC, communicator);
+        minMaxReduction(x, n, rank_of_min, MPI_MINLOC);
     }
 } // minReduction
 
 template <typename T>
 inline T
-IBTK_MPI::maxReduction(T x, int* rank_of_max, MPI_Comm communicator)
+IBTK_MPI::maxReduction(T x, int* rank_of_max)
 {
-    maxReduction(&x, 1, rank_of_max, communicator);
+    maxReduction(&x, 1, rank_of_max);
     return x;
 } // maxReduction
 
 template <typename T>
 inline void
-IBTK_MPI::maxReduction(T* x, const int n, int* rank_of_max, MPI_Comm communicator)
+IBTK_MPI::maxReduction(T* x, const int n, int* rank_of_max)
 {
     if (n == 0) return;
     if (rank_of_max == nullptr)
     {
-        MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_MAX, communicator);
+        MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_MAX, IBTK_MPI::getCommunicator());
     }
     else
     {
-        minMaxReduction(x, n, rank_of_max, MPI_MAXLOC, communicator);
+        minMaxReduction(x, n, rank_of_max, MPI_MAXLOC);
     }
 } // maxReduction
 
 template <typename T>
 inline T
-IBTK_MPI::sumReduction(T x, MPI_Comm communicator)
+IBTK_MPI::sumReduction(T x)
 {
     // This check is useful since it occurs earlier than the mpi_type_id() base
     // case failure (and it has a clearer error message)
     static_assert(!std::is_pointer<T>::value,
                   "This function cannot be instantiated for pointer types "
                   "since it does not make sense to sum pointers.");
-    sumReduction(&x, 1, communicator);
+    sumReduction(&x, 1);
     return x;
 } // sumReduction
 
 template <typename T>
 inline void
-IBTK_MPI::sumReduction(T* x, const int n, MPI_Comm communicator)
+IBTK_MPI::sumReduction(T* x, const int n)
 {
-    if (n == 0 || getNodes(communicator) < 2) return;
-    MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_SUM, communicator);
+    if (n == 0 || getNodes() < 2) return;
+    MPI_Allreduce(MPI_IN_PLACE, x, n, mpi_type_id(x[0]), MPI_SUM, IBTK_MPI::getCommunicator());
 } // sumReduction
 
 template <typename T>
 inline T
-IBTK_MPI::bcast(const T x, const int root, MPI_Comm communicator)
+IBTK_MPI::bcast(const T x, const int root)
 {
     int size = 1;
     T temp_copy = x;
-    bcast(&temp_copy, size, root, communicator);
+    bcast(&temp_copy, size, root);
     return temp_copy;
 }
 
 template <typename T>
 inline void
-IBTK_MPI::bcast(T* x, int& length, const int root, MPI_Comm communicator)
+IBTK_MPI::bcast(T* x, int& length, const int root)
 {
-    if (getNodes(communicator) > 1)
+    if (getNodes() > 1)
     {
-        MPI_Bcast(x, length, mpi_type_id(x[0]), root, communicator);
+        MPI_Bcast(x, length, mpi_type_id(x[0]), root, IBTK_MPI::getCommunicator());
     }
 } // bcast
 
 template <typename T>
 inline void
-IBTK_MPI::send(const T* buf,
-               const int length,
-               const int receiving_proc_number,
-               const bool send_length,
-               int tag,
-               MPI_Comm communicator)
+IBTK_MPI::send(const T* buf, const int length, const int receiving_proc_number, const bool send_length, int tag)
 {
     tag = (tag >= 0) ? tag : 0;
     int size = length;
     if (send_length)
     {
-        MPI_Send(&size, 1, MPI_INT, receiving_proc_number, tag, communicator);
+        MPI_Send(&size, 1, MPI_INT, receiving_proc_number, tag, IBTK_MPI::getCommunicator());
     }
-    MPI_Send(buf, length, mpi_type_id(buf[0]), receiving_proc_number, tag, communicator);
+    MPI_Send(buf, length, mpi_type_id(buf[0]), receiving_proc_number, tag, IBTK_MPI::getCommunicator());
 } // send
 
 template <typename T>
 inline void
-IBTK_MPI::recv(T* buf,
-               int& length,
-               const int sending_proc_number,
-               const bool get_length,
-               int tag,
-               MPI_Comm communicator)
+IBTK_MPI::recv(T* buf, int& length, const int sending_proc_number, const bool get_length, int tag)
 {
     MPI_Status status;
     tag = (tag >= 0) ? tag : 0;
     if (get_length)
     {
-        MPI_Recv(&length, 1, MPI_INT, sending_proc_number, tag, communicator, &status);
+        MPI_Recv(&length, 1, MPI_INT, sending_proc_number, tag, IBTK_MPI::getCommunicator(), &status);
     }
-    MPI_Recv(buf, length, mpi_type_id(buf[0]), sending_proc_number, tag, communicator, &status);
+    MPI_Recv(buf, length, mpi_type_id(buf[0]), sending_proc_number, tag, IBTK_MPI::getCommunicator(), &status);
 } // recv
 
 template <typename T>
 inline void
-IBTK_MPI::allGather(const T* x_in, int size_in, T* x_out, int size_out, MPI_Comm communicator)
+IBTK_MPI::allGather(const T* x_in, int size_in, T* x_out, int size_out)
 {
     std::vector<int> rcounts, disps;
-    allGatherSetup(size_in, size_out, rcounts, disps, communicator);
+    allGatherSetup(size_in, size_out, rcounts, disps);
 
-    MPI_Allgatherv(
-        x_in, size_in, mpi_type_id(x_in[0]), x_out, rcounts.data(), disps.data(), mpi_type_id(x_in[0]), communicator);
+    MPI_Allgatherv(x_in,
+                   size_in,
+                   mpi_type_id(x_in[0]),
+                   x_out,
+                   rcounts.data(),
+                   disps.data(),
+                   mpi_type_id(x_in[0]),
+                   IBTK_MPI::getCommunicator());
 } // allGather
 
 template <typename T>
 inline void
-IBTK_MPI::allGather(T x_in, T* x_out, MPI_Comm communicator)
+IBTK_MPI::allGather(T x_in, T* x_out)
 {
-    MPI_Allgather(&x_in, 1, mpi_type_id(x_in), x_out, 1, mpi_type_id(x_in), communicator);
+    MPI_Allgather(&x_in, 1, mpi_type_id(x_in), x_out, 1, mpi_type_id(x_in), IBTK_MPI::getCommunicator());
 } // allGather
 
 //////////////////////////////////////  PRIVATE  ///////////////////////////////////////////////////
 template <typename T>
 inline void
-IBTK_MPI::minMaxReduction(T* x, const int n, int* rank, MPI_Op op, MPI_Comm communicator)
+IBTK_MPI::minMaxReduction(T* x, const int n, int* rank, MPI_Op op)
 {
     std::vector<std::pair<T, int> > recv(n);
     std::vector<std::pair<T, int> > send(n);
     for (int i = 0; i < n; ++i)
     {
         send[i].first = x[i];
-        send[i].second = getRank(communicator);
+        send[i].second = getRank();
     }
-    MPI_Allreduce(send.data(), recv.data(), n, mpi_type_id(recv[0]), op, communicator);
+    MPI_Allreduce(send.data(), recv.data(), n, mpi_type_id(recv[0]), op, IBTK_MPI::getCommunicator());
     for (int i = 0; i < n; ++i)
     {
         x[i] = recv[i].first;

--- a/ibtk/include/ibtk/private/IBTK_MPI-inl.h
+++ b/ibtk/include/ibtk/private/IBTK_MPI-inl.h
@@ -16,10 +16,10 @@
 #ifndef included_IBTK_MPI_inc
 #define included_IBTK_MPI_inc
 
-#include "ibtk/IBTK_MPI.h"
+#include <ibtk/config.h>
+#include <ibtk/IBTK_MPI.h>
 
 namespace IBTK
-#include <ibtk/config.h>
 {
 template <typename T>
 inline T

--- a/ibtk/src/utilities/IBTK_MPI.cpp
+++ b/ibtk/src/utilities/IBTK_MPI.cpp
@@ -16,7 +16,6 @@
 #include <ibtk/IBTK_MPI.h>
 
 #include <tbox/SAMRAI_MPI.h>
-#include <tbox/Utilities.h>
 
 #include <ostream>
 #include <string>

--- a/ibtk/src/utilities/IBTK_MPI.cpp
+++ b/ibtk/src/utilities/IBTK_MPI.cpp
@@ -24,21 +24,21 @@
 
 namespace IBTK
 {
-IBTK_MPI::comm IBTK_MPI::s_communicator = MPI_COMM_WORLD;
+MPI_Comm IBTK_MPI::s_communicator = MPI_COMM_WORLD;
 
 void
-IBTK_MPI::setCommunicator(IBTK_MPI::comm communicator)
+IBTK_MPI::setCommunicator(MPI_Comm communicator)
 {
     s_communicator = communicator;
 } // setCommunicator
 
-IBTK_MPI::comm
+MPI_Comm
 IBTK_MPI::getCommunicator()
 {
     return (s_communicator);
 } // getCommunicator
 
-IBTK_MPI::comm
+MPI_Comm
 IBTK_MPI::getSAMRAIWorld()
 {
 #if SAMRAI_VERSION_MAJOR == 2
@@ -49,7 +49,7 @@ IBTK_MPI::getSAMRAIWorld()
 }
 
 int
-IBTK_MPI::getNodes(IBTK_MPI::comm communicator)
+IBTK_MPI::getNodes(MPI_Comm communicator)
 {
     int nodes = 1;
     MPI_Comm_size(communicator, &nodes);
@@ -57,7 +57,7 @@ IBTK_MPI::getNodes(IBTK_MPI::comm communicator)
 } // getNodes
 
 int
-IBTK_MPI::getRank(IBTK_MPI::comm communicator)
+IBTK_MPI::getRank(MPI_Comm communicator)
 {
     int node = 0;
     MPI_Comm_rank(communicator, &node);
@@ -65,17 +65,17 @@ IBTK_MPI::getRank(IBTK_MPI::comm communicator)
 } // getRank
 
 void
-IBTK_MPI::barrier(IBTK_MPI::comm communicator)
+IBTK_MPI::barrier(MPI_Comm communicator)
 {
     (void)MPI_Barrier(communicator);
 } // barrier
 
 void
-IBTK_MPI::allToOneSumReduction(int* x, const int n, const int root, IBTK_MPI::comm communicator)
+IBTK_MPI::allToOneSumReduction(int* x, const int n, const int root, MPI_Comm communicator)
 {
     if (getNodes(communicator) > 1)
     {
-        if (IBTK_MPI::getRank() == root)
+        if (IBTK_MPI::getRank(communicator) == root)
             MPI_Reduce(MPI_IN_PLACE, x, n, MPI_INT, MPI_SUM, root, communicator);
         else
             MPI_Reduce(x, x, n, MPI_INT, MPI_SUM, root, communicator);
@@ -83,16 +83,13 @@ IBTK_MPI::allToOneSumReduction(int* x, const int n, const int root, IBTK_MPI::co
 } // allToOneSumReduction
 
 void
-IBTK_MPI::sendBytes(const void* buf,
-                    const int number_bytes,
-                    const int receiving_proc_number,
-                    IBTK_MPI::comm communicator)
+IBTK_MPI::sendBytes(const void* buf, const int number_bytes, const int receiving_proc_number, MPI_Comm communicator)
 {
     MPI_Send((void*)buf, number_bytes, MPI_BYTE, receiving_proc_number, 0, communicator);
 } // sendBytes
 
 int
-IBTK_MPI::recvBytes(void* buf, int number_bytes, IBTK_MPI::comm communicator)
+IBTK_MPI::recvBytes(void* buf, int number_bytes, MPI_Comm communicator)
 {
     int rval = 0;
     MPI_Status status;
@@ -109,7 +106,7 @@ IBTK_MPI::allGatherSetup(int size_in,
                          int size_out,
                          std::vector<int>& rcounts,
                          std::vector<int>& disps,
-                         IBTK_MPI::comm communicator)
+                         MPI_Comm communicator)
 {
     int np = getNodes(communicator);
     rcounts.resize(np);

--- a/ibtk/src/utilities/IBTK_MPI.cpp
+++ b/ibtk/src/utilities/IBTK_MPI.cpp
@@ -48,51 +48,51 @@ IBTK_MPI::getSAMRAIWorld()
 }
 
 int
-IBTK_MPI::getNodes(MPI_Comm communicator)
+IBTK_MPI::getNodes()
 {
     int nodes = 1;
-    MPI_Comm_size(communicator, &nodes);
+    MPI_Comm_size(IBTK_MPI::getCommunicator(), &nodes);
     return nodes;
 } // getNodes
 
 int
-IBTK_MPI::getRank(MPI_Comm communicator)
+IBTK_MPI::getRank()
 {
     int node = 0;
-    MPI_Comm_rank(communicator, &node);
+    MPI_Comm_rank(IBTK_MPI::getCommunicator(), &node);
     return node;
 } // getRank
 
 void
-IBTK_MPI::barrier(MPI_Comm communicator)
+IBTK_MPI::barrier()
 {
-    (void)MPI_Barrier(communicator);
+    (void)MPI_Barrier(IBTK_MPI::getCommunicator());
 } // barrier
 
 void
-IBTK_MPI::allToOneSumReduction(int* x, const int n, const int root, MPI_Comm communicator)
+IBTK_MPI::allToOneSumReduction(int* x, const int n, const int root)
 {
-    if (getNodes(communicator) > 1)
+    if (getNodes() > 1)
     {
-        if (IBTK_MPI::getRank(communicator) == root)
-            MPI_Reduce(MPI_IN_PLACE, x, n, MPI_INT, MPI_SUM, root, communicator);
+        if (IBTK_MPI::getRank() == root)
+            MPI_Reduce(MPI_IN_PLACE, x, n, MPI_INT, MPI_SUM, root, IBTK_MPI::getCommunicator());
         else
-            MPI_Reduce(x, x, n, MPI_INT, MPI_SUM, root, communicator);
+            MPI_Reduce(x, x, n, MPI_INT, MPI_SUM, root, IBTK_MPI::getCommunicator());
     }
 } // allToOneSumReduction
 
 void
-IBTK_MPI::sendBytes(const void* buf, const int number_bytes, const int receiving_proc_number, MPI_Comm communicator)
+IBTK_MPI::sendBytes(const void* buf, const int number_bytes, const int receiving_proc_number)
 {
-    MPI_Send((void*)buf, number_bytes, MPI_BYTE, receiving_proc_number, 0, communicator);
+    MPI_Send((void*)buf, number_bytes, MPI_BYTE, receiving_proc_number, 0, IBTK_MPI::getCommunicator());
 } // sendBytes
 
 int
-IBTK_MPI::recvBytes(void* buf, int number_bytes, MPI_Comm communicator)
+IBTK_MPI::recvBytes(void* buf, int number_bytes)
 {
     int rval = 0;
     MPI_Status status;
-    MPI_Recv(buf, number_bytes, MPI_BYTE, MPI_ANY_SOURCE, MPI_ANY_TAG, communicator, &status);
+    MPI_Recv(buf, number_bytes, MPI_BYTE, MPI_ANY_SOURCE, MPI_ANY_TAG, IBTK_MPI::getCommunicator(), &status);
 
     rval = status.MPI_SOURCE;
     return rval;
@@ -101,18 +101,14 @@ IBTK_MPI::recvBytes(void* buf, int number_bytes, MPI_Comm communicator)
 //////////////////////////////////////  PRIVATE  ///////////////////////////////////////////////////
 
 void
-IBTK_MPI::allGatherSetup(int size_in,
-                         int size_out,
-                         std::vector<int>& rcounts,
-                         std::vector<int>& disps,
-                         MPI_Comm communicator)
+IBTK_MPI::allGatherSetup(int size_in, int size_out, std::vector<int>& rcounts, std::vector<int>& disps)
 {
-    int np = getNodes(communicator);
+    int np = getNodes();
     rcounts.resize(np);
     disps.resize(np);
 
     /* figure out where where each processor's input will be placed */
-    allGather(size_in, rcounts.data(), communicator);
+    allGather(size_in, rcounts.data());
 
     disps[0] = 0;
     for (int p = 1; p < np; ++p)

--- a/ibtk/src/utilities/ParallelEdgeMap.cpp
+++ b/ibtk/src/utilities/ParallelEdgeMap.cpp
@@ -16,6 +16,8 @@
 #include "ibtk/IBTK_MPI.h"
 #include "ibtk/ParallelEdgeMap.h"
 
+#include <tbox/Utilities.h>
+
 #include <algorithm>
 #include <map>
 #include <vector>

--- a/ibtk/src/utilities/ParallelSet.cpp
+++ b/ibtk/src/utilities/ParallelSet.cpp
@@ -16,6 +16,8 @@
 #include "ibtk/IBTK_MPI.h"
 #include "ibtk/ParallelSet.h"
 
+#include <tbox/Utilities.h>
+
 #include <set>
 #include <vector>
 


### PR DESCRIPTION
This came up on the mailing list and, unfortunately, the permanent fix is quite long.

The issue we have is that we made the MPI communicator argument implicit. Some versions of MPI have
```cpp
typedef unsigned int MPI_Comm;
```
which means that, with
```cpp
template <typename T>
static T sumReduction(T, IBTK_MPI::comm commiunicator = getCommunicator());
template <typename T>
static void sumReduction(T* x, const int n = 1, IBTK_MPI::comm communicator = getCommunicator());
```
if we do
```cpp
unsigned int size = 100;
double *values = array.begin();
sumReduction(values, size);
```
we end up calling the *first* function instead of the second one (due to C++ overload resolution rules its a better fit), which is wrong.

As far as I can tell, we have two reasonable options:
1. Audit every call site from now forward to make sure we always use the correct integer type.
2. Ban default arguments for communicators.

I am in favor of the second one because it is the permanent fix - if there aren't any overloads with optional arguments then we will always call the correct function and things won't randomly break. I marked this as WIP since I still need to run the full test suite and audit all the changes again.

If people agree with this approach then lets just change `IBTK_MPI` to not use default arguments any more. Minimally, we could keep the default communicator argument, but every other optional argument really needs to go (passing a default array length is not a great idea).

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
