### PR TITLE
Mark an example that requires libMesh as such.

### DIFF
--- a/examples/IBLevelSet/ex3/CMakeLists.txt
+++ b/examples/IBLevelSet/ex3/CMakeLists.txt
@@ -21,11 +21,13 @@ IBAMR_ADD_EXAMPLE(
   EXAMPLE_GROUP
     examples-IBLevelSet
   SOURCES
-    LevelSetInitialCondition.cpp  
-    SetFluidSolidDensity.cpp      
-    SetFluidSolidViscosity.cpp    
-    TagLSRefinementCells.cpp      
+    LevelSetInitialCondition.cpp
+    SetFluidSolidDensity.cpp
+    SetFluidSolidViscosity.cpp
+    TagLSRefinementCells.cpp
     example.cpp
+  REQUIRES
+    IBAMR_HAVE_LIBMESH
   LINK_TARGETS
     IBAMR2d
   INPUT_FILES


### PR DESCRIPTION
Yuck, another build system problem that I should have caught before - this is more evidence that we need better CI.

I compile the library without libMesh, and I compile the examples, but apparently I haven't done both recently.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?