### PR TITLE
Add capture variables to function pointers in IBRedundantInitializer.

### DIFF
--- a/doc/news/changes/incompatibilities/20200426AaronBarrett
+++ b/doc/news/changes/incompatibilities/20200426AaronBarrett
@@ -1,0 +1,3 @@
+Changed: IBRedundantInitializer now allows for passing object states to
+functions via optional void* parameters.
+<br> (Aaron Barrett, 2022/04/26)

--- a/examples/IB/explicit/ex0/example.cpp
+++ b/examples/IB/explicit/ex0/example.cpp
@@ -64,7 +64,8 @@ void
 generate_structure(const unsigned int& strct_num,
                    const int& ln,
                    int& num_vertices,
-                   std::vector<IBTK::Point>& vertex_posn)
+                   std::vector<IBTK::Point>& vertex_posn,
+                   void* /*ctx*/)
 {
     if (ln != finest_ln)
     {
@@ -150,7 +151,8 @@ generate_springs(
     const int& ln,
     std::multimap<int, IBRedundantInitializer::Edge>& spring_map,
     std::map<IBRedundantInitializer::Edge, IBRedundantInitializer::SpringSpec, IBRedundantInitializer::EdgeComp>&
-        spring_spec)
+        spring_spec,
+    void* /*ctx*/)
 {
     if (ln != finest_ln) return;
     double K = 1.0;

--- a/examples/IBLevelSet/ex0/example.cpp
+++ b/examples/IBLevelSet/ex0/example.cpp
@@ -254,7 +254,8 @@ void
 generate_interp_mesh(const unsigned int& /*strct_num*/,
                      const int& ln,
                      int& num_vertices,
-                     std::vector<IBTK::Point>& vertex_posn)
+                     std::vector<IBTK::Point>& vertex_posn,
+                     void* /*ctx*/)
 {
     if (ln != max_finest_ln)
     {

--- a/include/ibamr/IBRedundantInitializer.h
+++ b/include/ibamr/IBRedundantInitializer.h
@@ -132,7 +132,8 @@ public:
     using InitStructureOnLevel = void (*)(const unsigned int& strct_num,
                                           const int& level_num,
                                           int& num_vertices,
-                                          std::vector<IBTK::Point>& vertex_posn);
+                                          std::vector<IBTK::Point>& vertex_posn,
+                                          void* ctx);
 
     /*!
      * Register the function to initialize a structure on a given level.
@@ -140,7 +141,7 @@ public:
      * \note A function must be registered or IBRedundantInitializer will
      * return an error.
      */
-    void registerInitStructureFunction(InitStructureOnLevel fcn);
+    void registerInitStructureFunction(InitStructureOnLevel fcn, void* ctx = nullptr);
 
     /*
      * Edge data structures.
@@ -176,12 +177,13 @@ public:
     using InitSpringDataOnLevel = void (*)(const unsigned int& strct_num,
                                            const int& level_num,
                                            std::multimap<int, Edge>& spring_map,
-                                           std::map<Edge, SpringSpec, EdgeComp>& spring_spec);
+                                           std::map<Edge, SpringSpec, EdgeComp>& spring_spec,
+                                           void* ctx);
 
     /*!
      * \brief Register a function to initialize spring data structures on a given level.
      */
-    void registerInitSpringDataFunction(InitSpringDataOnLevel fcn);
+    void registerInitSpringDataFunction(InitSpringDataOnLevel fcn, void* ctx = nullptr);
 
     /*
      * Struct for xspring specifications.
@@ -205,12 +207,13 @@ public:
     using InitXSpringDataOnLevel = void (*)(const unsigned int& strct_num,
                                             const int& level_num,
                                             std::multimap<int, Edge>& xspring_map,
-                                            std::map<Edge, XSpringSpec, EdgeComp> xspring_spec);
+                                            std::map<Edge, XSpringSpec, EdgeComp> xspring_spec,
+                                            void* ctx);
 
     /*!
      * \brief Register a function to initialize xspring data structures on a given level.
      */
-    void registerInitXSpringDataFunction(InitXSpringDataOnLevel fcn);
+    void registerInitXSpringDataFunction(InitXSpringDataOnLevel fcn, void* ctx = nullptr);
 
     /*
      * Struct for beam specifications.
@@ -233,12 +236,13 @@ public:
      */
     using InitBeamDataOnLevel = void (*)(const unsigned int& strct_num,
                                          const int& level_num,
-                                         std::multimap<int, BeamSpec>& beam_spec);
+                                         std::multimap<int, BeamSpec>& beam_spec,
+                                         void* ctx);
 
     /*!
      * \brief Register a function to initialize beam data structures on a given level.
      */
-    void registerInitBeamDataFunction(InitBeamDataOnLevel fcn);
+    void registerInitBeamDataFunction(InitBeamDataOnLevel fcn, void* ctx = nullptr);
 
     /*!
      * Struct for rod specifications.
@@ -261,12 +265,13 @@ public:
                                                const int& level_num,
                                                std::vector<std::vector<double> >& director_spec,
                                                std::multimap<int, Edge>& rod_edge_map,
-                                               std::map<Edge, RodSpec, EdgeComp>& rod_spec);
+                                               std::map<Edge, RodSpec, EdgeComp>& rod_spec,
+                                               void* ctx);
 
     /*!
      * \brief Register a funcion to initialize director and rod data structures on a given level.
      */
-    void registerInitDirectorAndRodFunction(InitDirectorAndRodOnLevel fcn);
+    void registerInitDirectorAndRodFunction(InitDirectorAndRodOnLevel fcn, void* ctx = nullptr);
 
     /*
      * Struct for massive point specifications.
@@ -285,12 +290,13 @@ public:
      */
     using InitBoundaryMassOnLevel = void (*)(const unsigned int& strct_num,
                                              const int& level_num,
-                                             std::multimap<int, BdryMassSpec>& bdry_mass_spec);
+                                             std::multimap<int, BdryMassSpec>& bdry_mass_spec,
+                                             void* ctx);
 
     /*!
      * \brief Register a function to initialize massive points on a given level.
      */
-    void registerInitBoundaryMassFunction(InitBoundaryMassOnLevel fcn);
+    void registerInitBoundaryMassFunction(InitBoundaryMassOnLevel fcn, void* ctx = nullptr);
 
     /*!
      * Struct for target point specifications.
@@ -311,12 +317,13 @@ public:
 
     using InitTargetPtOnLevel = void (*)(const unsigned int& strct_num,
                                          const int& level_num,
-                                         std::multimap<int, TargetSpec>& tg_pt_spec);
+                                         std::multimap<int, TargetSpec>& tg_pt_spec,
+                                         void* ctx);
 
     /*!
      * \brief Register a function to initialize target points on a given level.
      */
-    void registerInitTargetPtFunction(InitTargetPtOnLevel fcn);
+    void registerInitTargetPtFunction(InitTargetPtOnLevel fcn, void* ctx = nullptr);
 
     /*!
      * Struct for anchor point specifications.
@@ -335,12 +342,13 @@ public:
      */
     using InitAnchorPtOnLevel = void (*)(const unsigned int& strct_num,
                                          const int& level_num,
-                                         std::multimap<int, AnchorSpec>& anchor_pt_spec);
+                                         std::multimap<int, AnchorSpec>& anchor_pt_spec,
+                                         void* ctx);
 
     /*!
      * \brief Register a function to initialize anchor points on a given level.
      */
-    void registerInitAnchorPtFunction(InitAnchorPtOnLevel fcn);
+    void registerInitAnchorPtFunction(InitAnchorPtOnLevel fcn, void* ctx = nullptr);
 
     /*!
      * Typedef specifying the interface for initializing flow meters and pressure gauges on a given level.
@@ -352,12 +360,13 @@ public:
     using InitInstrumentationOnLevel = void (*)(const unsigned int& strct_num,
                                                 const int& level_num,
                                                 std::vector<std::string>& instrument_name,
-                                                std::map<int, std::pair<int, int> >& instrument_spec);
+                                                std::map<int, std::pair<int, int> >& instrument_spec,
+                                                void* ctx);
 
     /*!
      * \brief Register a function to initialize instrumentation data on a given level.
      */
-    void registerInitInstrumentationFunction(InitInstrumentationOnLevel fcn);
+    void registerInitInstrumentationFunction(InitInstrumentationOnLevel fcn, void* ctx = nullptr);
 
     /*
      * Typedef specifying the interface for initializing source and sink data on a given level.
@@ -371,11 +380,12 @@ public:
                                        const int& level_num,
                                        std::map<int, int>& source_spec,
                                        std::vector<std::string>& source_names,
-                                       std::vector<double>& source_radii);
+                                       std::vector<double>& source_radii,
+                                       void* ctx);
     /*!
      * \brief Register a funciton to initialize source/sink data on a given level.
      */
-    void registerInitSourceFunction(InitSourceOnLevel fcn);
+    void registerInitSourceFunction(InitSourceOnLevel fcn, void* ctx = nullptr);
 
     /*!
      * \brief Initialize the structure indexing information on the patch level.
@@ -758,15 +768,25 @@ private:
      * Functions used to initialize structures programmatically.
      */
     InitStructureOnLevel d_init_structure_on_level_fcn = nullptr;
+    void* d_init_structure_on_level_ctx = nullptr;
     InitSpringDataOnLevel d_init_spring_on_level_fcn = nullptr;
+    void* d_init_spring_on_level_ctx = nullptr;
     InitXSpringDataOnLevel d_init_xspring_on_level_fcn = nullptr;
+    void* d_init_xspring_on_level_ctx = nullptr;
     InitBeamDataOnLevel d_init_beam_on_level_fcn = nullptr;
+    void* d_init_beam_on_level_ctx = nullptr;
     InitDirectorAndRodOnLevel d_init_director_and_rod_on_level_fcn = nullptr;
+    void* d_init_director_and_rod_on_level_ctx = nullptr;
     InitBoundaryMassOnLevel d_init_boundary_mass_on_level_fcn = nullptr;
+    void* d_init_boundary_mass_on_level_ctx = nullptr;
     InitTargetPtOnLevel d_init_target_pt_on_level_fcn = nullptr;
+    void* d_init_target_pt_on_level_ctx = nullptr;
     InitAnchorPtOnLevel d_init_anchor_pt_on_level_fcn = nullptr;
+    void* d_init_anchor_pt_on_level_ctx = nullptr;
     InitInstrumentationOnLevel d_init_instrumentation_on_level_fcn = nullptr;
+    void* d_init_instrumentation_on_level_ctx = nullptr;
     InitSourceOnLevel d_init_source_on_level_fcn = nullptr;
+    void* d_init_source_on_level_ctx = nullptr;
 };
 } // namespace IBAMR
 

--- a/src/IB/IBRedundantInitializer.cpp
+++ b/src/IB/IBRedundantInitializer.cpp
@@ -247,72 +247,82 @@ IBRedundantInitializer::initializeStructureIndexingOnPatchLevel(
 } // initializeStructureIndexingOnPatchLevel
 
 void
-IBRedundantInitializer::registerInitStructureFunction(InitStructureOnLevel fcn)
+IBRedundantInitializer::registerInitStructureFunction(InitStructureOnLevel fcn, void* ctx)
 {
     d_init_structure_on_level_fcn = fcn;
+    d_init_structure_on_level_ctx = ctx;
     return;
 }
 
 void
-IBRedundantInitializer::registerInitSpringDataFunction(InitSpringDataOnLevel fcn)
+IBRedundantInitializer::registerInitSpringDataFunction(InitSpringDataOnLevel fcn, void* ctx)
 {
     d_init_spring_on_level_fcn = fcn;
+    d_init_spring_on_level_ctx = ctx;
     return;
 }
 
 void
-IBRedundantInitializer::registerInitXSpringDataFunction(InitXSpringDataOnLevel fcn)
+IBRedundantInitializer::registerInitXSpringDataFunction(InitXSpringDataOnLevel fcn, void* ctx)
 {
     d_init_xspring_on_level_fcn = fcn;
+    d_init_xspring_on_level_ctx = ctx;
     return;
 }
 
 void
-IBRedundantInitializer::registerInitBeamDataFunction(InitBeamDataOnLevel fcn)
+IBRedundantInitializer::registerInitBeamDataFunction(InitBeamDataOnLevel fcn, void* ctx)
 {
     d_init_beam_on_level_fcn = fcn;
+    d_init_beam_on_level_ctx = ctx;
     return;
 }
 
 void
-IBRedundantInitializer::registerInitDirectorAndRodFunction(InitDirectorAndRodOnLevel fcn)
+IBRedundantInitializer::registerInitDirectorAndRodFunction(InitDirectorAndRodOnLevel fcn, void* ctx)
 {
     d_init_director_and_rod_on_level_fcn = fcn;
+    d_init_director_and_rod_on_level_ctx = ctx;
     return;
 }
 
 void
-IBRedundantInitializer::registerInitBoundaryMassFunction(InitBoundaryMassOnLevel fcn)
+IBRedundantInitializer::registerInitBoundaryMassFunction(InitBoundaryMassOnLevel fcn, void* ctx)
 {
     d_init_boundary_mass_on_level_fcn = fcn;
+    d_init_boundary_mass_on_level_ctx = ctx;
     return;
 }
 
 void
-IBRedundantInitializer::registerInitTargetPtFunction(InitTargetPtOnLevel fcn)
+IBRedundantInitializer::registerInitTargetPtFunction(InitTargetPtOnLevel fcn, void* ctx)
 {
     d_init_target_pt_on_level_fcn = fcn;
+    d_init_target_pt_on_level_ctx = ctx;
     return;
 }
 
 void
-IBRedundantInitializer::registerInitAnchorPtFunction(InitAnchorPtOnLevel fcn)
+IBRedundantInitializer::registerInitAnchorPtFunction(InitAnchorPtOnLevel fcn, void* ctx)
 {
     d_init_anchor_pt_on_level_fcn = fcn;
+    d_init_anchor_pt_on_level_ctx = ctx;
     return;
 }
 
 void
-IBRedundantInitializer::registerInitInstrumentationFunction(InitInstrumentationOnLevel fcn)
+IBRedundantInitializer::registerInitInstrumentationFunction(InitInstrumentationOnLevel fcn, void* ctx)
 {
     d_init_instrumentation_on_level_fcn = fcn;
+    d_init_instrumentation_on_level_ctx = ctx;
     return;
 }
 
 void
-IBRedundantInitializer::registerInitSourceFunction(InitSourceOnLevel fcn)
+IBRedundantInitializer::registerInitSourceFunction(InitSourceOnLevel fcn, void* ctx)
 {
     d_init_source_on_level_fcn = fcn;
+    d_init_source_on_level_ctx = ctx;
     return;
 }
 
@@ -341,7 +351,8 @@ IBRedundantInitializer::initializeStructurePosition()
                 d_vertex_offset[ln][j] = d_vertex_offset[ln][j - 1] + d_num_vertex[ln][j - 1];
             }
 
-            d_init_structure_on_level_fcn(j, ln, d_num_vertex[ln][j], d_vertex_posn[ln][j]);
+            d_init_structure_on_level_fcn(
+                j, ln, d_num_vertex[ln][j], d_vertex_posn[ln][j], d_init_structure_on_level_ctx);
 #if !defined(NDEBUG)
             if (d_vertex_posn[ln][j].size() != std::size_t(d_num_vertex[ln][j]))
             {
@@ -378,7 +389,8 @@ IBRedundantInitializer::initializeSprings()
         {
             for (unsigned int j = 0; j < num_base_filename; ++j)
             {
-                d_init_spring_on_level_fcn(j, ln, d_spring_edge_map[ln][j], d_spring_spec_data[ln][j]);
+                d_init_spring_on_level_fcn(
+                    j, ln, d_spring_edge_map[ln][j], d_spring_spec_data[ln][j], d_init_spring_on_level_ctx);
 
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
@@ -435,7 +447,8 @@ IBRedundantInitializer::initializeXSprings()
         {
             for (unsigned int j = 0; j < num_base_filename; ++j)
             {
-                d_init_xspring_on_level_fcn(j, ln, d_xspring_edge_map[ln][j], d_xspring_spec_data[ln][j]);
+                d_init_xspring_on_level_fcn(
+                    j, ln, d_xspring_edge_map[ln][j], d_xspring_spec_data[ln][j], d_init_xspring_on_level_ctx);
                 const int min_idx = 0;
                 const int max_idx = std::accumulate(d_num_vertex[ln].begin(), d_num_vertex[ln].end(), 0);
                 for (const auto& edge_pair : d_xspring_edge_map[ln][j])
@@ -490,7 +503,7 @@ IBRedundantInitializer::initializeBeams()
         {
             for (unsigned int j = 0; j < num_base_filename; ++j)
             {
-                d_init_beam_on_level_fcn(j, ln, d_beam_spec_data[ln][j]);
+                d_init_beam_on_level_fcn(j, ln, d_beam_spec_data[ln][j], d_init_beam_on_level_ctx);
 
                 const int min_idx = 0;
                 const int max_idx = d_num_vertex[ln][j];
@@ -539,7 +552,7 @@ IBRedundantInitializer::initializeTargetPts()
         {
             for (unsigned int j = 0; j < num_base_filename; ++j)
             {
-                d_init_target_pt_on_level_fcn(j, ln, tg_pt_spec);
+                d_init_target_pt_on_level_fcn(j, ln, tg_pt_spec, d_init_target_pt_on_level_ctx);
 
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
@@ -594,8 +607,12 @@ IBRedundantInitializer::initializeDirectorAndRods()
         {
             for (unsigned int j = 0; j < num_base_filename; ++j)
             {
-                d_init_director_and_rod_on_level_fcn(
-                    j, ln, d_directors[ln][j], d_rod_edge_map[ln][j], d_rod_spec_data[ln][j]);
+                d_init_director_and_rod_on_level_fcn(j,
+                                                     ln,
+                                                     d_directors[ln][j],
+                                                     d_rod_edge_map[ln][j],
+                                                     d_rod_spec_data[ln][j],
+                                                     d_init_director_and_rod_on_level_ctx);
 
                 const int min_idx = 0;
                 const int max_idx = d_num_vertex[ln][j];
@@ -712,7 +729,7 @@ IBRedundantInitializer::initializeBoundaryMass()
             std::multimap<int, BdryMassSpec> bdry_map;
             for (unsigned int j = 0; j < num_base_filename; ++j)
             {
-                d_init_boundary_mass_on_level_fcn(j, ln, bdry_map);
+                d_init_boundary_mass_on_level_fcn(j, ln, bdry_map, d_init_boundary_mass_on_level_ctx);
                 d_bdry_mass_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
@@ -767,7 +784,7 @@ IBRedundantInitializer::initializeAnchorPts()
             std::multimap<int, AnchorSpec> anchor_map;
             for (unsigned int j = 0; j < num_base_filename; ++j)
             {
-                d_init_anchor_pt_on_level_fcn(j, ln, anchor_map);
+                d_init_anchor_pt_on_level_fcn(j, ln, anchor_map, d_init_anchor_pt_on_level_ctx);
                 d_anchor_spec_data[ln][j].resize(d_num_vertex[ln][j], default_spec);
                 int min_idx = 0;
                 int max_idx = d_num_vertex[ln][j];
@@ -809,7 +826,8 @@ IBRedundantInitializer::initializeInstrumentationData()
             std::vector<std::string> new_names;
             for (unsigned int j = 0; j < num_base_filename; ++j)
             {
-                d_init_instrumentation_on_level_fcn(j, ln, new_names, d_instrument_idx[ln][j]);
+                d_init_instrumentation_on_level_fcn(
+                    j, ln, new_names, d_instrument_idx[ln][j], d_init_instrumentation_on_level_ctx);
                 std::vector<bool> encountered_instrument_idx;
                 std::map<int, std::vector<bool> > encountered_node_idxs;
                 for (const auto& new_name : new_names) instrument_names.push_back(new_name);
@@ -906,7 +924,8 @@ IBRedundantInitializer::initializeSourceData()
                 const int min_idx = 0;
                 const int max_idx = d_num_vertex[ln][j];
                 int num_source;
-                d_init_source_on_level_fcn(j, ln, d_source_idx[ln][j], new_names, new_radii);
+                d_init_source_on_level_fcn(
+                    j, ln, d_source_idx[ln][j], new_names, new_radii, d_init_source_on_level_ctx);
                 if (source_names.size() != source_radii.size())
                 {
                     TBOX_ERROR(d_object_name << ":\n Invalid number of sources/sinks. Number of sources "

--- a/tests/IB/explicit_ex0.cpp
+++ b/tests/IB/explicit_ex0.cpp
@@ -62,7 +62,8 @@ void
 generate_structure(const unsigned int& strct_num,
                    const int& ln,
                    int& num_vertices,
-                   std::vector<IBTK::Point>& vertex_posn)
+                   std::vector<IBTK::Point>& vertex_posn,
+                   void* /*ctx*/)
 {
     if (ln != finest_ln)
     {
@@ -190,7 +191,8 @@ generate_springs(
     const int& ln,
     std::multimap<int, IBRedundantInitializer::Edge>& spring_map,
     std::map<IBRedundantInitializer::Edge, IBRedundantInitializer::SpringSpec, IBRedundantInitializer::EdgeComp>&
-        spring_spec)
+        spring_spec,
+    void* /*ctx*/)
 {
     if (ln != finest_ln) return;
     double K = 1.0;

--- a/tests/IB/ib_body_force.cpp
+++ b/tests/IB/ib_body_force.cpp
@@ -51,7 +51,8 @@ void
 generate_structure(const unsigned int& struct_num,
                    const int& ln,
                    int& num_vertices,
-                   std::vector<IBTK::Point>& vertex_posn)
+                   std::vector<IBTK::Point>& vertex_posn,
+                   void* /*ctx*/)
 {
     if (ln != finest_ln)
     {

--- a/tests/IB/ib_body_force_kirchhoff.cpp
+++ b/tests/IB/ib_body_force_kirchhoff.cpp
@@ -51,7 +51,8 @@ void
 generate_structure(const unsigned int& struct_num,
                    const int& ln,
                    int& num_vertices,
-                   std::vector<IBTK::Point>& vertex_posn)
+                   std::vector<IBTK::Point>& vertex_posn,
+                   void* /*ctx*/)
 {
     if (ln != finest_ln)
     {

--- a/tests/IBTK/child_integrators.cpp
+++ b/tests/IBTK/child_integrators.cpp
@@ -130,7 +130,8 @@ void
 generate_structure(const unsigned int& /*strct_num*/,
                    const int& /*ln*/,
                    int& num_vertices,
-                   std::vector<IBTK::Point>& vertex_posn)
+                   std::vector<IBTK::Point>& vertex_posn,
+                   void* /*ctx*/)
 {
     num_vertices = 1;
     vertex_posn.resize(num_vertices);

--- a/tests/wave_tank/nwt_cylinder.cpp
+++ b/tests/wave_tank/nwt_cylinder.cpp
@@ -255,7 +255,8 @@ void
 generate_interp_mesh(const unsigned int& /*strct_num*/,
                      const int& ln,
                      int& num_vertices,
-                     std::vector<IBTK::Point>& vertex_posn)
+                     std::vector<IBTK::Point>& vertex_posn,
+                     void* /*ctx*/)
 {
     num_vertices = 0;
     vertex_posn.resize(num_vertices);


### PR DESCRIPTION
IBRedundantInitializer uses function pointers with no way to forward object states. This adds in `void *` to all the arguments with defaults of `nullptr` to bring the class in line with what happens in the rest of the library.

This change can potentially break user codes, but only requires adding the parameter `void *` to any functions that are passed to IBRedundantInitializer.
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
