### PR TITLE
Workaround an assertion in older boost versions.

### DIFF
--- a/examples/ConstraintIB/eel3d/IBEELKinematics3d.cpp
+++ b/examples/ConstraintIB/eel3d/IBEELKinematics3d.cpp
@@ -358,8 +358,10 @@ IBEELKinematics3d::setEelSpecificVelocity(const double time,
             auto f_y = [&](const double y) { return yVelocity(y, input); };
 
             namespace bmq = boost::math::quadrature;
-            const double dxdt = bmq::gauss_kronrod<double, 15>::integrate(f_x, 0.0, S, 15, 1e-12, nullptr);
-            const double dydt = bmq::gauss_kronrod<double, 15>::integrate(f_y, 0.0, S, 15, 1e-12, nullptr);
+            const double dxdt =
+                S == 0.0 ? 0.0 : bmq::gauss_kronrod<double, 15>::integrate(f_x, 0.0, S, 15, 1e-12, nullptr);
+            const double dydt =
+                S == 0.0 ? 0.0 : bmq::gauss_kronrod<double, 15>::integrate(f_y, 0.0, S, 15, 1e-12, nullptr);
 
             vec_vel[0] = dxdt * (std::cos(angleFromHorizontal)) + dydt * (-std::sin(angleFromHorizontal));
             vec_vel[1] = dydt * (std::cos(angleFromHorizontal)) + dxdt * (std::sin(angleFromHorizontal));
@@ -453,8 +455,10 @@ IBEELKinematics3d::setShape(const double time, const std::vector<double>& increm
                 auto f_y = [&](const double y) { return yPosition(y, input); };
 
                 namespace bmq = boost::math::quadrature;
-                const double xbase = bmq::gauss_kronrod<double, 15>::integrate(f_x, 0.0, S, 15, 1e-12, nullptr);
-                const double ybase = bmq::gauss_kronrod<double, 15>::integrate(f_y, 0.0, S, 15, 1e-12, nullptr);
+                const double xbase =
+                    S == 0.0 ? 0.0 : bmq::gauss_kronrod<double, 15>::integrate(f_x, 0.0, S, 15, 1e-12, nullptr);
+                const double ybase =
+                    S == 0.0 ? 0.0 : bmq::gauss_kronrod<double, 15>::integrate(f_y, 0.0, S, 15, 1e-12, nullptr);
 
                 // Fill the middle line first.
                 for (int k = -NumPtsInHeight; k <= NumPtsInHeight; ++k)

--- a/examples/ConstraintIB/eel3d/eelgenerator3d.cpp
+++ b/examples/ConstraintIB/eel3d/eelgenerator3d.cpp
@@ -160,8 +160,10 @@ main()
         auto f_y = [&](const double y) { return yPosition(y, input); };
 
         namespace bmq = boost::math::quadrature;
-        const double xbase = bmq::gauss_kronrod<double, 15>::integrate(f_x, 0.0, s, 15, 1e-12, nullptr);
-        const double ybase = bmq::gauss_kronrod<double, 15>::integrate(f_y, 0.0, s, 15, 1e-12, nullptr);
+        const double xbase =
+            s == 0.0 ? 0.0 : bmq::gauss_kronrod<double, 15>::integrate(f_x, 0.0, s, 15, 1e-12, nullptr);
+        const double ybase =
+            s == 0.0 ? 0.0 : bmq::gauss_kronrod<double, 15>::integrate(f_y, 0.0, s, 15, 1e-12, nullptr);
 
         if (numPtsInSection && numPtsInHeight)
         {

--- a/tests/external/eelgenerator3d.cpp
+++ b/tests/external/eelgenerator3d.cpp
@@ -165,8 +165,10 @@ main()
         auto f_y = [&](const double y) { return yPosition(y, input); };
 
         namespace bmq = boost::math::quadrature;
-        const double xbase = bmq::gauss_kronrod<double, 15>::integrate(f_x, 0.0, s, 15, 1e-12, nullptr);
-        const double ybase = bmq::gauss_kronrod<double, 15>::integrate(f_y, 0.0, s, 15, 1e-12, nullptr);
+        const double xbase =
+            s == 0.0 ? 0.0 : bmq::gauss_kronrod<double, 15>::integrate(f_x, 0.0, s, 15, 1e-12, nullptr);
+        const double ybase =
+            s == 0.0 ? 0.0 : bmq::gauss_kronrod<double, 15>::integrate(f_y, 0.0, s, 15, 1e-12, nullptr);
 
         if (numPtsInSection && numPtsInHeight)
         {


### PR DESCRIPTION
Some versions of boost expect the domain of the integral to be positive:
we can get around this by just returning 0.0 when the end points are
equal.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?