### PR TITLE
Fix how the advection diffusion integrators output variables with different depths.

### DIFF
--- a/doc/news/changes/minor/20220308AaronBarrett
+++ b/doc/news/changes/minor/20220308AaronBarrett
@@ -1,0 +1,4 @@
+Improved: The advection diffusion integrator now outputs visualization files
+correctly based on the depth of the advected variable.
+<br>
+(Aaron Barrett, 2022/03/08)

--- a/src/adv_diff/AdvDiffHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffHierarchyIntegrator.cpp
@@ -1142,7 +1142,29 @@ AdvDiffHierarchyIntegrator::registerVariables()
         const int Q_depth = Q_factory->getDefaultDepth();
         const bool Q_data_output = d_Q_output[Q_var];
         if (d_visit_writer && Q_data_output)
-            d_visit_writer->registerPlotQuantity(Q_var->getName(), Q_depth == 1 ? "SCALAR" : "VECTOR", Q_current_idx);
+        {
+            switch (Q_depth)
+            {
+            case 1:
+                // Scalar
+                d_visit_writer->registerPlotQuantity(Q_var->getName(), "SCALAR", Q_current_idx);
+                break;
+            case NDIM:
+                // Vector
+                d_visit_writer->registerPlotQuantity(Q_var->getName(), "VECTOR", Q_current_idx);
+                break;
+            case (NDIM * NDIM):
+                // Tensor
+                d_visit_writer->registerPlotQuantity(Q_var->getName(), "TENSOR", Q_current_idx);
+                break;
+            default:
+                // Plot components separately
+                for (int d = 0; d < Q_depth; ++d)
+                    d_visit_writer->registerPlotQuantity(
+                        Q_var->getName() + "_" + std::to_string(d), "SCALAR", Q_current_idx, d);
+                break;
+            }
+        }
     }
     for (const auto& F_var : d_F_var)
     {
@@ -1159,7 +1181,29 @@ AdvDiffHierarchyIntegrator::registerVariables()
         const int F_depth = F_factory->getDefaultDepth();
         const bool F_data_output = d_F_output[F_var];
         if (d_visit_writer && F_data_output)
-            d_visit_writer->registerPlotQuantity(F_var->getName(), F_depth == 1 ? "SCALAR" : "VECTOR", F_current_idx);
+        {
+            switch (F_depth)
+            {
+            case 1:
+                // Scalar
+                d_visit_writer->registerPlotQuantity(F_var->getName(), "SCALAR", F_current_idx);
+                break;
+            case NDIM:
+                // Vector
+                d_visit_writer->registerPlotQuantity(F_var->getName(), "VECTOR", F_current_idx);
+                break;
+            case (NDIM * NDIM):
+                // Tensor
+                d_visit_writer->registerPlotQuantity(F_var->getName(), "TENSOR", F_current_idx);
+                break;
+            default:
+                // Plot components separately
+                for (int d = 0; d < F_depth; ++d)
+                    d_visit_writer->registerPlotQuantity(
+                        F_var->getName() + "_" + std::to_string(d), "SCALAR", F_current_idx, d);
+                break;
+            }
+        }
     }
     for (const auto& D_var : d_diffusion_coef_var)
     {


### PR DESCRIPTION
The advection diffusion solver only draws scalar and vector quantities correctly. This adds a check if the advected quantity is a tensor, and defaults to outputting every component of the variable.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
