### PR TITLE
CMake: remove ZLIB in another place.

### DIFF
--- a/cmake/IBAMRConfig.cmake.in
+++ b/cmake/IBAMRConfig.cmake.in
@@ -49,10 +49,8 @@ ENDIF()
 # non-bundled muParser is not handled as a package so we don't set it up again
 # here
 
-IF(@IBAMR_HAVE_SILO@)
-  SET(ZLIB_ROOT "@ZLIB_ROOT@")
-  FIND_PACKAGE(ZLIB REQUIRED)
-ENDIF()
+# Our linkage with SILO is purely internal and none of our headers include
+# silo.h so we do not handle it as an externally-facing dependency here.
 
 SET(HDF5_ROOT "@HDF5_ROOT@")
 FIND_PACKAGE(HDF5 REQUIRED)


### PR DESCRIPTION
I noticed this while working on #1456.

Followup to 1f21eb0f68 (i.e., #1429): I forgot to delete this check. While I'm at it we should clarify the SILO situation.
