### PR TITLE
Exclude tests from all

### DIFF
--- a/.github/cmake/configure_common.cmake
+++ b/.github/cmake/configure_common.cmake
@@ -11,19 +11,19 @@
 ##
 ## ---------------------------------------------------------------------
 
-set(CTEST_USE_LAUNCHERS "ON" CACHE STRING "")
+SET(CTEST_USE_LAUNCHERS "ON" CACHE STRING "")
 
-set(IBAMR_ENABLE_TESTING "ON" CACHE BOOL "")
+SET(IBAMR_ENABLE_TESTING "ON" CACHE BOOL "")
 
-include("${CMAKE_CURRENT_LIST_DIR}/configure_sccache.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/configure_sccache.cmake")
 
-set(CMAKE_C_FLAGS "-O1" CACHE STRING "C flags")
-set(CMAKE_CXX_FLAGS "-O1" CACHE STRING "C++ flags")
-set(CMAKE_Fortran_FLAGS "-O3" CACHE STRING "Fortran flags")
-set(CMAKE_INSTALL_PREFIX "/ibamr" CACHE PATH "Install destination")
-set(SAMRAI_ROOT "/samrai" CACHE PATH "Location of SAMRAI")
-set(LIBMESH_ROOT "/libmesh" CACHE PATH "Location of libmesh")
-set(LIBMESH_METHOD "OPT" CACHE STRING "Type of libmesh build (OPT or DBG)")
-set(PETSC_ROOT "/petsc/x86_64" CACHE PATH "Location of PetSC")
-set(HYPRE_ROOT "/petsc/x86_64" CACHE PATH "Location of Hypre")
-set(NUMDIFF_ROOT "/numdiff" CACHE PATH "Location of numdiff")
+SET(CMAKE_C_FLAGS "-O1" CACHE STRING "C flags")
+SET(CMAKE_CXX_FLAGS "-O1" CACHE STRING "C++ flags")
+SET(CMAKE_Fortran_FLAGS "-O3" CACHE STRING "Fortran flags")
+SET(CMAKE_INSTALL_PREFIX "/ibamr" CACHE PATH "Install destination")
+SET(SAMRAI_ROOT "/samrai" CACHE PATH "Location of SAMRAI")
+SET(LIBMESH_ROOT "/libmesh" CACHE PATH "Location of libmesh")
+SET(LIBMESH_METHOD "OPT" CACHE STRING "Type of libmesh build (OPT or DBG)")
+SET(PETSC_ROOT "/petsc/x86_64" CACHE PATH "Location of PetSC")
+SET(HYPRE_ROOT "/petsc/x86_64" CACHE PATH "Location of Hypre")
+SET(NUMDIFF_ROOT "/numdiff" CACHE PATH "Location of numdiff")

--- a/.github/cmake/configure_fedora33.cmake
+++ b/.github/cmake/configure_fedora33.cmake
@@ -11,4 +11,4 @@
 ##
 ## ---------------------------------------------------------------------
 
-include("${CMAKE_CURRENT_LIST_DIR}/configure_common.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/configure_common.cmake")

--- a/.github/cmake/configure_sccache.cmake
+++ b/.github/cmake/configure_sccache.cmake
@@ -11,6 +11,6 @@
 ##
 ## ---------------------------------------------------------------------
 
-set(CMAKE_C_COMPILER_LAUNCHER "sccache" CACHE STRING "Use sccache to compile C code.")
-set(CMAKE_CXX_COMPILER_LAUNCHER "sccache" CACHE STRING "Use sccache to compile C++ code.")
-set(CMAKE_Fortran_COMPILER_LAUNCHER "sccache" CACHE STRING "Use sccache to compile Fortran code.")
+SET(CMAKE_C_COMPILER_LAUNCHER "sccache" CACHE STRING "Use sccache to compile C code.")
+SET(CMAKE_CXX_COMPILER_LAUNCHER "sccache" CACHE STRING "Use sccache to compile C++ code.")
+SET(CMAKE_Fortran_COMPILER_LAUNCHER "sccache" CACHE STRING "Use sccache to compile Fortran code.")

--- a/.github/cmake/ctest_build.cmake
+++ b/.github/cmake/ctest_build.cmake
@@ -29,11 +29,11 @@ IF (CTEST_CMAKE_GENERATOR STREQUAL "Unix Makefiles")
   ProcessorCount(nproc)
 ENDIF ()
 
-ctest_build(
+CTEST_BUILD(
   NUMBER_WARNINGS num_warnings
-  RETURN_VALUE build_result)
-# ctest_submit_multi(PARTS Build)
-ctest_submit(PARTS Build)
+  RETURN_VALUE build_result
+  TARGET tests
+  )
 
 CTEST_SUBMIT(PARTS Build)
 

--- a/.github/cmake/ctest_build.cmake
+++ b/.github/cmake/ctest_build.cmake
@@ -11,26 +11,23 @@
 ##
 ## ---------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.8)
-
-include("${CMAKE_CURRENT_LIST_DIR}/github_ci.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/github_ci.cmake")
 
 # Read the files from the build directory.
-ctest_read_custom_files("${CTEST_BINARY_DIRECTORY}")
+CTEST_READ_CUSTOM_FILES("${CTEST_BINARY_DIRECTORY}")
 # Uncomment the line below and all ctest_submit_multi lines
 # if CTestConfig.cmake defines `drop_sites`.
 # include("${CMAKE_CURRENT_LIST_DIR}/ctest_submit_multi.cmake")
 
 # Pick up from where the configure left off.
-ctest_start(APPEND)
+CTEST_START(APPEND)
 
 # Other generators automatically parallelize, but makefiles
 # require an explicit thread-count.
-if (CTEST_CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-  include(ProcessorCount)
+IF (CTEST_CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+  INCLUDE(ProcessorCount)
   ProcessorCount(nproc)
-  set(CTEST_BUILD_FLAGS "-j${nproc}")
-endif ()
+ENDIF ()
 
 ctest_build(
   NUMBER_WARNINGS num_warnings
@@ -38,12 +35,14 @@ ctest_build(
 # ctest_submit_multi(PARTS Build)
 ctest_submit(PARTS Build)
 
-if (build_result)
+CTEST_SUBMIT(PARTS Build)
+
+IF (build_result)
   message(FATAL_ERROR
     "Failed to build")
-endif ()
+ENDIF ()
 
-if ("$ENV{CTEST_NO_WARNINGS_ALLOWED}" AND num_warnings GREATER 0)
-  message(FATAL_ERROR
+IF ("$ENV{CTEST_NO_WARNINGS_ALLOWED}" AND num_warnings GREATER 0)
+  MESSAGE(FATAL_ERROR
     "Found ${num_warnings} warnings (treating as fatal).")
-endif ()
+ENDIF ()

--- a/.github/cmake/ctest_configure.cmake
+++ b/.github/cmake/ctest_configure.cmake
@@ -11,35 +11,34 @@
 ##
 ## ---------------------------------------------------------------------
 
-include("${CMAKE_CURRENT_LIST_DIR}/github_ci.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/github_ci.cmake")
 
-set(cmake_args
+SET(cmake_args
   -C "${CMAKE_CURRENT_LIST_DIR}/configure_$ENV{CMAKE_CONFIGURATION}.cmake"
 )
 
 # Create an entry in CDash.
-ctest_start(Experimental TRACK "${ctest_track}")
+CTEST_START(Experimental TRACK "${ctest_track}")
 
 # Gather update information.
-find_package(Git)
-set(CTEST_UPDATE_VERSION_ONLY ON)
-set(CTEST_UPDATE_COMMAND "${GIT_EXECUTABLE}")
-ctest_update()
+FIND_PACKAGE(Git)
+SET(CTEST_UPDATE_VERSION_ONLY ON)
+SET(CTEST_UPDATE_COMMAND "${GIT_EXECUTABLE}")
+CTEST_UPDATE()
 
 # Configure the project.
-ctest_configure(
+CTEST_CONFIGURE(
   OPTIONS "${cmake_args}"
   RETURN_VALUE configure_result
 )
 
 # Read the files from the build directory.
-ctest_read_custom_files("${CTEST_BINARY_DIRECTORY}")
+CTEST_READ_CUSTOM_FILES("${CTEST_BINARY_DIRECTORY}")
 
 # We can now submit because we've configured. This is idiomatic.
-ctest_submit(PARTS Update)
-ctest_submit(PARTS Configure)
+CTEST_SUBMIT(PARTS Update)
+CTEST_SUBMIT(PARTS Configure)
 
-if (configure_result)
-  message(FATAL_ERROR
-    "Failed to configure ${configure_result}")
-endif ()
+IF (configure_result)
+  MESSAGE(FATAL_ERROR "Failed to configure ${configure_result}")
+ENDIF ()

--- a/.github/cmake/ctest_exclusions.cmake
+++ b/.github/cmake/ctest_exclusions.cmake
@@ -12,18 +12,17 @@
 ## ---------------------------------------------------------------------
 
 # List tests here whose results should be omitted.
-set(test_exclusions
-)
+SET(test_exclusions)
 
 # Platform specific exclusions:
-if ("$ENV{CMAKE_CONFIGURATION}" MATCHES "fedora")
-  list(APPEND test_exclusions
+IF ("$ENV{CMAKE_CONFIGURATION}" MATCHES "fedora")
+  LIST(APPEND test_exclusions
     # Comment on why the test fails.
     # Regular expression matching test: "^RenderMesh$"
   )
-endif ()
+ENDIF ()
 
-string(REPLACE ";" "|" test_exclusions "${test_exclusions}")
-if (test_exclusions)
-  set(test_exclusions "(${test_exclusions})")
-endif ()
+STRING(REPLACE ";" "|" test_exclusions "${test_exclusions}")
+IF (test_exclusions)
+  SET(test_exclusions "(${test_exclusions})")
+ENDIF ()

--- a/.github/cmake/ctest_submit_multi.cmake
+++ b/.github/cmake/ctest_submit_multi.cmake
@@ -11,17 +11,17 @@
 ##
 ## ---------------------------------------------------------------------
 
-function (ctest_submit_multi)
-  foreach (site IN LISTS drop_sites)
-    foreach (variable IN ITEMS SITE METHOD LOCATION SITE_CDASH)
-      if (NOT DEFINED "CTEST_DROP_${variable}_${site}")
-        message(SEND_ERROR
+FUNCTION (ctest_submit_multi)
+  FOREACH (site IN LISTS drop_sites)
+    FOREACH (variable IN ITEMS SITE METHOD LOCATION SITE_CDASH)
+      IF (NOT DEFINED "CTEST_DROP_${variable}_${site}")
+        MESSAGE(SEND_ERROR
           "The ${site} site is missing the CTEST_DROP_${variable} "
           "setting.")
-      endif ()
-      set("CTEST_DROP_${variable}" "${CTEST_DROP_${variable}_${site}}")
-    endforeach ()
+      ENDIF ()
+      SET("CTEST_DROP_${variable}" "${CTEST_DROP_${variable}_${site}}")
+    ENDFOREACH ()
 
-    ctest_submit(${ARGN})
-  endforeach ()
-endfunction ()
+    CTEST_SUBMIT(${ARGN})
+  ENDFOREACH ()
+ENDFUNCTION ()

--- a/.github/cmake/ctest_test.cmake
+++ b/.github/cmake/ctest_test.cmake
@@ -11,24 +11,22 @@
 ##
 ## ---------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.8)
-
-include("${CMAKE_CURRENT_LIST_DIR}/github_ci.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/github_ci.cmake")
 
 # Read the files from the build directory.
-ctest_read_custom_files("${CTEST_BINARY_DIRECTORY}")
+CTEST_READ_CUSTOM_FILES("${CTEST_BINARY_DIRECTORY}")
 # Uncomment the line below and all ctest_submit_multi lines
 # if CTestConfig.cmake defines `drop_sites`.
 # include("${CMAKE_CURRENT_LIST_DIR}/ctest_submit_multi.cmake")
 
 # Pick up from where the configure left off.
-ctest_start(APPEND)
+CTEST_START(APPEND)
 
-include(ProcessorCount)
+INCLUDE(ProcessorCount)
 ProcessorCount(nproc)
 
-include("${CMAKE_CURRENT_LIST_DIR}/ctest_exclusions.cmake")
-ctest_test(
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ctest_exclusions.cmake")
+CTEST_TEST(
   PARALLEL_LEVEL "${nproc}"
   RETURN_VALUE test_result
   EXCLUDE "${test_exclusions}")
@@ -43,9 +41,8 @@ ctest_test(
 # endif()
 
 # ctest_submit_multi(PARTS Test)
-ctest_submit(PARTS Test)
+CTEST_SUBMIT(PARTS Test)
 
-if (test_result)
-  message(FATAL_ERROR
-    "Failed to test")
-endif ()
+IF (test_result)
+  MESSAGE(FATAL_ERROR "Failed to test")
+ENDIF ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ MESSAGE(STATUS "This is CMake ${CMAKE_VERSION}")
 MESSAGE(STATUS "")
 INCLUDE(GNUInstallDirs)
 INCLUDE(CMakePackageConfigHelpers)
-include(CTest)
+INCLUDE(CTest)
 
 # Version info:
 FILE(STRINGS "${CMAKE_SOURCE_DIR}/VERSION" _version LIMIT_COUNT 1)
@@ -36,7 +36,6 @@ STRING(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" IBTK_VERSION_MINOR "${_version
 STRING(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" IBTK_VERSION_SUBMINOR "${_version}")
 SET(IBTK_VERSION ${IBTK_VERSION_MAJOR}.${IBTK_VERSION_MINOR}.${IBTK_VERSION_SUBMINOR})
 SET(IBAMR_VERSION ${IBTK_VERSION})
-SET(IBAMR_DEPENDENCY_LINK_ARGUMENTS "")
 
 # Build tests?
 option(IBAMR_ENABLE_TESTING "Should tests be compiled and configured to run with ctest?" ON)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 ##
 ## ---------------------------------------------------------------------
 
-ADD_CUSTOM_TARGET(tests ALL)
+ADD_CUSTOM_TARGET(tests)
 
 # We use the list of test directories in two ways:
 # 1. each test is added to a target tests-dir so that, e.g., 'make tests-IBFE'
@@ -297,18 +297,18 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/attest.conf.in
   ${CMAKE_BINARY_DIR}/attest.conf)
 
 # For the time being, run `attest` as if it were a single test.
-set(disabled_tests)
-list(APPEND disabled_tests "mpirun=[3-9]")
-list(APPEND disabled_tests "explicit_ex1_2d.mpirun=4.input")
-list(APPEND disabled_tests "explicit_ex2_3d.nodal_quadrature.input")
-list(APPEND disabled_tests "explicit_ex4_3d.mpirun=4.input")
-list(APPEND disabled_tests "explicit_ex5_3d.mpirun=2.input")
-list(APPEND disabled_tests "explicit_ex8_2d.input")
-list(APPEND disabled_tests "explicit_ex8_2d.scratch_hier.input")
-list(APPEND disabled_tests "free_falling_cyl_cib|cib_plate")
-list(APPEND disabled_tests "nwt_cylinder|rotating_barge|cib_double_shell")
-list(JOIN disabled_tests "|" disabled_test_regex)
-add_test(
+SET(disabled_tests)
+LIST(APPEND disabled_tests "mpirun=[3-9]")
+LIST(APPEND disabled_tests "explicit_ex1_2d.mpirun=4.input")
+LIST(APPEND disabled_tests "explicit_ex2_3d.nodal_quadrature.input")
+LIST(APPEND disabled_tests "explicit_ex4_3d.mpirun=4.input")
+LIST(APPEND disabled_tests "explicit_ex5_3d.mpirun=2.input")
+LIST(APPEND disabled_tests "explicit_ex8_2d.input")
+LIST(APPEND disabled_tests "explicit_ex8_2d.scratch_hier.input")
+LIST(APPEND disabled_tests "free_falling_cyl_cib|cib_plate")
+LIST(APPEND disabled_tests "nwt_cylinder|rotating_barge|cib_double_shell")
+LIST(JOIN disabled_tests "|" disabled_test_regex)
+ADD_TEST(
   NAME autotests
   COMMAND "${CMAKE_SOURCE_DIR}/attest"
     "-j4"
@@ -316,8 +316,7 @@ add_test(
     "--test-timeout=120"
      -E
      "${disabled_test_regex}"
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-)
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_tests_properties(autotests
   PROPERTIES
     ENVIRONMENT "PYTHONUNBUFFERED=yes"


### PR DESCRIPTION
Most of the time I want to compile `tests` independently of the library - i.e., `tests` should not be part of the `all` target. This isn't the standard CMake practice but 

This should work with the GitHub CI infrastructure - lets see if the tests still run with these changes.