### PR TITLE
FEMechanicsBase: fix the component coupling.

### DIFF
--- a/src/IB/FEMechanicsBase.cpp
+++ b/src/IB/FEMechanicsBase.cpp
@@ -525,7 +525,6 @@ FEMechanicsBase::doInitializeFEEquationSystems()
             {
                 X_system.add_variable("X_" + std::to_string(d), d_fe_order_position[part], d_fe_family_position[part]);
             }
-            X_system.get_dof_map()._dof_coupling = &d_diagonal_system_coupling;
 
             auto& dX_system = equation_systems.add_system<ExplicitSystem>(getDisplacementSystemName());
             for (unsigned int d = 0; d < NDIM; ++d)
@@ -533,21 +532,18 @@ FEMechanicsBase::doInitializeFEEquationSystems()
                 dX_system.add_variable(
                     "dX_" + std::to_string(d), d_fe_order_position[part], d_fe_family_position[part]);
             }
-            dX_system.get_dof_map()._dof_coupling = &d_diagonal_system_coupling;
 
             auto& U_system = equation_systems.add_system<ExplicitSystem>(getVelocitySystemName());
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 U_system.add_variable("U_" + std::to_string(d), d_fe_order_position[part], d_fe_family_position[part]);
             }
-            U_system.get_dof_map()._dof_coupling = &d_diagonal_system_coupling;
 
             auto& F_system = equation_systems.add_system<ExplicitSystem>(getForceSystemName());
             for (unsigned int d = 0; d < NDIM; ++d)
             {
                 F_system.add_variable("F_" + std::to_string(d), d_fe_order_force[part], d_fe_family_force[part]);
             }
-            F_system.get_dof_map()._dof_coupling = &d_diagonal_system_coupling;
         }
     }
 }
@@ -584,6 +580,12 @@ FEMechanicsBase::doInitializeFEData(const bool use_present_data)
         auto& dX_system = equation_systems.get_system<System>(getDisplacementSystemName());
         auto& U_system = equation_systems.get_system<System>(getVelocitySystemName());
         auto& F_system = equation_systems.get_system<System>(getForceSystemName());
+
+        // We don't do off-diagonal coupling
+        X_system.get_dof_map()._dof_coupling = &d_diagonal_system_coupling;
+        dX_system.get_dof_map()._dof_coupling = &d_diagonal_system_coupling;
+        U_system.get_dof_map()._dof_coupling = &d_diagonal_system_coupling;
+        F_system.get_dof_map()._dof_coupling = &d_diagonal_system_coupling;
 
         X_system.assemble_before_solve = false;
         X_system.assemble();


### PR DESCRIPTION
We should set these values immediately before 'assemble'. I don't think this will make a significant difference since we do MAT_IGNORE_ZERO_ENTRIES elsewhere but not allocating them at all is an improvement.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?