### PR TITLE
Compile examples with warnings

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -76,14 +76,15 @@ jobs:
           # To get around this, always make the key unique and rely on
           # restore-keys to find the highest-indexed key available. Explicitly
           # try to restore things from the most recent builds.
-          key: ${{ runner.os }}-build-cmake-${{ github.run_number }}
+          key: ${{ runner.os }}-build-cmake-libmesh-${{ github.run_number }}
           restore-keys: |
-            ${{ runner.os }}-build-cmake-${{ steps.keys.outputs.key1 }}
-            ${{ runner.os }}-build-cmake-${{ steps.keys.outputs.key2 }}
-            ${{ runner.os }}-build-cmake-${{ steps.keys.outputs.key3 }}
-            ${{ runner.os }}-build-cmake-${{ steps.keys.outputs.key4 }}
-            ${{ runner.os }}-build-cmake-${{ steps.keys.outputs.key5 }}
-            ${{ runner.os }}-build-cmake-
+            ${{ runner.os }}-build-cmake-libmesh-${{ steps.keys.outputs.key1 }}
+            ${{ runner.os }}-build-cmake-libmesh-${{ steps.keys.outputs.key2 }}
+            ${{ runner.os }}-build-cmake-libmesh-${{ steps.keys.outputs.key3 }}
+            ${{ runner.os }}-build-cmake-libmesh-${{ steps.keys.outputs.key4 }}
+            ${{ runner.os }}-build-cmake-libmesh-${{ steps.keys.outputs.key5 }}
+            ${{ runner.os }}-build-cmake-libmesh-
+            ${{ runner.os }}-build-cmake
       - name: Start sccache server
         id: cache-server
         run: sccache --start-server

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -126,7 +126,7 @@ jobs:
         id: build
         run: |
           cd /build/ibamr
-          make -j2 tests
+          make -j2 tests examples
           sccache --show-stats
       - name: Test IBAMR
         id: test
@@ -406,7 +406,7 @@ jobs:
         id: build
         run: |
           cd /build/ibamr
-          make -j2
+          make -j2 examples
           ccache --show-stats
       - name: Install IBAMR
         id: install


### PR DESCRIPTION
More CI stuff - I noticed in #1465 that we are not actually compiling the examples under cmake with warnings turned into errors.