### PR TITLE
Fix IIM restarts with older versions of libMesh.

### DIFF
--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -435,8 +435,8 @@ void setup_system_vectors(libMesh::EquationSystems* equation_systems,
  *   the normal way.</li>
  *   <li>If @p from_restart is true then the vector stored in the System
  *   corresponding to the given name is overwritten and has its type changed
- *   from PARALLEL to GHOSTED. This works around a bug in libMesh where vectors
- *   are always serialized as PARALLEL.</li>
+ *   from PARALLEL to GHOSTED. This works around a bug in libMesh versions prior
+ *   to 1.7.0 where vectors are always serialized as PARALLEL.</li>
  * </ol>
  */
 void setup_system_vector(libMesh::System& system, const std::string& vector_name, const bool from_restart);


### PR DESCRIPTION
We encounter the same issue here as we do in IBFEMethod - serialized vectors are
not set up as ghosted when they should be. It looks like newer versions of
libMesh fixed this, but it is definitely present in 1.5.1.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
