### PR TITLE
Fix floating point comparisons

### DIFF
--- a/doc/news/changes/minor/20211223AaronBarrett
+++ b/doc/news/changes/minor/20211223AaronBarrett
@@ -1,0 +1,3 @@
+Fixed: IBAMR now uses appropriate comparisons that respect finite precision.
+<br>
+(Aaron Barrett, 2021/12/23)

--- a/examples/CIB/ex0/example.cpp
+++ b/examples/CIB/ex0/example.cpp
@@ -284,7 +284,7 @@ main(int argc, char* argv[])
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
 
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/CIB/ex1/example.cpp
+++ b/examples/CIB/ex1/example.cpp
@@ -396,7 +396,7 @@ main(int argc, char* argv[])
         double current_time, new_time;
         double dt = 0.0;
 
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/CIB/ex2/example.cpp
+++ b/examples/CIB/ex2/example.cpp
@@ -297,7 +297,7 @@ main(int argc, char* argv[])
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
 
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/CIB/ex3/example.cpp
+++ b/examples/CIB/ex3/example.cpp
@@ -271,7 +271,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/CIB/ex4/example.cpp
+++ b/examples/CIB/ex4/example.cpp
@@ -329,7 +329,7 @@ main(int argc, char* argv[])
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
 
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/ConstraintIB/eel2d/IBEELKinematics.cpp
+++ b/examples/ConstraintIB/eel2d/IBEELKinematics.cpp
@@ -405,7 +405,7 @@ IBEELKinematics::setEelSpecificVelocity(const double time,
             {
                 radius_circular_path = CUT_OFF_RADIUS;
             }
-            else if (MathUtilities<double>::equalEps(MathUtilities<double>::Abs(angle_bw_target_vision), 0.0))
+            else if (IBTK::abs_equal_eps(MathUtilities<double>::Abs(angle_bw_target_vision), 0.0))
             {
                 radius_circular_path = __INFINITY;
             }

--- a/examples/ConstraintIB/eel2d/example.cpp
+++ b/examples/ConstraintIB/eel2d/example.cpp
@@ -280,7 +280,7 @@ main(int argc, char* argv[])
         double dt = 0.0;
         double current_time, new_time;
         double box_disp = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/ConstraintIB/eel3d/example.cpp
+++ b/examples/ConstraintIB/eel3d/example.cpp
@@ -235,7 +235,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/ConstraintIB/falling_sphere/example.cpp
+++ b/examples/ConstraintIB/falling_sphere/example.cpp
@@ -255,7 +255,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/ConstraintIB/flow_past_cylinder/example.cpp
+++ b/examples/ConstraintIB/flow_past_cylinder/example.cpp
@@ -274,7 +274,7 @@ main(int argc, char* argv[])
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
         double current_time, new_time;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             current_time = loop_time = time_integrator->getIntegratorTime();

--- a/examples/ConstraintIB/impulsively_started_cylinder/example.cpp
+++ b/examples/ConstraintIB/impulsively_started_cylinder/example.cpp
@@ -235,7 +235,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/ConstraintIB/knifefish/KnifeFishKinematics.cpp
+++ b/examples/ConstraintIB/knifefish/KnifeFishKinematics.cpp
@@ -283,7 +283,7 @@ KnifeFishKinematics::setKinematicsVelocity(const double new_time,
 {
     d_new_time = new_time;
     // fill current velocity at new time
-    if (!MathUtilities<double>::equalEps(0.0, d_new_time)) setKnifefishSpecificVelocity(d_new_time);
+    if (!IBTK::abs_equal_eps(0.0, d_new_time)) setKnifefishSpecificVelocity(d_new_time);
 
     d_current_time = d_new_time;
 

--- a/examples/ConstraintIB/knifefish/example.cpp
+++ b/examples/ConstraintIB/knifefish/example.cpp
@@ -235,7 +235,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/ConstraintIB/moving_plate/example.cpp
+++ b/examples/ConstraintIB/moving_plate/example.cpp
@@ -285,7 +285,7 @@ main(int argc, char* argv[])
         double current_time, new_time;
 
         double box_disp = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             current_time = loop_time = time_integrator->getIntegratorTime();

--- a/examples/ConstraintIB/oscillating_rigid_cylinder/OscillatingCylinderKinematics.cpp
+++ b/examples/ConstraintIB/oscillating_rigid_cylinder/OscillatingCylinderKinematics.cpp
@@ -188,10 +188,10 @@ OscillatingCylinderKinematics::setKinematicsVelocity(
 {
     d_new_time = new_time;
     // fill current velocity at new time
-    if (!MathUtilities<double>::equalEps(0.0, d_new_time)) setOscillatingCylinderSpecificVelocity(d_new_time);
+    if (!IBTK::abs_equal_eps(0.0, d_new_time)) setOscillatingCylinderSpecificVelocity(d_new_time);
 
     // swap current and new velocity
-    if (MathUtilities<double>::equalEps(0.0, d_new_time))
+    if (IBTK::abs_equal_eps(0.0, d_new_time))
         d_new_kinematics_vel = d_current_kinematics_vel;
     else
         d_new_kinematics_vel.swap(d_current_kinematics_vel);

--- a/examples/ConstraintIB/oscillating_rigid_cylinder/example.cpp
+++ b/examples/ConstraintIB/oscillating_rigid_cylinder/example.cpp
@@ -235,7 +235,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/ConstraintIB/stokes_first_problem/example.cpp
+++ b/examples/ConstraintIB/stokes_first_problem/example.cpp
@@ -235,7 +235,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IB/explicit/ex0/example.cpp
+++ b/examples/IB/explicit/ex0/example.cpp
@@ -440,7 +440,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IB/explicit/ex1/example.cpp
+++ b/examples/IB/explicit/ex1/example.cpp
@@ -239,7 +239,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IB/explicit/ex2/example.cpp
+++ b/examples/IB/explicit/ex2/example.cpp
@@ -243,7 +243,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IB/explicit/ex3/example.cpp
+++ b/examples/IB/explicit/ex3/example.cpp
@@ -257,7 +257,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IB/explicit/ex4/example.cpp
+++ b/examples/IB/explicit/ex4/example.cpp
@@ -279,7 +279,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IB/explicit/ex5/example.cpp
+++ b/examples/IB/explicit/ex5/example.cpp
@@ -250,7 +250,7 @@ main(int argc, char* argv[])
 
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IB/explicit/ex6/example.cpp
+++ b/examples/IB/explicit/ex6/example.cpp
@@ -238,7 +238,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex0/example.cpp
+++ b/examples/IBFE/explicit/ex0/example.cpp
@@ -410,7 +410,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex1/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex1/convergence_tester.cpp
@@ -225,7 +225,7 @@ main(int argc, char* argv[])
 
             fine_hier_db->close();
 
-            TBOX_ASSERT(tbox::MathUtilities<double>::equalEps(coarse_loop_time, fine_loop_time));
+            TBOX_ASSERT(IBTK::rel_equal_eps(coarse_loop_time, fine_loop_time));
             loop_time = fine_loop_time;
             tbox::pout << "     loop time = " << loop_time << endl;
 

--- a/examples/IBFE/explicit/ex1/example.cpp
+++ b/examples/IBFE/explicit/ex1/example.cpp
@@ -388,7 +388,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex10/example.cpp
+++ b/examples/IBFE/explicit/ex10/example.cpp
@@ -354,7 +354,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex11/example.cpp
+++ b/examples/IBFE/explicit/ex11/example.cpp
@@ -389,7 +389,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex2/example.cpp
+++ b/examples/IBFE/explicit/ex2/example.cpp
@@ -379,7 +379,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex3/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex3/convergence_tester.cpp
@@ -223,7 +223,7 @@ main(int argc, char* argv[])
 
             fine_hier_db->close();
 
-            TBOX_ASSERT(tbox::MathUtilities<double>::equalEps(coarse_loop_time, fine_loop_time));
+            TBOX_ASSERT(IBTK::rel_equal_eps(coarse_loop_time, fine_loop_time));
             loop_time = fine_loop_time;
             tbox::pout << "     loop time = " << loop_time << endl;
 

--- a/examples/IBFE/explicit/ex3/example.cpp
+++ b/examples/IBFE/explicit/ex3/example.cpp
@@ -386,7 +386,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex4/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex4/convergence_tester.cpp
@@ -224,7 +224,7 @@ main(int argc, char* argv[])
 
             fine_hier_db->close();
 
-            TBOX_ASSERT(tbox::MathUtilities<double>::equalEps(coarse_loop_time, fine_loop_time));
+            TBOX_ASSERT(IBTK::rel_equal_eps(coarse_loop_time, fine_loop_time));
             loop_time = fine_loop_time;
             tbox::pout << "     loop time = " << loop_time << endl;
 

--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -454,7 +454,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex5/example.cpp
+++ b/examples/IBFE/explicit/ex5/example.cpp
@@ -546,7 +546,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex6/example.cpp
+++ b/examples/IBFE/explicit/ex6/example.cpp
@@ -481,7 +481,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex7/example.cpp
+++ b/examples/IBFE/explicit/ex7/example.cpp
@@ -382,7 +382,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex8/example.cpp
+++ b/examples/IBFE/explicit/ex8/example.cpp
@@ -129,7 +129,7 @@ beam_PK1_dil_stress_function(TensorValue<double>& PP,
     J_dil_min = std::min(J, J_dil_min);
     J_dil_max = std::max(J, J_dil_max);
     PP.zero();
-    if (!MathUtilities<double>::equalEps(beta_s, 0.0))
+    if (!IBTK::abs_equal_eps(beta_s, 0.0))
     {
         const TensorValue<double> FF_inv_trans = tensor_inverse_transpose(FF, NDIM);
         PP -= 2.0 * beta_s * log(FF.det()) * FF_inv_trans;
@@ -618,7 +618,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBFE/explicit/ex9/example.cpp
+++ b/examples/IBFE/explicit/ex9/example.cpp
@@ -429,7 +429,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBLevelSet/ex0/SetFluidGasSolidDensity.cpp
+++ b/examples/IBLevelSet/ex0/SetFluidGasSolidDensity.cpp
@@ -84,11 +84,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
 
     int ls_solid_idx = -1, ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -97,11 +97,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/IBLevelSet/ex0/SetFluidGasSolidViscosity.cpp
+++ b/examples/IBLevelSet/ex0/SetFluidGasSolidViscosity.cpp
@@ -81,11 +81,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_solid_idx = -1, ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -94,11 +94,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/IBLevelSet/ex0/example.cpp
+++ b/examples/IBLevelSet/ex0/example.cpp
@@ -942,7 +942,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBLevelSet/ex1/SetFluidSolidDensity.cpp
+++ b/examples/IBLevelSet/ex1/SetFluidSolidDensity.cpp
@@ -75,11 +75,11 @@ SetFluidSolidDensity::setDensityPatchData(int rho_idx,
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
 
     int ls_solid_idx = -1, ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/IBLevelSet/ex1/SetFluidSolidViscosity.cpp
+++ b/examples/IBLevelSet/ex1/SetFluidSolidViscosity.cpp
@@ -75,11 +75,11 @@ SetFluidSolidViscosity::setViscosityPatchData(int mu_idx,
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_solid_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/IBLevelSet/ex1/example.cpp
+++ b/examples/IBLevelSet/ex1/example.cpp
@@ -476,7 +476,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IBLevelSet/ex2/SetFluidGasSolidDensity.cpp
+++ b/examples/IBLevelSet/ex2/SetFluidGasSolidDensity.cpp
@@ -88,11 +88,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
 
     int ls_solid_idx = -1, ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -101,11 +101,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/IBLevelSet/ex2/SetFluidGasSolidViscosity.cpp
+++ b/examples/IBLevelSet/ex2/SetFluidGasSolidViscosity.cpp
@@ -85,11 +85,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_solid_idx = -1, ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -98,11 +98,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/IBLevelSet/ex2/example.cpp
+++ b/examples/IBLevelSet/ex2/example.cpp
@@ -543,7 +543,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/IMP/explicit/ex0/main.cpp
+++ b/examples/IMP/explicit/ex0/main.cpp
@@ -65,11 +65,11 @@ PK1_stress_function(TensorValue<double>& PP,
     const TensorValue<double> FF_inv_trans = tensor_inverse_transpose(FF, NDIM);
     const TensorValue<double> CC = FF.transpose() * FF;
     PP = 2.0 * c1_s * FF;
-    if (!MathUtilities<double>::equalEps(p0_s, 0.0))
+    if (!IBTK::abs_equal_eps(p0_s, 0.0))
     {
         PP -= 2.0 * p0_s * FF_inv_trans;
     }
-    if (!MathUtilities<double>::equalEps(beta_s, 0.0))
+    if (!IBTK::abs_equal_eps(beta_s, 0.0))
     {
         PP += beta_s * log(CC.det()) * FF_inv_trans;
     }
@@ -301,7 +301,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/adv_diff/ex0/example.cpp
+++ b/examples/adv_diff/ex0/example.cpp
@@ -176,7 +176,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/adv_diff/ex1/example.cpp
+++ b/examples/adv_diff/ex1/example.cpp
@@ -194,7 +194,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/adv_diff/ex2/example.cpp
+++ b/examples/adv_diff/ex2/example.cpp
@@ -173,7 +173,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/adv_diff/ex3/example.cpp
+++ b/examples/adv_diff/ex3/example.cpp
@@ -287,7 +287,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/adv_diff/ex4/example.cpp
+++ b/examples/adv_diff/ex4/example.cpp
@@ -326,7 +326,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/adv_diff/ex5/example.cpp
+++ b/examples/adv_diff/ex5/example.cpp
@@ -325,7 +325,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/adv_diff/ex6/example.cpp
+++ b/examples/adv_diff/ex6/example.cpp
@@ -613,7 +613,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/adv_diff/ex7/example.cpp
+++ b/examples/adv_diff/ex7/example.cpp
@@ -396,7 +396,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/advect/example.cpp
+++ b/examples/advect/example.cpp
@@ -200,7 +200,7 @@ main(int argc, char* argv[])
 
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/complex_fluids/ex0/example.cpp
+++ b/examples/complex_fluids/ex0/example.cpp
@@ -227,7 +227,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/complex_fluids/ex1/example.cpp
+++ b/examples/complex_fluids/ex1/example.cpp
@@ -219,7 +219,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/complex_fluids/ex2/convergence_tester.cpp
+++ b/examples/complex_fluids/ex2/convergence_tester.cpp
@@ -224,7 +224,7 @@ main(int argc, char* argv[])
 
         fine_hier_db->close();
 
-        TBOX_ASSERT(MathUtilities<double>::equalEps(coarse_loop_time, fine_loop_time));
+        TBOX_ASSERT(IBTK::rel_equal_eps(coarse_loop_time, fine_loop_time));
         loop_time = fine_loop_time;
         pout << "     loop time = " << loop_time << endl;
 

--- a/examples/complex_fluids/ex2/example.cpp
+++ b/examples/complex_fluids/ex2/example.cpp
@@ -428,7 +428,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/complex_fluids/ex3/example.cpp
+++ b/examples/complex_fluids/ex3/example.cpp
@@ -210,7 +210,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/complex_fluids/ex4/example.cpp
+++ b/examples/complex_fluids/ex4/example.cpp
@@ -487,7 +487,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/fe_mechanics/ex0/example.cpp
+++ b/examples/fe_mechanics/ex0/example.cpp
@@ -410,7 +410,7 @@ main(int argc, char* argv[])
         }
 
         // Main time step loop.
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end))
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end))
         {
             pout << "\n";
             pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";

--- a/examples/level_set/ex0/example.cpp
+++ b/examples/level_set/ex0/example.cpp
@@ -250,7 +250,7 @@ main(int argc, char* argv[])
 
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/level_set/ex1/example.cpp
+++ b/examples/level_set/ex1/example.cpp
@@ -334,7 +334,7 @@ main(int argc, char* argv[])
 
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex0/SetFluidProperties.cpp
+++ b/examples/multiphase_flow/ex0/SetFluidProperties.cpp
@@ -110,11 +110,11 @@ SetFluidProperties::setDensityPatchData(int rho_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }
@@ -286,11 +286,11 @@ SetFluidProperties::setViscosityPatchData(int mu_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex0/example.cpp
+++ b/examples/multiphase_flow/ex0/example.cpp
@@ -342,7 +342,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex1/SetFluidGasSolidDensity.cpp
+++ b/examples/multiphase_flow/ex1/SetFluidGasSolidDensity.cpp
@@ -96,11 +96,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
 
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -109,11 +109,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex1/SetFluidGasSolidViscosity.cpp
+++ b/examples/multiphase_flow/ex1/SetFluidGasSolidViscosity.cpp
@@ -93,11 +93,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -106,11 +106,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex1/example.cpp
+++ b/examples/multiphase_flow/ex1/example.cpp
@@ -482,7 +482,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex10/SetFluidGasSolidDensity.cpp
+++ b/examples/multiphase_flow/ex10/SetFluidGasSolidDensity.cpp
@@ -96,11 +96,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
 
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -109,11 +109,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex10/SetFluidGasSolidViscosity.cpp
+++ b/examples/multiphase_flow/ex10/SetFluidGasSolidViscosity.cpp
@@ -93,11 +93,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -106,11 +106,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex10/example.cpp
+++ b/examples/multiphase_flow/ex10/example.cpp
@@ -515,7 +515,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex11/SetFluidGasSolidDensity.cpp
+++ b/examples/multiphase_flow/ex11/SetFluidGasSolidDensity.cpp
@@ -96,11 +96,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
 
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -109,11 +109,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex11/SetFluidGasSolidViscosity.cpp
+++ b/examples/multiphase_flow/ex11/SetFluidGasSolidViscosity.cpp
@@ -93,11 +93,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -106,11 +106,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex11/example.cpp
+++ b/examples/multiphase_flow/ex11/example.cpp
@@ -497,7 +497,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex12/SetFluidGasSolidDensity.cpp
+++ b/examples/multiphase_flow/ex12/SetFluidGasSolidDensity.cpp
@@ -96,11 +96,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
 
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -109,11 +109,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex12/SetFluidGasSolidViscosity.cpp
+++ b/examples/multiphase_flow/ex12/SetFluidGasSolidViscosity.cpp
@@ -93,11 +93,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -106,11 +106,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex12/example.cpp
+++ b/examples/multiphase_flow/ex12/example.cpp
@@ -495,7 +495,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex13/SetFluidGasSolidDensity.cpp
+++ b/examples/multiphase_flow/ex13/SetFluidGasSolidDensity.cpp
@@ -96,11 +96,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
 
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -109,11 +109,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex13/SetFluidGasSolidViscosity.cpp
+++ b/examples/multiphase_flow/ex13/SetFluidGasSolidViscosity.cpp
@@ -93,11 +93,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -106,11 +106,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex13/example.cpp
+++ b/examples/multiphase_flow/ex13/example.cpp
@@ -548,7 +548,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex2/SetFluidGasSolidDensity.cpp
+++ b/examples/multiphase_flow/ex2/SetFluidGasSolidDensity.cpp
@@ -96,11 +96,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
 
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -109,11 +109,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex2/SetFluidGasSolidViscosity.cpp
+++ b/examples/multiphase_flow/ex2/SetFluidGasSolidViscosity.cpp
@@ -93,11 +93,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -106,11 +106,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex2/example.cpp
+++ b/examples/multiphase_flow/ex2/example.cpp
@@ -575,7 +575,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex3/SetFluidProperties.cpp
+++ b/examples/multiphase_flow/ex3/SetFluidProperties.cpp
@@ -110,11 +110,11 @@ SetFluidProperties::setDensityPatchData(int rho_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }
@@ -286,11 +286,11 @@ SetFluidProperties::setViscosityPatchData(int mu_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex3/example.cpp
+++ b/examples/multiphase_flow/ex3/example.cpp
@@ -338,7 +338,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex4/SetFluidProperties.cpp
+++ b/examples/multiphase_flow/ex4/SetFluidProperties.cpp
@@ -110,11 +110,11 @@ SetFluidProperties::setDensityPatchData(int rho_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }
@@ -286,11 +286,11 @@ SetFluidProperties::setViscosityPatchData(int mu_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex4/example.cpp
+++ b/examples/multiphase_flow/ex4/example.cpp
@@ -333,7 +333,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex5/SetFluidProperties.cpp
+++ b/examples/multiphase_flow/ex5/SetFluidProperties.cpp
@@ -110,11 +110,11 @@ SetFluidProperties::setDensityPatchData(int rho_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }
@@ -286,11 +286,11 @@ SetFluidProperties::setViscosityPatchData(int mu_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex5/example.cpp
+++ b/examples/multiphase_flow/ex5/example.cpp
@@ -355,7 +355,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex6/SetFluidProperties.cpp
+++ b/examples/multiphase_flow/ex6/SetFluidProperties.cpp
@@ -110,11 +110,11 @@ SetFluidProperties::setDensityPatchData(int rho_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }
@@ -286,11 +286,11 @@ SetFluidProperties::setViscosityPatchData(int mu_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex6/example.cpp
+++ b/examples/multiphase_flow/ex6/example.cpp
@@ -363,7 +363,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex7/SetFluidGasSolidDensity.cpp
+++ b/examples/multiphase_flow/ex7/SetFluidGasSolidDensity.cpp
@@ -96,11 +96,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
 
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -109,11 +109,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex7/SetFluidGasSolidViscosity.cpp
+++ b/examples/multiphase_flow/ex7/SetFluidGasSolidViscosity.cpp
@@ -93,11 +93,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -106,11 +106,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex7/example.cpp
+++ b/examples/multiphase_flow/ex7/example.cpp
@@ -490,7 +490,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex8/SetFluidGasSolidDensity.cpp
+++ b/examples/multiphase_flow/ex8/SetFluidGasSolidDensity.cpp
@@ -96,11 +96,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
 
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -109,11 +109,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex8/SetFluidGasSolidViscosity.cpp
+++ b/examples/multiphase_flow/ex8/SetFluidGasSolidViscosity.cpp
@@ -93,11 +93,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -106,11 +106,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex8/example.cpp
+++ b/examples/multiphase_flow/ex8/example.cpp
@@ -490,7 +490,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/multiphase_flow/ex9/SetFluidGasSolidDensity.cpp
+++ b/examples/multiphase_flow/ex9/SetFluidGasSolidDensity.cpp
@@ -96,11 +96,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
 
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -109,11 +109,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex9/SetFluidGasSolidViscosity.cpp
+++ b/examples/multiphase_flow/ex9/SetFluidGasSolidViscosity.cpp
@@ -93,11 +93,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -106,11 +106,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/multiphase_flow/ex9/example.cpp
+++ b/examples/multiphase_flow/ex9/example.cpp
@@ -519,7 +519,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/navier_stokes/ex0/example.cpp
+++ b/examples/navier_stokes/ex0/example.cpp
@@ -194,7 +194,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/navier_stokes/ex1/convergence_tester.cpp
+++ b/examples/navier_stokes/ex1/convergence_tester.cpp
@@ -184,7 +184,7 @@ main(int argc, char* argv[])
 
         fine_hier_db->close();
 
-        TBOX_ASSERT(MathUtilities<double>::equalEps(coarse_loop_time, fine_loop_time));
+        TBOX_ASSERT(IBTK::rel_equal_eps(coarse_loop_time, fine_loop_time));
         loop_time = fine_loop_time;
         pout << "     loop time = " << loop_time << endl;
 

--- a/examples/navier_stokes/ex1/example.cpp
+++ b/examples/navier_stokes/ex1/example.cpp
@@ -194,7 +194,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/navier_stokes/ex2/example.cpp
+++ b/examples/navier_stokes/ex2/example.cpp
@@ -194,7 +194,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/navier_stokes/ex3/example.cpp
+++ b/examples/navier_stokes/ex3/example.cpp
@@ -195,7 +195,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/navier_stokes/ex4/example.cpp
+++ b/examples/navier_stokes/ex4/example.cpp
@@ -245,7 +245,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/navier_stokes/ex5/example.cpp
+++ b/examples/navier_stokes/ex5/example.cpp
@@ -208,7 +208,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/navier_stokes/ex6/example.cpp
+++ b/examples/navier_stokes/ex6/example.cpp
@@ -198,7 +198,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/vc_navier_stokes/ex0/example.cpp
+++ b/examples/vc_navier_stokes/ex0/example.cpp
@@ -238,7 +238,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/vc_navier_stokes/ex1/example.cpp
+++ b/examples/vc_navier_stokes/ex1/example.cpp
@@ -276,7 +276,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/vc_navier_stokes/ex2/SetFluidProperties.cpp
+++ b/examples/vc_navier_stokes/ex2/SetFluidProperties.cpp
@@ -110,11 +110,11 @@ SetFluidProperties::setDensityPatchData(int rho_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }
@@ -286,11 +286,11 @@ SetFluidProperties::setViscosityPatchData(int mu_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/vc_navier_stokes/ex2/example.cpp
+++ b/examples/vc_navier_stokes/ex2/example.cpp
@@ -346,7 +346,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/wave_tank/ex0/SetFluidProperties.cpp
+++ b/examples/wave_tank/ex0/SetFluidProperties.cpp
@@ -102,11 +102,11 @@ SetFluidProperties::setDensityPatchData(int rho_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }
@@ -278,11 +278,11 @@ SetFluidProperties::setViscosityPatchData(int mu_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/wave_tank/ex0/example.cpp
+++ b/examples/wave_tank/ex0/example.cpp
@@ -510,7 +510,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/examples/wave_tank/ex1/SetFluidGasSolidDensity.cpp
+++ b/examples/wave_tank/ex1/SetFluidGasSolidDensity.cpp
@@ -85,11 +85,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
 
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -98,11 +98,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/wave_tank/ex1/SetFluidGasSolidViscosity.cpp
+++ b/examples/wave_tank/ex1/SetFluidGasSolidViscosity.cpp
@@ -85,11 +85,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     int ls_solid_idx = -1;
     int ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -98,11 +98,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/examples/wave_tank/ex1/example.cpp
+++ b/examples/wave_tank/ex1/example.cpp
@@ -572,7 +572,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/ibtk/examples/PhysBdryOps/example.cpp
+++ b/ibtk/examples/PhysBdryOps/example.cpp
@@ -143,7 +143,7 @@ main(int argc, char* argv[])
                         val += 4 * (d + 1) * (d + 1) * i(d);
                     }
 
-                    if (!MathUtilities<double>::equalEps(val, (*data)(i)))
+                    if (!IBTK::rel_equal_eps(val, (*data)(i)))
                     {
                         warning = true;
                         pout << "warning: value at location " << i << " is not correct\n";
@@ -208,7 +208,7 @@ main(int argc, char* argv[])
                     }
                     double val = 2.0 * X[NDIM - 1] + shift;
 
-                    if (!MathUtilities<double>::equalEps(val, (*data)(i)))
+                    if (!IBTK::rel_equal_eps(val, (*data)(i)))
                     {
                         warning = true;
                         pout << "warning: value at location " << i << " is not correct\n";
@@ -251,7 +251,7 @@ main(int argc, char* argv[])
                     }
                     double val = 2.0 * X[NDIM - 1] + shift;
 
-                    if (!MathUtilities<double>::equalEps(val, (*data)(i)))
+                    if (!IBTK::rel_equal_eps(val, (*data)(i)))
                     {
                         warning = true;
                         pout << "warning: value at location " << i << " is not correct\n";

--- a/ibtk/include/ibtk/LNodeIndex.h
+++ b/ibtk/include/ibtk/LNodeIndex.h
@@ -336,7 +336,7 @@ public:
         const double* const X_rhs = &(*d_X_ghosted_local_form_array)[rhs.getLocalPETScIndex()][0];
         for (unsigned int d = 0; d < NDIM; ++d)
         {
-            if (!SAMRAI::tbox::MathUtilities<double>::equalEps(X_lhs[d], X_rhs[d])) return false;
+            if (!IBTK::rel_equal_eps(X_lhs[d], X_rhs[d])) return false;
         }
         return true;
     } // operator()

--- a/ibtk/include/ibtk/ibtk_utilities.h
+++ b/ibtk/include/ibtk/ibtk_utilities.h
@@ -119,34 +119,6 @@ static const bool ENABLE_TIMERS = true;
 
 namespace IBTK
 {
-inline std::string
-get_data_time_str(const double data_time, const double current_time, const double new_time)
-{
-    const double half_time = 0.5 * (current_time + new_time);
-    if (SAMRAI::tbox::MathUtilities<double>::equalEps(data_time, current_time))
-    {
-        return "current";
-    }
-    else if (SAMRAI::tbox::MathUtilities<double>::equalEps(data_time, half_time))
-    {
-        return "half";
-    }
-    else if (SAMRAI::tbox::MathUtilities<double>::equalEps(data_time, new_time))
-    {
-        return "new";
-    }
-    else
-    {
-        return "unknown";
-    }
-}
-
-/*!
- * Get the smallest cell width on the specified level. This operation is
- * collective.
- */
-double get_min_patch_dx(const SAMRAI::hier::PatchLevel<NDIM>& patch_level);
-
 /*!
  * Check whether the relative difference between a and b are within the threshold eps.
  *
@@ -170,6 +142,34 @@ abs_equal_eps(double a, double b, double eps = std::sqrt(std::numeric_limits<dou
 {
     return std::abs(a - b) < eps;
 }
+
+inline std::string
+get_data_time_str(const double data_time, const double current_time, const double new_time)
+{
+    const double half_time = 0.5 * (current_time + new_time);
+    if (rel_equal_eps(data_time, current_time))
+    {
+        return "current";
+    }
+    else if (rel_equal_eps(data_time, half_time))
+    {
+        return "half";
+    }
+    else if (rel_equal_eps(data_time, new_time))
+    {
+        return "new";
+    }
+    else
+    {
+        return "unknown";
+    }
+}
+
+/*!
+ * Get the smallest cell width on the specified level. This operation is
+ * collective.
+ */
+double get_min_patch_dx(const SAMRAI::hier::PatchLevel<NDIM>& patch_level);
 
 template <class T, unsigned N>
 inline std::array<T, N>

--- a/ibtk/src/boundary/physical_boundary/StaggeredPhysicalBoundaryHelper.cpp
+++ b/ibtk/src/boundary/physical_boundary/StaggeredPhysicalBoundaryHelper.cpp
@@ -15,6 +15,7 @@
 
 #include "ibtk/PhysicalBoundaryUtilities.h"
 #include "ibtk/StaggeredPhysicalBoundaryHelper.h"
+#include "ibtk/ibtk_utilities.h"
 
 #include "ArrayData.h"
 #include "BoundaryBox.h"
@@ -251,12 +252,10 @@ StaggeredPhysicalBoundaryHelper::cacheBcCoefData(const std::vector<RobinBcCoefSt
                         const double& alpha = (*acoef_data)(i, 0);
                         const double& beta = (*bcoef_data)(i, 0);
 #if !defined(NDEBUG)
-                        TBOX_ASSERT(MathUtilities<double>::equalEps(alpha + beta, 1.0));
-                        TBOX_ASSERT(MathUtilities<double>::equalEps(alpha, 1.0) ||
-                                    MathUtilities<double>::equalEps(beta, 1.0));
+                        TBOX_ASSERT(IBTK::rel_equal_eps(alpha + beta, 1.0));
+                        TBOX_ASSERT(IBTK::rel_equal_eps(alpha, 1.0) || IBTK::rel_equal_eps(beta, 1.0));
 #endif
-                        bdry_locs_data(i, 0) = MathUtilities<double>::equalEps(alpha, 1.0) &&
-                                               (beta == 0.0 || MathUtilities<double>::equalEps(beta, 0.0));
+                        bdry_locs_data(i, 0) = IBTK::rel_equal_eps(alpha, 1.0) && IBTK::abs_equal_eps(beta, 0.0);
                     }
                 }
             }

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -2435,7 +2435,7 @@ LDataManager::applyGradientDetector(const Pointer<BasePatchHierarchy<NDIM> > hie
             for (CellIterator<NDIM> ic(patch_box); ic; ic++)
             {
                 const CellIndex<NDIM>& i = ic();
-                if (!MathUtilities<double>::equalEps((*node_count_data)(i), 0.0))
+                if (!IBTK::abs_equal_eps((*node_count_data)(i), 0.0))
                 {
                     (*tag_data)(i) = 1;
                 }

--- a/ibtk/src/math/HierarchyMathOps.cpp
+++ b/ibtk/src/math/HierarchyMathOps.cpp
@@ -2186,7 +2186,7 @@ HierarchyMathOps::laplace(const int dst_idx,
         }
 
         // Take the divergence of the flux.
-        if (MathUtilities<double>::equalEps(beta, 0.0) && MathUtilities<double>::equalEps(gamma, 0.0))
+        if (IBTK::abs_equal_eps(beta, 0.0) && IBTK::abs_equal_eps(gamma, 0.0))
         {
             div(dst_idx,
                 dst_var,
@@ -2201,7 +2201,7 @@ HierarchyMathOps::laplace(const int dst_idx,
                 Pointer<CellVariable<NDIM, double> >(nullptr),
                 dst_depth);
         }
-        else if (MathUtilities<double>::equalEps(beta, 0.0))
+        else if (IBTK::abs_equal_eps(beta, 0.0))
         {
             div(dst_idx,
                 dst_var,
@@ -2217,7 +2217,7 @@ HierarchyMathOps::laplace(const int dst_idx,
                 dst_depth,
                 src2_depth);
         }
-        else if (MathUtilities<double>::equalEps(gamma, 0.0))
+        else if (IBTK::abs_equal_eps(gamma, 0.0))
         {
             div(dst_idx,
                 dst_var,

--- a/ibtk/src/math/PETScMatUtilities.cpp
+++ b/ibtk/src/math/PETScMatUtilities.cpp
@@ -1116,7 +1116,7 @@ PETScMatUtilities::constructRestrictionScalingOp(Mat& P, Vec& L)
     for (int k = 0; k < N; ++k)
     {
         const double sum = column_sum_inv[k];
-        if (!MathUtilities<double>::equalEps(sum, 0.0))
+        if (!IBTK::abs_equal_eps(sum, 0.0))
         {
             column_sum_inv[k] = 1.0 / sum;
         }

--- a/ibtk/src/math/PoissonUtilities.cpp
+++ b/ibtk/src/math/PoissonUtilities.cpp
@@ -676,7 +676,7 @@ PoissonUtilities::computeMatrixCoefficients(SideData<NDIM, double>& matrix_coeff
                 else
                 {
 #if !defined(NDEBUG)
-                    TBOX_ASSERT(!MathUtilities<double>::equalEps(b, 0.0));
+                    TBOX_ASSERT(!IBTK::abs_equal_eps(b, 0.0));
 #endif
                     if (is_lower)
                     {
@@ -1191,7 +1191,7 @@ PoissonUtilities::computeVCSCViscousOpMatrixCoefficients(
                 else
                 {
 #if !defined(NDEBUG)
-                    TBOX_ASSERT(!MathUtilities<double>::equalEps(b, 0.0));
+                    TBOX_ASSERT(!IBTK::abs_equal_eps(b, 0.0));
 #endif
                     if (is_lower)
                     {
@@ -1543,7 +1543,7 @@ PoissonUtilities::adjustRHSAtPhysicalBoundary(SideData<NDIM, double>& rhs_data,
                 if (b != 0.0)
                 {
 #if !defined(NDEBUG)
-                    TBOX_ASSERT(!MathUtilities<double>::equalEps(b, 0.0));
+                    TBOX_ASSERT(!IBTK::abs_equal_eps(b, 0.0));
 #endif
                     rhs_data(i_s_bdry) += (D / h) * (-2.0 * g) / b;
                 }
@@ -1926,7 +1926,7 @@ PoissonUtilities::adjustVCSCViscousOpRHSAtPhysicalBoundary(SideData<NDIM, double
                 if (b != 0.0)
                 {
 #if !defined(NDEBUG)
-                    TBOX_ASSERT(!MathUtilities<double>::equalEps(b, 0.0));
+                    TBOX_ASSERT(!IBTK::abs_equal_eps(b, 0.0));
 #endif
                     rhs_data(i_s_bdry) += (2.0 * alpha) * (D / h) * (-2.0 * g) / b;
                 }

--- a/ibtk/src/refine_ops/CartSideDoubleDivPreservingRefine.cpp
+++ b/ibtk/src/refine_ops/CartSideDoubleDivPreservingRefine.cpp
@@ -103,7 +103,7 @@ CartSideDoubleDivPreservingRefine::setPhysicalBoundaryConditions(Patch<NDIM>& pa
                                                                  const IntVector<NDIM>& ghost_width_to_fill)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(fill_time, d_fill_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(fill_time, d_fill_time));
 #else
     NULL_USE(d_fill_time);
 #endif

--- a/ibtk/src/refine_ops/LMarkerRefine.cpp
+++ b/ibtk/src/refine_ops/LMarkerRefine.cpp
@@ -134,12 +134,12 @@ LMarkerRefine::refine(Patch<NDIM>& fine,
                 // so this is not an issue that is unique to markers.)
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {
-                    if (MathUtilities<double>::equalEps(X_shifted[d], fine_patchXLower[d]))
+                    if (IBTK::rel_equal_eps(X_shifted[d], fine_patchXLower[d]))
                     {
                         X_shifted[d] = fine_patchXLower[d];
                         fine_i(d) = fine_patch_lower(d);
                     }
-                    else if (MathUtilities<double>::equalEps(X_shifted[d], fine_patchXUpper[d]))
+                    else if (IBTK::rel_equal_eps(X_shifted[d], fine_patchXUpper[d]))
                     {
                         X_shifted[d] = fine_patchXUpper[d];
                         fine_i(d) = fine_patch_upper(d) + 1;

--- a/ibtk/src/solvers/wrappers/PETScSAMRAIVectorReal.cpp
+++ b/ibtk/src/solvers/wrappers/PETScSAMRAIVectorReal.cpp
@@ -438,11 +438,11 @@ PETScSAMRAIVectorReal::VecAXPY_SAMRAI(Vec y, PetscScalar alpha, Vec x)
     IBTK_TIMER_START(t_vec_axpy);
     PSVR_CHECK2(x, y);
     static const bool interior_only = false;
-    if (MathUtilities<double>::equalEps(alpha, 1.0))
+    if (IBTK::rel_equal_eps(alpha, 1.0))
     {
         PSVR_CAST2(y)->add(PSVR_CAST2(x), PSVR_CAST2(y), interior_only);
     }
-    else if (MathUtilities<double>::equalEps(alpha, -1.0))
+    else if (IBTK::rel_equal_eps(alpha, -1.0))
     {
         PSVR_CAST2(y)->subtract(PSVR_CAST2(y), PSVR_CAST2(x), interior_only);
     }
@@ -462,15 +462,15 @@ PETScSAMRAIVectorReal::VecAXPBY_SAMRAI(Vec y, PetscScalar alpha, PetscScalar bet
     IBTK_TIMER_START(t_vec_axpby);
     PSVR_CHECK2(x, y);
     static const bool interior_only = false;
-    if (MathUtilities<double>::equalEps(alpha, 1.0) && MathUtilities<double>::equalEps(beta, 1.0))
+    if (IBTK::rel_equal_eps(alpha, 1.0) && IBTK::rel_equal_eps(beta, 1.0))
     {
         PSVR_CAST2(y)->add(PSVR_CAST2(x), PSVR_CAST2(y), interior_only);
     }
-    else if (MathUtilities<double>::equalEps(beta, 1.0))
+    else if (IBTK::rel_equal_eps(beta, 1.0))
     {
         PSVR_CAST2(y)->axpy(alpha, PSVR_CAST2(x), PSVR_CAST2(y), interior_only);
     }
-    else if (MathUtilities<double>::equalEps(alpha, 1.0))
+    else if (IBTK::rel_equal_eps(alpha, 1.0))
     {
         PSVR_CAST2(y)->axpy(beta, PSVR_CAST2(y), PSVR_CAST2(x), interior_only);
     }
@@ -493,11 +493,11 @@ PETScSAMRAIVectorReal::VecMAXPY_SAMRAI(Vec y, PetscInt nv, const PetscScalar* al
     static const bool interior_only = false;
     for (PetscInt i = 0; i < nv; ++i)
     {
-        if (MathUtilities<double>::equalEps(alpha[i], 1.0))
+        if (IBTK::rel_equal_eps(alpha[i], 1.0))
         {
             PSVR_CAST2(y)->add(PSVR_CAST2(x[i]), PSVR_CAST2(y), interior_only);
         }
-        else if (MathUtilities<double>::equalEps(alpha[i], -1.0))
+        else if (IBTK::rel_equal_eps(alpha[i], -1.0))
         {
             PSVR_CAST2(y)->subtract(PSVR_CAST2(y), PSVR_CAST2(x[i]), interior_only);
         }
@@ -518,11 +518,11 @@ PETScSAMRAIVectorReal::VecAYPX_SAMRAI(Vec y, const PetscScalar alpha, Vec x)
     IBTK_TIMER_START(t_vec_aypx);
     PSVR_CHECK2(x, y);
     static const bool interior_only = false;
-    if (MathUtilities<double>::equalEps(alpha, 1.0))
+    if (IBTK::rel_equal_eps(alpha, 1.0))
     {
         PSVR_CAST2(y)->add(PSVR_CAST2(x), PSVR_CAST2(y), interior_only);
     }
-    else if (MathUtilities<double>::equalEps(alpha, -1.0))
+    else if (IBTK::rel_equal_eps(alpha, -1.0))
     {
         PSVR_CAST2(y)->subtract(PSVR_CAST2(x), PSVR_CAST2(y), interior_only);
     }
@@ -542,11 +542,11 @@ PETScSAMRAIVectorReal::VecWAXPY_SAMRAI(Vec w, PetscScalar alpha, Vec x, Vec y)
     IBTK_TIMER_START(t_vec_waxpy);
     PSVR_CHECK3(w, x, y);
     static const bool interior_only = false;
-    if (MathUtilities<double>::equalEps(alpha, 1.0))
+    if (IBTK::rel_equal_eps(alpha, 1.0))
     {
         PSVR_CAST2(w)->add(PSVR_CAST2(x), PSVR_CAST2(y), interior_only);
     }
-    else if (MathUtilities<double>::equalEps(alpha, -1.0))
+    else if (IBTK::rel_equal_eps(alpha, -1.0))
     {
         PSVR_CAST2(w)->subtract(PSVR_CAST2(y), PSVR_CAST2(x), interior_only);
     }

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -261,7 +261,7 @@ HierarchyIntegrator::advanceHierarchy(double dt)
         TBOX_ERROR(d_object_name << "::advanceHierarchy():\n"
                                  << "  at time = " << d_integrator_time << ": time step size dt = " << dt << ".\n");
     }
-    else if (current_time == new_time || MathUtilities<double>::equalEps(current_time, new_time))
+    else if (current_time == new_time || IBTK::rel_equal_eps(current_time, new_time))
     {
         TBOX_ERROR(d_object_name << "::advanceHierarchy():\n"
                                  << "  at time = " << d_integrator_time << ": time step size dt = " << dt
@@ -442,7 +442,7 @@ HierarchyIntegrator::regridHierarchy()
 
     const double new_volume = check_volume_change ? d_hier_math_ops->getVolumeOfPhysicalDomain() : 0.0;
 
-    if (check_volume_change && !MathUtilities<double>::equalEps(old_volume, new_volume))
+    if (check_volume_change && !IBTK::rel_equal_eps(old_volume, new_volume))
     {
         TBOX_WARNING(
             d_object_name << "::regridHierarchy():\n"
@@ -522,7 +522,7 @@ bool
 HierarchyIntegrator::stepsRemaining() const
 {
     return ((d_integrator_step < d_max_integrator_steps) && (d_integrator_time < d_end_time) &&
-            !MathUtilities<double>::equalEps(d_integrator_time, d_end_time));
+            !IBTK::rel_equal_eps(d_integrator_time, d_end_time));
 } // stepsRemaining
 
 void
@@ -647,7 +647,7 @@ HierarchyIntegrator::integrateHierarchy(const double current_time, const double 
 {
     ++d_current_cycle_num;
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(d_current_dt, new_time - current_time));
+    TBOX_ASSERT(IBTK::abs_equal_eps(d_current_dt, new_time - current_time));
     TBOX_ASSERT(d_current_cycle_num == cycle_num);
     TBOX_ASSERT(d_current_cycle_num < d_current_num_cycles);
 #else
@@ -663,7 +663,7 @@ HierarchyIntegrator::skipCycle(const double current_time, const double new_time,
 {
     ++d_current_cycle_num;
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(d_current_dt, new_time - current_time));
+    TBOX_ASSERT(IBTK::abs_equal_eps(d_current_dt, new_time - current_time));
     TBOX_ASSERT(d_current_cycle_num == cycle_num);
     TBOX_ASSERT(d_current_cycle_num < d_current_num_cycles);
 #else
@@ -681,7 +681,7 @@ HierarchyIntegrator::postprocessIntegrateHierarchy(const double current_time,
                                                    const int num_cycles)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(d_current_dt, new_time - current_time));
+    TBOX_ASSERT(IBTK::abs_equal_eps(d_current_dt, new_time - current_time));
     TBOX_ASSERT(num_cycles == d_current_num_cycles);
     TBOX_ASSERT(d_current_cycle_num + 1 == d_current_num_cycles);
 #else
@@ -1213,7 +1213,7 @@ double
 HierarchyIntegrator::getMaximumTimeStepSizeSpecialized()
 {
     double dt = d_dt_max;
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     if (initial_time)
     {
         dt = std::min(d_dt_init, d_dt_max);
@@ -1322,7 +1322,7 @@ HierarchyIntegrator::atRegridPointSpecialized() const
         // By default, always regrid before integrating the first time step.
         //
         // Subsequently, regrid according to the regrid interval.
-        const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
+        const bool initial_time = IBTK::abs_equal_eps(d_integrator_time, d_start_time);
         return initial_time ||
                ((d_integrator_step > 0) && (d_regrid_interval != 0) && (d_integrator_step % d_regrid_interval == 0));
     }

--- a/ibtk/src/utilities/LMarkerUtilities.cpp
+++ b/ibtk/src/utilities/LMarkerUtilities.cpp
@@ -202,7 +202,7 @@ LMarkerUtilities::readMarkerPositions(std::vector<Point>& mark_init_posns,
                     const double* const X = mark_init_posns[k].data();
                     for (unsigned int d = 0; d < NDIM; ++d)
                     {
-                        if (MathUtilities<double>::equalEps(X[d], grid_xLower[d]))
+                        if (IBTK::rel_equal_eps(X[d], grid_xLower[d]))
                         {
                             TBOX_ERROR("LMarkerUtilities::readMarkerPositions():\n"
                                        << "  encountered marker intersecting lower physical "
@@ -221,7 +221,7 @@ LMarkerUtilities::readMarkerPositions(std::vector<Point>& mark_init_posns,
                                        << std::endl);
                         }
 
-                        if (MathUtilities<double>::equalEps(X[d], grid_xUpper[d]))
+                        if (IBTK::rel_equal_eps(X[d], grid_xUpper[d]))
                         {
                             TBOX_ERROR("LMarkerUtilities::readMarkerPositions():\n"
                                        << "  encountered marker intersecting upper physical "

--- a/src/IB/BrinkmanPenalizationRigidBodyDynamics.cpp
+++ b/src/IB/BrinkmanPenalizationRigidBodyDynamics.cpp
@@ -71,7 +71,7 @@ set_rotation_matrix(const Eigen::Vector3d& rot_vel,
                     const double dt)
 {
     const double norm = rot_vel.norm();
-    if (!MathUtilities<double>::equalEps(norm, 0.0))
+    if (!IBTK::abs_equal_eps(norm, 0.0))
     {
         Eigen::Vector3d rot_axis = rot_vel / norm;
         Eigen::Quaterniond q(Eigen::AngleAxisd(norm * dt, rot_axis));
@@ -205,7 +205,7 @@ void
 BrinkmanPenalizationRigidBodyDynamics::computeBrinkmanVelocity(int u_idx, double time, int cycle_num)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(time, d_new_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(time, d_new_time));
 #endif
 
     const double hydro_compute_time = cycle_num > 0 ? time : d_current_time;
@@ -357,7 +357,7 @@ void
 BrinkmanPenalizationRigidBodyDynamics::demarcateBrinkmanZone(int u_idx, double time, int /*cycle_num*/)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(time, d_new_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(time, d_new_time));
 #else
     NULL_USE(time);
 #endif

--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -636,7 +636,7 @@ CIBMethod::interpolateVelocity(const int u_data_idx,
     if (d_lag_velvec_is_initialized)
     {
 #if !defined(NDEBUG)
-        TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+        TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_half_time));
 #endif
         std::vector<Pointer<LData> >*U_half_data, *X_half_data;
         bool* X_half_needs_ghost_fill;
@@ -661,7 +661,7 @@ CIBMethod::spreadForce(
     if (d_constraint_force_is_initialized)
     {
 #if !defined(NDEBUG)
-        TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+        TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_half_time));
 #endif
         if (f_phys_bdry_op == nullptr)
         {
@@ -965,7 +965,7 @@ void
 CIBMethod::setConstraintForce(Vec L, const double data_time, const double scale)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_half_time));
 #else
     NULL_USE(data_time);
 #endif
@@ -989,8 +989,7 @@ void
 CIBMethod::getConstraintForce(Vec* L, const double data_time)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_current_time) ||
-                MathUtilities<double>::equalEps(data_time, d_new_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_current_time) || IBTK::rel_equal_eps(data_time, d_new_time));
 #else
     NULL_USE(data_time);
 #endif
@@ -1006,8 +1005,7 @@ void
 CIBMethod::getFreeRigidVelocities(Vec* U, const double data_time)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_current_time) ||
-                MathUtilities<double>::equalEps(data_time, d_new_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_current_time) || IBTK::rel_equal_eps(data_time, d_new_time));
 #endif
 
     CIBStrategy::getFreeRigidVelocities(U, data_time);
@@ -1019,8 +1017,7 @@ void
 CIBMethod::getNetExternalForceTorque(Vec* F, const double data_time)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_current_time) ||
-                MathUtilities<double>::equalEps(data_time, d_new_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_current_time) || IBTK::rel_equal_eps(data_time, d_new_time));
 #endif
 
     CIBStrategy::getNetExternalForceTorque(F, data_time);
@@ -1085,7 +1082,7 @@ void
 CIBMethod::setInterpolatedVelocityVector(Vec /*V*/, const double data_time)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_half_time));
 #else
     NULL_USE(data_time);
 #endif
@@ -1098,7 +1095,7 @@ void
 CIBMethod::getInterpolatedVelocity(Vec V, const double data_time, const double scale)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_half_time));
 #else
     NULL_USE(data_time);
 #endif
@@ -1953,7 +1950,7 @@ CIBMethod::setRegularizationWeight(const int level_number)
                 const double& weight = reg_weight[lag_idx - lag_idx_range.first];
 
                 // For zero weight we do not use any regularization
-                if (!MathUtilities<double>::equalEps(weight, 0.0))
+                if (!IBTK::abs_equal_eps(weight, 0.0))
                 {
                     for (unsigned int d = 0; d < NDIM; ++d)
                     {

--- a/src/IB/CIBSaddlePointSolver.cpp
+++ b/src/IB/CIBSaddlePointSolver.cpp
@@ -639,7 +639,7 @@ CIBSaddlePointSolver::initializeStokesSolver(const SAMRAIVectorReal<NDIM, double
 
     // Set the nullspace of the LInv and subdomain solvers
     const double rho = d_ins_integrator->getStokesSpecifications()->getRho();
-    const bool has_velocity_nullspace = d_normalize_velocity && MathUtilities<double>::equalEps(rho, 0.0);
+    const bool has_velocity_nullspace = d_normalize_velocity && IBTK::abs_equal_eps(rho, 0.0);
     const bool has_pressure_nullspace = d_normalize_pressure;
 
     for (const auto& nul_vec : d_nul_vecs)

--- a/src/IB/CIBStaggeredStokesOperator.cpp
+++ b/src/IB/CIBStaggeredStokesOperator.cpp
@@ -233,7 +233,7 @@ CIBStaggeredStokesOperator::apply(Vec x, Vec y)
 
     VecScale(Vrigid, d_scale_interp);
     VecAYPX(V, -1.0, Vrigid);
-    if (!MathUtilities<double>::equalEps(d_reg_mob_factor, 0.0))
+    if (!IBTK::abs_equal_eps(d_reg_mob_factor, 0.0))
     {
         d_cib_strategy->computeMobilityRegularization(Vrigid, L);
         VecAXPY(V, -1.0 * d_scale_interp * d_reg_mob_factor, Vrigid);

--- a/src/IB/CIBStrategy.cpp
+++ b/src/IB/CIBStrategy.cpp
@@ -862,7 +862,7 @@ CIBStrategy::setRotationMatrix(const IBTK::EigenAlignedVector<Eigen::Vector3d>& 
     for (unsigned struct_no = 0; struct_no < d_num_rigid_parts; ++struct_no)
     {
         const double norm = rot_vel[struct_no].norm();
-        if (!MathUtilities<double>::equalEps(norm, 0.0))
+        if (!IBTK::abs_equal_eps(norm, 0.0))
         {
             Eigen::Vector3d rot_axis = rot_vel[struct_no] / norm;
             Eigen::Quaterniond q(Eigen::AngleAxisd(norm * dt, rot_axis));

--- a/src/IB/ConstraintIBMethod.cpp
+++ b/src/IB/ConstraintIBMethod.cpp
@@ -930,7 +930,7 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
         // structures.
         Pointer<LData> ptr_x_lag_data_current(nullptr), ptr_x_lag_data_new(nullptr);
         ptr_x_lag_data_current = d_l_data_manager->getLData("X", ln);
-        if (tbox::MathUtilities<double>::equalEps(d_FuRMoRP_current_time, 0.0))
+        if (IBTK::abs_equal_eps(d_FuRMoRP_current_time, 0.0))
         {
             ptr_x_lag_data_new = d_l_data_manager->getLData("X", ln);
         }
@@ -1056,7 +1056,7 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
         // Get LData corresponding to the present position of the structures.
         Pointer<LData> ptr_x_lag_data_current, ptr_x_lag_data_new;
         ptr_x_lag_data_current = d_l_data_manager->getLData("X", ln);
-        if (tbox::MathUtilities<double>::equalEps(d_FuRMoRP_current_time, 0.0))
+        if (IBTK::abs_equal_eps(d_FuRMoRP_current_time, 0.0))
         {
             ptr_x_lag_data_new = d_l_data_manager->getLData("X", ln);
         }
@@ -1177,7 +1177,7 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
 
     // write the COM and MOI to the output file
     if (!IBTK_MPI::getRank() && d_print_output && d_output_COM_coordinates &&
-        (d_timestep_counter % d_output_interval) == 0 && !MathUtilities<double>::equalEps(d_FuRMoRP_current_time, 0.0))
+        (d_timestep_counter % d_output_interval) == 0 && !IBTK::abs_equal_eps(d_FuRMoRP_current_time, 0.0))
     {
         for (int struct_no = 0; struct_no < d_no_structures; ++struct_no)
         {
@@ -1189,7 +1189,7 @@ ConstraintIBMethod::calculateCOMandMOIOfStructures()
     }
 
     if (!IBTK_MPI::getRank() && d_print_output && d_output_MOI && (d_timestep_counter % d_output_interval) == 0 &&
-        !MathUtilities<double>::equalEps(d_FuRMoRP_current_time, 0.0))
+        !IBTK::abs_equal_eps(d_FuRMoRP_current_time, 0.0))
     {
         for (int struct_no = 0; struct_no < d_no_structures; ++struct_no)
         {
@@ -1312,7 +1312,7 @@ ConstraintIBMethod::calculateMomentumOfKinematicsVelocity(const int position_han
 
             // Get LData corresponding to the present position of the structures.
             Pointer<LData> ptr_x_lag_data;
-            if (MathUtilities<double>::equalEps(d_FuRMoRP_current_time, 0.0))
+            if (IBTK::abs_equal_eps(d_FuRMoRP_current_time, 0.0))
             {
                 ptr_x_lag_data = d_l_data_manager->getLData("X", ln);
             }

--- a/src/IB/DirectMobilitySolver.cpp
+++ b/src/IB/DirectMobilitySolver.cpp
@@ -667,14 +667,14 @@ DirectMobilitySolver::factorizeDenseMatrix(double* mat_data,
         }
         for (int i = 0; i < mat_size; ++i)
         {
-            if (MathUtilities<double>::equalEps(eigenvalues[i], 0.0))
+            if (IBTK::abs_equal_eps(w[i], 0.0))
             {
                 counter_zero++;
             }
 
             for (int j = 0; j < mat_size; ++j)
             {
-                if (MathUtilities<double>::equalEps(eigenvalues[j], 0.0))
+                if (IBTK::abs_equal_eps(w[j], 0.0))
                 {
                     mat_view(i, j) = 0.0;
                 }

--- a/src/IB/DirectMobilitySolver.cpp
+++ b/src/IB/DirectMobilitySolver.cpp
@@ -667,14 +667,14 @@ DirectMobilitySolver::factorizeDenseMatrix(double* mat_data,
         }
         for (int i = 0; i < mat_size; ++i)
         {
-            if (IBTK::abs_equal_eps(w[i], 0.0))
+            if (IBTK::abs_equal_eps(eigenvalues[i], 0.0))
             {
                 counter_zero++;
             }
 
             for (int j = 0; j < mat_size; ++j)
             {
-                if (IBTK::abs_equal_eps(w[j], 0.0))
+                if (IBTK::abs_equal_eps(eigenvalues[j], 0.0))
                 {
                     mat_view(i, j) = 0.0;
                 }

--- a/src/IB/GeneralizedIBMethod.cpp
+++ b/src/IB/GeneralizedIBMethod.cpp
@@ -178,7 +178,7 @@ GeneralizedIBMethod::preprocessIntegrateData(double current_time, double new_tim
     {
         if (d_ib_force_and_torque_fcn_needs_init)
         {
-            const bool initial_time = MathUtilities<double>::equalEps(current_time, start_time);
+            const bool initial_time = IBTK::rel_equal_eps(current_time, start_time);
             resetLagrangianForceAndTorqueFunction(current_time, initial_time);
             d_ib_force_and_torque_fcn_needs_init = false;
         }
@@ -252,18 +252,18 @@ GeneralizedIBMethod::interpolateVelocity(const int u_data_idx,
 
     // Interpolate the angular velocities.
     std::vector<Pointer<LData> >* W_data = nullptr;
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         W_data = &d_W_current_data;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         TBOX_ERROR(d_object_name << "::interpolateVelocity():\n"
                                  << "  time-stepping type MIDPOINT_RULE not supported by "
                                     "class GeneralizedIBMethod;\n"
                                  << "  use TRAPEZOIDAL_RULE instead.\n");
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         W_data = &d_W_new_data;
     }
@@ -442,7 +442,7 @@ GeneralizedIBMethod::computeLagrangianForce(const double data_time)
     std::vector<Pointer<LData> >* N_data = nullptr;
     std::vector<Pointer<LData> >* X_data = nullptr;
     std::vector<Pointer<LData> >* D_data = nullptr;
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         d_F_current_needs_ghost_fill = true;
         d_N_current_needs_ghost_fill = true;
@@ -451,14 +451,14 @@ GeneralizedIBMethod::computeLagrangianForce(const double data_time)
         X_data = &d_X_current_data;
         D_data = &d_D_current_data;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         TBOX_ERROR(d_object_name << "::computeLagrangianForce():\n"
                                  << "  time-stepping type MIDPOINT_RULE not supported by "
                                     "class GeneralizedIBMethod;\n"
                                  << "  use TRAPEZOIDAL_RULE instead.\n");
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         d_F_new_needs_ghost_fill = true;
         d_N_new_needs_ghost_fill = true;
@@ -499,19 +499,19 @@ GeneralizedIBMethod::spreadForce(const int f_data_idx,
 
     std::vector<Pointer<LData> >* N_data = nullptr;
     bool* N_needs_ghost_fill = nullptr;
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         N_data = &d_N_current_data;
         N_needs_ghost_fill = &d_N_current_needs_ghost_fill;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         TBOX_ERROR(d_object_name << "::spreadForce():\n"
                                  << "  time-stepping type MIDPOINT_RULE not supported by "
                                     "class GeneralizedIBMethod;\n"
                                  << "  use TRAPEZOIDAL_RULE instead.\n");
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         N_data = &d_N_new_data;
         N_needs_ghost_fill = &d_N_new_needs_ghost_fill;

--- a/src/IB/IBFEDirectForcingKinematics.cpp
+++ b/src/IB/IBFEDirectForcingKinematics.cpp
@@ -111,7 +111,7 @@ set_rotation_matrix(const Eigen::Vector3d& rot_vel,
                     const double dt)
 {
     const double norm = rot_vel.norm();
-    if (!MathUtilities<double>::equalEps(norm, 0.0))
+    if (!IBTK::abs_equal_eps(norm, 0.0))
     {
         Eigen::Vector3d rot_axis = rot_vel / norm;
         Eigen::Quaterniond q(Eigen::AngleAxisd(norm * dt, rot_axis));
@@ -435,7 +435,7 @@ IBFEDirectForcingKinematics::computeLagrangianForce(PetscVector<double>& F_petsc
                                                     PetscVector<double>& U_petsc,
                                                     const double data_time)
 {
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_half_time));
 
     bool all_imposed_dofs = true;
     for (int k = 0; k < s_max_free_dofs; ++k)

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1084,7 +1084,7 @@ void
 IBFEMethod::computeLagrangianFluidSource(double data_time)
 {
     IBAMR_TIMER_START(t_compute_lagrangian_fluid_source);
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_half_time));
     for (unsigned int part = 0; part < d_meshes.size(); ++part)
     {
         if (!d_lag_body_source_part[part]) continue;
@@ -1190,7 +1190,7 @@ IBFEMethod::spreadFluidSource(const int q_data_idx,
     IBAMR_TIMER_START(t_spread_fluid_source);
     std::vector<PetscVector<double>*> X_IB_ghost_vecs = d_X_IB_vecs->getIBGhosted("tmp");
     std::vector<PetscVector<double>*> Q_IB_ghost_vecs = d_Q_IB_vecs->getIBGhosted("tmp");
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_half_time));
     batch_vec_copy({ d_X_vecs->get("half"), d_Q_vecs->get("half") }, { X_IB_ghost_vecs, Q_IB_ghost_vecs });
     batch_vec_ghost_update({ X_IB_ghost_vecs, Q_IB_ghost_vecs }, INSERT_VALUES, SCATTER_FORWARD);
 

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -693,7 +693,7 @@ IBFESurfaceMethod::trapezoidalStep(const double current_time, const double new_t
 void
 IBFESurfaceMethod::computeLagrangianForce(const double data_time)
 {
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_half_time));
     const std::string data_time_str = get_data_time_str(data_time, d_current_time, d_new_time);
     batch_vec_ghost_update(d_X_vecs->get(data_time_str), INSERT_VALUES, SCATTER_FORWARD);
     for (unsigned part = 0; part < d_num_parts; ++part)
@@ -981,7 +981,7 @@ IBFESurfaceMethod::spreadForce(const int f_data_idx,
     f_active_data_ops->resetLevels(ln, ln);
     f_active_data_ops->setToScalar(f_scratch_data_idx, 0.0, /*interior_only*/ false);
 
-    TBOX_ASSERT(MathUtilities<double>::equalEps(data_time, d_half_time));
+    TBOX_ASSERT(IBTK::rel_equal_eps(data_time, d_half_time));
     for (unsigned int part = 0; part < d_num_parts; ++part)
     {
         PetscVector<double>* X_ghost_vec = X_IB_ghost_vecs[part];

--- a/src/IB/IBHierarchyIntegrator.cpp
+++ b/src/IB/IBHierarchyIntegrator.cpp
@@ -172,11 +172,10 @@ IBHierarchyIntegrator::preprocessIntegrateHierarchy(const double current_time,
 
     // Determine whether there has been a time step size change.
     const double dt = new_time - current_time;
-    static bool skip_check_for_dt_change = MathUtilities<double>::equalEps(d_integrator_time, d_start_time) ||
-                                           RestartManager::getManager()->isFromRestart();
+    static bool skip_check_for_dt_change =
+        IBTK::rel_equal_eps(d_integrator_time, d_start_time) || RestartManager::getManager()->isFromRestart();
     if (!skip_check_for_dt_change && (d_error_on_dt_change || d_warn_on_dt_change) &&
-        !MathUtilities<double>::equalEps(dt, d_dt_previous[0]) &&
-        !MathUtilities<double>::equalEps(new_time, d_end_time))
+        !IBTK::rel_equal_eps(dt, d_dt_previous[0]) && !IBTK::rel_equal_eps(new_time, d_end_time))
     {
         if (d_error_on_dt_change)
         {
@@ -475,7 +474,7 @@ IBHierarchyIntegrator::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > h
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     const int u_current_idx = var_db->mapVariableAndContextToIndex(d_u_var, getCurrentContext());
     d_hier_velocity_data_ops->copyData(d_u_idx, u_current_idx);
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
     d_u_phys_bdry_op->setHomogeneousBc(false);
     d_ib_method_ops->initializePatchHierarchy(hierarchy,
@@ -585,7 +584,7 @@ IBHierarchyIntegrator::IBHierarchyIntegrator(const std::string& object_name,
 bool
 IBHierarchyIntegrator::atRegridPointSpecialized() const
 {
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     if (initial_time) return true;
     if (d_regrid_fluid_cfl_interval > 0.0 || d_regrid_structure_cfl_interval > 0.0)
     {

--- a/src/IB/IBHydrodynamicForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicForceEvaluator.cpp
@@ -144,7 +144,7 @@ IBHydrodynamicForceEvaluator::registerStructure(IBTK::Vector3d& box_X_lower,
             double num_cells_lower = (box_X_lower[d] - grid_X_lower[d]) / dx_coarsest[d];
             double num_cells_upper = (box_X_upper[d] - grid_X_lower[d]) / dx_coarsest[d];
 
-            if (!MathUtilities<double>::equalEps(num_cells_lower, floor(num_cells_lower)))
+            if (!IBTK::rel_equal_eps(num_cells_lower, floor(num_cells_lower)))
             {
                 TBOX_WARNING("Lower side of integration box is not aligned with sides on coarsest level in dimension "
                              << d << ". Modifying coordinate to nearest box side\n");
@@ -153,7 +153,7 @@ IBHydrodynamicForceEvaluator::registerStructure(IBTK::Vector3d& box_X_lower,
                 modified_box = true;
             }
 
-            if (!MathUtilities<double>::equalEps(num_cells_upper, floor(num_cells_upper)))
+            if (!IBTK::rel_equal_eps(num_cells_upper, floor(num_cells_upper)))
             {
                 TBOX_WARNING("Upper side of integration box is not aligned with sides on coarsest level in dimension "
                              << d << ". Modifying coordinate to nearest box side\n");
@@ -270,7 +270,7 @@ IBHydrodynamicForceEvaluator::updateStructureDomain(const IBTK::Vector3d& box_ve
 #endif
         ;
 
-    TBOX_ASSERT(MathUtilities<double>::equalEps(fobj.box_vol_current, fobj.box_vol_new));
+    TBOX_ASSERT(IBTK::rel_equal_eps(fobj.box_vol_current, fobj.box_vol_new));
 
     return;
 

--- a/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
@@ -209,11 +209,11 @@ IBHydrodynamicSurfaceForceEvaluator::computeHydrodynamicForceTorque(IBTK::Vector
                                                                     double new_time)
 {
     bool use_current_ctx = false, use_new_ctx = false;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         use_current_ctx = true;
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         use_new_ctx = true;
     }

--- a/src/IB/IBInstrumentPanel.cpp
+++ b/src/IB/IBInstrumentPanel.cpp
@@ -936,7 +936,7 @@ IBInstrumentPanel::readInstrumentData(const int U_data_idx,
                                  << std::endl);
     }
 
-    if (!MathUtilities<double>::equalEps(data_time, d_instrument_read_time))
+    if (!IBTK::rel_equal_eps(data_time, d_instrument_read_time))
     {
         TBOX_ERROR(d_object_name << "::readInstrumentData():\n"
                                  << "  data read time: " << data_time

--- a/src/IB/IBInterpolantHierarchyIntegrator.cpp
+++ b/src/IB/IBInterpolantHierarchyIntegrator.cpp
@@ -123,7 +123,7 @@ IBInterpolantHierarchyIntegrator::preprocessIntegrateHierarchy(const double curr
     d_ins_hier_integrator->preprocessIntegrateHierarchy(current_time, new_time, num_cycles);
 
     // At initial time interpolate Q.
-    bool initial_time = MathUtilities<double>::equalEps(current_time, 0.0);
+    bool initial_time = IBTK::abs_equal_eps(current_time, 0.0);
     if (initial_time) d_ib_interpolant_method_ops->interpolateQ();
 
     // Execute any registered callbacks.

--- a/src/IB/IBInterpolantMethod.cpp
+++ b/src/IB/IBInterpolantMethod.cpp
@@ -112,7 +112,7 @@ set_rotation_matrix(const EigenAlignedVector<Eigen::Vector3d>& rot_vel,
     for (unsigned struct_no = 0; struct_no < n_structs; ++struct_no)
     {
         const double norm = rot_vel[struct_no].norm();
-        if (!MathUtilities<double>::equalEps(norm, 0.0))
+        if (!IBTK::abs_equal_eps(norm, 0.0))
         {
             Eigen::Vector3d rot_axis = rot_vel[struct_no] / norm;
             Eigen::Quaterniond q(Eigen::AngleAxisd(norm * dt, rot_axis));
@@ -784,11 +784,11 @@ IBInterpolantMethod::putToDatabase(Pointer<Database> db)
 void
 IBInterpolantMethod::getPositionData(std::vector<Pointer<LData> >** X_data, double data_time)
 {
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         *X_data = &d_X_current_data;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         *X_data = &d_X_new_data;
     }
@@ -810,11 +810,11 @@ IBInterpolantMethod::copyEulerianDataFromIntegrator(const std::string& var_name,
     Pointer<Variable<NDIM> > var = d_q_var[var_name];
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         q_hier_idx = var_db->mapVariableAndContextToIndex(var, hier_integrator->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         q_hier_idx = var_db->mapVariableAndContextToIndex(var, hier_integrator->getNewContext());
     }
@@ -874,11 +874,11 @@ IBInterpolantMethod::copyEulerianDataToIntegrator(const std::string& var_name, i
     Pointer<Variable<NDIM> > var = d_q_var[var_name];
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         q_hier_idx = var_db->mapVariableAndContextToIndex(var, hier_integrator->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         q_hier_idx = var_db->mapVariableAndContextToIndex(var, hier_integrator->getNewContext());
     }
@@ -910,11 +910,11 @@ IBInterpolantMethod::copyEulerianDataToIntegrator(const std::string& var_name, i
 void
 IBInterpolantMethod::getQData(const std::string& var_name, std::vector<Pointer<LData> >** Q_data, double data_time)
 {
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         *Q_data = &d_Q_current_data[var_name];
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         *Q_data = &d_Q_new_data[var_name];
     }

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -334,7 +334,7 @@ IBMethod::preprocessIntegrateData(double current_time, double new_time, int /*nu
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
     const double start_time = d_ib_solver->getStartTime();
-    const bool initial_time = MathUtilities<double>::equalEps(current_time, start_time);
+    const bool initial_time = IBTK::rel_equal_eps(current_time, start_time);
 
     if (d_ib_force_fcn)
     {
@@ -688,7 +688,7 @@ IBMethod::interpolateVelocity(const int u_data_idx,
                            /*coarsest_ln*/ 0,
                            /*finest_ln*/ d_hierarchy->getFinestLevelNumber());
 
-    if (!MathUtilities<double>::equalEps(data_time, d_half_time))
+    if (!IBTK::rel_equal_eps(data_time, d_half_time))
     {
         std::vector<Pointer<LData> >* U_half_data;
         getVelocityData(&U_half_data, d_half_time);
@@ -1712,17 +1712,17 @@ IBMethod::putToDatabase(Pointer<Database> db)
 void
 IBMethod::getPositionData(std::vector<Pointer<LData> >** X_data, bool** X_needs_ghost_fill, double data_time)
 {
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         *X_data = &d_X_current_data;
         *X_needs_ghost_fill = &d_X_current_needs_ghost_fill;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         *X_data = &d_X_half_data;
         *X_needs_ghost_fill = &d_X_half_needs_ghost_fill;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         *X_data = &d_X_new_data;
         *X_needs_ghost_fill = &d_X_new_needs_ghost_fill;
@@ -1760,17 +1760,17 @@ IBMethod::getLECouplingPositionData(std::vector<Pointer<LData> >** X_LE_data,
         return;
     }
 
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         *X_LE_data = &d_X_current_data;
         *X_LE_needs_ghost_fill = &d_X_current_needs_ghost_fill;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         *X_LE_data = &d_X_LE_half_data;
         *X_LE_needs_ghost_fill = &d_X_LE_half_needs_ghost_fill;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         *X_LE_data = &d_X_LE_new_data;
         *X_LE_needs_ghost_fill = &d_X_LE_new_needs_ghost_fill;
@@ -1781,15 +1781,15 @@ IBMethod::getLECouplingPositionData(std::vector<Pointer<LData> >** X_LE_data,
 void
 IBMethod::getVelocityData(std::vector<Pointer<LData> >** U_data, double data_time)
 {
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         *U_data = &d_U_current_data;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         *U_data = &d_U_half_data;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         *U_data = &d_U_new_data;
     }
@@ -1818,17 +1818,17 @@ IBMethod::getForceData(std::vector<Pointer<LData> >** F_data, bool** F_needs_gho
 {
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         *F_data = &d_F_current_data;
         *F_needs_ghost_fill = &d_F_current_needs_ghost_fill;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         *F_data = &d_F_half_data;
         *F_needs_ghost_fill = &d_F_half_needs_ghost_fill;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
         {

--- a/src/IB/IBRedundantInitializer.cpp
+++ b/src/IB/IBRedundantInitializer.cpp
@@ -586,7 +586,7 @@ IBRedundantInitializer::initializeDirectorAndRods()
                             D_norm_squared += d_directors[ln][j][k][3 * n + d] * d_directors[ln][j][k][3 * n + d];
                         }
                         const double D_norm = std::sqrt(D_norm_squared);
-                        if (!MathUtilities<double>::equalEps(D_norm, 1.0))
+                        if (!IBTK::rel_equal_eps(D_norm, 1.0))
                         {
                             TBOX_WARNING(d_object_name << ":\n  Director vector for index " << k << " of structure "
                                                        << j << " on level " << ln
@@ -1099,7 +1099,7 @@ IBRedundantInitializer::initializeMassDataOnPatchLevel(const unsigned int /*glob
             const double K = spec.stiffness;
 
             // Avoid division by zero at massless nodes.
-            if (MathUtilities<double>::equalEps(M, 0.0))
+            if (IBTK::abs_equal_eps(M, 0.0))
             {
                 M_array[local_petsc_idx] = std::numeric_limits<double>::epsilon();
                 K_array[local_petsc_idx] = 0.0;

--- a/src/IB/IBStandardInitializer.cpp
+++ b/src/IB/IBStandardInitializer.cpp
@@ -456,7 +456,7 @@ IBStandardInitializer::readSpringFiles(const std::string& extension, const bool 
                     // Check to see if the spring constant is zero and, if so,
                     // emit a warning.
                     if (!warned && d_enable_springs[ln][j] &&
-                        (parameters[0] == 0.0 || MathUtilities<double>::equalEps(parameters[0], 0.0)))
+                        (parameters[0] == 0.0 || IBTK::abs_equal_eps(parameters[0], 0.0)))
                     {
                         TBOX_WARNING(d_object_name << ":\n  Spring with zero spring constant "
                                                       "encountered in ASCII input file named "
@@ -690,7 +690,7 @@ IBStandardInitializer::readXSpringFiles(const std::string& extension, const bool
                     // Check to see if the spring constant is zero and, if so,
                     // emit a warning.
                     if (!warned && d_enable_xsprings[ln][j] &&
-                        (parameters[0] == 0.0 || MathUtilities<double>::equalEps(parameters[0], 0.0)))
+                        (parameters[0] == 0.0 || IBTK::abs_equal_eps(parameters[0], 0.0)))
                     {
                         TBOX_WARNING(d_object_name << ":\n  Crosslink spring with zero spring "
                                                       "constant encountered in ASCII input file "
@@ -930,7 +930,7 @@ IBStandardInitializer::readBeamFiles(const std::string& extension, const bool in
 
                     // Check to see if the bending rigidity is zero and, if so,
                     // emit a warning.
-                    if (!warned && d_enable_beams[ln][j] && (bend == 0.0 || MathUtilities<double>::equalEps(bend, 0.0)))
+                    if (!warned && d_enable_beams[ln][j] && (bend == 0.0 || IBTK::abs_equal_eps(bend, 0.0)))
                     {
                         TBOX_WARNING(d_object_name << ":\n  Beam with zero bending rigidity "
                                                       "encountered in ASCII input file named "
@@ -1453,7 +1453,7 @@ IBStandardInitializer::readTargetPointFiles(const std::string& extension)
                             // if so, emit a warning.
                             const double kappa = d_target_spec_data[ln][j][n].stiffness;
                             if (!warned && d_enable_target_points[ln][j] &&
-                                (kappa == 0.0 || MathUtilities<double>::equalEps(kappa, 0.0)))
+                                (kappa == 0.0 || IBTK::abs_equal_eps(kappa, 0.0)))
                             {
                                 TBOX_WARNING(d_object_name << ":\n  Target point with zero penalty spring "
                                                               "constant encountered in ASCII input file "
@@ -1908,7 +1908,7 @@ IBStandardInitializer::readDirectorFiles(const std::string& extension)
                                 D_norm_squared += d_directors[ln][j][k][3 * n + d] * d_directors[ln][j][k][3 * n + d];
                             }
                             const double D_norm = std::sqrt(D_norm_squared);
-                            if (!MathUtilities<double>::equalEps(D_norm, 1.0))
+                            if (!IBTK::rel_equal_eps(D_norm, 1.0))
                             {
                                 TBOX_WARNING(d_object_name << ":\n  Director vector on line " << 3 * k + n + 2
                                                            << " of file " << directors_filename

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -517,7 +517,7 @@ IMPMethod::interpolateVelocity(const int u_data_idx,
         (*Grad_U_data)[ln]->restoreArrays();
         (*X_data)[ln]->restoreArrays();
     }
-    d_U_half_needs_reinit = !MathUtilities<double>::equalEps(data_time, d_half_time);
+    d_U_half_needs_reinit = !IBTK::rel_equal_eps(data_time, d_half_time);
     return;
 } // interpolateVelocity
 
@@ -1085,12 +1085,12 @@ IMPMethod::getPositionData(std::vector<Pointer<LData> >** X_data, bool** X_needs
 {
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         *X_data = &d_X_current_data;
         *X_needs_ghost_fill = &d_X_current_needs_ghost_fill;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
         {
@@ -1110,7 +1110,7 @@ IMPMethod::getPositionData(std::vector<Pointer<LData> >** X_data, bool** X_needs
         *X_data = &d_X_half_data;
         *X_needs_ghost_fill = &d_X_half_needs_ghost_fill;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         *X_data = &d_X_new_data;
         *X_needs_ghost_fill = &d_X_new_needs_ghost_fill;
@@ -1125,12 +1125,12 @@ IMPMethod::getVelocityData(std::vector<Pointer<LData> >** U_data,
 {
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         *U_data = &d_U_current_data;
         *Grad_U_data = &d_Grad_U_current_data;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
         {
@@ -1151,7 +1151,7 @@ IMPMethod::getVelocityData(std::vector<Pointer<LData> >** U_data,
         *U_data = &d_U_half_data;
         *Grad_U_data = &d_Grad_U_half_data;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         *U_data = &d_U_new_data;
         *Grad_U_data = &d_Grad_U_new_data;
@@ -1162,15 +1162,15 @@ IMPMethod::getVelocityData(std::vector<Pointer<LData> >** U_data,
 void
 IMPMethod::getDeformationGradientData(std::vector<Pointer<LData> >** F_data, double data_time)
 {
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         *F_data = &d_F_current_data;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         *F_data = &d_F_half_data;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         *F_data = &d_F_new_data;
     }

--- a/src/IB/KrylovMobilitySolver.cpp
+++ b/src/IB/KrylovMobilitySolver.cpp
@@ -593,7 +593,7 @@ KrylovMobilitySolver::initializeStokesSolver(const SAMRAIVectorReal<NDIM, double
 
     // Set the nullspace of the LInv and subdomain solvers
     const double rho = d_ins_integrator->getStokesSpecifications()->getRho();
-    const bool has_velocity_nullspace = d_normalize_velocity && MathUtilities<double>::equalEps(rho, 0.0);
+    const bool has_velocity_nullspace = d_normalize_velocity && IBTK::abs_equal_eps(rho, 0.0);
     const bool has_pressure_nullspace = d_normalize_pressure;
 
     for (const auto& nul_vec : d_nul_vecs)
@@ -926,7 +926,7 @@ KrylovMobilitySolver::MatVecMult_KMInv(Mat A, Vec x, Vec y)
     solver->d_cib_strategy->getInterpolatedVelocity(y, half_time, beta);
 
     // 4) Regularize mobility.
-    if (!MathUtilities<double>::equalEps(delta, 0.0))
+    if (!IBTK::abs_equal_eps(delta, 0.0))
     {
         Vec D;
         VecDuplicate(x, &D);

--- a/src/IB/PenaltyIBMethod.cpp
+++ b/src/IB/PenaltyIBMethod.cpp
@@ -278,7 +278,7 @@ PenaltyIBMethod::computeLagrangianForce(const double data_time)
 
     double max_displacement = 0.0;
 
-    if (MathUtilities<double>::equalEps(data_time, d_current_time))
+    if (IBTK::rel_equal_eps(data_time, d_current_time))
     {
         for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
         {
@@ -302,7 +302,7 @@ PenaltyIBMethod::computeLagrangianForce(const double data_time)
         }
         d_F_current_needs_ghost_fill = true;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_half_time))
+    else if (IBTK::rel_equal_eps(data_time, d_half_time))
     {
         for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
         {
@@ -330,7 +330,7 @@ PenaltyIBMethod::computeLagrangianForce(const double data_time)
         }
         d_F_half_needs_ghost_fill = true;
     }
-    else if (MathUtilities<double>::equalEps(data_time, d_new_time))
+    else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
         {

--- a/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
@@ -293,7 +293,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
     const double half_time = current_time + 0.5 * dt;
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
 
     // Check to make sure that the number of cycles is what we expect it to be.
@@ -450,7 +450,7 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
 
     // Indicate that all linear solvers need to be reinitialized if the current
     // timestep size is different from the previous one.
-    if (cycle_num == 0 && (initial_time || !MathUtilities<double>::equalEps(dt, d_dt_previous[0])))
+    if (cycle_num == 0 && (initial_time || !IBTK::rel_equal_eps(dt, d_dt_previous[0])))
     {
         std::fill(d_helmholtz_solvers_need_init.begin(), d_helmholtz_solvers_need_init.end(), true);
         d_coarsest_reset_ln = 0;
@@ -664,7 +664,7 @@ double
 AdvDiffPredictorCorrectorHierarchyIntegrator::getMaximumTimeStepSizeSpecialized()
 {
     double dt = HierarchyIntegrator::getMaximumTimeStepSizeSpecialized();
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     for (int ln = 0; ln <= d_hierarchy->getFinestLevelNumber(); ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);

--- a/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
@@ -437,7 +437,7 @@ int
 AdvDiffSemiImplicitHierarchyIntegrator::getNumberOfCycles() const
 {
     int num_cycles = d_num_cycles;
-    if (MathUtilities<double>::equalEps(d_integrator_time, d_start_time))
+    if (IBTK::abs_equal_eps(d_integrator_time, d_start_time))
     {
         for (const auto& Q_var : d_Q_var)
         {
@@ -462,12 +462,12 @@ AdvDiffSemiImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
     const double dt = new_time - current_time;
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
 
     // Indicate that all solvers need to be reinitialized if the current
     // timestep size is different from the previous one.
-    const bool dt_change = initial_time || !MathUtilities<double>::equalEps(dt, d_dt_previous[0]);
+    const bool dt_change = initial_time || !IBTK::abs_equal_eps(dt, d_dt_previous[0]);
     if (dt_change)
     {
         std::fill(d_helmholtz_solvers_need_init.begin(), d_helmholtz_solvers_need_init.end(), true);

--- a/src/adv_diff/BrinkmanAdvDiffSemiImplicitHierarchyIntegrator.cpp
+++ b/src/adv_diff/BrinkmanAdvDiffSemiImplicitHierarchyIntegrator.cpp
@@ -195,12 +195,12 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(con
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
     const double dt = new_time - current_time;
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
 
     // Indicate that all solvers need to be reinitialized if the current
     // timestep size is different from the previous one.
-    const bool dt_change = initial_time || !MathUtilities<double>::equalEps(dt, d_dt_previous[0]);
+    const bool dt_change = initial_time || !IBTK::abs_equal_eps(dt, d_dt_previous[0]);
     if (dt_change)
     {
         std::fill(d_helmholtz_solvers_need_init.begin(), d_helmholtz_solvers_need_init.end(), true);

--- a/src/level_set/FESurfaceDistanceEvaluator.cpp
+++ b/src/level_set/FESurfaceDistanceEvaluator.cpp
@@ -413,7 +413,7 @@ FESurfaceDistanceEvaluator::computeSignedDistance(int n_idx, int d_idx)
                     w << n1(0), n1(1);
 
                     const double L2 = (v - w).squaredNorm();
-                    if (MathUtilities<double>::equalEps(L2, 0.0))
+                    if (IBTK::abs_equal_eps(L2, 0.0))
                     {
                         // Special case where line element collapses to a
                         // point. Shouldn't happen.
@@ -433,7 +433,7 @@ FESurfaceDistanceEvaluator::computeSignedDistance(int n_idx, int d_idx)
                     // If the distance is the same as the minimal
                     // distance, then the cell is equidistant to multiple
                     // elements, so add it to the set.
-                    if (MathUtilities<double>::equalEps(dist, min_dist))
+                    if (IBTK::rel_equal_eps(dist, min_dist))
                     {
                         vec_equidistant_pair.push_back(std::make_pair(proj, d_elem_face_normal[elem]));
                     }
@@ -458,7 +458,7 @@ FESurfaceDistanceEvaluator::computeSignedDistance(int n_idx, int d_idx)
                     // If the distance is the same as the minimal
                     // distance, then the cell is equidistant to multiple
                     // elements, so add it to the set.
-                    if (MathUtilities<double>::equalEps(dist, min_dist))
+                    if (IBTK::rel_equal_eps(dist, min_dist))
                     {
                         vec_equidistant_pair.push_back(std::make_pair(proj, proj_and_normal.second));
                     }

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1264,8 +1264,7 @@ INSCollocatedHierarchyIntegrator::integrateHierarchy(const double current_time,
                             new_time);
 
     // Project U(*) to compute U(n+1) and u_ADV(n+1).
-    const double div_fac =
-        (MathUtilities<double>::equalEps(rho, 0.0) || MathUtilities<double>::equalEps(dt, 0.0) ? 1.0 : rho / dt);
+    const double div_fac = (IBTK::abs_equal_eps(rho, 0.0) || IBTK::abs_equal_eps(dt, 0.0) ? 1.0 : rho / dt);
     d_hier_math_ops->div(d_Phi_rhs_vec->getComponentDescriptorIndex(0),
                          d_Phi_rhs_vec->getComponentVariable(0),
                          -div_fac,
@@ -1335,7 +1334,7 @@ INSCollocatedHierarchyIntegrator::integrateHierarchy(const double current_time,
         TBOX_ERROR("this statment should not be reached");
     }
     PoissonSpecifications helmholtz_spec(d_object_name + "::helmholtz_spec");
-    if (MathUtilities<double>::equalEps(rho, 0.0))
+    if (IBTK::abs_equal_eps(rho, 0.0))
     {
         helmholtz_spec.setCConstant(0.0);
         helmholtz_spec.setDConstant(-K * mu);
@@ -2017,8 +2016,8 @@ INSCollocatedHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double c
 {
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
     const double dt = new_time - current_time;
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     const double half_time = current_time + 0.5 * dt;
     const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
     const double rho = d_problem_coefs.getRho();
@@ -2048,14 +2047,14 @@ INSCollocatedHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double c
 
     // Ensure that solver components are appropriately reinitialized when the
     // time step size changes.
-    const bool dt_change = initial_time || !MathUtilities<double>::equalEps(dt, d_dt_previous[0]);
+    const bool dt_change = initial_time || !IBTK::rel_equal_eps(dt, d_dt_previous[0]);
     if (dt_change)
     {
         d_velocity_solver_needs_init = true;
     }
 
     // Setup solver vectors.
-    const bool has_velocity_nullspace = d_normalize_velocity && MathUtilities<double>::equalEps(rho, 0.0);
+    const bool has_velocity_nullspace = d_normalize_velocity && IBTK::abs_equal_eps(rho, 0.0);
     const bool has_pressure_nullspace = d_normalize_pressure;
     if (d_vectors_need_init)
     {

--- a/src/navier_stokes/INSCollocatedVelocityBcCoef.cpp
+++ b/src/navier_stokes/INSCollocatedVelocityBcCoef.cpp
@@ -257,8 +257,8 @@ INSCollocatedVelocityBcCoef::setBcCoefs(Pointer<ArrayData<NDIM, double> >& acoef
         double& alpha = (*acoef_data)(i, 0);
         double& beta = (*bcoef_data)(i, 0);
         double& gamma = (*gcoef_data)(i, 0);
-        const bool velocity_bc = MathUtilities<double>::equalEps(alpha, 1.0);
-        const bool traction_bc = MathUtilities<double>::equalEps(beta, 1.0);
+        const bool velocity_bc = IBTK::rel_equal_eps(alpha, 1.0);
+        const bool traction_bc = IBTK::rel_equal_eps(beta, 1.0);
 #if !defined(NDEBUG)
         TBOX_ASSERT((velocity_bc || traction_bc) && !(velocity_bc && traction_bc));
 #endif

--- a/src/navier_stokes/INSHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSHierarchyIntegrator.cpp
@@ -383,7 +383,7 @@ int
 INSHierarchyIntegrator::getNumberOfCycles() const
 {
     int num_cycles = d_num_cycles;
-    if (!d_creeping_flow && MathUtilities<double>::equalEps(d_integrator_time, d_start_time) &&
+    if (!d_creeping_flow && IBTK::abs_equal_eps(d_integrator_time, d_start_time) &&
         is_multistep_time_stepping_type(d_convective_time_stepping_type) &&
         d_init_convective_time_stepping_type != FORWARD_EULER)
     {

--- a/src/navier_stokes/INSProjectionBcCoef.cpp
+++ b/src/navier_stokes/INSProjectionBcCoef.cpp
@@ -162,8 +162,8 @@ INSProjectionBcCoef::setBcCoefs(Pointer<ArrayData<NDIM, double> >& acoef_data,
         double& alpha = acoef_data ? (*acoef_data)(i, 0) : dummy_val;
         double& beta = bcoef_data ? (*bcoef_data)(i, 0) : dummy_val;
         double& gamma = gcoef_data ? (*gcoef_data)(i, 0) : dummy_val;
-        const bool velocity_bc = MathUtilities<double>::equalEps(alpha, 1.0);
-        const bool traction_bc = MathUtilities<double>::equalEps(beta, 1.0);
+        const bool velocity_bc = IBTK::rel_equal_eps(alpha, 1.0);
+        const bool traction_bc = IBTK::rel_equal_eps(beta, 1.0);
 #if !defined(NDEBUG)
         TBOX_ASSERT((velocity_bc || traction_bc) && !(velocity_bc && traction_bc));
 #endif

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1151,7 +1151,7 @@ INSStaggeredHierarchyIntegrator::initializePatchHierarchy(Pointer<PatchHierarchy
 {
     HierarchyIntegrator::initializePatchHierarchy(hierarchy, gridding_alg);
 
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
+    const bool initial_time = IBTK::abs_equal_eps(d_integrator_time, d_start_time);
 
     // Initialize mean quantities.
     if (d_flow_averaging_interval && initial_time)
@@ -2520,8 +2520,8 @@ INSStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double cu
 {
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
     const double dt = new_time - current_time;
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     const double half_time = current_time + 0.5 * dt;
     const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
     const int wgt_sc_idx = d_hier_math_ops->getSideWeightPatchDescriptorIndex();
@@ -2552,7 +2552,7 @@ INSStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double cu
 
     // Ensure that solver components are appropriately reinitialized when the
     // time step size changes.
-    const bool dt_change = initial_time || !MathUtilities<double>::equalEps(dt, d_dt_previous[0]);
+    const bool dt_change = initial_time || !IBTK::rel_equal_eps(dt, d_dt_previous[0]);
     if (dt_change)
     {
         d_velocity_solver_needs_init = true;
@@ -2560,7 +2560,7 @@ INSStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double cu
     }
 
     // Setup solver vectors.
-    const bool has_velocity_nullspace = d_normalize_velocity && MathUtilities<double>::equalEps(rho, 0.0);
+    const bool has_velocity_nullspace = d_normalize_velocity && IBTK::abs_equal_eps(rho, 0.0);
     const bool has_pressure_nullspace = d_normalize_pressure;
     if (d_vectors_need_init)
     {

--- a/src/navier_stokes/INSStaggeredPressureBcCoef.cpp
+++ b/src/navier_stokes/INSStaggeredPressureBcCoef.cpp
@@ -257,8 +257,8 @@ INSStaggeredPressureBcCoef::setBcCoefs(Pointer<ArrayData<NDIM, double> >& acoef_
         double& alpha = acoef_data ? (*acoef_data)(i, 0) : dummy_val;
         double& beta = bcoef_data ? (*bcoef_data)(i, 0) : dummy_val;
         double& gamma = gcoef_data ? (*gcoef_data)(i, 0) : dummy_val;
-        const bool velocity_bc = MathUtilities<double>::equalEps(alpha, 1.0);
-        const bool traction_bc = MathUtilities<double>::equalEps(beta, 1.0);
+        const bool velocity_bc = IBTK::rel_equal_eps(alpha, 1.0);
+        const bool traction_bc = IBTK::rel_equal_eps(beta, 1.0);
 #if !defined(NDEBUG)
         TBOX_ASSERT((velocity_bc || traction_bc) && !(velocity_bc && traction_bc));
 #endif

--- a/src/navier_stokes/INSStaggeredVelocityBcCoef.cpp
+++ b/src/navier_stokes/INSStaggeredVelocityBcCoef.cpp
@@ -264,8 +264,8 @@ INSStaggeredVelocityBcCoef::setBcCoefs(Pointer<ArrayData<NDIM, double> >& acoef_
         double& alpha = (*acoef_data)(i, 0);
         double& beta = (*bcoef_data)(i, 0);
         double& gamma = (*gcoef_data)(i, 0);
-        const bool velocity_bc = MathUtilities<double>::equalEps(alpha, 1.0);
-        const bool traction_bc = MathUtilities<double>::equalEps(beta, 1.0);
+        const bool velocity_bc = IBTK::rel_equal_eps(alpha, 1.0);
+        const bool traction_bc = IBTK::rel_equal_eps(beta, 1.0);
 #if !defined(NDEBUG)
         TBOX_ASSERT((velocity_bc || traction_bc) && !(velocity_bc && traction_bc));
 #endif

--- a/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
@@ -509,7 +509,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::preprocessIntegrateHierarchy(cons
 
         // Set the velocities used to update the density and the previous time step
         // size
-        if (MathUtilities<double>::equalEps(d_integrator_time, d_start_time))
+        if (IBTK::rel_equal_eps(d_integrator_time, d_start_time))
         {
             d_rho_p_integrator->setFluidVelocityPatchDataIndices(
                 /*old*/ -1, /*current*/ d_U_current_idx, /*new*/ -1);
@@ -648,7 +648,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::integrateHierarchy(const double c
             d_rho_p_integrator->setSideCenteredDensityPatchDataIndex(d_rho_sc_current_idx);
 
             // Set the velocities used to update the density
-            if (MathUtilities<double>::equalEps(d_integrator_time, d_start_time))
+            if (IBTK::rel_equal_eps(d_integrator_time, d_start_time))
             {
                 d_rho_p_integrator->setFluidVelocityPatchDataIndices(
                     /*old*/ -1, /*current*/ d_U_current_idx, /*new*/ d_U_new_idx);
@@ -726,7 +726,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::integrateHierarchy(const double c
     {
         d_hier_sc_data_ops->resetLevels(ln, ln);
         const double A_scale = d_A_scale[ln];
-        if (!MathUtilities<double>::equalEps(A_scale, 1.0))
+        if (!IBTK::rel_equal_eps(A_scale, 1.0))
         {
             d_hier_sc_data_ops->scale(d_rhs_vec->getComponentDescriptorIndex(0),
                                       A_scale,
@@ -744,7 +744,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::integrateHierarchy(const double c
     {
         d_hier_sc_data_ops->resetLevels(ln, ln);
         const double A_scale = d_A_scale[ln];
-        if (!MathUtilities<double>::equalEps(A_scale, 1.0))
+        if (!IBTK::rel_equal_eps(A_scale, 1.0))
         {
             d_hier_sc_data_ops->scale(d_rhs_vec->getComponentDescriptorIndex(0),
                                       1.0 / A_scale,
@@ -1135,7 +1135,7 @@ void
 INSVCStaggeredConservativeHierarchyIntegrator::updateOperatorsAndSolvers(const double current_time,
                                                                          const double new_time)
 {
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     const double dt = new_time - current_time;
     const double half_time = current_time + 0.5 * dt;
     const double mu = d_mu_is_const ? d_problem_coefs.getMu() : -1.0;
@@ -1176,7 +1176,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::updateOperatorsAndSolvers(const d
 
         // C_sc = (rho / dt) + K * lambda + L(x,t^n+1)
         d_hier_sc_data_ops->scale(d_velocity_C_idx, A_scale / dt, d_rho_sc_scratch_idx, /*interior_only*/ true);
-        if (!MathUtilities<double>::equalEps(lambda, 0.0))
+        if (!IBTK::abs_equal_eps(lambda, 0.0))
         {
             d_hier_sc_data_ops->addScalar(d_velocity_C_idx,
                                           d_velocity_C_idx,
@@ -1247,7 +1247,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::updateOperatorsAndSolvers(const d
     // Ensure that solver components are appropriately reinitialized at the
     // correct intervals or
     // when the time step size changes.
-    const bool dt_change = initial_time || !MathUtilities<double>::equalEps(dt, d_dt_previous[0]);
+    const bool dt_change = initial_time || !IBTK::rel_equal_eps(dt, d_dt_previous[0]);
     const bool precond_reinit = d_integrator_step % d_precond_reinit_interval == 0;
     if (precond_reinit)
     {
@@ -1447,7 +1447,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::setupSolverVectors(
     {
         d_hier_cc_data_ops->resetLevels(ln, ln);
         const double A_scale = d_A_scale[ln];
-        if (!MathUtilities<double>::equalEps(A_scale, 1.0))
+        if (!IBTK::rel_equal_eps(A_scale, 1.0))
         {
             d_hier_cc_data_ops->scale(sol_vec->getComponentDescriptorIndex(1),
                                       A_scale,
@@ -1503,7 +1503,7 @@ INSVCStaggeredConservativeHierarchyIntegrator::resetSolverVectors(
     {
         d_hier_cc_data_ops->resetLevels(ln, ln);
         const double A_scale = d_A_scale[ln];
-        if (!MathUtilities<double>::equalEps(A_scale, 1.0))
+        if (!IBTK::rel_equal_eps(A_scale, 1.0))
         {
             d_hier_cc_data_ops->scale(d_P_new_idx,
                                       1.0 / A_scale,

--- a/src/navier_stokes/INSVCStaggeredConservativeMassMomentumIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredConservativeMassMomentumIntegrator.cpp
@@ -1190,7 +1190,7 @@ INSVCStaggeredConservativeMassMomentumIntegrator::integrate(double dt)
 #endif
 
 #if !defined(NDEBUG)
-    TBOX_ASSERT(MathUtilities<double>::equalEps(dt, getDt()));
+    TBOX_ASSERT(IBTK::rel_equal_eps(dt, getDt()));
 #endif
 
     if (d_V_old_idx == d_V_current_idx)

--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -2009,8 +2009,7 @@ INSVCStaggeredHierarchyIntegrator::preprocessOperatorsAndSolvers(const double cu
     const int wgt_sc_idx = d_hier_math_ops->getSideWeightPatchDescriptorIndex();
 
     // Setup solver vectors.
-    const bool has_velocity_nullspace =
-        d_normalize_velocity && (d_rho_is_const && MathUtilities<double>::equalEps(rho, 0.0));
+    const bool has_velocity_nullspace = d_normalize_velocity && (d_rho_is_const && IBTK::abs_equal_eps(rho, 0.0));
     const bool has_pressure_nullspace = d_normalize_pressure;
     if (d_vectors_need_init)
     {

--- a/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
@@ -751,7 +751,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::integrateHierarchy(const doubl
     {
         d_hier_sc_data_ops->resetLevels(ln, ln);
         const double A_scale = d_A_scale[ln];
-        if (!MathUtilities<double>::equalEps(A_scale, 1.0))
+        if (!IBTK::rel_equal_eps(A_scale, 1.0))
         {
             d_hier_sc_data_ops->scale(d_rhs_vec->getComponentDescriptorIndex(0),
                                       A_scale,
@@ -769,7 +769,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::integrateHierarchy(const doubl
     {
         d_hier_sc_data_ops->resetLevels(ln, ln);
         const double A_scale = d_A_scale[ln];
-        if (!MathUtilities<double>::equalEps(A_scale, 1.0))
+        if (!IBTK::rel_equal_eps(A_scale, 1.0))
         {
             d_hier_sc_data_ops->scale(d_rhs_vec->getComponentDescriptorIndex(0),
                                       1.0 / A_scale,
@@ -1246,8 +1246,8 @@ void
 INSVCStaggeredNonConservativeHierarchyIntegrator::updateOperatorsAndSolvers(const double current_time,
                                                                             const double new_time)
 {
-    const bool initial_time = MathUtilities<double>::equalEps(d_integrator_time, d_start_time);
     const double dt = new_time - current_time;
+    const bool initial_time = IBTK::rel_equal_eps(d_integrator_time, d_start_time);
     const double half_time = current_time + 0.5 * dt;
     const double rho = d_rho_is_const ? d_problem_coefs.getRho() : -1.0;
     const double mu = d_mu_is_const ? d_problem_coefs.getMu() : -1.0;
@@ -1295,7 +1295,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::updateOperatorsAndSolvers(cons
         {
             d_hier_sc_data_ops->scale(d_velocity_C_idx, A_scale / dt, d_rho_interp_idx, /*interior_only*/ true);
 
-            if (!MathUtilities<double>::equalEps(lambda, 0.0))
+            if (!IBTK::rel_equal_eps(lambda, 0.0))
             {
                 d_hier_sc_data_ops->addScalar(d_velocity_C_idx,
                                               d_velocity_C_idx,
@@ -1372,7 +1372,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::updateOperatorsAndSolvers(cons
 
     // Ensure that solver components are appropriately reinitialized at the
     // correct intervals or when the time step size changes.
-    const bool dt_change = initial_time || !MathUtilities<double>::equalEps(dt, d_dt_previous[0]);
+    const bool dt_change = initial_time || !IBTK::rel_equal_eps(dt, d_dt_previous[0]);
     const bool precond_reinit = d_integrator_step % d_precond_reinit_interval == 0;
     if (precond_reinit)
     {
@@ -1387,8 +1387,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::updateOperatorsAndSolvers(cons
     }
 
     // Setup subdomain solvers.
-    const bool has_velocity_nullspace =
-        d_normalize_velocity && (d_rho_is_const && MathUtilities<double>::equalEps(rho, 0.0));
+    const bool has_velocity_nullspace = d_normalize_velocity && (d_rho_is_const && IBTK::abs_equal_eps(rho, 0.0));
     const bool has_pressure_nullspace = d_normalize_pressure;
 
     if (d_velocity_solver)
@@ -1682,7 +1681,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::setupSolverVectors(
     {
         d_hier_cc_data_ops->resetLevels(ln, ln);
         const double A_scale = d_A_scale[ln];
-        if (!MathUtilities<double>::equalEps(A_scale, 1.0))
+        if (!IBTK::rel_equal_eps(A_scale, 1.0))
         {
             d_hier_cc_data_ops->scale(sol_vec->getComponentDescriptorIndex(1),
                                       A_scale,
@@ -1739,7 +1738,7 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::resetSolverVectors(
     {
         d_hier_cc_data_ops->resetLevels(ln, ln);
         const double A_scale = d_A_scale[ln];
-        if (!MathUtilities<double>::equalEps(A_scale, 1.0))
+        if (!IBTK::rel_equal_eps(A_scale, 1.0))
         {
             d_hier_cc_data_ops->scale(d_P_new_idx,
                                       1.0 / A_scale,

--- a/src/navier_stokes/INSVCStaggeredPressureBcCoef.cpp
+++ b/src/navier_stokes/INSVCStaggeredPressureBcCoef.cpp
@@ -274,8 +274,8 @@ INSVCStaggeredPressureBcCoef::setBcCoefs(Pointer<ArrayData<NDIM, double> >& acoe
         double& alpha = acoef_data ? (*acoef_data)(i, 0) : dummy_val;
         double& beta = bcoef_data ? (*bcoef_data)(i, 0) : dummy_val;
         double& gamma = gcoef_data ? (*gcoef_data)(i, 0) : dummy_val;
-        const bool velocity_bc = MathUtilities<double>::equalEps(alpha, 1.0);
-        const bool traction_bc = MathUtilities<double>::equalEps(beta, 1.0);
+        const bool velocity_bc = IBTK::rel_equal_eps(alpha, 1.0);
+        const bool traction_bc = IBTK::rel_equal_eps(beta, 1.0);
 #if !defined(NDEBUG)
         TBOX_ASSERT((velocity_bc || traction_bc) && !(velocity_bc && traction_bc));
 #endif

--- a/src/navier_stokes/INSVCStaggeredVelocityBcCoef.cpp
+++ b/src/navier_stokes/INSVCStaggeredVelocityBcCoef.cpp
@@ -281,8 +281,8 @@ INSVCStaggeredVelocityBcCoef::setBcCoefs(Pointer<ArrayData<NDIM, double> >& acoe
         double& alpha = (*acoef_data)(i, 0);
         double& beta = (*bcoef_data)(i, 0);
         double& gamma = (*gcoef_data)(i, 0);
-        const bool velocity_bc = MathUtilities<double>::equalEps(alpha, 1.0);
-        const bool traction_bc = MathUtilities<double>::equalEps(beta, 1.0);
+        const bool velocity_bc = IBTK::rel_equal_eps(alpha, 1.0);
+        const bool traction_bc = IBTK::rel_equal_eps(beta, 1.0);
 #if !defined(NDEBUG)
         TBOX_ASSERT((velocity_bc || traction_bc) && !(velocity_bc && traction_bc));
 #endif

--- a/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesBlockFactorizationPreconditioner.cpp
@@ -515,7 +515,7 @@ StaggeredStokesBlockFactorizationPreconditioner::solvePressureSubsystem(SAMRAIVe
     // in which K depends on the form of the time stepping scheme.
     const bool steady_state =
         d_U_problem_coefs.cIsZero() ||
-        (d_U_problem_coefs.cIsConstant() && MathUtilities<double>::equalEps(d_U_problem_coefs.getCConstant(), 0.0));
+        (d_U_problem_coefs.cIsConstant() && IBTK::abs_equal_eps(d_U_problem_coefs.getCConstant(), 0.0));
     if (steady_state)
     {
         d_pressure_data_ops->scale(P_idx, d_U_problem_coefs.getDConstant(), F_P_idx);

--- a/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
@@ -384,8 +384,8 @@ StaggeredStokesPETScMatUtilities::constructPatchLevelMACStokesOp(
                     const hier::Index<NDIM>& i = bc();
                     const double& a = (*acoef_data)(i, 0);
                     const double& b = (*bcoef_data)(i, 0);
-                    const bool velocity_bc = (a == 1.0 || MathUtilities<double>::equalEps(a, 1.0));
-                    const bool traction_bc = (b == 1.0 || MathUtilities<double>::equalEps(b, 1.0));
+                    const bool velocity_bc = (a == 1.0 || IBTK::rel_equal_eps(a, 1.0));
+                    const bool traction_bc = (b == 1.0 || IBTK::rel_equal_eps(b, 1.0));
 #if !defined(NDEBUG)
                     TBOX_ASSERT((velocity_bc || traction_bc) && !(velocity_bc && traction_bc));
 #endif
@@ -485,8 +485,8 @@ StaggeredStokesPETScMatUtilities::constructPatchLevelMACStokesOp(
                     const SideIndex<NDIM> i_s(i, axis, SideIndex<NDIM>::Lower);
                     const double& a = (*acoef_data)(i, 0);
                     const double& b = (*bcoef_data)(i, 0);
-                    const bool velocity_bc = (a == 1.0 || MathUtilities<double>::equalEps(a, 1.0));
-                    const bool traction_bc = (b == 1.0 || MathUtilities<double>::equalEps(b, 1.0));
+                    const bool velocity_bc = (a == 1.0 || IBTK::rel_equal_eps(a, 1.0));
+                    const bool traction_bc = (b == 1.0 || IBTK::rel_equal_eps(b, 1.0));
 #if !defined(NDEBUG)
                     TBOX_ASSERT((velocity_bc || traction_bc) && !(velocity_bc && traction_bc));
 #endif

--- a/src/navier_stokes/StaggeredStokesPhysicalBoundaryHelper.cpp
+++ b/src/navier_stokes/StaggeredStokesPhysicalBoundaryHelper.cpp
@@ -115,11 +115,10 @@ StaggeredStokesPhysicalBoundaryHelper::enforceNormalVelocityBoundaryConditions(
                         const double gamma = homogeneous_bc && !extended_bc_coef ? 0.0 : (*gcoef_data)(i, 0);
 #if !defined(NDEBUG)
                         const double& beta = (*bcoef_data)(i, 0);
-                        TBOX_ASSERT(MathUtilities<double>::equalEps(alpha + beta, 1.0));
-                        TBOX_ASSERT(MathUtilities<double>::equalEps(alpha, 1.0) ||
-                                    MathUtilities<double>::equalEps(beta, 1.0));
+                        TBOX_ASSERT(IBTK::rel_equal_eps(alpha + beta, 1.0));
+                        TBOX_ASSERT(IBTK::rel_equal_eps(alpha, 1.0) || IBTK::rel_equal_eps(beta, 1.0));
 #endif
-                        if (MathUtilities<double>::equalEps(alpha, 1.0))
+                        if (IBTK::rel_equal_eps(alpha, 1.0))
                             (*u_data)(SideIndex<NDIM>(i, bdry_normal_axis, SideIndex<NDIM>::Lower)) = gamma;
                     }
                 }

--- a/src/navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
@@ -159,7 +159,7 @@ StaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, doub
     // Determine whether we are solving a steady-state problem.
     const bool steady_state =
         d_U_problem_coefs.cIsZero() ||
-        (d_U_problem_coefs.cIsConstant() && MathUtilities<double>::equalEps(d_U_problem_coefs.getCConstant(), 0.0));
+        (d_U_problem_coefs.cIsConstant() && IBTK::abs_equal_eps(d_U_problem_coefs.getCConstant(), 0.0));
 
     // Get the vector components.
     const int F_U_idx = b.getComponentDescriptorIndex(0);

--- a/src/navier_stokes/VCStaggeredStokesProjectionPreconditioner.cpp
+++ b/src/navier_stokes/VCStaggeredStokesProjectionPreconditioner.cpp
@@ -166,7 +166,7 @@ VCStaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, do
     // Determine whether we are solving a steady-state problem.
     const bool steady_state =
         d_U_problem_coefs.cIsZero() ||
-        (d_U_problem_coefs.cIsConstant() && MathUtilities<double>::equalEps(d_U_problem_coefs.getCConstant(), 0.0));
+        (d_U_problem_coefs.cIsConstant() && IBTK::abs_equal_eps(d_U_problem_coefs.getCConstant(), 0.0));
 
     // Get the vector components.
     const int F_U_idx = b.getComponentDescriptorIndex(0);

--- a/tests/CIB/cib_double_shell.cpp
+++ b/tests/CIB/cib_double_shell.cpp
@@ -424,7 +424,7 @@ main(int argc, char* argv[])
         double current_time, new_time;
         double dt = 0.0;
 
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/CIB/cib_plate.cpp
+++ b/tests/CIB/cib_plate.cpp
@@ -318,7 +318,7 @@ main(int argc, char* argv[])
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
 
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/ConstraintIB/OscillatingCylinderKinematics.cpp
+++ b/tests/ConstraintIB/OscillatingCylinderKinematics.cpp
@@ -188,10 +188,10 @@ OscillatingCylinderKinematics::setKinematicsVelocity(
 {
     d_new_time = new_time;
     // fill current velocity at new time
-    if (!MathUtilities<double>::equalEps(0.0, d_new_time)) setOscillatingCylinderSpecificVelocity(d_new_time);
+    if (!IBTK::rel_equal_eps(0.0, d_new_time)) setOscillatingCylinderSpecificVelocity(d_new_time);
 
     // swap current and new velocity
-    if (MathUtilities<double>::equalEps(0.0, d_new_time))
+    if (IBTK::rel_equal_eps(0.0, d_new_time))
         d_new_kinematics_vel = d_current_kinematics_vel;
     else
         d_new_kinematics_vel.swap(d_current_kinematics_vel);

--- a/tests/ConstraintIB/oscillating_rigid_cylinder.cpp
+++ b/tests/ConstraintIB/oscillating_rigid_cylinder.cpp
@@ -287,7 +287,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IB/explicit_ex0.cpp
+++ b/tests/IB/explicit_ex0.cpp
@@ -396,7 +396,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IB/explicit_ex1.cpp
+++ b/tests/IB/explicit_ex1.cpp
@@ -259,7 +259,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IB/ib_body_force.cpp
+++ b/tests/IB/ib_body_force.cpp
@@ -140,7 +140,7 @@ main(int argc, char* argv[])
         double loop_time = time_integrator->getIntegratorTime();
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IB/ib_body_force_kirchhoff.cpp
+++ b/tests/IB/ib_body_force_kirchhoff.cpp
@@ -141,7 +141,7 @@ main(int argc, char* argv[])
         double loop_time = time_integrator->getIntegratorTime();
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IBFE/explicit_ex0.cpp
+++ b/tests/IBFE/explicit_ex0.cpp
@@ -412,7 +412,7 @@ main(int argc, char** argv)
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IBFE/explicit_ex1.cpp
+++ b/tests/IBFE/explicit_ex1.cpp
@@ -416,7 +416,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IBFE/explicit_ex2.cpp
+++ b/tests/IBFE/explicit_ex2.cpp
@@ -402,7 +402,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IBFE/explicit_ex4.cpp
+++ b/tests/IBFE/explicit_ex4.cpp
@@ -541,7 +541,7 @@ main(int argc, char** argv)
         plog << std::setprecision(20);
         plog << "Total number of elems: " << mesh.n_elem() << std::endl;
         plog << "Total number of DoFs: " << equation_systems->n_dofs() << std::endl;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IBFE/explicit_ex5.cpp
+++ b/tests/IBFE/explicit_ex5.cpp
@@ -535,7 +535,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IBFE/explicit_ex8.cpp
+++ b/tests/IBFE/explicit_ex8.cpp
@@ -129,7 +129,7 @@ beam_PK1_dil_stress_function(TensorValue<double>& PP,
     J_dil_min = std::min(J, J_dil_min);
     J_dil_max = std::max(J, J_dil_max);
     PP.zero();
-    if (!MathUtilities<double>::equalEps(beta_s, 0.0))
+    if (!IBTK::abs_equal_eps(beta_s, 0.0))
     {
         const TensorValue<double> FF_inv_trans = tensor_inverse_transpose(FF, NDIM);
         PP -= 2.0 * beta_s * log(FF.det()) * FF_inv_trans;
@@ -612,7 +612,7 @@ main(int argc, char** argv)
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IBTK/child_integrators.cpp
+++ b/tests/IBTK/child_integrators.cpp
@@ -246,7 +246,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IBTK/hierarchy_callbacks.cpp
+++ b/tests/IBTK/hierarchy_callbacks.cpp
@@ -219,7 +219,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/IBTK/phys_boundary_ops.cpp
+++ b/tests/IBTK/phys_boundary_ops.cpp
@@ -31,6 +31,7 @@
 #include <ibtk/CartExtrapPhysBdryOp.h>
 #include <ibtk/IBTKInit.h>
 #include <ibtk/IBTK_MPI.h>
+#include <ibtk/ibtk_utilities.h>
 
 #include <LocationIndexRobinBcCoefs.h>
 
@@ -146,7 +147,7 @@ main(int argc, char* argv[])
                         val += 4 * (d + 1) * (d + 1) * i(d);
                     }
 
-                    if (!MathUtilities<double>::equalEps(val, (*data)(i)))
+                    if (!IBTK::rel_equal_eps(val, (*data)(i)))
                     {
                         warning = true;
                         pout << "warning: value at location " << i << " is not correct\n";
@@ -212,7 +213,7 @@ main(int argc, char* argv[])
                     }
                     double val = 2.0 * X[NDIM - 1] + shift;
 
-                    if (!MathUtilities<double>::equalEps(val, (*data)(i)))
+                    if (!IBTK::rel_equal_eps(val, (*data)(i)))
                     {
                         warning = true;
                         pout << "warning: value at location " << i << " is not correct\n";
@@ -256,7 +257,7 @@ main(int argc, char* argv[])
                     }
                     double val = 2.0 * X[NDIM - 1] + shift;
 
-                    if (!MathUtilities<double>::equalEps(val, (*data)(i)))
+                    if (!IBTK::rel_equal_eps(val, (*data)(i)))
                     {
                         warning = true;
                         pout << "warning: value at location " << i << " is not correct\n";

--- a/tests/adv_diff/adv_diff_01.cpp
+++ b/tests/adv_diff/adv_diff_01.cpp
@@ -178,7 +178,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/adv_diff/adv_diff_02.cpp
+++ b/tests/adv_diff/adv_diff_02.cpp
@@ -185,7 +185,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/adv_diff/adv_diff_03.cpp
+++ b/tests/adv_diff/adv_diff_03.cpp
@@ -164,7 +164,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/adv_diff/bp_adv_diff_01.cpp
+++ b/tests/adv_diff/bp_adv_diff_01.cpp
@@ -289,7 +289,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/adv_diff/bp_adv_diff_02.cpp
+++ b/tests/adv_diff/bp_adv_diff_02.cpp
@@ -604,7 +604,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/advect/advect_01.cpp
+++ b/tests/advect/advect_01.cpp
@@ -172,7 +172,7 @@ main(int argc, char* argv[])
 
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/complex_fluids/cf_four_roll_mill.cpp
+++ b/tests/complex_fluids/cf_four_roll_mill.cpp
@@ -139,7 +139,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/complex_fluids/cf_relaxation_op_01.cpp
+++ b/tests/complex_fluids/cf_relaxation_op_01.cpp
@@ -205,7 +205,7 @@ main(int argc, char* argv[])
                     {
                         double relax_val = (*relax_data)(idx, d);
                         double exact_val = (*exact_data)(idx, d);
-                        if (!MathUtilities<double>::equalEps(exact_val, relax_val))
+                        if (!IBTK::rel_equal_eps(exact_val, relax_val))
                         {
                             pout << "Incorrect value found at patch index " << idx << " at depth " << d << "\n";
                             pout << "Found " << relax_val << ". Expected " << exact_val << "\n";

--- a/tests/fe_mechanics/fe_mechanics_ex0.cpp
+++ b/tests/fe_mechanics/fe_mechanics_ex0.cpp
@@ -410,7 +410,7 @@ main(int argc, char* argv[])
         }
 
         // Main time step loop.
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end))
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end))
         {
             pout << "\n";
             pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";

--- a/tests/multiphase_flow/SetFluidGasSolidDensity.h
+++ b/tests/multiphase_flow/SetFluidGasSolidDensity.h
@@ -85,11 +85,11 @@ public:
 
         int ls_solid_idx = -1;
         int ls_gas_idx = -1;
-        if (SAMRAI::tbox::MathUtilities<double>::equalEps(time, current_time))
+        if (IBTK::rel_equal_eps(time, current_time))
         {
             ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
         }
-        else if (SAMRAI::tbox::MathUtilities<double>::equalEps(time, new_time))
+        else if (IBTK::rel_equal_eps(time, new_time))
         {
             ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
         }
@@ -98,11 +98,11 @@ public:
             TBOX_ERROR("This statement should not be reached");
         }
 
-        if (SAMRAI::tbox::MathUtilities<double>::equalEps(time, current_time))
+        if (IBTK::rel_equal_eps(time, current_time))
         {
             ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
         }
-        else if (SAMRAI::tbox::MathUtilities<double>::equalEps(time, new_time))
+        else if (IBTK::rel_equal_eps(time, new_time))
         {
             ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
         }

--- a/tests/multiphase_flow/SetFluidGasSolidViscosity.h
+++ b/tests/multiphase_flow/SetFluidGasSolidViscosity.h
@@ -82,11 +82,11 @@ public:
         int ls_solid_idx = -1;
         int ls_gas_idx = -1;
 
-        if (SAMRAI::tbox::MathUtilities<double>::equalEps(time, current_time))
+        if (IBTK::rel_equal_eps(time, current_time))
         {
             ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
         }
-        else if (SAMRAI::tbox::MathUtilities<double>::equalEps(time, new_time))
+        else if (IBTK::rel_equal_eps(time, new_time))
         {
             ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
         }
@@ -95,11 +95,11 @@ public:
             TBOX_ERROR("This statement should not be reached");
         }
 
-        if (SAMRAI::tbox::MathUtilities<double>::equalEps(time, current_time))
+        if (IBTK::rel_equal_eps(time, current_time))
         {
             ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
         }
-        else if (SAMRAI::tbox::MathUtilities<double>::equalEps(time, new_time))
+        else if (IBTK::rel_equal_eps(time, new_time))
         {
             ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
         }

--- a/tests/multiphase_flow/SetFluidProperties.h
+++ b/tests/multiphase_flow/SetFluidProperties.h
@@ -96,11 +96,11 @@ public:
         // Get the current level set information
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         int ls_idx = -1;
-        if (MathUtilities<double>::equalEps(time, current_time))
+        if (IBTK::rel_equal_eps(time, current_time))
         {
             ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
         }
-        else if (MathUtilities<double>::equalEps(time, new_time))
+        else if (IBTK::rel_equal_eps(time, new_time))
         {
             ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
         }
@@ -275,11 +275,11 @@ public:
         // Get the current level set information
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         int ls_idx = -1;
-        if (MathUtilities<double>::equalEps(time, current_time))
+        if (IBTK::rel_equal_eps(time, current_time))
         {
             ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
         }
-        else if (MathUtilities<double>::equalEps(time, new_time))
+        else if (IBTK::rel_equal_eps(time, new_time))
         {
             ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
         }

--- a/tests/multiphase_flow/free_falling_cyl_cib.cpp
+++ b/tests/multiphase_flow/free_falling_cyl_cib.cpp
@@ -456,7 +456,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/multiphase_flow/high_density_droplet.cpp
+++ b/tests/multiphase_flow/high_density_droplet.cpp
@@ -337,7 +337,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/multiphase_flow/rotating_barge_cib.cpp
+++ b/tests/multiphase_flow/rotating_barge_cib.cpp
@@ -473,7 +473,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/navier_stokes/navier_stokes_01.cpp
+++ b/tests/navier_stokes/navier_stokes_01.cpp
@@ -197,7 +197,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/physical_boundary/01.cpp
+++ b/tests/physical_boundary/01.cpp
@@ -237,7 +237,7 @@ main(int argc, char* argv[])
                                 X[d] = x_lower[d] + dx[d] * (static_cast<double>(i(d) - patch_lower(d)) + 0.5);
                             }
                             double val = fcn_map[extrap_type](X);
-                            if (!MathUtilities<double>::equalEps(val, (*data)(i)))
+                            if (!IBTK::rel_equal_eps(val, (*data)(i)))
                             {
                                 warning = true;
                                 pout << "warning: value at location " << i << " is not correct\n";
@@ -287,7 +287,7 @@ main(int argc, char* argv[])
                                 }
                                 double val = fcn_map[extrap_type](X);
 
-                                if (!MathUtilities<double>::equalEps(val, (*data)(i)))
+                                if (!IBTK::rel_equal_eps(val, (*data)(i)))
                                 {
                                     warning = true;
                                     pout << "warning: value at location " << i << " is not correct\n";

--- a/tests/physical_boundary/extrapolation_01.cpp
+++ b/tests/physical_boundary/extrapolation_01.cpp
@@ -30,6 +30,7 @@
 #include <ibtk/CartCellRobinPhysBdryOp.h>
 #include <ibtk/CartExtrapPhysBdryOp.h>
 #include <ibtk/IBTKInit.h>
+#include <ibtk/ibtk_utilities.h>
 
 #include <LocationIndexRobinBcCoefs.h>
 
@@ -239,7 +240,7 @@ main(int argc, char* argv[])
                         }
                         auto fcn = fcnMap[extrap_type];
                         double val = fcn(x.data());
-                        if (!MathUtilities<double>::equalEps(val, (*c_data)(i)))
+                        if (!IBTK::rel_equal_eps(val, (*c_data)(i)))
                         {
                             warning = true;
                             pout << "warning: value at location " << i << " is not correct\n";
@@ -260,7 +261,7 @@ main(int argc, char* argv[])
                             }
                             auto fcn = fcnMap[extrap_type];
                             double val = fcn(x.data());
-                            if (!MathUtilities<double>::equalEps(val, (*s_data)(i)))
+                            if (!IBTK::rel_equal_eps(val, (*s_data)(i)))
                             {
                                 warning = true;
                                 pout << "warning: value at location " << i << " is not correct\n";
@@ -282,7 +283,7 @@ main(int argc, char* argv[])
                             }
                             auto fcn = fcnMap[extrap_type];
                             double val = fcn(x.data());
-                            if (!MathUtilities<double>::equalEps(val, (*f_data)(i)))
+                            if (!IBTK::rel_equal_eps(val, (*f_data)(i)))
                             {
                                 warning = true;
                                 pout << "warning: value at location " << i << " is not correct\n";
@@ -302,7 +303,7 @@ main(int argc, char* argv[])
                         }
                         auto fcn = fcnMap[extrap_type];
                         double val = fcn(x.data());
-                        if (!MathUtilities<double>::equalEps(val, (*n_data)(i)))
+                        if (!IBTK::rel_equal_eps(val, (*n_data)(i)))
                         {
                             warning = true;
                             pout << "warning: value at location " << i << " is not correct\n";

--- a/tests/unfinished-tests/Stokes-IB/test0/main.cpp
+++ b/tests/unfinished-tests/Stokes-IB/test0/main.cpp
@@ -1024,7 +1024,7 @@ buildSAJCoarsestFromSAMRAIOperators(Mat& SAJ_coarse,
         nnz_indices.reserve(n_local_coarsest);
         for (int j = 0; j < n_local_coarsest; ++j)
         {
-            if (!MathUtilities<double>::equalEps(y_array[j], 0.0))
+            if (!IBTK::abs_equal_eps(y_array[j], 0.0))
             {
                 const int global_idx = i_lower_coarsest + j;
                 nnz_indices.push_back(global_idx);

--- a/tests/unfinished-tests/Stokes-IB/test1/main.cpp
+++ b/tests/unfinished-tests/Stokes-IB/test1/main.cpp
@@ -220,7 +220,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/unfinished-tests/Stokes-IB/test2/main.cpp
+++ b/tests/unfinished-tests/Stokes-IB/test2/main.cpp
@@ -233,7 +233,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/unfinished-tests/Stokes/test0/main.cpp
+++ b/tests/unfinished-tests/Stokes/test0/main.cpp
@@ -179,7 +179,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/vc_navier_stokes/vc_navier_stokes_01.cpp
+++ b/tests/vc_navier_stokes/vc_navier_stokes_01.cpp
@@ -241,7 +241,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/wave_tank/SetFluidGasSolidDensity.cpp
+++ b/tests/wave_tank/SetFluidGasSolidDensity.cpp
@@ -95,11 +95,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
 
     int ls_solid_idx = -1, ls_gas_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -108,11 +108,11 @@ SetFluidGasSolidDensity::setDensityPatchData(int rho_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/tests/wave_tank/SetFluidGasSolidViscosity.cpp
+++ b/tests/wave_tank/SetFluidGasSolidViscosity.cpp
@@ -92,11 +92,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_solid_idx = -1, ls_gas_idx = -1;
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
     }
@@ -105,11 +105,11 @@ SetFluidGasSolidViscosity::setViscosityPatchData(int mu_idx,
         TBOX_ERROR("This statement should not be reached");
     }
 
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_gas_idx = var_db->mapVariableAndContextToIndex(d_ls_gas_var, d_adv_diff_solver->getNewContext());
     }

--- a/tests/wave_tank/SetFluidProperties.cpp
+++ b/tests/wave_tank/SetFluidProperties.cpp
@@ -102,11 +102,11 @@ SetFluidProperties::setDensityPatchData(int rho_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }
@@ -278,11 +278,11 @@ SetFluidProperties::setViscosityPatchData(int mu_idx,
     // Get the current level set information
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     int ls_idx = -1;
-    if (MathUtilities<double>::equalEps(time, current_time))
+    if (IBTK::rel_equal_eps(time, current_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getCurrentContext());
     }
-    else if (MathUtilities<double>::equalEps(time, new_time))
+    else if (IBTK::rel_equal_eps(time, new_time))
     {
         ls_idx = var_db->mapVariableAndContextToIndex(d_ls_var, d_adv_diff_solver->getNewContext());
     }

--- a/tests/wave_tank/nwt.cpp
+++ b/tests/wave_tank/nwt.cpp
@@ -519,7 +519,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();

--- a/tests/wave_tank/nwt_cylinder.cpp
+++ b/tests/wave_tank/nwt_cylinder.cpp
@@ -1087,7 +1087,7 @@ main(int argc, char* argv[])
         // Main time step loop.
         double loop_time_end = time_integrator->getEndTime();
         double dt = 0.0;
-        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
         {
             iteration_num = time_integrator->getIntegratorStep();
             loop_time = time_integrator->getIntegratorTime();


### PR DESCRIPTION
Fixes #1177. This replaces all `SAMRAI::equalEps` with an appropriate call to either `IBTK::abs_equal_eps` or `IBTK::rel_equal_eps`.
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
