### PR TITLE
Disable checking MPI library linking if we use mpicc etc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,7 +766,11 @@ using a different version of MPI than the one supplied to IBAMR.")
 
   FIND_PROGRAM(_ldd "ldd")
   FIND_PROGRAM(_readlink "readlink")
-  IF(NOT "${_ldd}" STREQUAL "_ldd-NOTFOUND" AND NOT "${_readlink}" STREQUAL "_readlink-NOTFOUND")
+  IF(NOT "${_ldd}" STREQUAL "_ldd-NOTFOUND"
+      AND NOT "${_readlink}" STREQUAL "_readlink-NOTFOUND"
+      # if we are using the MPI compiler wrappers these aren't populated and we
+      # cannot perform this check - things should blow up later, though
+      AND NOT "${MPI_C_LIBRARIES}" STREQUAL "")
     MESSAGE(STATUS "\
 Verifying that ${_dependency_name} and IBAMR use the same MPI implementation")
     FOREACH(_lib ${_dependency_libraries})


### PR DESCRIPTION
If we use the MPI compiler wrappers then MPI_C_LIBRARIES is empty, as there are no additional libraries for us to link against. In this case this check will unconditionally fail since whatever MPI library an external dependency links against will obviously not be in that empty list.

Hence, only run the check if MPI_C_LIBRARIES has something in it. Regardless of the link check, we use PETSc's preprocessor logic to verify that we have the same MPI library version, so we still have pretty good protection against mixing MPI implementations by accident.

Like #1397, this is a small CMake fix that will make it easy for users to set up everything with autoibamr.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
