### PR TITLE
Test oldest configuration

### DIFF
--- a/.github/cmake/configure_centos7.cmake
+++ b/.github/cmake/configure_centos7.cmake
@@ -1,0 +1,36 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2022 - 2022 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+SET(CTEST_USE_LAUNCHERS "ON" CACHE STRING "")
+
+SET(IBAMR_ENABLE_TESTING "ON" CACHE BOOL "")
+
+# avoid funny problems with recursive ccache calls by providing explicit paths here
+SET(CMAKE_C_COMPILER_LAUNCHER "/usr/bin/ccache" CACHE STRING "Use ccache to compile C code.")
+SET(CMAKE_CXX_COMPILER_LAUNCHER "/usr/bin/ccache" CACHE STRING "Use ccache to compile C++ code.")
+
+SET(CMAKE_C_COMPILER "/usr/bin/gcc" CACHE STRING "C Compiler")
+SET(CMAKE_CXX_COMPILER "/usr/bin/g++" CACHE STRING "C++ Compiler")
+SET(CMAKE_Fortran_COMPILER "/usr/bin/gfortran" CACHE STRING "Fortran Compiler")
+
+SET(CMAKE_C_FLAGS "-O1" CACHE STRING "C flags")
+SET(CMAKE_CXX_FLAGS "-O1" CACHE STRING "C++ flags")
+SET(CMAKE_Fortran_FLAGS "-O3" CACHE STRING "Fortran flags")
+SET(CMAKE_INSTALL_PREFIX "/ibamr" CACHE PATH "Install destination")
+SET(SAMRAI_ROOT "/samrai" CACHE PATH "Location of SAMRAI")
+SET(PETSC_ROOT "/petsc/" CACHE PATH "Location of PETSc")
+# HDF5 is handled by the module system
+SET(HYPRE_ROOT "/petsc/" CACHE PATH "Location of Hypre")
+SET(NUMDIFF_ROOT "/numdiff" CACHE PATH "Location of numdiff")
+SET(LIBMESH_ROOT "/libmesh" CACHE PATH "Location of libmesh")
+SET(LIBMESH_METHOD "OPT" CACHE STRING "Type of libmesh build (OPT or DBG)")

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -277,3 +277,58 @@ jobs:
           cd build
           make -j 2 tests examples
           sccache --show-stats
+
+  # build IBAMR with CMake and run tests with our oldest dependencies on CENTOS 7
+  build_ibamr_centos:
+    runs-on: ubuntu-latest
+    name: Build IBAMR and run tests (CENTOS 7)
+    container:
+      image: 'docker://wellsd2/ibamr:ibamr-0.10-oldest-bundled-deps'
+    env:
+      CMAKE_CONFIGURATION: centos7
+      CTEST_NO_WARNINGS_ALLOWED: true
+      CCACHE_MAXSIZE: 1G
+      CMAKE_GENERATOR: Unix Makefiles
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+        id: git
+      - name: Create keys
+        id: keys
+        run: |
+          echo "::set-output name=key1::$(( ${{ github.run_number }} - 1))"
+          echo "::set-output name=key2::$(( ${{ github.run_number }} - 2))"
+          echo "::set-output name=key3::$(( ${{ github.run_number }} - 3))"
+          echo "::set-output name=key4::$(( ${{ github.run_number }} - 4))"
+          echo "::set-output name=key5::$(( ${{ github.run_number }} - 5))"
+      - name: Populate ccache
+        uses: actions/cache@v2
+        env:
+          cache-name: ccache
+        id: cache
+        with:
+          path: ~/.ccache/
+          key: ${{ runner.os }}-build-centos-cmake-${{ github.run_number }}
+          restore-keys: |
+            ${{ runner.os }}-build-centos-cmake-${{ steps.keys.outputs.key1 }}
+            ${{ runner.os }}-build-centos-cmake-${{ steps.keys.outputs.key2 }}
+            ${{ runner.os }}-build-centos-cmake-${{ steps.keys.outputs.key3 }}
+            ${{ runner.os }}-build-centos-cmake-${{ steps.keys.outputs.key4 }}
+            ${{ runner.os }}-build-centos-cmake-${{ steps.keys.outputs.key5 }}
+            ${{ runner.os }}-build-centos-cmake-
+      - name: Configure IBAMR
+        id: configure
+        run: |
+          # Don't bother with MPI/HDF5 paths and just let module handle it
+          bash -c "source /etc/profile.d/modules.sh && module load mpi && ctest3 -VV -S .github/cmake/ctest_configure.cmake"
+          ccache --show-stats
+      - name: Compile IBAMR
+        id: build
+        run: |
+          bash -c "ctest3 -VV -S .github/cmake/ctest_build.cmake"
+          ccache --show-stats
+      - name: Test IBAMR
+        id: test
+        run: |
+          bash -c "ctest3 --output-on-failure -VV -S .github/cmake/ctest_test.cmake"
+          ccache --show-stats

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,22 @@ FOREACH(_d ${IBAMR_DIMENSIONS})
   ENDFOREACH()
 ENDFOREACH()
 
+# sanity check:
+SET(CMAKE_REQUIRED_INCLUDES ${SAMRAI_INCLUDE_DIRS})
+CHECK_CXX_SOURCE_COMPILES(
+  "
+  #include <SAMRAI_config.h>
+  #ifndef HAVE_MPI
+  #error
+  #endif
+  int main() {}
+  "
+  SAMRAI_WITH_MPI)
+SET(CMAKE_REQUIRED_INCLUDES "")
+IF(NOT ${SAMRAI_WITH_MPI})
+  MESSAGE(FATAL_ERROR "IBAMR requires that SAMRAI is built with MPI support.")
+ENDIF()
+
 #
 # PETSc:
 #

--- a/ibtk/contrib/boost/boost/math/policies/policy.hpp
+++ b/ibtk/contrib/boost/boost/math/policies/policy.hpp
@@ -22,9 +22,9 @@ namespace boost{ namespace math{
 namespace tools{
 
 template <class T>
-constexpr int digits(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept;
+BOOST_MATH_CONSTEXPR int digits(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE_SPEC(T)) BOOST_NOEXCEPT;
 template <class T>
-constexpr T epsilon(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept(std::is_floating_point<T>::value);
+BOOST_MATH_CONSTEXPR T epsilon(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE_SPEC(T)) BOOST_MATH_NOEXCEPT(T);
 
 }
 
@@ -793,7 +793,7 @@ struct precision<BOOST_MATH_FLOAT128_TYPE, Policy>
 namespace detail{
 
 template <class T, class Policy>
-inline constexpr int digits_imp(std::true_type const&) noexcept
+inline BOOST_MATH_CONSTEXPR int digits_imp(std::true_type const&) noexcept
 {
    static_assert( std::numeric_limits<T>::is_specialized, "std::numeric_limits<T>::is_specialized");
    typedef typename boost::math::policies::precision<T, Policy>::type p_t;
@@ -801,7 +801,7 @@ inline constexpr int digits_imp(std::true_type const&) noexcept
 }
 
 template <class T, class Policy>
-inline constexpr int digits_imp(std::false_type const&) noexcept
+inline BOOST_MATH_CONSTEXPR int digits_imp(std::false_type const&) noexcept
 {
    return tools::digits<T>();
 }
@@ -809,7 +809,7 @@ inline constexpr int digits_imp(std::false_type const&) noexcept
 } // namespace detail
 
 template <class T, class Policy>
-inline constexpr int digits(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept
+inline BOOST_MATH_CONSTEXPR int digits(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept
 {
    typedef std::integral_constant<bool, std::numeric_limits<T>::is_specialized > tag_type;
    return detail::digits_imp<T, Policy>(tag_type());
@@ -848,7 +848,7 @@ struct series_factor_calc
 template <class T, class Digits>
 struct series_factor_calc<T, Digits, std::true_type, std::true_type>
 {
-   static constexpr T get() noexcept(std::is_floating_point<T>::value)
+   static BOOST_MATH_CONSTEXPR T get() noexcept(std::is_floating_point<T>::value)
    {
       return boost::math::tools::epsilon<T>();
    }
@@ -856,7 +856,7 @@ struct series_factor_calc<T, Digits, std::true_type, std::true_type>
 template <class T, class Digits>
 struct series_factor_calc<T, Digits, std::true_type, std::false_type>
 {
-   static constexpr T get() noexcept(std::is_floating_point<T>::value)
+   static BOOST_MATH_CONSTEXPR T get() noexcept(std::is_floating_point<T>::value)
    {
       return 1 / static_cast<T>(static_cast<std::uintmax_t>(1u) << (Digits::value - 1));
    }
@@ -864,14 +864,14 @@ struct series_factor_calc<T, Digits, std::true_type, std::false_type>
 template <class T, class Digits>
 struct series_factor_calc<T, Digits, std::false_type, std::true_type>
 {
-   static constexpr T get() noexcept(std::is_floating_point<T>::value)
+   static BOOST_MATH_CONSTEXPR T get() noexcept(std::is_floating_point<T>::value)
    {
       return boost::math::tools::epsilon<T>();
    }
 };
 
 template <class T, class Policy>
-inline constexpr T get_epsilon_imp(std::true_type const&) noexcept(std::is_floating_point<T>::value)
+inline BOOST_MATH_CONSTEXPR T get_epsilon_imp(std::true_type const&) noexcept(std::is_floating_point<T>::value)
 {
    static_assert(std::numeric_limits<T>::is_specialized, "std::numeric_limits<T>::is_specialized");
    static_assert(std::numeric_limits<T>::radix == 2, "std::numeric_limits<T>::radix == 2");
@@ -883,7 +883,7 @@ inline constexpr T get_epsilon_imp(std::true_type const&) noexcept(std::is_float
 }
 
 template <class T, class Policy>
-inline constexpr T get_epsilon_imp(std::false_type const&) noexcept(std::is_floating_point<T>::value)
+inline BOOST_MATH_CONSTEXPR T get_epsilon_imp(std::false_type const&) noexcept(std::is_floating_point<T>::value)
 {
    return tools::epsilon<T>();
 }
@@ -891,7 +891,7 @@ inline constexpr T get_epsilon_imp(std::false_type const&) noexcept(std::is_floa
 } // namespace detail
 
 template <class T, class Policy>
-inline constexpr T get_epsilon(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept(std::is_floating_point<T>::value)
+inline BOOST_MATH_CONSTEXPR T get_epsilon(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept(std::is_floating_point<T>::value)
 {
    typedef std::integral_constant<bool, (std::numeric_limits<T>::is_specialized && (std::numeric_limits<T>::radix == 2)) > tag_type;
    return detail::get_epsilon_imp<T, Policy>(tag_type());


### PR DESCRIPTION
Now that the CI is set up its relatively easy to copy and paste what we have to add more testers.

We can't catch bugs like #1425 with our present configurations since we only use relatively recent compilers. This PR adds another tester based on CENTOS 7 (first released in 2014, formally supported through 2024) which uses gcc 4.8, libmesh 1.1 and PETSc 3.7.7.

This might take a few rounds to get working correctly.