### PR TITLE
update .gitignore to include .clang-tidy files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ compile_flags.txt
 *.sublime-workspace
 .cache
 .clangd
+.clang-tidy
 
 # Created by https://www.gitignore.io/api/linux,osx,c,c++,fortran
 


### PR DESCRIPTION
The usual checklist does not apply.