### PR TITLE
Add some workarounds for newly deprecated libMesh functions.

### DIFF
--- a/ibtk/src/lagrangian/StableCentroidPartitioner.cpp
+++ b/ibtk/src/lagrangian/StableCentroidPartitioner.cpp
@@ -21,6 +21,7 @@
 #include <libmesh/elem.h>
 #include <libmesh/id_types.h>
 #include <libmesh/libmesh_config.h>
+#include <libmesh/libmesh_version.h>
 #include <libmesh/mesh_base.h>
 #include <libmesh/point.h>
 
@@ -50,7 +51,7 @@ StableCentroidPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
 {
     // We assume every cell is on every processor: this function is only in
     // libMesh 1.2.0 and newer
-#if 1 < LIBMESH_MINOR_VERSION
+#if !LIBMESH_VERSION_LESS_THAN(1, 2, 0)
     TBOX_ASSERT(mesh.is_replicated());
 #endif
     // only implemented when we use SAMRAI's partitioning
@@ -60,7 +61,11 @@ StableCentroidPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
     auto el_end = mesh.elements_end();
     for (auto it = mesh.elements_begin(); it != el_end; ++it)
     {
+#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
         const libMesh::Point centroid = (*it)->centroid();
+#else
+        const libMesh::Point centroid = (*it)->vertex_average();
+#endif
 
         std::array<float, LIBMESH_DIM> rounded_centroid = { 0.0f };
         for (unsigned int d = 0; d < LIBMESH_DIM; ++d)

--- a/src/level_set/FESurfaceDistanceEvaluator.cpp
+++ b/src/level_set/FESurfaceDistanceEvaluator.cpp
@@ -54,6 +54,7 @@
 #include "libmesh/type_vector.h"
 #include "libmesh/variant_filter_iterator.h"
 #include "libmesh/vector_value.h"
+#include <libmesh/libmesh_version.h>
 
 #include <algorithm>
 #include <array>
@@ -1395,7 +1396,11 @@ FESurfaceDistanceEvaluator::collectNeighboringPatchElements(int level_number)
             }
 
             // First check the centroids.
-            const libMesh::Point& c = elem->centroid();
+#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
+            const libMesh::Point c = elem->centroid();
+#else
+            const libMesh::Point c = elem->vertex_average();
+#endif
 
             bool centroid_in_patch = true;
             for (unsigned int d = 0; d < NDIM; ++d)

--- a/tests/IBFE/explicit_ex4.cpp
+++ b/tests/IBFE/explicit_ex4.cpp
@@ -229,7 +229,11 @@ main(int argc, char** argv)
             const MeshBase::element_iterator el_end = mesh.active_elements_end();
             for (MeshBase::element_iterator el = mesh.active_elements_begin(); el != el_end; ++el)
             {
-                const auto centroid = (*el)->centroid();
+#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
+                const libMesh::Point centroid = (*el)->centroid();
+#else
+                const libMesh::Point centroid = (*el)->vertex_average();
+#endif
                 if (centroid.norm() > 0.75 * R)
                 {
                     (*el)->subdomain_id() = outer_id;
@@ -248,7 +252,11 @@ main(int argc, char** argv)
             for (MeshBase::element_iterator el = mesh.elements_begin(); el != el_end; ++el)
             {
                 Elem* elem = *el;
-                const auto centroid = elem->centroid();
+#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
+                const libMesh::Point centroid = elem->centroid();
+#else
+                const libMesh::Point centroid = elem->vertex_average();
+#endif
 
                 if (centroid(1) > 0.0) elem->set_refinement_flag(Elem::REFINE);
             }

--- a/tests/IBFE/interpolate_velocity_01.cpp
+++ b/tests/IBFE/interpolate_velocity_01.cpp
@@ -183,7 +183,11 @@ main(int argc, char** argv)
             for (auto elem_iter = mesh.active_elements_begin(); elem_iter != mesh.active_elements_end(); ++elem_iter)
             {
                 Elem* elem = *elem_iter;
-                const auto centroid = elem->centroid();
+#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
+                const libMesh::Point centroid = elem->centroid();
+#else
+                const libMesh::Point centroid = elem->vertex_average();
+#endif
 #if NDIM == 2
                 if (centroid(1) > 0.0)
                     elem->subdomain_id() = 1;

--- a/tests/IBTK/multilevel_fe_01.cpp
+++ b/tests/IBTK/multilevel_fe_01.cpp
@@ -98,7 +98,11 @@ public:
         for (MeshBase::element_iterator el = d_mesh.elements_begin(); el != el_end; ++el)
         {
             Elem* elem = *el;
-            const auto centroid = elem->centroid();
+#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
+            const libMesh::Point centroid = elem->centroid();
+#else
+            const libMesh::Point centroid = elem->vertex_average();
+#endif
 #if NDIM == 2
             if (centroid(1) > 0.0)
                 elem->subdomain_id() = 1;

--- a/tests/spread/spread_02.cpp
+++ b/tests/spread/spread_02.cpp
@@ -129,7 +129,11 @@ main(int argc, char** argv)
             MeshBase::element_iterator el_end = mesh.active_elements_end();
             for (MeshBase::element_iterator el = mesh.active_elements_begin(); el != el_end; ++el)
             {
-                const auto centroid = (*el)->centroid();
+#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
+                const libMesh::Point centroid = (*el)->centroid();
+#else
+                const libMesh::Point centroid = (*el)->vertex_average();
+#endif
                 if (centroid(0) < 0.5)
                 {
                     (*el)->subdomain_id() = 2;


### PR DESCRIPTION
The upcoming release of libMesh (1.7.0) deprecates `Elem::centroid()` in favor of `Elem::vertex_average()` and `Elem::true_centroid()`.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
