### PR TITLE
CMake: fix compatibility with 3.15-3.19.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,8 +177,6 @@ MESSAGE(STATUS "Setting up Boost")
 # will resolve to the correct (bundled or external) boost. This makes it easy
 # to set things up that depend on boost but not IBAMR.
 ADD_LIBRARY(BOOST_INTERFACE INTERFACE)
-SET_PROPERTY(TARGET BOOST_INTERFACE PROPERTY CXX_STANDARD 11)
-TARGET_COMPILE_FEATURES(BOOST_INTERFACE INTERFACE cxx_std_11)
 IF(${IBAMR_FORCE_BUNDLED_BOOST})
   SET(IBAMR_USE_BUNDLED_BOOST TRUE)
 ELSE()


### PR DESCRIPTION
Newer versions of CMake let you set this, but in our case it doesn't matter - we never compile standalone boost files so the language version attached to them is never used.

Like the other such patches, since we didn't change anything in the library, the normal checklist isn't helpful.