### PR TITLE
Clean up some CMake comments.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1249,13 +1249,6 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
   STRING(APPEND CMAKE_CXX_FLAGS " -Wno-unneeded-internal-declaration")
 ENDIF()
 
-#
-# Set up specific targets for executables and libraries that want to link to
-# IBAMR. As noted above, we have to do this since SAMRAI might not be compiled
-# with -fPIC: i.e., if we added SAMRAI as a link dependency to libIBTK and
-# libIBTK as a link dependency to libFoo, then the linker would encounter errors
-# as a result. With executables we can use the full link interface.
-#
 SET(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/ibamr/)
 
 # Set up actual files containing the export target information:

--- a/cmake/IBAMRConfig.cmake.in
+++ b/cmake/IBAMRConfig.cmake.in
@@ -11,9 +11,9 @@
 ##
 ## ---------------------------------------------------------------------
 
-# This file is a template that is populated by CMake with the actual locations
-# of external dependencies and also the file containing information on IBAMR's
-# own targets.
+# This file is a template populated by CMake with the actual locations of
+# external dependencies and also the file containing information on IBAMR's own
+# targets.
 @PACKAGE_INIT@
 
 # Don't set compiler flags, but save them

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -242,11 +242,6 @@ TARGET_LINK_LIBRARIES(IBAMR3d PUBLIC IBAMRHeaders)
 # Since libIBAMR and libIBTK have the same dependencies (and libIBAMR always
 # depends on libIBTK), satisfy the dependencies (and NDIM definition) for
 # libIBAMR by linking against libIBTK.
-#
-# The order we resolve libIBAMR's dependencies in is important since SAMRAI is
-# usually staticly linked - if we do SAMRAI then IBTK we will end up with
-# duplicate symbols, so it has to be the other way around (so that we pick up
-# any SAMRAI symbols in libIBTK rather than adding them to libIBAMR).
 TARGET_LINK_LIBRARIES(IBAMR2d PUBLIC IBTK2d)
 TARGET_LINK_LIBRARIES(IBAMR3d PUBLIC IBTK3d)
 


### PR DESCRIPTION
One comment is out of date - the other two could use grammar improvements.

Since this doesn't modify the library itself the usual checklist doesn't apply.