### PR TITLE
Avoid using a deprecated feature in attest.

### DIFF
--- a/attest
+++ b/attest
@@ -18,7 +18,6 @@ import argparse
 import ast
 import concurrent.futures as cf
 import configparser
-import distutils.util as du
 import enum
 import os
 import re
@@ -31,6 +30,16 @@ import threading
 
 # We rely on subprocess.run, which is new in 3.5
 assert sys.version_info >= (3, 5)
+
+
+def string_to_boolean(string):
+    lower = string.lower()
+    if lower in ['y', 'yes', '1', 'on', 'true', 't']:
+        return True
+    elif lower in ['n', 'no', '0', 'off', 'false', 'f']:
+        return False
+    else:
+        raise ValueError("Cannot convert '{}' to a boolean".format(string))
 
 
 def interrupt_handler(sig, frame):
@@ -422,7 +431,7 @@ def main():
                               "cores) will be used."))
     parser.add_argument('--keep-work-directories',
                         default=bool(
-                            du.strtobool(conf['keep_work_directories'])),
+                            string_to_boolean(conf['keep_work_directories'])),
                         dest='keep_work_directories',
                         action='store_true',
                         help=("Whether or not to keep temporary work " +
@@ -462,7 +471,7 @@ def main():
                         help="The time limit, in seconds, for each test.")
     parser.add_argument('--verbose',
                         default=bool(
-                            du.strtobool(conf['verbose'])),
+                            string_to_boolean(conf['verbose'])),
                         dest='verbose',
                         action='store_true',
                         help=("If true, print the stderr or failing diff for"


### PR DESCRIPTION
python 3.10 deprecates distutils with no replacement for strtobool - implement
our own.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?