### PR TITLE
fix harmonic avg in PoissonUtilities

### DIFF
--- a/ibtk/src/math/PoissonUtilities.cpp
+++ b/ibtk/src/math/PoissonUtilities.cpp
@@ -96,7 +96,12 @@ compute_mu_harmonic_avg(const hier::Index<NDIM>& i, const NodeData<NDIM, double>
     int total_nodes = 0;
     for (NodeIterator<NDIM> n(node_box); n; n++, total_nodes++)
     {
-        avg_mu += 1.0 / mu_data(n(), /*depth*/ 0);
+        const double mu = mu_data(n(), /*depth*/ 0);
+        if (IBTK::abs_equal_eps(mu, 0.0))
+        {
+            return 0.0;
+        }
+        avg_mu += 1.0 / mu;
     }
 
 #if !defined(NDEBUG)
@@ -141,7 +146,12 @@ compute_mu_harmonic_avg(const hier::Index<NDIM>& i, const EdgeData<NDIM, double>
     {
         for (EdgeIterator<NDIM> e(edge_box, axis); e; e++, total_edges++)
         {
-            avg_mu += 1.0 / mu_data(e(), /*depth*/ 0);
+            const double mu = mu_data(e(), /*depth*/ 0);
+            if (IBTK::abs_equal_eps(mu, 0.0))
+            {
+                return 0.0;
+            }
+            avg_mu += 1.0 / mu;
         }
     }
 


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?

I missed this class while fixing harmonic averaging to avoid division by zero. I also checked through git grep to make sure no other files require a harmonic average fix. The test suite runs fine.
