### PR TITLE
CI: compile more examples on CENTOS-7.

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -339,7 +339,8 @@ jobs:
         id: build
         run: |
           cd /build/ibamr
-          make -j2 tests
+          # compile examples which depend on libMesh to verify that they still work with libMesh 1.1.0
+          make -j2 tests examples-IBFE examples-IBLevelSet examples-IIM examples-IMP examples-complex_fluids examples-fe_mechanics
           ccache --show-stats
       - name: Test IBAMR
         id: test


### PR DESCRIPTION
We should automatically check that all our examples work with the oldest set of dependencies - in practice this really means checking libMesh since that's the only external dependency we typically use in some significant way in examples.