### PR TITLE
Enable a small number of flags by default in CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1106,6 +1106,15 @@ INSTALL(TARGETS IBAMRHeaders EXPORT IBAMRTargets)
 # ---------------------------------------------------------------------------- #
 
 #
+# Work around some pedantic compiler warnings coming from SAMRAI.
+#
+IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "8.0")
+  STRING(APPEND CMAKE_CXX_FLAGS " -Wno-undefined-var-template")
+  STRING(APPEND CMAKE_CXX_FLAGS " -Wno-unneeded-internal-declaration")
+ENDIF()
+
+#
 # Set up specific targets for executables and libraries that want to link to
 # IBAMR. As noted above, we have to do this since SAMRAI might not be compiled
 # with -fPIC: i.e., if we added SAMRAI as a link dependency to libIBTK and

--- a/cmake/IBAMRConfig.cmake.in
+++ b/cmake/IBAMRConfig.cmake.in
@@ -16,6 +16,11 @@
 # own targets.
 @PACKAGE_INIT@
 
+# Don't set compiler flags, but save them
+SET(IBAMR_C_FLAGS "@CMAKE_C_FLAGS@")
+SET(IBAMR_CXX_FLAGS "@CMAKE_CXX_FLAGS@")
+SET(IBAMR_Fortran_FLAGS "@CMAKE_Fortran_FLAGS@")
+
 SET(MPI_ROOT "@MPI_ROOT@")
 FIND_PACKAGE(MPI REQUIRED)
 

--- a/doc/cmake.md
+++ b/doc/cmake.md
@@ -158,6 +158,8 @@ ADD_EXECUTABLE(main2d main.cpp)
 
 FIND_PACKAGE(IBAMR 0.8.0 REQUIRED)
 TARGET_LINK_LIBRARIES(main2d IBAMR::IBAMR2d)
+# IBAMR saves the flags it used to compile - you can reuse them if you want to
+SET(CMAKE_CXX_FLAGS ${IBAMR_CXX_FLAGS})
 ```
 Run cmake as
 ```


### PR DESCRIPTION
This PR adds two minor tweaks to the CMake build system:
1. If we are using a new enough version of clang, then automatically turn off some warnings that generate huge amounts of line noise
2. Save the flags we use when compiling IBAMR - this will let users set things up in their own projects. These don't include preprocessor directives like defining NDIM.

I'll put up a version of this for 0.10.0 later.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
