### PR TITLE
Cmake fixes + bump silo version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,8 +245,6 @@ ADD_LIBRARY(BOOST_INTERFACE INTERFACE)
 IF(${IBAMR_FORCE_BUNDLED_BOOST})
   SET(IBAMR_USE_BUNDLED_BOOST TRUE)
 ELSE()
-  # set up the root with the proper package name too
-  SET(Boost_ROOT ${BOOST_ROOT})
   # Disable default search paths if we have an explicitly provided path
   IF("${BOOST_ROOT}" STREQUAL "")
     SET(USER_PROVIDED_BOOST_ROOT OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -856,6 +856,47 @@ IF(NOT "${SILO_ROOT}" STREQUAL "")
       NOT "${SILO_INCLUDE_DIRS}" STREQUAL "SILO_INCLUDE_DIRS-NOTFOUND")
     MESSAGE(STATUS "SILO_INCLUDE_DIRS: ${SILO_INCLUDE_DIRS}")
     MESSAGE(STATUS "SILO_LIBRARIES: ${SILO_LIBRARIES}")
+
+    # silo version info (use the symbol):
+    FILE(STRINGS "${SILO_ROOT}/include/silo.h" SILO_VERSION_LINE
+      REGEX "#define.*SILO_VERS_TAG.*Silo_version_")
+    STRING(REGEX REPLACE ".*Silo_version_([0-9]+)_.*" "\\1"
+      SILO_VERSION_MAJOR "${SILO_VERSION_LINE}")
+    STRING(REGEX REPLACE ".*Silo_version_[0-9]+_([0-9]+).*" "\\1"
+      SILO_VERSION_MINOR "${SILO_VERSION_LINE}")
+    SET(SILO_VERSION_STRING "${SILO_VERSION_MAJOR}.${SILO_VERSION_MINOR}")
+
+    # that didn't work - try the configuration file:
+    IF ("${SILO_VERSION_STRING}" STREQUAL ".")
+      SET(_silo_settings_file "")
+      IF(EXISTS "${SILO_ROOT}/lib/libsilo.settings")
+        SET(_silo_settings_file "${SILO_ROOT}/lib/libsilo.settings")
+      ELSEIF(EXISTS "${SILO_ROOT}/lib/libsiloh5.settings")
+        SET(_silo_settings_file "${SILO_ROOT}/lib/libsiloh5.settings")
+      ELSE()
+        MESSAGE(FATAL_ERROR "Unable to determine the SILO version from either \
+silo.h, libsilo.settings, or libsiloh5.settings.")
+      ENDIF()
+
+      MESSAGE(STATUS "Unable to parse SILO version string from silo.h - using \
+fallback check")
+      FILE(STRINGS "${_silo_settings_file}" SILO_VERSION_LINE
+        REGEX "Silo Version")
+      STRING(REGEX REPLACE ".*: *([0-9]+.[0-9]+)" "\\1" SILO_VERSION_STRING
+        "${SILO_VERSION_LINE}")
+    ENDIF()
+
+    IF("${SILO_VERSION_STRING}" STREQUAL ".")
+      MESSAGE(FATAL_ERROR "Unable to parse the SILO version string.")
+    ENDIF()
+
+    MESSAGE(STATUS "Found SILO ${SILO_VERSION_STRING} at ${SILO_ROOT}")
+
+    IF(${SILO_VERSION_STRING} VERSION_LESS "4.11")
+      MESSAGE(FATAL_ERROR "IBAMR is incompatible with Silo versions prior to
+4.11. Either disable Silo or use a newer version.")
+    ENDIF()
+
     SET(IBAMR_HAVE_SILO TRUE)
 
     ADD_LIBRARY(SILO INTERFACE)

--- a/cmake/IBAMRConfig.cmake.in
+++ b/cmake/IBAMRConfig.cmake.in
@@ -56,13 +56,13 @@ ENDIF()
 FIND_PACKAGE(MPI REQUIRED COMPONENTS C CXX)
 
 IF(NOT @IBAMR_USE_BUNDLED_BOOST@)
-  SET(Boost_ROOT "@BOOST_ROOT@")
+  SET(BOOST_ROOT "@BOOST_ROOT@")
   IF(@USER_PROVIDED_BOOST_ROOT@)
     SET(Boost_NO_SYSTEM_PATHS ON)
     # Modern versions of Boost install some extra files which we want to ignore
     # since they are incompatible with Boost_NO_SYSTEM_PATHS. If we don't set
     # this then CMake will set us up with a system copy of boost even when
-    # Boost_ROOT is something else
+    # BOOST_ROOT is something else
     #
     # This was fixed in CMake in 3.19: see
     # https://gitlab.kitware.com/cmake/cmake/-/issues/21200

--- a/configure
+++ b/configure
@@ -29074,8 +29074,8 @@ fi
 
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Silo version >= 4.9.1" >&5
-$as_echo_n "checking for Silo version >= 4.9.1... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Silo version >= 4.11" >&5
+$as_echo_n "checking for Silo version >= 4.11... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -29093,7 +29093,7 @@ int
 main ()
 {
 
-#if SILO_VERSION_GE(4,9,1)
+#if SILO_VERSION_GE(4,11,0)
 #else
 asdf
 #endif
@@ -29112,10 +29112,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${SILO_VERSION_VALID}" >&5
 $as_echo "${SILO_VERSION_VALID}" >&6; }
   if test "$SILO_VERSION_VALID" = no; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Silo versions prior to 4.9.1 are likely to be usable but are not officially supported" >&5
-$as_echo "$as_me: WARNING: Silo versions prior to 4.9.1 are likely to be usable but are not officially supported" >&2;}
-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: suggest upgrading to Silo 4.9.1" >&5
-$as_echo "$as_me: WARNING: suggest upgrading to Silo 4.9.1" >&2;}
+    as_fn_error $? "invalid SILO version detected: please use SILO 4.11 or newer" "$LINENO" 5
   fi
 
   LDFLAGS="$SILO_LDFLAGS $LDFLAGS"

--- a/ibtk/configure
+++ b/ibtk/configure
@@ -29234,8 +29234,8 @@ fi
 
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Silo version >= 4.9.1" >&5
-$as_echo_n "checking for Silo version >= 4.9.1... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Silo version >= 4.11" >&5
+$as_echo_n "checking for Silo version >= 4.11... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -29253,7 +29253,7 @@ int
 main ()
 {
 
-#if SILO_VERSION_GE(4,9,1)
+#if SILO_VERSION_GE(4,11,0)
 #else
 asdf
 #endif
@@ -29272,10 +29272,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${SILO_VERSION_VALID}" >&5
 $as_echo "${SILO_VERSION_VALID}" >&6; }
   if test "$SILO_VERSION_VALID" = no; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Silo versions prior to 4.9.1 are likely to be usable but are not officially supported" >&5
-$as_echo "$as_me: WARNING: Silo versions prior to 4.9.1 are likely to be usable but are not officially supported" >&2;}
-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: suggest upgrading to Silo 4.9.1" >&5
-$as_echo "$as_me: WARNING: suggest upgrading to Silo 4.9.1" >&2;}
+    as_fn_error $? "invalid SILO version detected: please use SILO 4.11 or newer" "$LINENO" 5
   fi
 
   LDFLAGS="$SILO_LDFLAGS $LDFLAGS"

--- a/m4/configure_silo.m4
+++ b/m4/configure_silo.m4
@@ -78,11 +78,11 @@ if test "$SILO_ENABLED" = yes; then
   CPPFLAGS_PREPEND($SILO_CPPFLAGS)
   AC_CHECK_HEADER([silo.h],,AC_MSG_ERROR([Silo enabled but could not find working silo.h]))
 
-  AC_MSG_CHECKING([for Silo version >= 4.9.1])
+  AC_MSG_CHECKING([for Silo version >= 4.11])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <silo.h>
   ]], [[
-#if SILO_VERSION_GE(4,9,1)
+#if SILO_VERSION_GE(4,11,0)
 #else
 asdf
 #endif
@@ -90,8 +90,7 @@ asdf
 
   AC_MSG_RESULT([${SILO_VERSION_VALID}])
   if test "$SILO_VERSION_VALID" = no; then
-    AC_MSG_WARN([Silo versions prior to 4.9.1 are likely to be usable but are not officially supported])
-    AC_MSG_WARN([suggest upgrading to Silo 4.9.1])
+    AC_MSG_ERROR([invalid SILO version detected: please use SILO 4.11 or newer])
   fi
 
   LDFLAGS_PREPEND($SILO_LDFLAGS)


### PR DESCRIPTION
Two small build system fixes:
1. Fix some issues with boost that only occur when the user installs boost on their own in a non-system directory
2. Enforce using SILO 4.11 or newer. I saw someone use SILO 4.10 last week, which is not compatible with IBAMR - it is not const-correct so we get compilation errors.