### PR TITLE
Fix the 'point outside' check with some other examples.

### DIFF
--- a/src/IB/IBRedundantInitializer.cpp
+++ b/src/IB/IBRedundantInitializer.cpp
@@ -153,26 +153,22 @@ IBRedundantInitializer::getIsAllLagrangianDataInDomain(const Pointer<PatchHierar
     Pointer<CartesianGridGeometry<NDIM> > grid_geom = hierarchy->getGridGeometry();
     const double* const domain_x_lower = grid_geom->getXLower();
     const double* const domain_x_upper = grid_geom->getXUpper();
+    const IntVector<NDIM> periodic_shift = grid_geom->getPeriodicShift();
 
     for (unsigned int vertex_level_number = 0; vertex_level_number < d_num_vertex.size(); ++vertex_level_number)
     {
-        Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(vertex_level_number);
-        const IntVector<NDIM>& ratio = level->getRatio();
-        const IntVector<NDIM>& periodic_shift = grid_geom->getPeriodicShift(ratio);
-
         for (int j = 0; j < int(d_num_vertex[vertex_level_number].size()); ++j)
         {
             for (int k = 0; k < d_num_vertex[vertex_level_number][j]; ++k)
             {
-                // Points that are inside the domain with periodicity are OK -
-                // exclude points that are truly outside.
+                // Points that are outside the domain in a periodic direction
+                // are OK: only check non-periodic directions.
                 std::pair<int, int> point_index(j, k);
-                const Point& X = getShiftedVertexPosn(
-                    point_index, vertex_level_number, domain_x_lower, domain_x_upper, periodic_shift);
+                const Point& X = getVertexPosn(point_index, vertex_level_number);
 
                 for (int d = 0; d < NDIM; ++d)
                 {
-                    if ((X[d] < domain_x_lower[d]) || (domain_x_upper[d] < X[d]))
+                    if (!periodic_shift(d) && (X[d] < domain_x_lower[d]) || (domain_x_upper[d] < X[d]))
                     {
                         return false;
                     }


### PR DESCRIPTION
The line

    hierarchy->getPatchLevel(vertex_level_number);

fails inside SAMRAI with a difficult to understand type casting error for some
tests in which the grid is not fully set up at the point when this is called.
Fortunately the fix is pretty easy - we don't actually need to account for the
periodic shift to get the actual position of a vertex, we just need to know
which directions are periodic since those can be ignored when we check for
points outside the physical domain.

Thanks @abarret for pointing this out.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?