### PR TITLE
Allow multiple AdvDiffHierarchyIntegrator objects to be registered with the INS solvers.

### DIFF
--- a/doc/news/changes/minor/20220526AaronBarrett
+++ b/doc/news/changes/minor/20220526AaronBarrett
@@ -1,0 +1,4 @@
+Improved: Multiple advection diffusion integrators can be registered with the
+navier stokes integrator.
+<br>
+(Aaron Barrett, 2022/05/26)

--- a/include/ibamr/INSHierarchyIntegrator.h
+++ b/include/ibamr/INSHierarchyIntegrator.h
@@ -458,7 +458,7 @@ protected:
      * The AdvDiffHierarchyIntegrator is used to provide time integration
      * capability for quantities transported by the fluid velocity field.
      */
-    SAMRAI::tbox::Pointer<AdvDiffHierarchyIntegrator> d_adv_diff_hier_integrator;
+    std::vector<SAMRAI::tbox::Pointer<AdvDiffHierarchyIntegrator> > d_adv_diff_hier_integrators;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::FaceVariable<NDIM, double> > d_U_adv_diff_var;
 
     /*!

--- a/include/ibamr/INSVCStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredHierarchyIntegrator.h
@@ -309,9 +309,13 @@ public:
      * \brief Set the transported viscosity variable if it is being maintained by the advection-diffusion integrator.
      *
      * \note The variable set here MUST be registered and maintained by the advection-diffusion integrator.
+     *
+     * \note If multiple advection diffusion integrators are registered, you can specify which advection diffusion
+     * integrator is used to evolve the viscosity.
      */
     void
-    setTransportedViscosityVariable(SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > mu_adv_diff_var);
+    setTransportedViscosityVariable(SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > mu_adv_diff_var,
+                                    unsigned int adv_diff_idx = 0);
 
     /*!
      * \brief Get the transported viscosity variable that is being manintained by an advection-diffusion integrator
@@ -712,6 +716,11 @@ protected:
      * Variable to keep track of a transported viscosity variable maintained by an advection-diffusion integrator
      */
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_mu_adv_diff_var;
+
+    /*
+     * Index to track which advection diffusion integrator maintains the viscosity.
+     */
+    unsigned int d_mu_adv_diff_idx = 0;
 
 private:
     /*!

--- a/include/ibamr/INSVCStaggeredNonConservativeHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredNonConservativeHierarchyIntegrator.h
@@ -143,9 +143,13 @@ public:
      * \brief Set the transported density variable if it is being maintained by the advection-diffusion integrator.
      *
      * \note The variable set here MUST be registered and maintained by the advection-diffusion integrator.
+     *
+     * \note If multiple advection diffusion integrators are registered, you can specify which advection diffusion
+     * integrator is used to evolve the density.
      */
-    void setTransportedMassDensityVariable(
-        SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > rho_adv_diff_var);
+    void
+    setTransportedMassDensityVariable(SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > rho_adv_diff_var,
+                                      unsigned int adv_diff_idx = 0);
 
 protected:
     /*!
@@ -281,6 +285,11 @@ private:
      * Variable to keep track of a transported density variable maintained by an advection-diffusion integrator
      */
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_rho_adv_diff_var;
+
+    /*
+     * Index to track which advection diffusion integrator maintains the density variable.
+     */
+    unsigned int d_rho_adv_diff_idx = 0;
 };
 } // namespace IBAMR
 

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -856,11 +856,11 @@ INSCollocatedHierarchyIntegrator::initializePatchHierarchy(Pointer<PatchHierarch
 
     // When necessary, initialize the value of the advection velocity registered
     // with a coupled advection-diffusion solver.
-    if (d_adv_diff_hier_integrator)
+    for (const auto& adv_diff_hier_integrator : d_adv_diff_hier_integrators)
     {
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         const int U_adv_diff_current_idx =
-            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, d_adv_diff_hier_integrator->getCurrentContext());
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_hier_integrator->getCurrentContext());
         if (isAllocatedPatchData(U_adv_diff_current_idx))
         {
             d_hier_fc_data_ops->copyData(U_adv_diff_current_idx, d_u_ADV_current_idx);
@@ -963,9 +963,9 @@ INSCollocatedHierarchyIntegrator::preprocessIntegrateHierarchy(const double curr
     d_hier_cc_data_ops->copyData(d_P_new_idx, d_P_current_idx);
 
     // Initialize any registered advection-diffusion solver.
-    if (d_adv_diff_hier_integrator)
+    for (const auto& adv_diff_hier_integrator : d_adv_diff_hier_integrators)
     {
-        const int adv_diff_num_cycles = d_adv_diff_hier_integrator->getNumberOfCycles();
+        const int adv_diff_num_cycles = adv_diff_hier_integrator->getNumberOfCycles();
         if (adv_diff_num_cycles != d_current_num_cycles && d_current_num_cycles != 1)
         {
             TBOX_ERROR(d_object_name << "::preprocessIntegrateHierarchy():\n"
@@ -981,20 +981,20 @@ INSCollocatedHierarchyIntegrator::preprocessIntegrateHierarchy(const double curr
         }
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         const int U_adv_diff_current_idx =
-            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, d_adv_diff_hier_integrator->getCurrentContext());
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_hier_integrator->getCurrentContext());
         if (isAllocatedPatchData(U_adv_diff_current_idx))
         {
             d_hier_fc_data_ops->copyData(U_adv_diff_current_idx, d_u_ADV_current_idx);
         }
-        d_adv_diff_hier_integrator->preprocessIntegrateHierarchy(current_time, new_time, adv_diff_num_cycles);
+        adv_diff_hier_integrator->preprocessIntegrateHierarchy(current_time, new_time, adv_diff_num_cycles);
         const int U_adv_diff_scratch_idx =
-            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, d_adv_diff_hier_integrator->getScratchContext());
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_hier_integrator->getScratchContext());
         if (isAllocatedPatchData(U_adv_diff_scratch_idx))
         {
             d_hier_fc_data_ops->copyData(U_adv_diff_scratch_idx, d_u_ADV_current_idx);
         }
         const int U_adv_diff_new_idx =
-            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, d_adv_diff_hier_integrator->getNewContext());
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_hier_integrator->getNewContext());
         if (isAllocatedPatchData(U_adv_diff_new_idx))
         {
             d_hier_fc_data_ops->copyData(U_adv_diff_new_idx, d_u_ADV_current_idx);
@@ -1080,11 +1080,11 @@ INSCollocatedHierarchyIntegrator::integrateHierarchy(const double current_time,
 
     // Perform a single step of fixed point iteration.
 
-    if (d_adv_diff_hier_integrator)
+    for (const auto& adv_diff_hier_integrator : d_adv_diff_hier_integrators)
     {
         // Update the state variables maintained by the advection-diffusion
         // solver.
-        d_adv_diff_hier_integrator->integrateHierarchy(current_time, new_time, cycle_num);
+        adv_diff_hier_integrator->integrateHierarchy(current_time, new_time, cycle_num);
     }
 
     // Compute the current approximation to the pressure gradient.
@@ -1400,21 +1400,21 @@ INSCollocatedHierarchyIntegrator::integrateHierarchy(const double current_time,
             d_Phi_rhs_vec->getComponentDescriptorIndex(0), d_Phi_rhs_vec->getComponentDescriptorIndex(0), d_Q_new_idx);
     }
 
-    if (d_adv_diff_hier_integrator)
+    for (const auto& adv_diff_hier_integrator : d_adv_diff_hier_integrators)
     {
         // Update the advection velocities used by the advection-diffusion
         // solver.
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         const int U_adv_diff_new_idx =
-            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, d_adv_diff_hier_integrator->getNewContext());
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_hier_integrator->getNewContext());
         if (isAllocatedPatchData(U_adv_diff_new_idx))
         {
             d_hier_fc_data_ops->copyData(U_adv_diff_new_idx, d_u_ADV_new_idx);
         }
         const int U_adv_diff_current_idx =
-            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, d_adv_diff_hier_integrator->getCurrentContext());
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_hier_integrator->getCurrentContext());
         const int U_adv_diff_scratch_idx =
-            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, d_adv_diff_hier_integrator->getScratchContext());
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_hier_integrator->getScratchContext());
         if (isAllocatedPatchData(U_adv_diff_scratch_idx))
         {
             d_hier_fc_data_ops->linearSum(U_adv_diff_scratch_idx, 0.5, U_adv_diff_current_idx, 0.5, U_adv_diff_new_idx);
@@ -1424,7 +1424,7 @@ INSCollocatedHierarchyIntegrator::integrateHierarchy(const double current_time,
         // solver.
         //
         // NOTE: We already performed cycle 0 above.
-        const int adv_diff_num_cycles = d_adv_diff_hier_integrator->getNumberOfCycles();
+        const int adv_diff_num_cycles = adv_diff_hier_integrator->getNumberOfCycles();
         if (d_current_num_cycles != adv_diff_num_cycles)
         {
 #if !defined(NDEBUG)
@@ -1432,7 +1432,7 @@ INSCollocatedHierarchyIntegrator::integrateHierarchy(const double current_time,
 #endif
             for (int adv_diff_cycle_num = 1; adv_diff_cycle_num < adv_diff_num_cycles; ++adv_diff_cycle_num)
             {
-                d_adv_diff_hier_integrator->integrateHierarchy(current_time, new_time, adv_diff_cycle_num);
+                adv_diff_hier_integrator->integrateHierarchy(current_time, new_time, adv_diff_cycle_num);
             }
         }
     }
@@ -1516,10 +1516,10 @@ INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(const double cur
     }
 
     // Deallocate any registered advection-diffusion solver.
-    if (d_adv_diff_hier_integrator)
+    for (const auto& adv_diff_hier_integrator : d_adv_diff_hier_integrators)
     {
-        const int adv_diff_num_cycles = d_adv_diff_hier_integrator->getNumberOfCycles();
-        d_adv_diff_hier_integrator->postprocessIntegrateHierarchy(
+        const int adv_diff_num_cycles = adv_diff_hier_integrator->getNumberOfCycles();
+        adv_diff_hier_integrator->postprocessIntegrateHierarchy(
             current_time, new_time, skip_synchronize_new_state_data, adv_diff_num_cycles);
     }
 

--- a/src/navier_stokes/INSHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSHierarchyIntegrator.cpp
@@ -102,11 +102,17 @@ INSHierarchyIntegrator::registerAdvDiffHierarchyIntegrator(Pointer<AdvDiffHierar
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(adv_diff_hier_integrator);
+    // Bad things happen if the same integrator is registered twice.
+    auto pointer_compare = [adv_diff_hier_integrator](Pointer<AdvDiffHierarchyIntegrator> integrator) -> bool {
+        return adv_diff_hier_integrator.getPointer() == integrator.getPointer();
+    };
+    TBOX_ASSERT(std::find_if(d_adv_diff_hier_integrators.begin(), d_adv_diff_hier_integrators.end(), pointer_compare) ==
+                d_adv_diff_hier_integrators.end());
 #endif
-    d_adv_diff_hier_integrator = adv_diff_hier_integrator;
-    registerChildHierarchyIntegrator(d_adv_diff_hier_integrator);
-    d_adv_diff_hier_integrator->registerAdvectionVelocity(d_U_adv_diff_var);
-    d_adv_diff_hier_integrator->setAdvectionVelocityIsDivergenceFree(d_U_adv_diff_var, !d_Q_fcn);
+    d_adv_diff_hier_integrators.push_back(adv_diff_hier_integrator);
+    registerChildHierarchyIntegrator(adv_diff_hier_integrator);
+    adv_diff_hier_integrator->registerAdvectionVelocity(d_U_adv_diff_var);
+    adv_diff_hier_integrator->setAdvectionVelocityIsDivergenceFree(d_U_adv_diff_var, !d_Q_fcn);
     return;
 } // registerAdvDiffHierarchyIntegrator
 

--- a/tests/IBTK/child_integrators.2_hierarchies.input
+++ b/tests/IBTK/child_integrators.2_hierarchies.input
@@ -1,0 +1,214 @@
+// constants
+PI = 3.14159265358979
+
+// physical parameters
+L   = 1.0
+MU  = 1.0e-2
+RHO = 1.0
+K   = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 1                                 // maximum number of levels in locally refined grid
+REF_RATIO  = 4                                 // refinement ratio between levels
+N = 64                                         // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N       // effective number of grid cells on finest   grid level
+DX_FINEST = L/NFINEST
+USE_SECOND_INTEGRATOR = TRUE
+
+// solver parameters
+DELTA_FUNCTION      = "IB_4"
+START_TIME          = 0.0e0                    // initial simulation time
+GROW_DT             = 2.0e0                    // growth factor for timesteps
+NUM_CYCLES          = 2                        // number of cycles of fixed-point iteration
+CONVECTIVE_TS_TYPE  = "MIDPOINT_RULE"        // convective time stepping type
+CONVECTIVE_OP_TYPE  = "PPM"                    // convective differencing discretization type
+CONVECTIVE_FORM     = "ADVECTIVE"              // how to compute the convective terms
+NORMALIZE_PRESSURE  = TRUE                     // whether to explicitly force the pressure to have mean zero
+CFL_MAX             = 0.3                      // maximum CFL number
+DT                  = (1.0/K)*1.6e-2*DX_FINEST // maximum timestep size
+END_TIME            = 2 * DT
+ERROR_ON_DT_CHANGE  = TRUE                     // whether to emit an error message if the time step size changes
+VORTICITY_TAGGING   = FALSE                    // whether to tag cells for refinement based on vorticity thresholds
+TAG_BUFFER          = 1                        // size of tag buffer used by grid generation algorithm
+REGRID_CFL_INTERVAL = 0.5                      // regrid whenever any material point could have moved 0.5 meshwidths since previous regrid
+OUTPUT_U            = TRUE
+OUTPUT_P            = TRUE
+OUTPUT_F            = FALSE
+OUTPUT_OMEGA        = TRUE
+OUTPUT_DIV_U        = TRUE
+ENABLE_LOGGING      = TRUE
+
+// collocated solver parameters
+PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
+SECOND_ORDER_PRESSURE_UPDATE = TRUE
+
+VelocityInitialConditions {
+   function_0 = "0.0"
+   function_1 = "0.0"
+}
+
+VelocityBcCoefs_0 {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+VelocityBcCoefs_1 {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+PressureInitialConditions {
+   R = 0.25
+   mu = K
+   function = "(X_0-0.5)^2 + (X_1-0.5)^2 <= R^2 ? mu*(1/R - pi*R) : -mu*pi*R"
+}
+
+IBHierarchyIntegrator {
+   start_time          = START_TIME
+   end_time            = END_TIME
+   grow_dt             = GROW_DT
+   num_cycles          = NUM_CYCLES
+   regrid_cfl_interval = REGRID_CFL_INTERVAL
+   dt_max              = DT
+   error_on_dt_change  = ERROR_ON_DT_CHANGE
+   tag_buffer          = TAG_BUFFER
+   enable_logging      = FALSE
+}
+
+IBMethod {
+   delta_fcn      = DELTA_FUNCTION
+   enable_logging = ENABLE_LOGGING
+}
+
+IBRedundantInitializer {
+   max_levels      = MAX_LEVELS
+   base_filenames_0 = "x"
+}
+
+INSStaggeredHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT
+   num_cycles                    = NUM_CYCLES
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_rel_thresh          = 0.25,0.125
+   tag_buffer                    = TAG_BUFFER
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+   enable_logging_solver_iterations = FALSE
+}
+
+Main {
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt","Silo"
+   viz_dump_interval           = 1
+   viz_dump_dirname            = "viz_IB2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 1
+   restart_dump_dirname        = "restart"
+
+// hierarchy data dump parameters
+   data_dump_interval          = int(END_TIME/(100*DT))
+   data_dump_dirname           = "hier_data_IB2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+      level_4 = REF_RATIO,REF_RATIO
+      level_5 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "GRADIENT_DETECTOR"
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+
+DummyAdvDiff {
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   num_cycles                    = NUM_CYCLES
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   cfl                           = CFL_MAX
+   dt_max                        = DT
+   tag_buffer                    = TAG_BUFFER
+   enable_logging                = ENABLE_LOGGING
+}

--- a/tests/IBTK/child_integrators.2_hierarchies.output
+++ b/tests/IBTK/child_integrators.2_hierarchies.output
@@ -1,38 +1,55 @@
 IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 DummyAdvDiff: initializeLevelDataSpecialized()
+DummyAdvDiff2: initializeLevelDataSpecialized()
 DummyAdvDiff: resetHierarchyConfigurationSpecialized()
+DummyAdvDiff2: resetHierarchyConfigurationSpecialized()
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
 INSStaggeredHierarchyIntegrator::regridProjection(): regrid projection solve residual norm        = 0
 DummyAdvDiff: synchronizeHierarchyDataSpecialized()
+DummyAdvDiff2: synchronizeHierarchyDataSpecialized()
 DummyAdvDiff: initializeCompositeHierarchyDataSpecialized()
+DummyAdvDiff2: initializeCompositeHierarchyDataSpecialized()
 DummyAdvDiff: synchronizeHierarchyDataSpecialized()
+DummyAdvDiff2: synchronizeHierarchyDataSpecialized()
 
 
 Writing visualization files...
 
 DummyAdvDiff: setupPlotDataSpecialized()
+DummyAdvDiff2: setupPlotDataSpecialized()
 
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 At beginning of timestep # 0
 Simulation time is 0
 DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
+DummyAdvDiff2: getMaximumTimeStepSizeSpecialized()
 DummyAdvDiff: getMinimumTimeStepSizeSpecialized()
+DummyAdvDiff2: getMinimumTimeStepSizeSpecialized()
 DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
+DummyAdvDiff2: getMaximumTimeStepSizeSpecialized()
 DummyAdvDiff: regridHierarchyBeginSpecialized()
+DummyAdvDiff2: regridHierarchyBeginSpecialized()
 DummyAdvDiff: regridHierarchyEndSpecialized()
+DummyAdvDiff2: regridHierarchyEndSpecialized()
 DummyAdvDiff: initializeCompositeHierarchyDataSpecialized()
+DummyAdvDiff2: initializeCompositeHierarchyDataSpecialized()
 DummyAdvDiff: synchronizeHierarchyDataSpecialized()
+DummyAdvDiff2: synchronizeHierarchyDataSpecialized()
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing incompressible Stokes solver
 DummyAdvDiff: integrateHierarchy()
+DummyAdvDiff2: integrateHierarchy()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
 DummyAdvDiff: integrateHierarchy()
+DummyAdvDiff2: integrateHierarchy()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
 DummyAdvDiff: synchronizeHierarchyDataSpecialized()
+DummyAdvDiff2: synchronizeHierarchyDataSpecialized()
 DummyAdvDiff: resetTimeDependentHierarchyDataSpecialized()
+DummyAdvDiff2: resetTimeDependentHierarchyDataSpecialized()
 
 At end       of timestep # 0
 Simulation time is 0.00025
@@ -42,24 +59,34 @@ Simulation time is 0.00025
 Writing visualization files...
 
 DummyAdvDiff: setupPlotDataSpecialized()
+DummyAdvDiff2: setupPlotDataSpecialized()
 
 Writing restart files...
 
 DummyAdvDiff: putToDatabaseSpecialized()
+DummyAdvDiff2: putToDatabaseSpecialized()
 
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 At beginning of timestep # 1
 Simulation time is 0.00025
 DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
+DummyAdvDiff2: getMaximumTimeStepSizeSpecialized()
 DummyAdvDiff: getMinimumTimeStepSizeSpecialized()
+DummyAdvDiff2: getMinimumTimeStepSizeSpecialized()
 DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
+DummyAdvDiff2: getMaximumTimeStepSizeSpecialized()
 DummyAdvDiff: atRegridPointSpecialized()
+DummyAdvDiff2: atRegridPointSpecialized()
 DummyAdvDiff: integrateHierarchy()
+DummyAdvDiff2: integrateHierarchy()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
 DummyAdvDiff: integrateHierarchy()
+DummyAdvDiff2: integrateHierarchy()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
 DummyAdvDiff: synchronizeHierarchyDataSpecialized()
+DummyAdvDiff2: synchronizeHierarchyDataSpecialized()
 DummyAdvDiff: resetTimeDependentHierarchyDataSpecialized()
+DummyAdvDiff2: resetTimeDependentHierarchyDataSpecialized()
 
 At end       of timestep # 1
 Simulation time is 0.0005
@@ -69,8 +96,10 @@ Simulation time is 0.0005
 Writing visualization files...
 
 DummyAdvDiff: setupPlotDataSpecialized()
+DummyAdvDiff2: setupPlotDataSpecialized()
 
 Writing restart files...
 
 DummyAdvDiff: putToDatabaseSpecialized()
+DummyAdvDiff2: putToDatabaseSpecialized()
 IBRedundantInitializer:  Deallocating initialization data.

--- a/tests/IBTK/child_integrators.cpp
+++ b/tests/IBTK/child_integrators.cpp
@@ -46,6 +46,7 @@ public:
 
     void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override
     {
+        plog << d_object_name << ": integrateHierarchy()\n";
         HierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
         return;
     }
@@ -188,10 +189,18 @@ main(int argc, char* argv[])
         // and, if this is a restarted run, from the restart database.
         Pointer<AdvDiffHierarchyIntegrator> adv_diff_integrator =
             new DummyAdvDiffIntegrator("DummyAdvDiff", app_initializer->getComponentDatabase("DummyAdvDiff"));
+        Pointer<AdvDiffHierarchyIntegrator> adv_diff_integrator_2;
         Pointer<INSStaggeredHierarchyIntegrator> navier_stokes_integrator = new INSStaggeredHierarchyIntegrator(
             "INSStaggeredHierarchyIntegrator",
             app_initializer->getComponentDatabase("INSStaggeredHierarchyIntegrator"));
         navier_stokes_integrator->registerAdvDiffHierarchyIntegrator(adv_diff_integrator);
+        bool use_second_integrator = input_db->getBoolWithDefault("USE_SECOND_INTEGRATOR", false);
+        if (use_second_integrator)
+        {
+            adv_diff_integrator_2 =
+                new DummyAdvDiffIntegrator("DummyAdvDiff2", app_initializer->getComponentDatabase("DummyAdvDiff"));
+            navier_stokes_integrator->registerAdvDiffHierarchyIntegrator(adv_diff_integrator_2);
+        }
         Pointer<IBMethod> ib_method_ops = new IBMethod("IBMethod", app_initializer->getComponentDatabase("IBMethod"));
         Pointer<IBHierarchyIntegrator> time_integrator =
             new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",


### PR DESCRIPTION
It's useful to be able to evolve different fields with different kinds of advection diffusion integrators. This replaces the single `AdvDiffHierarchyIntegrator` object in `INSHierarchyIntegrator` with a vector of integrators.

Note that we can not use a similar strategy as `IBStrategySet` for this as the INS solver needs to directly interact with the advection diffusion solver.

Also, for the VC INS solvers, the correct index of the advection diffusion integrator that owns the density or viscosity variable needs to be set.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
