### PR TITLE
Refactor pre and post timestep

### DIFF
--- a/include/ibamr/IBInterpolantHierarchyIntegrator.h
+++ b/include/ibamr/IBInterpolantHierarchyIntegrator.h
@@ -55,7 +55,7 @@ namespace IBAMR
  * \brief Class IBInterpolantHierarchyIntegrator is an implementation of Brinkman
  * penalization immersed boundary method.
  */
-class IBInterpolantHierarchyIntegrator : public IBAMR::IBHierarchyIntegrator
+class IBInterpolantHierarchyIntegrator : public IBHierarchyIntegrator
 {
 public:
     /*!

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -219,20 +219,6 @@ IBImplicitStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
     // Initialize IB data.
     d_ib_implicit_ops->preprocessIntegrateData(current_time, new_time, num_cycles);
 
-    // Initialize the fluid solver.
-    const int ins_num_cycles = d_ins_hier_integrator->getNumberOfCycles();
-    if (ins_num_cycles != d_current_num_cycles && d_current_num_cycles != 1)
-    {
-        TBOX_ERROR(d_object_name << "::preprocessIntegrateHierarchy():\n"
-                                 << "  attempting to perform " << d_current_num_cycles
-                                 << " cycles of fixed point iteration.\n"
-                                 << "  number of cycles required by Navier-Stokes solver = " << ins_num_cycles << ".\n"
-                                 << "  current implementation requires either that both solvers "
-                                    "use the same number of cycles,\n"
-                                 << "  or that the IB solver use only a single cycle.\n");
-    }
-    d_ins_hier_integrator->preprocessIntegrateHierarchy(current_time, new_time, ins_num_cycles);
-
     // Compute an initial prediction of the updated positions of the Lagrangian
     // structure.
     //

--- a/src/IB/IBInterpolantHierarchyIntegrator.cpp
+++ b/src/IB/IBInterpolantHierarchyIntegrator.cpp
@@ -103,26 +103,10 @@ IBInterpolantHierarchyIntegrator::preprocessIntegrateHierarchy(const double curr
                                                                const double new_time,
                                                                const int num_cycles)
 {
+    // preprocess our dependencies...
     IBHierarchyIntegrator::preprocessIntegrateHierarchy(current_time, new_time, num_cycles);
 
-    const int coarsest_level_num = 0;
-    const int finest_level_num = d_hierarchy->getFinestLevelNumber();
-
-    // Allocate Eulerian scratch and new data.
-    for (int level_num = coarsest_level_num; level_num <= finest_level_num; ++level_num)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(level_num);
-        level->allocatePatchData(d_scratch_data, current_time);
-        level->allocatePatchData(d_new_data, new_time);
-    }
-
-    // Initialize IB data.
-    d_ib_method_ops->preprocessIntegrateData(current_time, new_time, num_cycles);
-
-    // Initialize the fluid solver.
-    d_ins_hier_integrator->preprocessIntegrateHierarchy(current_time, new_time, num_cycles);
-
-    // At initial time interpolate Q.
+    // ... and preprocess objects owned by this class.
     bool initial_time = IBTK::abs_equal_eps(current_time, 0.0);
     if (initial_time) d_ib_interpolant_method_ops->interpolateQ();
 


### PR DESCRIPTION
We need to move a few things around to get marker points working. In particular - if a class sets up an object in `preprocess` it should be responsible for it in `postprocess` and classes should be responsible for managing their own class members. Hence - this patch moves a bunch of stuff down to `IBHierarchyIntegrator`, which will make it simpler to implement marker points as we can compute them from the INS hierarchy integrator before it gets reset.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?