### PR TITLE
Use class-specific names for libMesh restart files.

### DIFF
--- a/include/ibamr/FEMechanicsBase.h
+++ b/include/ibamr/FEMechanicsBase.h
@@ -543,10 +543,10 @@ protected:
     /*!
      * Get the libMesh restart file name.
      */
-    static std::string libmesh_restart_file_name(const std::string& restart_dump_dirname,
-                                                 unsigned int time_step_number,
-                                                 unsigned int part,
-                                                 const std::string& extension);
+    virtual std::string libmesh_restart_file_name(const std::string& restart_dump_dirname,
+                                                  unsigned int time_step_number,
+                                                  unsigned int part,
+                                                  const std::string& extension);
 
     /*!
      * Cached input databases.

--- a/include/ibamr/FEMechanicsExplicitIntegrator.h
+++ b/include/ibamr/FEMechanicsExplicitIntegrator.h
@@ -187,6 +187,14 @@ protected:
     void doInitializeFEData(bool use_present_data) override;
 
     /*!
+     * Get the libMesh restart file name.
+     */
+    std::string libmesh_restart_file_name(const std::string& restart_dump_dirname,
+                                          unsigned int time_step_number,
+                                          unsigned int part,
+                                          const std::string& extension) override;
+
+    /*!
      * Perform a forward Euler step.
      */
     void doForwardEulerStep(libMesh::PetscVector<double>& X_new_vec,

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -842,6 +842,14 @@ protected:
     virtual void doInitializeFEData(bool use_present_data) override;
 
     /*!
+     * Get the libMesh restart file name.
+     */
+    std::string libmesh_restart_file_name(const std::string& restart_dump_dirname,
+                                          unsigned int time_step_number,
+                                          unsigned int part,
+                                          const std::string& extension) override;
+
+    /*!
      * \brief Compute the stress normalization field.
      */
     void computeStressNormalization(libMesh::PetscVector<double>& P_vec,

--- a/src/IB/FEMechanicsBase.cpp
+++ b/src/IB/FEMechanicsBase.cpp
@@ -82,7 +82,7 @@ namespace IBAMR
 namespace
 {
 // Version of FEMechanicsBase restart file data.
-const int FE_MECHANICS_BASE_VERSION = 1;
+const int FE_MECHANICS_BASE_VERSION = 2;
 
 static Timer* t_assemble_interior_force_density_rhs;
 
@@ -1468,7 +1468,7 @@ FEMechanicsBase::libmesh_restart_file_name(const std::string& restart_dump_dirna
                                            const std::string& extension)
 {
     std::ostringstream file_name_prefix;
-    file_name_prefix << restart_dump_dirname << "/libmesh_data_part_" << part << "." << std::setw(6)
+    file_name_prefix << restart_dump_dirname << "/libmesh_data_femechanicsbase_part_" << part << "." << std::setw(6)
                      << std::setfill('0') << std::right << time_step_number << "." << extension;
     return file_name_prefix.str();
 }

--- a/src/IB/FEMechanicsExplicitIntegrator.cpp
+++ b/src/IB/FEMechanicsExplicitIntegrator.cpp
@@ -43,7 +43,7 @@ namespace IBAMR
 namespace
 {
 // Version of FEMechanicsExplicitIntegrator restart file data.
-const int EXPLICIT_FE_MECHANICS_INTEGRATOR_VERSION = 0;
+const int EXPLICIT_FE_MECHANICS_INTEGRATOR_VERSION = 1;
 } // namespace
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
@@ -812,6 +812,18 @@ FEMechanicsExplicitIntegrator::doForwardEulerStep(PetscVector<double>& X_new_vec
         ierr = VecWAXPY(P_new_vec->vec(), dt, dP_dt_current_vec->vec(), P_current_vec->vec());
         IBTK_CHKERRQ(ierr);
     }
+}
+
+std::string
+FEMechanicsExplicitIntegrator::libmesh_restart_file_name(const std::string& restart_dump_dirname,
+                                                         unsigned int time_step_number,
+                                                         unsigned int part,
+                                                         const std::string& extension)
+{
+    std::ostringstream file_name_prefix;
+    file_name_prefix << restart_dump_dirname << "/libmesh_data_femechanicsexplicitintegrator_part_" << part << "."
+                     << std::setw(6) << std::setfill('0') << std::right << time_step_number << "." << extension;
+    return file_name_prefix.str();
 }
 
 /////////////////////////////// PRIVATE //////////////////////////////////////

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -171,7 +171,7 @@ static Timer* t_begin_data_redistribution;
 static Timer* t_end_data_redistribution;
 static Timer* t_apply_gradient_detector;
 // Version of IBFEMethod restart file data.
-const int IBFE_METHOD_VERSION = 6;
+const int IBFE_METHOD_VERSION = 7;
 
 inline boundary_id_type
 get_dirichlet_bdry_ids(const std::vector<boundary_id_type>& bdry_ids)
@@ -2778,6 +2778,18 @@ IBFEMethod::getProlongationSchedule(const int level_number, const int coarse_dat
     }
     return *d_prolongation_schedules[key];
 } // getProlongationSchedule
+
+std::string
+IBFEMethod::libmesh_restart_file_name(const std::string& restart_dump_dirname,
+                                      unsigned int time_step_number,
+                                      unsigned int part,
+                                      const std::string& extension)
+{
+    std::ostringstream file_name_prefix;
+    file_name_prefix << restart_dump_dirname << "/libmesh_data_ibfemethod_part_" << part << "." << std::setw(6)
+                     << std::setfill('0') << std::right << time_step_number << "." << extension;
+    return file_name_prefix.str();
+}
 
 /////////////////////////////// PRIVATE //////////////////////////////////////
 

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -127,7 +127,7 @@ namespace IBAMR
 namespace
 {
 // Version of IBFESurfaceMethod restart file data.
-static const int IBFE_METHOD_VERSION = 3;
+static const int IBFE_METHOD_VERSION = 4;
 
 std::string
 libmesh_restart_file_name(const std::string& restart_dump_dirname,
@@ -136,7 +136,7 @@ libmesh_restart_file_name(const std::string& restart_dump_dirname,
                           const std::string& extension)
 {
     std::ostringstream file_name_prefix;
-    file_name_prefix << restart_dump_dirname << "/libmesh_data_part_" << part << "." << std::setw(6)
+    file_name_prefix << restart_dump_dirname << "/libmesh_data_ibfesurfacemethod_part_" << part << "." << std::setw(6)
                      << std::setfill('0') << std::right << time_step_number << "." << extension;
     return file_name_prefix.str();
 }

--- a/src/IB/IIMethod.cpp
+++ b/src/IB/IIMethod.cpp
@@ -137,7 +137,7 @@ static Timer* t_begin_data_redistribution;
 static Timer* t_end_data_redistribution;
 static Timer* t_apply_gradient_detector;
 // Version of IIMethod restart file data.
-static const int IIM_VERSION = 3;
+static const int IIM_VERSION = 4;
 
 std::string
 libmesh_restart_file_name(const std::string& restart_dump_dirname,
@@ -146,7 +146,7 @@ libmesh_restart_file_name(const std::string& restart_dump_dirname,
                           const std::string& extension)
 {
     std::ostringstream file_name_prefix;
-    file_name_prefix << restart_dump_dirname << "/libmesh_data_part_" << part << "." << std::setw(6)
+    file_name_prefix << restart_dump_dirname << "/libmesh_data_iimethod_part_" << part << "." << std::setw(6)
                      << std::setfill('0') << std::right << time_step_number << "." << extension;
     return file_name_prefix.str();
 }


### PR DESCRIPTION
This fixes the "FEMechanicsExplicitIntegrator and IBFEMethod try to write the same restart file" bug in 99% of cases. We should still add some extra error checking and perhaps optional file prefixes.

Part of #1535. The downside to this approach is we need to increment the restart file number, which we haven't in awhile.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
