### PR TITLE
Fix compilation of examples that depend just on boost.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -74,10 +74,14 @@ MACRO(IBAMR_ADD_EXAMPLE)
       "${EX_OUTPUT_NAME}")
     TARGET_INCLUDE_DIRECTORIES("${EX_TARGET_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-    IF("${EX_LINK_TARGETS}" STREQUAL "")
-      # If we have no target link libraries we need to set up the C++ standard ourselves
+    # If we have no target link libraries or rely on just boost (which is
+    # header-only and, until CMake 3.20 or later, we cannot set a C++ standard
+    # on) we need to set up the C++ standard ourselves
+    IF("${EX_LINK_TARGETS}" STREQUAL "" OR
+       "${EX_LINK_TARGETS}" STREQUAL "BOOST_INTERFACE")
       TARGET_COMPILE_FEATURES("${EX_TARGET_NAME}" PUBLIC cxx_std_11)
-    ELSE()
+    ENDIF()
+    IF(NOT "${EX_LINK_TARGETS}" STREQUAL "")
       TARGET_LINK_LIBRARIES("${EX_TARGET_NAME}" PRIVATE ${EX_LINK_TARGETS})
     ENDIF()
     ADD_DEPENDENCIES("${EX_EXAMPLE_GROUP}" "${EX_TARGET_NAME}")


### PR DESCRIPTION
Equivalent of #1416 for master.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
