### PR TITLE
Remove ZLIB as an explicit dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ FOREACH(_root ${_required_roots})
   ENDIF()
 ENDFOREACH()
 
-SET(_optional_roots "LIBMESH_ROOT" "NUMDIFF_ROOT" "SILO_ROOT" "ZLIB_ROOT")
+SET(_optional_roots "LIBMESH_ROOT" "NUMDIFF_ROOT" "SILO_ROOT")
 FOREACH(_root ${_optional_roots})
   IF("${${_root}}" STREQUAL "")
     MESSAGE(STATUS "${_root} was not provided to CMake: since this is an \
@@ -740,9 +740,6 @@ IF(NOT "${SILO_ROOT}" STREQUAL "")
     MESSAGE(STATUS "SILO_LIBRARIES: ${SILO_LIBRARIES}")
     SET(IBAMR_HAVE_SILO TRUE)
 
-    # Silo depends on zlib
-    FIND_PACKAGE(ZLIB REQUIRED)
-
     ADD_LIBRARY(SILO INTERFACE)
     TARGET_INCLUDE_DIRECTORIES(
       SILO
@@ -751,10 +748,6 @@ IF(NOT "${SILO_ROOT}" STREQUAL "")
       SILO
       INTERFACE
       ${SILO_LIBRARIES})
-    TARGET_LINK_LIBRARIES(
-      SILO
-      INTERFACE
-      ZLIB::ZLIB)
   ELSE()
     MESSAGE(FATAL_ERROR "\
 Silo (an optional dependency) was specified with SILO_ROOT=${SILO_ROOT} but a \

--- a/doc/cmake.md
+++ b/doc/cmake.md
@@ -96,7 +96,7 @@ The CMake build system will attempt to find these with default search paths and
 also in the directory provided by `PKG_ROOT` (i.e., for Boost, the build system
 will search in `BOOST_ROOT`).
 
-IBAMR's optional dependencies are Silo (which depends on zlib) and libMesh.
+IBAMR's optional dependencies are Silo and libMesh.
 These are only searched for if a directory path is provided (i.e., by passing
 `-DSILO_ROOT=/usr/`). libMesh also requires that the caller pass
 `LIBMESH_METHOD` to CMake to indicate which libMesh variant we should use (e.g.,

--- a/doc/news/changes/minor/20220221DavidWells
+++ b/doc/news/changes/minor/20220221DavidWells
@@ -1,0 +1,3 @@
+Changed: IBAMR's CMake build system now lets HDF5 resolve the zlib dependency.
+<br>
+(David Wells, 2022/02/21)


### PR DESCRIPTION
SILO's source code contains the following explanation:

    # Checking for hdf5 is complicated by the fact that hdf5 may or may not
    # in turn depend on zlib compression lib. In and of itself, Silo does NOT
    # depend on zlib. So, we don't want -lz on the link line if zlib is either
    # not needed or, worse, not present as this generates warning messages
    # or fatal errors. So, we first test for hdf5 without -lz on the link line.

in configure.ac: hence, if we link against HDF5 correctly then we will always get the correct zlib propagation.

To the best of my knowledge, we/SAMRAI never use zlib compression for writing out Eulerian data, so the only place it might get used is inside SILO. I tested this on a machine without any installation of zlib (i.e., with headers or without) and its fine.

That being said - I'm not sure that we are pulling in HDF5's full link interface with autotools so I left things alone there. CMake will use hdf5's compiler wrappers to get the full link interface, and I don't think we have that set up in autotools.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
