### PR TITLE
Output linear solver times for each System.

### DIFF
--- a/doc/news/changes/minor/20211215DavidWells
+++ b/doc/news/changes/minor/20211215DavidWells
@@ -1,0 +1,3 @@
+Improved: IBTK::FEProjector now logs solve times for each libMesh system.
+<br>
+(David Wells, 2021/12/15)

--- a/ibtk/include/ibtk/FEProjector.h
+++ b/ibtk/include/ibtk/FEProjector.h
@@ -24,6 +24,9 @@
 
 #include <ibtk/FischerGuess.h>
 
+#include <tbox/Pointer.h>
+#include <tbox/Timer.h>
+
 #include <libmesh/equation_systems.h>
 #include <libmesh/petsc_linear_solver.h>
 #include <libmesh/petsc_matrix.h>
@@ -196,6 +199,14 @@ protected:
     std::map<std::string, FischerGuess> d_initial_guesses;
 
 private:
+    /*!
+     * Pointers for system-specific solver timers.
+     *
+     * SAMRAI stores timers in a single unsorted array. To keep timer lookups
+     * quick we cache the pointers here.
+     */
+    std::map<std::string, SAMRAI::tbox::Pointer<SAMRAI::tbox::Timer> > d_linear_solve_system_timers;
+
     /*!
      * Whether or not to log data to the screen: see
      * FEProjector::setLoggingEnabled() and

--- a/ibtk/src/lagrangian/FEProjector.cpp
+++ b/ibtk/src/lagrangian/FEProjector.cpp
@@ -674,7 +674,14 @@ FEProjector::computeL2Projection(PetscVector<double>& U_vec,
                                  const double tol,
                                  const unsigned int max_its)
 {
-    IBTK_TIMER_START(t_compute_L2_projection);
+    tbox::Pointer<tbox::Timer>& system_timer = d_linear_solve_system_timers[system_name];
+    if (system_timer.isNull())
+    {
+        system_timer =
+            TimerManager::getManager()->getTimer("IBTK::FEProjector::computeL2Projection()[" + system_name + "]");
+        TBOX_ASSERT(system_timer);
+    }
+    IBTK_TIMER_START(system_timer);
 
     int ierr;
     bool converged = false;
@@ -730,7 +737,7 @@ FEProjector::computeL2Projection(PetscVector<double>& U_vec,
     if (close_U) U_vec.close();
     system.get_dof_map().enforce_constraints_exactly(system, &U_vec);
 
-    IBTK_TIMER_STOP(t_compute_L2_projection);
+    IBTK_TIMER_STOP(system_timer);
     return converged;
 }
 


### PR DESCRIPTION
This is a bit more useful and it shows a difference between force projection and velocity interpolation. I want to use this information in the L2 guess paper.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?

example output:
```
                                          xfer::RefineSchedule::fillData()   0.053352 (1%)  
                 IBTK::FEProjector::computeL2Projection()[IB force system]  0.0448761 (1%)  
                                      xfer::RefineSchedule::recursive_fill  0.0446169 (1%)  
                 IBTK::HierarchyGhostCellInterpolation::fillData()[refine]  0.0446052 (1%)  
              IBTK::FEProjector::computeL2Projection()[IB velocity system]  0.0429819 (1%)  
                  IBTK::SCPoissonHypreLevelSolver::initializeSolverState()    0.04158 (1%)  
                              IBTK::FEDataManager::reinitElementMappings()  0.0374197 (1%)  
                              IBTK::FEProjector::buildL2ProjectionSolver()  0.0351367 (1%)  
                              IBTK::HierarchyIntegrator::regridHierarchy()  0.0338281 (0%)  
                                             IBTK::FEDataManager::interp()  0.0333063 (0%)  
        IBTK::FEProjector::computeL2Projection()[p_f interpolation system]   0.028769 (0%)  
                                          IBTK::CCLaplaceOperator::apply()  0.0282346 (0%)  
```