### PR TITLE
Fix some minor warnings under clang.

### DIFF
--- a/ibtk/include/ibtk/BoxPartitioner.h
+++ b/ibtk/include/ibtk/BoxPartitioner.h
@@ -24,9 +24,11 @@
 
 #include <ibtk/PartitioningBox.h>
 
+IBTK_DISABLE_EXTRA_WARNINGS
 #include <libmesh/mesh_base.h>
 #include <libmesh/partitioner.h>
 #include <libmesh/system.h>
+IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <memory>
 #include <string>

--- a/ibtk/include/ibtk/StableCentroidPartitioner.h
+++ b/ibtk/include/ibtk/StableCentroidPartitioner.h
@@ -24,9 +24,11 @@
 
 #include <ibtk/PartitioningBox.h>
 
+IBTK_DISABLE_EXTRA_WARNINGS
 #include <libmesh/mesh_base.h>
 #include <libmesh/partitioner.h>
 #include <libmesh/system.h>
+IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <memory>
 #include <string>

--- a/ibtk/src/lagrangian/LSiloDataWriter.cpp
+++ b/ibtk/src/lagrangian/LSiloDataWriter.cpp
@@ -1959,6 +1959,10 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
     }
     IBTK_MPI::barrier();
 #else
+    NULL_USE(SILO_MPI_ROOT);
+    NULL_USE(SILO_MPI_TAG);
+    NULL_USE(SILO_NAME_BUFSIZE);
+    NULL_USE(d_time_step_number);
     NULL_USE(time_step_number);
     NULL_USE(simulation_time);
     TBOX_WARNING("LSiloDataWriter::writePlotData(): SILO is not installed; cannot write data." << std::endl);

--- a/src/IB/IBInstrumentPanel.cpp
+++ b/src/IB/IBInstrumentPanel.cpp
@@ -1321,6 +1321,8 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
         }
     }
 #else
+    NULL_USE(SILO_MPI_ROOT);
+    NULL_USE(SILO_NAME_BUFSIZE);
     NULL_USE(timestep_num);
     NULL_USE(simulation_time);
     TBOX_WARNING("IBInstrumentPanel::writePlotData(): SILO is not installed; cannot write data." << std::endl);


### PR DESCRIPTION
- We get some deprecated header warnings from libMesh
- We have some unused variables when SILO isn't installed

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] ~Does the test suite pass?~ skipped, none of these changes effect behavior
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
