### PR TITLE
Libmesh dev compat

### DIFF
--- a/doc/news/changes/incompatibilities/20220317DavidWells
+++ b/doc/news/changes/incompatibilities/20220317DavidWells
@@ -1,0 +1,5 @@
+Changed: The return type of FESurfaceDistanceEvaluator::getNeighborIntersectionsMap()
+has changed to use <tt>const libMesh::Elem*</tt> values to fix a compatibility issue
+with upcoming versions of libMesh.
+<br>
+(David Wells, 2022/03/17)

--- a/examples/IBFE/explicit/ex0/example.cpp
+++ b/examples/IBFE/explicit/ex0/example.cpp
@@ -548,11 +548,11 @@ main(int argc, char* argv[])
             const std::vector<std::vector<VectorValue<double> > >& dphi = fe->get_dphi();
             TensorValue<double> FF;
             boost::multi_array<double, 2> X_node;
-            const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-            const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-            for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+            const auto el_begin = mesh.active_local_elements_begin();
+            const auto el_end = mesh.active_local_elements_end();
+            for (auto el_it = el_begin; el_it != el_end; ++el_it)
             {
-                Elem* const elem = *el_it;
+                const auto elem = *el_it;
                 fe->reinit(elem);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {

--- a/examples/IBFE/explicit/ex1/example.cpp
+++ b/examples/IBFE/explicit/ex1/example.cpp
@@ -466,11 +466,11 @@ main(int argc, char* argv[])
             const std::vector<std::vector<VectorValue<double> > >& dphi = fe->get_dphi();
             TensorValue<double> FF;
             boost::multi_array<double, 2> X_node;
-            const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-            const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-            for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+            const auto el_begin = mesh.active_local_elements_begin();
+            const auto el_end = mesh.active_local_elements_end();
+            for (auto el_it = el_begin; el_it != el_end; ++el_it)
             {
-                Elem* const elem = *el_it;
+                const auto elem = *el_it;
                 fe->reinit(elem);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {

--- a/examples/IBFE/explicit/ex11/example.cpp
+++ b/examples/IBFE/explicit/ex11/example.cpp
@@ -494,11 +494,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
     boost::multi_array<double, 2> F_node;
     VectorValue<double> F;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        const auto elem = *el_it;
         fe->reinit(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {

--- a/examples/IBFE/explicit/ex2/example.cpp
+++ b/examples/IBFE/explicit/ex2/example.cpp
@@ -188,10 +188,10 @@ main(int argc, char* argv[])
                                           1,
                                           Utility::string_to_enum<ElemType>(elem_type));
 #endif
-        const MeshBase::const_element_iterator end_el = mesh.elements_end();
-        for (MeshBase::const_element_iterator el = mesh.elements_begin(); el != end_el; ++el)
+        const auto end_el = mesh.elements_end();
+        for (auto el = mesh.elements_begin(); el != end_el; ++el)
         {
-            Elem* const elem = *el;
+            const auto elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
                 const bool at_mesh_bdry = !elem->neighbor_ptr(side);

--- a/examples/IBFE/explicit/ex3/example.cpp
+++ b/examples/IBFE/explicit/ex3/example.cpp
@@ -171,10 +171,10 @@ main(int argc, char* argv[])
                                             0.0,
                                             0.5,
                                             Utility::string_to_enum<ElemType>(elem_type));
-        const MeshBase::const_element_iterator end_el = mesh.elements_end();
-        for (MeshBase::const_element_iterator el = mesh.elements_begin(); el != end_el; ++el)
+        const auto end_el = mesh.elements_end();
+        for (auto el = mesh.elements_begin(); el != end_el; ++el)
         {
-            Elem* const elem = *el;
+            const auto elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
                 const bool at_mesh_bdry = !elem->neighbor_ptr(side);

--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -539,11 +539,11 @@ main(int argc, char* argv[])
             const vector<vector<VectorValue<double> > >& dphi = fe->get_dphi();
             TensorValue<double> FF;
             boost::multi_array<double, 2> X_node;
-            const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-            const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-            for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+            const auto el_begin = mesh.active_local_elements_begin();
+            const auto el_end = mesh.active_local_elements_end();
+            for (auto el_it = el_begin; el_it != el_end; ++el_it)
             {
-                Elem* const elem = *el_it;
+                const auto elem = *el_it;
                 fe->reinit(elem);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {

--- a/examples/IBFE/explicit/ex5/example.cpp
+++ b/examples/IBFE/explicit/ex5/example.cpp
@@ -686,11 +686,11 @@ postprocess_data(Pointer<Database> input_db,
     boost::multi_array<double, 2> X_node, U_node;
     VectorValue<double> F, N, U, n, x;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        auto elem = *el_it;
         fe->reinit(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {

--- a/examples/IBFE/explicit/ex5/example.cpp
+++ b/examples/IBFE/explicit/ex5/example.cpp
@@ -158,7 +158,7 @@ tether_force_function(VectorValue<double>& F,
 
 void
 tether_force_function(VectorValue<double>& F,
-                      const VectorValue<double>& n,
+                      const VectorValue<double>& /*n*/,
                       const VectorValue<double>& /*N*/,
                       const TensorValue<double>& /*FF*/,
                       const libMesh::Point& x,
@@ -173,10 +173,8 @@ tether_force_function(VectorValue<double>& F,
     const TetherData* const tether_data = reinterpret_cast<TetherData*>(ctx);
 
     VectorValue<double> D = X - x;
-    VectorValue<double> D_n = (D * n) * n;
     VectorValue<double> U;
     for (unsigned int d = 0; d < NDIM; ++d) U(d) = (*var_data[0])[d];
-    VectorValue<double> U_t = U - (U * n) * n;
     F = tether_data->kappa_s_surface * D - tether_data->eta_s_surface * U;
     return;
 } // tether_force_function

--- a/examples/IBFE/explicit/ex6/example.cpp
+++ b/examples/IBFE/explicit/ex6/example.cpp
@@ -595,11 +595,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
         const std::vector<std::vector<double> >& phi = fe->get_phi();
         const std::vector<double>& JxW = fe->get_JxW();
         boost::multi_array<double, 2> F_node;
-        const MeshBase::const_element_iterator el_begin = mesh[k]->active_local_elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh[k]->active_local_elements_end();
-        for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+        const auto el_begin = mesh[k]->active_local_elements_begin();
+        const auto el_end = mesh[k]->active_local_elements_end();
+        for (auto el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            const auto elem = *el_it;
             fe->reinit(elem);
             for (unsigned int d = 0; d < NDIM; ++d)
             {

--- a/examples/IIM/ex0/example.cpp
+++ b/examples/IIM/ex0/example.cpp
@@ -594,11 +594,11 @@ postprocess_data(Pointer<Database> input_db,
 
     VectorValue<double> F, N, U, n, x, X, TAU;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        const auto elem = *el_it;
         fe->reinit(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {

--- a/examples/complex_fluids/ex2/example.cpp
+++ b/examples/complex_fluids/ex2/example.cpp
@@ -586,11 +586,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     boost::multi_array<double, 2> x_node, U_node;
     VectorValue<double> F, N, U, n, x;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        const auto elem = *el_it;
         fe->reinit(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {

--- a/examples/fe_mechanics/ex0/example.cpp
+++ b/examples/fe_mechanics/ex0/example.cpp
@@ -269,8 +269,8 @@ main(int argc, char* argv[])
                                               Utility::string_to_enum<ElemType>(elem_type));
 
             // Map unit square onto cook's membrane
-            MeshBase::const_node_iterator nd = mesh.nodes_begin();
-            const MeshBase::const_node_iterator end_nd = mesh.nodes_end();
+            auto nd = mesh.nodes_begin();
+            const auto end_nd = mesh.nodes_end();
             for (; nd != end_nd; ++nd)
             {
                 libMesh::Point s = **nd;
@@ -437,15 +437,15 @@ main(int argc, char* argv[])
             const vector<vector<VectorValue<double> > >& dphi = fe->get_dphi();
             TensorValue<double> FF;
             boost::multi_array<double, 2> X_node;
-            const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-            const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-            for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+            const auto el_begin = mesh.active_local_elements_begin();
+            const auto el_end = mesh.active_local_elements_end();
+            for (auto el_it = el_begin; el_it != el_end; ++el_it)
             {
                 elem_area = 0.0;
                 L_oo_temp = 0.0;
                 J_integral = 0.0;
 
-                Elem* const elem = *el_it;
+                const auto elem = *el_it;
                 fe->reinit(elem);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -3086,7 +3086,11 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
                                           const int finest_elem_ln)
 {
     // Get the necessary FE data.
-    const MeshBase& mesh = d_fe_data->d_es->get_mesh();
+    //
+    // We once relied on libMesh not correctly implementing iterator constness
+    // correctly. Here, we don't need to change the mesh, but we use Elem *s
+    // (not const Elem *s): hence we cannot use a const MeshBase& any more.
+    MeshBase& mesh = d_fe_data->d_es->get_mesh();
     System& X_system = d_fe_data->d_es->get_system(COORDINATES_SYSTEM_NAME);
 
     // Setup data structures used to assign elements to patches.

--- a/ibtk/src/lagrangian/FEProjector.cpp
+++ b/ibtk/src/lagrangian/FEProjector.cpp
@@ -269,7 +269,7 @@ FEProjector::buildL2ProjectionSolver(const std::string& system_name)
         // Reset values at Dirichlet boundaries.
         for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            const auto elem = *el_it;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
                 if (elem->neighbor_ptr(side)) continue;
@@ -518,7 +518,7 @@ FEProjector::buildStabilizedL2ProjectionSolver(const std::string& system_name, c
         // Reset values at Dirichlet boundaries.
         for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            const auto elem = *el_it;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
                 if (elem->neighbor_ptr(side)) continue;

--- a/include/ibamr/FESurfaceDistanceEvaluator.h
+++ b/include/ibamr/FESurfaceDistanceEvaluator.h
@@ -77,7 +77,7 @@ public:
     /*!
      * \brief Get the map maintaining triangle-cell intersection and neighbors.
      */
-    const std::map<SAMRAI::pdat::CellIndex<NDIM>, std::set<libMesh::Elem*>, IBTK::CellIndexFortranOrder>&
+    const std::map<SAMRAI::pdat::CellIndex<NDIM>, std::set<const libMesh::Elem*>, IBTK::CellIndexFortranOrder>&
     getNeighborIntersectionsMap();
 
     /*!
@@ -161,7 +161,7 @@ private:
      * its corresponding angle-weighted pseudo-normal from the surface mesh elements.
      */
     std::pair<IBTK::Vector3d, IBTK::Vector3d> getClosestPointandAngleWeightedNormal3D(const IBTK::Vector3d& P,
-                                                                                      libMesh::Elem* elem);
+                                                                                      const libMesh::Elem* elem);
 
     /*!
      * Name of this object.
@@ -201,29 +201,29 @@ private:
     /*!
      * Data to manage mapping between boundary mesh elements and grid patches.
      */
-    std::vector<std::vector<libMesh::Elem*> > d_active_neighbor_patch_bdry_elem_map;
+    std::vector<std::vector<const libMesh::Elem*> > d_active_neighbor_patch_bdry_elem_map;
 
     /*!
      * Map object keeping track of element-cell intersections as well as elements intersecting that cell
      * and its neighboring cells within the ghost cell width. Note that the elements contained in thie
      * map belong to the original solid mesh.
      */
-    std::map<SAMRAI::pdat::CellIndex<NDIM>, std::set<libMesh::Elem*>, IBTK::CellIndexFortranOrder>
+    std::map<SAMRAI::pdat::CellIndex<NDIM>, std::set<const libMesh::Elem*>, IBTK::CellIndexFortranOrder>
         d_cell_elem_neighbor_map;
 
     /*!
      * Map the node and the set of elements sharing this node.
      */
-    std::map<libMesh::Node*, std::set<libMesh::Elem*> > d_node_to_elem;
+    std::map<const libMesh::Node*, std::set<const libMesh::Elem*> > d_node_to_elem;
     /*!
      * Map the edge and the set of elements sharing this edge.
      */
-    std::map<std::pair<libMesh::Node*, libMesh::Node*>, std::set<libMesh::Elem*> > d_edge_to_elem;
+    std::map<std::pair<const libMesh::Node*, const libMesh::Node*>, std::set<const libMesh::Elem*> > d_edge_to_elem;
 
     /*!
      * Map the element and its face normal.
      */
-    std::map<libMesh::Elem*, IBTK::VectorNd> d_elem_face_normal;
+    std::map<const libMesh::Elem*, IBTK::VectorNd> d_elem_face_normal;
 
     /*!
      * Object to create a bounding box for sign update sweeping algorithm.

--- a/src/IB/FEMechanicsBase.cpp
+++ b/src/IB/FEMechanicsBase.cpp
@@ -586,11 +586,11 @@ FEMechanicsBase::doInitializeFEData(const bool use_present_data)
         DofMap& U_dof_map = U_system.get_dof_map();
         const unsigned int F_sys_num = F_system.number();
         const unsigned int U_sys_num = U_system.number();
-        MeshBase::const_element_iterator el_it = mesh.elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.elements_end();
+        auto el_it = mesh.elements_begin();
+        const auto el_end = mesh.elements_end();
         for (; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            const auto elem = *el_it;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
                 const bool at_mesh_bdry = !elem->neighbor_ptr(side);
@@ -689,11 +689,11 @@ FEMechanicsBase::computeStaticPressure(PetscVector<double>& P_vec,
 
     TensorValue<double> FF;
     std::vector<libMesh::dof_id_type> dof_id_scratch;
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        const auto elem = *el_it;
         const auto& P_dof_indices = P_dof_map_cache.dof_indices(elem);
         P_rhs_e.resize(static_cast<int>(P_dof_indices[0].size()));
         fe.reinit(elem);
@@ -797,11 +797,11 @@ FEMechanicsBase::computeDynamicPressureRateOfChange(PetscVector<double>& dP_dt_v
 
     TensorValue<double> FF, FF_inv_trans, Grad_U;
     std::vector<libMesh::dof_id_type> dof_id_scratch;
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        const auto elem = *el_it;
         const auto& P_dof_indices = P_dof_map_cache.dof_indices(elem);
         dP_dt_rhs_e.resize(static_cast<int>(P_dof_indices[0].size()));
         fe.reinit(elem);
@@ -864,7 +864,9 @@ FEMechanicsBase::assembleInteriorForceDensityRHS(PetscVector<double>& F_rhs_vec,
 
     // Extract the mesh.
     EquationSystems& equation_systems = *d_equation_systems[part];
-    const MeshBase& mesh = equation_systems.get_mesh();
+    // We need to get Elem *s for use in e.g. PK1 function pointers so use a
+    // mutable reference even though we will never modify the mesh
+    MeshBase& mesh = equation_systems.get_mesh();
     const BoundaryInfo& boundary_info = mesh.get_boundary_info();
     const unsigned int dim = mesh.mesh_dimension();
 
@@ -962,11 +964,11 @@ FEMechanicsBase::assembleInteriorForceDensityRHS(PetscVector<double>& F_rhs_vec,
         // the interior elastic force density.
         TensorValue<double> PP, FF, FF_inv_trans;
         VectorValue<double> F, F_qp, n, x;
-        const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-        for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+        const auto el_begin = mesh.active_local_elements_begin();
+        const auto el_end = mesh.active_local_elements_end();
+        for (auto el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            auto elem = *el_it;
             const auto& F_dof_indices = F_dof_map_cache.dof_indices(elem);
             for (unsigned int d = 0; d < NDIM; ++d)
             {
@@ -1148,11 +1150,11 @@ FEMechanicsBase::assembleInteriorForceDensityRHS(PetscVector<double>& F_rhs_vec,
     VectorValue<double> F, F_b, F_s, F_qp, n, x;
     boost::multi_array<double, 2> X_node;
     boost::multi_array<double, 1> P_node;
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        auto elem = *el_it;
         const auto& F_dof_indices = F_dof_map_cache.dof_indices(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {
@@ -1536,8 +1538,8 @@ FEMechanicsBase::commonConstructor(const std::string& object_name,
         const MeshBase& mesh = *meshes[part];
         bool mesh_has_first_order_elems = false;
         bool mesh_has_second_order_elems = false;
-        MeshBase::const_element_iterator el_it = mesh.elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.elements_end();
+        auto el_it = mesh.elements_begin();
+        const auto el_end = mesh.elements_end();
         for (; el_it != el_end; ++el_it)
         {
             const Elem* const elem = *el_it;

--- a/src/IB/IBFECentroidPostProcessor.cpp
+++ b/src/IB/IBFECentroidPostProcessor.cpp
@@ -149,7 +149,7 @@ void
 IBFECentroidPostProcessor::reconstructVariables(double data_time)
 {
     EquationSystems* equation_systems = d_fe_data_manager->getEquationSystems();
-    const MeshBase& mesh = equation_systems->get_mesh();
+    MeshBase& mesh = equation_systems->get_mesh();
     const int dim = mesh.mesh_dimension();
     std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, NDIM, CONSTANT);
 
@@ -219,11 +219,11 @@ IBFECentroidPostProcessor::reconstructVariables(double data_time)
     TensorValue<double> FF_qp, VV;
     VectorValue<double> V, x_qp;
     double v;
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        auto elem = *el_it;
         fe.reinit(elem);
         fe.collectDataForInterpolation(elem);
         fe.interpolate(elem);

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1089,7 +1089,7 @@ IBFEMethod::computeLagrangianFluidSource(double data_time)
         if (!d_lag_body_source_part[part]) continue;
 
         EquationSystems& equation_systems = *d_primary_fe_data_managers[part]->getEquationSystems();
-        const MeshBase& mesh = equation_systems.get_mesh();
+        MeshBase& mesh = equation_systems.get_mesh();
         const unsigned int dim = mesh.mesh_dimension();
 
         // Extract the FE systems and DOF maps, and setup the FE object.
@@ -1136,11 +1136,11 @@ IBFEMethod::computeLagrangianFluidSource(double data_time)
         VectorValue<double> x;
         double Q;
         std::vector<libMesh::dof_id_type> dof_id_scratch;
-        const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-        for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+        const auto el_begin = mesh.active_local_elements_begin();
+        const auto el_end = mesh.active_local_elements_end();
+        for (auto el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            auto elem = *el_it;
             const auto& Q_dof_indices = Q_dof_map_cache.dof_indices(elem);
             Q_rhs_e.resize(static_cast<int>(Q_dof_indices[0].size()));
             fe.reinit(elem);
@@ -1823,7 +1823,7 @@ IBFEMethod::computeStressNormalization(PetscVector<double>& Phi_vec,
 {
     // Extract the mesh.
     EquationSystems& equation_systems = *d_primary_fe_data_managers[part]->getEquationSystems();
-    const MeshBase& mesh = equation_systems.get_mesh();
+    MeshBase& mesh = equation_systems.get_mesh();
     const BoundaryInfo& boundary_info = mesh.get_boundary_info();
     const unsigned int dim = mesh.mesh_dimension();
 
@@ -1889,11 +1889,11 @@ IBFEMethod::computeStressNormalization(PetscVector<double>& Phi_vec,
     TensorValue<double> PP, FF, FF_trans, FF_inv_trans;
     VectorValue<double> F, F_s, F_qp, n, x;
     std::vector<libMesh::dof_id_type> dof_id_scratch;
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        auto elem = *el_it;
         bool reinit_all_data = true;
         for (unsigned int side = 0; side < elem->n_sides(); ++side)
         {

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -699,7 +699,7 @@ IBFESurfaceMethod::computeLagrangianForce(const double data_time)
     for (unsigned part = 0; part < d_num_parts; ++part)
     {
         EquationSystems* equation_systems = d_fe_data_managers[part]->getEquationSystems();
-        const MeshBase& mesh = equation_systems->get_mesh();
+        MeshBase& mesh = equation_systems->get_mesh();
         const unsigned int dim = mesh.mesh_dimension();
 
         // Setup global and elemental right-hand-side vectors.
@@ -788,11 +788,11 @@ IBFESurfaceMethod::computeLagrangianForce(const double data_time)
         VectorValue<double> F, F_b, F_s, F_qp, N, X, n, x;
         std::array<VectorValue<double>, 2> dX_dxi, dx_dxi;
         std::vector<libMesh::dof_id_type> dof_id_scratch;
-        const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-        for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+        const auto el_begin = mesh.active_local_elements_begin();
+        const auto el_end = mesh.active_local_elements_end();
+        for (auto el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            auto elem = *el_it;
             const auto& F_dof_indices = F_dof_map_cache.dof_indices(elem);
             const auto& X_dof_indices = X_dof_map_cache.dof_indices(elem);
             for (unsigned int d = 0; d < NDIM; ++d)

--- a/src/IB/IIMethod.cpp
+++ b/src/IB/IIMethod.cpp
@@ -2381,7 +2381,7 @@ IIMethod::computeLagrangianForce(const double data_time)
     for (unsigned part = 0; part < d_num_parts; ++part)
     {
         EquationSystems* equation_systems = d_fe_data_managers[part]->getEquationSystems();
-        const MeshBase& mesh = equation_systems->get_mesh();
+        MeshBase& mesh = equation_systems->get_mesh();
         const unsigned int dim = mesh.mesh_dimension();
 
         // Setup global and elemental right-hand-side vectors.
@@ -2524,11 +2524,11 @@ IIMethod::computeLagrangianForce(const double data_time)
         VectorValue<double> F, F_b, F_s, F_qp, N, X, n, x;
         std::array<VectorValue<double>, 2> dX_dxi, dx_dxi;
         std::vector<libMesh::dof_id_type> dof_id_scratch;
-        const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-        for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+        const auto el_begin = mesh.active_local_elements_begin();
+        const auto el_end = mesh.active_local_elements_end();
+        for (auto el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            auto elem = *el_it;
             const auto& F_dof_indices = F_dof_map_cache.dof_indices(elem);
             const auto& X_dof_indices = X_dof_map_cache.dof_indices(elem);
 
@@ -4104,11 +4104,11 @@ IIMethod::commonConstructor(const std::string& object_name,
         const MeshBase& mesh = *meshes[part];
         bool mesh_has_first_order_elems = false;
         bool mesh_has_second_order_elems = false;
-        MeshBase::const_element_iterator el_it = mesh.elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.elements_end();
+        auto el_it = mesh.elements_begin();
+        const auto el_end = mesh.elements_end();
         for (; el_it != el_end; ++el_it)
         {
-            const Elem* const elem = *el_it;
+            auto elem = *el_it;
             mesh_has_first_order_elems = mesh_has_first_order_elems || elem->default_order() == FIRST;
             mesh_has_second_order_elems = mesh_has_second_order_elems || elem->default_order() == SECOND;
         }

--- a/tests/IBFE/explicit_ex0.cpp
+++ b/tests/IBFE/explicit_ex0.cpp
@@ -550,11 +550,11 @@ main(int argc, char** argv)
             const std::vector<std::vector<VectorValue<double> > >& dphi = fe->get_dphi();
             TensorValue<double> FF;
             boost::multi_array<double, 2> X_node;
-            const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-            const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-            for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+            const auto el_begin = mesh.active_local_elements_begin();
+            const auto el_end = mesh.active_local_elements_end();
+            for (auto el_it = el_begin; el_it != el_end; ++el_it)
             {
-                Elem* const elem = *el_it;
+                const auto elem = *el_it;
                 fe->reinit(elem);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {

--- a/tests/IBFE/explicit_ex1.cpp
+++ b/tests/IBFE/explicit_ex1.cpp
@@ -494,11 +494,11 @@ main(int argc, char* argv[])
             const std::vector<std::vector<VectorValue<double> > >& dphi = fe->get_dphi();
             TensorValue<double> FF;
             boost::multi_array<double, 2> X_node;
-            const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-            const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-            for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+            const auto el_begin = mesh.active_local_elements_begin();
+            const auto el_end = mesh.active_local_elements_end();
+            for (auto el_it = el_begin; el_it != el_end; ++el_it)
             {
-                Elem* const elem = *el_it;
+                const auto elem = *el_it;
                 fe->reinit(elem);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {

--- a/tests/IBFE/explicit_ex2.cpp
+++ b/tests/IBFE/explicit_ex2.cpp
@@ -215,10 +215,10 @@ main(int argc, char* argv[])
                                           1,
                                           Utility::string_to_enum<ElemType>(elem_type));
 #endif
-        const MeshBase::const_element_iterator end_el = mesh.elements_end();
-        for (MeshBase::const_element_iterator el = mesh.elements_begin(); el != end_el; ++el)
+        const auto end_el = mesh.elements_end();
+        for (auto el = mesh.elements_begin(); el != end_el; ++el)
         {
-            Elem* const elem = *el;
+            const auto elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
                 const bool at_mesh_bdry = !elem->neighbor_ptr(side);

--- a/tests/IBFE/explicit_ex4.cpp
+++ b/tests/IBFE/explicit_ex4.cpp
@@ -612,11 +612,11 @@ main(int argc, char** argv)
             const vector<vector<VectorValue<double> > >& dphi = fe->get_dphi();
             TensorValue<double> FF;
             boost::multi_array<double, 2> X_node;
-            const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-            const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-            for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+            const auto el_begin = mesh.active_local_elements_begin();
+            const auto el_end = mesh.active_local_elements_end();
+            for (auto el_it = el_begin; el_it != el_end; ++el_it)
             {
-                Elem* const elem = *el_it;
+                const auto elem = *el_it;
                 fe->reinit(elem);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {

--- a/tests/IBFE/explicit_ex5.cpp
+++ b/tests/IBFE/explicit_ex5.cpp
@@ -661,11 +661,11 @@ postprocess_data(Pointer<Database> input_db,
     boost::multi_array<double, 2> x_node, U_node;
     VectorValue<double> F, N, U, n, x;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        auto elem = *el_it;
         fe->reinit(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {

--- a/tests/IBFE/explicit_ex5.cpp
+++ b/tests/IBFE/explicit_ex5.cpp
@@ -161,7 +161,7 @@ tether_force_function(VectorValue<double>& F,
 
 void
 tether_force_function(VectorValue<double>& F,
-                      const VectorValue<double>& n,
+                      const VectorValue<double>& /*n*/,
                       const VectorValue<double>& /*N*/,
                       const TensorValue<double>& /*FF*/,
                       const libMesh::Point& x,
@@ -176,10 +176,8 @@ tether_force_function(VectorValue<double>& F,
     const TetherData* const tether_data = reinterpret_cast<TetherData*>(ctx);
 
     VectorValue<double> D = X - x;
-    VectorValue<double> D_n = (D * n) * n;
     VectorValue<double> U;
     for (unsigned int d = 0; d < NDIM; ++d) U(d) = (*var_data[0])[d];
-    VectorValue<double> U_t = U - (U * n) * n;
     F = tether_data->kappa_s_surface * D - tether_data->eta_s_surface * U;
     return;
 } // tether_force_function

--- a/tests/IIM/flow_past_cylinder.cpp
+++ b/tests/IIM/flow_past_cylinder.cpp
@@ -545,9 +545,9 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
     boost::multi_array<double, 2> x_node, U_node, TAU_node, X0_node;
     VectorValue<double> F_qp, U_qp, x_qp, W_qp, TAU_qp, N, n, X;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
         Elem* const elem = *el_it;
         fe->reinit(elem);

--- a/tests/IIM/flow_past_sphere.cpp
+++ b/tests/IIM/flow_past_sphere.cpp
@@ -480,11 +480,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
     boost::multi_array<double, 2> x_node, U_node, TAU_node, X0_node;
     VectorValue<double> F_qp, U_qp, x_qp, TAU_qp, n, N, X;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        const auto elem = *el_it;
         fe->reinit(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {

--- a/tests/IIM/hagen_poiseuille_flow.cpp
+++ b/tests/IIM/hagen_poiseuille_flow.cpp
@@ -271,10 +271,10 @@ main(int argc, char* argv[])
             elem->set_node(3) = cylinder_mesh_thin.node_ptr(idx(NRi_elem, NRi_elem - 1, j + 1));
         }
 
-        MeshBase::const_element_iterator el_end = cylinder_mesh_thin.elements_end();
-        for (MeshBase::const_element_iterator el = cylinder_mesh_thin.elements_begin(); el != el_end; ++el)
+        const auto el_end = cylinder_mesh_thin.elements_end();
+        for (auto el = cylinder_mesh_thin.elements_begin(); el != el_end; ++el)
         {
-            Elem* const elem = *el;
+            const auto elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
             {
                 const bool at_mesh_bdry = !elem->neighbor_ptr(side);
@@ -782,11 +782,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
     boost::multi_array<double, 2> x_node, X_node, U_node;
     VectorValue<double> F_qp, U_qp, x_qp, X_qp, N, n;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        const auto elem = *el_it;
         fe->reinit(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {
@@ -859,11 +859,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
         double P_o_qp, P_j_qp, P_i_qp;
         boost::multi_array<double, 2> U_node, WSS_node;
         boost::multi_array<double, 1> P_o_node, P_j_node;
-        const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-        for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+        const auto el_begin = mesh.active_local_elements_begin();
+        const auto el_end = mesh.active_local_elements_end();
+        for (auto el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            const auto elem = *el_it;
             // fe->reinit(elem);
             for (unsigned int d = 0; d < NDIM; ++d)
             {

--- a/tests/IIM/poiseuille_flow.cpp
+++ b/tests/IIM/poiseuille_flow.cpp
@@ -885,11 +885,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
     boost::multi_array<double, 2> x_node, X_node, U_node, P_o_node, P_i_node, P_j_node;
     VectorValue<double> F_qp, U_qp, x_qp, X_qp, N, n;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        const auto elem = *el_it;
         fe->reinit(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {
@@ -968,11 +968,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
         int qp_tot = 0;
         boost::multi_array<double, 2> U_node, WSS_node;
         boost::multi_array<double, 1> P_o_node, P_i_node, P_j_node;
-        const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-        for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+        const auto el_begin = mesh.active_local_elements_begin();
+        const auto el_end = mesh.active_local_elements_end();
+        for (auto el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            const auto elem = *el_it;
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 dof_map.dof_indices(elem, dof_indices[d], d);

--- a/tests/IIM/taylor_couette_2d.cpp
+++ b/tests/IIM/taylor_couette_2d.cpp
@@ -802,11 +802,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
     boost::multi_array<double, 2> x_node, X_node, U_node, P_o_node, P_j_node;
     VectorValue<double> F_qp, U_qp, x_qp, X_qp, N, n;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        const auto elem = *el_it;
         fe->reinit(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {
@@ -880,11 +880,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
         int qp_tot = 0;
         boost::multi_array<double, 2> U_node, WSS_node;
         boost::multi_array<double, 1> P_o_node, P_j_node;
-        const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-        for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+        const auto el_begin = mesh.active_local_elements_begin();
+        const auto el_end = mesh.active_local_elements_end();
+        for (auto el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            const auto elem = *el_it;
             // fe->reinit(elem);
             for (unsigned int d = 0; d < NDIM; ++d)
             {

--- a/tests/IIM/taylor_couette_3d.cpp
+++ b/tests/IIM/taylor_couette_3d.cpp
@@ -244,8 +244,8 @@ main(int argc, char* argv[])
             elem->set_node(3) = inner_mesh.node_ptr(idx(NRi_elem, NRi_elem - 1, j + 1));
         }
 
-        MeshBase::const_element_iterator el_end = inner_mesh.elements_end();
-        for (MeshBase::const_element_iterator el = inner_mesh.elements_begin(); el != el_end; ++el)
+        const auto el_end = inner_mesh.elements_end();
+        for (auto el = inner_mesh.elements_begin(); el != el_end; ++el)
         {
             Elem* const elem = *el;
             for (unsigned int side = 0; side < elem->n_sides(); ++side)
@@ -799,11 +799,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
     boost::multi_array<double, 2> x_node, X_node, U_node, P_o_node, P_j_node;
     VectorValue<double> F_qp, U_qp, x_qp, X_qp, N, n;
 
-    const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-    for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+    const auto el_begin = mesh.active_local_elements_begin();
+    const auto el_end = mesh.active_local_elements_end();
+    for (auto el_it = el_begin; el_it != el_end; ++el_it)
     {
-        Elem* const elem = *el_it;
+        auto elem = *el_it;
         fe->reinit(elem);
         for (unsigned int d = 0; d < NDIM; ++d)
         {
@@ -877,11 +877,11 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/,
         int qp_tot = 0;
         boost::multi_array<double, 2> U_node, WSS_node;
         boost::multi_array<double, 1> P_o_node, P_j_node;
-        const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-        const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-        for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+        const auto el_begin = mesh.active_local_elements_begin();
+        const auto el_end = mesh.active_local_elements_end();
+        for (auto el_it = el_begin; el_it != el_end; ++el_it)
         {
-            Elem* const elem = *el_it;
+            const auto elem = *el_it;
             // fe->reinit(elem);
             for (unsigned int d = 0; d < NDIM; ++d)
             {

--- a/tests/fe_mechanics/fe_mechanics_ex0.cpp
+++ b/tests/fe_mechanics/fe_mechanics_ex0.cpp
@@ -269,8 +269,8 @@ main(int argc, char* argv[])
                                               Utility::string_to_enum<ElemType>(elem_type));
 
             // Map unit square onto cook's membrane
-            MeshBase::const_node_iterator nd = mesh.nodes_begin();
-            const MeshBase::const_node_iterator end_nd = mesh.nodes_end();
+            auto nd = mesh.nodes_begin();
+            const auto end_nd = mesh.nodes_end();
             for (; nd != end_nd; ++nd)
             {
                 libMesh::Point s = **nd;
@@ -437,15 +437,15 @@ main(int argc, char* argv[])
             const vector<vector<VectorValue<double> > >& dphi = fe->get_dphi();
             TensorValue<double> FF;
             boost::multi_array<double, 2> X_node;
-            const MeshBase::const_element_iterator el_begin = mesh.active_local_elements_begin();
-            const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-            for (MeshBase::const_element_iterator el_it = el_begin; el_it != el_end; ++el_it)
+            const auto el_begin = mesh.active_local_elements_begin();
+            const auto el_end = mesh.active_local_elements_end();
+            for (auto el_it = el_begin; el_it != el_end; ++el_it)
             {
                 elem_area = 0.0;
                 L_oo_temp = 0.0;
                 J_integral = 0.0;
 
-                Elem* const elem = *el_it;
+                const Elem* const elem = *el_it;
                 fe->reinit(elem);
                 for (unsigned int d = 0; d < NDIM; ++d)
                 {


### PR DESCRIPTION
We presently don't compile with the master branch of libMesh and deprecated features turned off because we rely on their old const-incorrect iterator handling (e.g., you could get an `Elem *` to a `const Mesh`, which doesn't make sense and is now fixed). I did have to change the API of `FESurfaceDistanceEvaluator`: @amneetb no examples or tests use this function: can we remove it from the public interface?

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?