### PR TITLE
CarmanKozenyDragForce

### DIFF
--- a/include/ibamr/BrinkmanPenalizationRigidBodyDynamics.h
+++ b/include/ibamr/BrinkmanPenalizationRigidBodyDynamics.h
@@ -62,8 +62,8 @@ namespace IBAMR
  * variable-coefficient INS solvers of INSVCStaggeredHierarchyIntegrator. This
  * is done in the BrinkmanPenalizationRigidBodyDynamics::demarcateBrinkmanZone
  * method. Here \f$ \chi \f$ is the body indicator function and \f$\kappa \sim
- * \Delta t/ \rho \ll 1 \f$ is the vanishing permeability of the body. The
- * rigid body velocity \f$\bm{u}_b\f$ is computed through Newton's law of
+ * (\Delta t/ \rho + h^2/\mu) \ll 1 \f$ is the vanishing permeability of the body.
+ * The rigid body velocity \f$\bm{u}_b\f$ is computed through Newton's law of
  * motion by netting the hydrodynamic and external forces and torques on the
  * body in the BrinkmanPenalizationRigidBodyDynamics::computeBrinkmanVelocity
  * method. A simple forward-Euler scheme is employed for the second-law of

--- a/include/ibamr/BrinkmanPenalizationStrategy.h
+++ b/include/ibamr/BrinkmanPenalizationStrategy.h
@@ -20,6 +20,8 @@
 
 #include <ibamr/config.h>
 
+#include "ibtk/ibtk_utilities.h"
+
 #include "tbox/Database.h"
 #include "tbox/Pointer.h"
 #include "tbox/Serializable.h"
@@ -79,9 +81,16 @@ public:
     virtual void postprocessComputeBrinkmanPenalization(double current_time, double new_time, int num_cycles);
 
     /*!
-     * \brief Set Brinkman penalization penalty factor.
+     * \brief Set the Brinkman penalization coefficient.
+     *
+     * @deprecated Use setBrinkmanPenaltyFactor() instead.
      */
     virtual void setBrinkmanCoefficient(double chi);
+
+    /*!
+     * \brief Set Brinkman penalization penalty factor.
+     */
+    virtual void setBrinkmanPenaltyFactor(double penalty_factor);
 
     /*!
      * \brief Write out object state to the given database.
@@ -100,10 +109,23 @@ public:
 
     /*
      * \brief Get the Brinkman coefficient.
+     *
+     * @deprecated Use getBrinkmanPenaltyFactor() instead.
+     *
      */
     double getBrinkmanCoefficient() const
     {
-        return d_chi;
+        IBTK_DEPRECATED_MEMBER_FUNCTION2(
+            "BrinkmanPenalizationStrategy", "getBrinkmanCoefficient", "getBrinkmanPenaltyFactor");
+        return d_penalty_factor;
+    } // getBrinkmanCoefficient
+
+    /*
+     * \brief Get the Brinkman coefficient.
+     */
+    double getBrinkmanPenaltyFactor() const
+    {
+        return d_penalty_factor;
     } // getBrinkmanPenaltyFactor
 
     /*
@@ -134,9 +156,20 @@ protected:
            d_new_time = std::numeric_limits<double>::quiet_NaN();
 
     /*
-     * Brinkman coefficient.
+     * Factor to be multiplied with the penalty term.
      */
-    double d_chi = 1e8;
+    double d_penalty_factor = 1.0;
+
+    /*
+     * Boolean to use the inertial scale \f$ \rho/\Delta t \f$ as the penalty value.
+     * By default inertia scale is used.
+     */
+    bool d_use_rho_scale = true;
+
+    /*
+     * Boolean to use the viscous scale \f$ \mu/h^2 \f$ as the penalty value.
+     */
+    bool d_use_mu_scale = false;
 
 private:
     /*!

--- a/include/ibamr/CarmanKozenyDragForce.h
+++ b/include/ibamr/CarmanKozenyDragForce.h
@@ -1,0 +1,169 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2019 - 2021 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+/////////////////////////////// INCLUDE GUARD ////////////////////////////////
+
+#ifndef included_CarmanKozenyDragForce
+#define included_CarmanKozenyDragForce
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include "ibamr/BrinkmanPenalizationStrategy.h"
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace IBAMR
+{
+class INSVCStaggeredHierarchyIntegrator;
+class AdvDiffHierarchyIntegrator;
+} // namespace IBAMR
+namespace SAMRAI
+{
+namespace pdat
+{
+template <int DIM, class TYPE>
+class CellVariable;
+} // namespace pdat
+} // namespace SAMRAI
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+namespace IBAMR
+{
+/*!
+ * \brief CarmanKozenyDragForce provides an implementation of Carman-Kozeny drag force
+ * to impose zero velocity inside the solid \f$ \bm{u}=\bm{u}_b = 0\f$.
+ *
+ * The penalization force is taken to be \f$ A_d(\bm{u}_b - \bm{u}^{n+1}) \f$. The class
+ * computes the coefficient \f$A_d \f$ of the fluid velocity \f$ \bm{u}^{n+1} \f$ for the
+ * variable-coefficient INS solvers of INSVCStaggeredHierarchyIntegrator. This is done in
+ * the CarmanKozenyDragForce::demarcateBrinkmanZone method. Here \f$ A_d =
+ * C_d\frac{\alpha_S}{(1-alpha_S)^3+e_d}\f$, \f$ \alpha_S \f$ is the volume fraction of
+ * the solid, \f$ C_d\f$ and  \f$ e_d\f$ are the model parameters. The rigid body velocity
+ * \f$\bm{u}_b\f$ is taken to be zero. The penalty
+ * parameter C_d is taken to be \f$C_d = ( \rho / \Delta t + \mu / h^2)\f$. The user can choose
+ * the density or the inertia scale or both for \f$C_d\f$ through input.
+ */
+class CarmanKozenyDragForce : public BrinkmanPenalizationStrategy
+{
+public:
+    /*
+     * \brief Constructor of the class.
+     */
+    CarmanKozenyDragForce(std::string object_name,
+                          SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > H_var,
+                          SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > lf_var,
+                          SAMRAI::tbox::Pointer<IBAMR::AdvDiffHierarchyIntegrator> adv_diff_solver,
+                          SAMRAI::tbox::Pointer<IBAMR::INSVCStaggeredHierarchyIntegrator> fluid_solver,
+                          SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db = nullptr,
+                          bool register_for_restart = true);
+
+    /*
+     * \brief Destructor of the class.
+     */
+    ~CarmanKozenyDragForce() = default;
+
+    /*!
+     * \brief Preprocess routine before computing Carman-Kozeny term.
+     *
+     */
+    void preprocessComputeBrinkmanPenalization(double current_time, double new_time, int num_cycles) override;
+
+    /*!
+     * \brief Compute the desired rigid body velocity in the Brinkman penalized (solid) zone. The present
++    * implementation sets rigid body velocity to be zero.
+     */
+    void computeBrinkmanVelocity(int u_idx, double time, int cycle_num) override;
+
+    /*!
+     * \brief Demarcate the Brinkman zone (solid) with Carman-Kozeny term term.
+     */
+    void demarcateBrinkmanZone(int u_idx, double time, int cycle_num) override;
+
+    /*!
+     * \brief Postprocess routine after computing Brinkman penalization terms.
+     */
+    void postprocessComputeBrinkmanPenalization(double current_time, double new_time, int num_cycles) override;
+
+    /*!
+     * \brief Write out object state to the given database.
+     */
+    void putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
+
+protected:
+    /*!
+     * \brief Pointers to solvers.
+     */
+    SAMRAI::tbox::Pointer<IBAMR::AdvDiffHierarchyIntegrator> d_adv_diff_solver;
+    SAMRAI::tbox::Pointer<IBAMR::INSVCStaggeredHierarchyIntegrator> d_fluid_solver;
+
+    /*!
+     * \brief Heaviside variable defining the gas-pcm interface.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_H_var;
+
+    /*!
+     * \brief Liquid fraction variable.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_lf_var;
+
+    /*!
+     * \brief Number of interface cells to compute the Heaviside function.
+     */
+    double d_num_interface_cells = 2.0;
+
+private:
+    /*!
+     * \brief Copy constructor.
+     *
+     * \note This constructor is not implemented and should not be used.
+     *
+     * \param from The value to copy to this object.
+     */
+    CarmanKozenyDragForce(const CarmanKozenyDragForce& from) = delete;
+
+    /*!
+     * \brief Assignment operator.
+     *
+     * \note This operator is not implemented and should not be used.
+     *
+     * \param that The value to assign to this object.
+     *
+     * \return A reference to this object.
+     */
+    CarmanKozenyDragForce& operator=(const CarmanKozenyDragForce& that) = delete;
+
+    /*!
+     * \brief Get options from input database.
+     */
+    /*!
+     * Read input values from a given database.
+     */
+    void getFromInput(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db, bool is_from_restart);
+
+    /*!
+     * Read object state from the restart file and initialize class data
+     * members.
+     */
+    void getFromRestart();
+
+    /*!
+     * Constant added to avoid zero division.
+     */
+    double d_ed = 1e-3;
+};
+
+} // namespace IBAMR
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif //#ifndef included_CarmanKozenyDragForce

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -50,6 +50,7 @@ DIM_INDEPENDENT_SOURCES = \
 ../src/IB/BrinkmanAdvDiffBcHelper.cpp \
 ../src/IB/BrinkmanPenalizationRigidBodyDynamics.cpp \
 ../src/IB/BrinkmanPenalizationStrategy.cpp \
+../src/IB/CarmanKozenyDragForce.cpp \
 ../src/IB/CIBMethod.cpp \
 ../src/IB/CIBMobilitySolver.cpp \
 ../src/IB/CIBSaddlePointSolver.cpp \
@@ -230,6 +231,7 @@ pkg_include_HEADERS += \
 ../include/ibamr/CIBStaggeredStokesOperator.h \
 ../include/ibamr/CIBStaggeredStokesSolver.h \
 ../include/ibamr/CIBStrategy.h \
+../include/ibamr/CarmanKozenyDragForce.h \
 ../include/ibamr/ConstraintIBKinematics.h \
 ../include/ibamr/ConstraintIBMethod.h \
 ../include/ibamr/ConvectiveOperator.h \

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -199,7 +199,8 @@ libIBAMR2d_a_LIBADD =
 am__libIBAMR2d_a_SOURCES_DIST = ../src/IB/BrinkmanAdvDiffBcHelper.cpp \
 	../src/IB/BrinkmanPenalizationRigidBodyDynamics.cpp \
 	../src/IB/BrinkmanPenalizationStrategy.cpp \
-	../src/IB/CIBMethod.cpp ../src/IB/CIBMobilitySolver.cpp \
+	../src/IB/CarmanKozenyDragForce.cpp ../src/IB/CIBMethod.cpp \
+	../src/IB/CIBMobilitySolver.cpp \
 	../src/IB/CIBSaddlePointSolver.cpp \
 	../src/IB/CIBStaggeredStokesOperator.cpp \
 	../src/IB/CIBStaggeredStokesSolver.cpp \
@@ -378,6 +379,7 @@ am__objects_2 =  \
 	../src/IB/libIBAMR2d_a-BrinkmanAdvDiffBcHelper.$(OBJEXT) \
 	../src/IB/libIBAMR2d_a-BrinkmanPenalizationRigidBodyDynamics.$(OBJEXT) \
 	../src/IB/libIBAMR2d_a-BrinkmanPenalizationStrategy.$(OBJEXT) \
+	../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.$(OBJEXT) \
 	../src/IB/libIBAMR2d_a-CIBMethod.$(OBJEXT) \
 	../src/IB/libIBAMR2d_a-CIBMobilitySolver.$(OBJEXT) \
 	../src/IB/libIBAMR2d_a-CIBSaddlePointSolver.$(OBJEXT) \
@@ -543,7 +545,8 @@ libIBAMR3d_a_LIBADD =
 am__libIBAMR3d_a_SOURCES_DIST = ../src/IB/BrinkmanAdvDiffBcHelper.cpp \
 	../src/IB/BrinkmanPenalizationRigidBodyDynamics.cpp \
 	../src/IB/BrinkmanPenalizationStrategy.cpp \
-	../src/IB/CIBMethod.cpp ../src/IB/CIBMobilitySolver.cpp \
+	../src/IB/CarmanKozenyDragForce.cpp ../src/IB/CIBMethod.cpp \
+	../src/IB/CIBMobilitySolver.cpp \
 	../src/IB/CIBSaddlePointSolver.cpp \
 	../src/IB/CIBStaggeredStokesOperator.cpp \
 	../src/IB/CIBStaggeredStokesSolver.cpp \
@@ -722,6 +725,7 @@ am__objects_4 =  \
 	../src/IB/libIBAMR3d_a-BrinkmanAdvDiffBcHelper.$(OBJEXT) \
 	../src/IB/libIBAMR3d_a-BrinkmanPenalizationRigidBodyDynamics.$(OBJEXT) \
 	../src/IB/libIBAMR3d_a-BrinkmanPenalizationStrategy.$(OBJEXT) \
+	../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.$(OBJEXT) \
 	../src/IB/libIBAMR3d_a-CIBMethod.$(OBJEXT) \
 	../src/IB/libIBAMR3d_a-CIBMobilitySolver.$(OBJEXT) \
 	../src/IB/libIBAMR3d_a-CIBSaddlePointSolver.$(OBJEXT) \
@@ -907,6 +911,7 @@ am__depfiles_remade = ../src/$(DEPDIR)/dummy.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStaggeredStokesOperator.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStaggeredStokesSolver.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStrategy.Po \
+	../src/IB/$(DEPDIR)/libIBAMR2d_a-CarmanKozenyDragForce.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-ConstraintIBKinematics.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-ConstraintIBMethod.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-DirectMobilitySolver.Po \
@@ -977,6 +982,7 @@ am__depfiles_remade = ../src/$(DEPDIR)/dummy.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStaggeredStokesOperator.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStaggeredStokesSolver.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStrategy.Po \
+	../src/IB/$(DEPDIR)/libIBAMR3d_a-CarmanKozenyDragForce.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-ConstraintIBKinematics.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-ConstraintIBMethod.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-DirectMobilitySolver.Po \
@@ -1299,6 +1305,7 @@ am__pkg_include_HEADERS_DIST = ../include/ibamr/app_namespaces.h \
 	../include/ibamr/CIBStaggeredStokesOperator.h \
 	../include/ibamr/CIBStaggeredStokesSolver.h \
 	../include/ibamr/CIBStrategy.h \
+	../include/ibamr/CarmanKozenyDragForce.h \
 	../include/ibamr/ConstraintIBKinematics.h \
 	../include/ibamr/ConstraintIBMethod.h \
 	../include/ibamr/ConvectiveOperator.h \
@@ -1722,6 +1729,7 @@ pkg_include_HEADERS = ../include/ibamr/app_namespaces.h \
 	../include/ibamr/CIBStaggeredStokesOperator.h \
 	../include/ibamr/CIBStaggeredStokesSolver.h \
 	../include/ibamr/CIBStrategy.h \
+	../include/ibamr/CarmanKozenyDragForce.h \
 	../include/ibamr/ConstraintIBKinematics.h \
 	../include/ibamr/ConstraintIBMethod.h \
 	../include/ibamr/ConvectiveOperator.h \
@@ -1828,7 +1836,8 @@ pkg_include_HEADERS = ../include/ibamr/app_namespaces.h \
 DIM_INDEPENDENT_SOURCES = ../src/IB/BrinkmanAdvDiffBcHelper.cpp \
 	../src/IB/BrinkmanPenalizationRigidBodyDynamics.cpp \
 	../src/IB/BrinkmanPenalizationStrategy.cpp \
-	../src/IB/CIBMethod.cpp ../src/IB/CIBMobilitySolver.cpp \
+	../src/IB/CarmanKozenyDragForce.cpp ../src/IB/CIBMethod.cpp \
+	../src/IB/CIBMobilitySolver.cpp \
 	../src/IB/CIBSaddlePointSolver.cpp \
 	../src/IB/CIBStaggeredStokesOperator.cpp \
 	../src/IB/CIBStaggeredStokesSolver.cpp \
@@ -2096,6 +2105,8 @@ libIBAMR.a: $(libIBAMR_a_OBJECTS) $(libIBAMR_a_DEPENDENCIES) $(EXTRA_libIBAMR_a_
 ../src/IB/libIBAMR2d_a-BrinkmanPenalizationRigidBodyDynamics.$(OBJEXT):  \
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
 ../src/IB/libIBAMR2d_a-BrinkmanPenalizationStrategy.$(OBJEXT):  \
+	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
+../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.$(OBJEXT):  \
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
 ../src/IB/libIBAMR2d_a-CIBMethod.$(OBJEXT): ../src/IB/$(am__dirstamp) \
 	../src/IB/$(DEPDIR)/$(am__dirstamp)
@@ -2629,6 +2640,8 @@ libIBAMR2d.a: $(libIBAMR2d_a_OBJECTS) $(libIBAMR2d_a_DEPENDENCIES) $(EXTRA_libIB
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
 ../src/IB/libIBAMR3d_a-BrinkmanPenalizationStrategy.$(OBJEXT):  \
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
+../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.$(OBJEXT):  \
+	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
 ../src/IB/libIBAMR3d_a-CIBMethod.$(OBJEXT): ../src/IB/$(am__dirstamp) \
 	../src/IB/$(DEPDIR)/$(am__dirstamp)
 ../src/IB/libIBAMR3d_a-CIBMobilitySolver.$(OBJEXT):  \
@@ -3114,6 +3127,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStaggeredStokesOperator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStaggeredStokesSolver.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStrategy.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-CarmanKozenyDragForce.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-ConstraintIBKinematics.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-ConstraintIBMethod.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-DirectMobilitySolver.Po@am__quote@ # am--include-marker
@@ -3184,6 +3198,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStaggeredStokesOperator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStaggeredStokesSolver.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStrategy.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-CarmanKozenyDragForce.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-ConstraintIBKinematics.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-ConstraintIBMethod.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-DirectMobilitySolver.Po@am__quote@ # am--include-marker
@@ -3487,6 +3502,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/BrinkmanPenalizationStrategy.cpp' object='../src/IB/libIBAMR2d_a-BrinkmanPenalizationStrategy.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR2d_a-BrinkmanPenalizationStrategy.obj `if test -f '../src/IB/BrinkmanPenalizationStrategy.cpp'; then $(CYGPATH_W) '../src/IB/BrinkmanPenalizationStrategy.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/BrinkmanPenalizationStrategy.cpp'; fi`
+
+../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.o: ../src/IB/CarmanKozenyDragForce.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.o -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR2d_a-CarmanKozenyDragForce.Tpo -c -o ../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.o `test -f '../src/IB/CarmanKozenyDragForce.cpp' || echo '$(srcdir)/'`../src/IB/CarmanKozenyDragForce.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR2d_a-CarmanKozenyDragForce.Tpo ../src/IB/$(DEPDIR)/libIBAMR2d_a-CarmanKozenyDragForce.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/CarmanKozenyDragForce.cpp' object='../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.o `test -f '../src/IB/CarmanKozenyDragForce.cpp' || echo '$(srcdir)/'`../src/IB/CarmanKozenyDragForce.cpp
+
+../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.obj: ../src/IB/CarmanKozenyDragForce.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.obj -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR2d_a-CarmanKozenyDragForce.Tpo -c -o ../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.obj `if test -f '../src/IB/CarmanKozenyDragForce.cpp'; then $(CYGPATH_W) '../src/IB/CarmanKozenyDragForce.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/CarmanKozenyDragForce.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR2d_a-CarmanKozenyDragForce.Tpo ../src/IB/$(DEPDIR)/libIBAMR2d_a-CarmanKozenyDragForce.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/CarmanKozenyDragForce.cpp' object='../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR2d_a-CarmanKozenyDragForce.obj `if test -f '../src/IB/CarmanKozenyDragForce.cpp'; then $(CYGPATH_W) '../src/IB/CarmanKozenyDragForce.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/CarmanKozenyDragForce.cpp'; fi`
 
 ../src/IB/libIBAMR2d_a-CIBMethod.o: ../src/IB/CIBMethod.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR2d_a-CIBMethod.o -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBMethod.Tpo -c -o ../src/IB/libIBAMR2d_a-CIBMethod.o `test -f '../src/IB/CIBMethod.cpp' || echo '$(srcdir)/'`../src/IB/CIBMethod.cpp
@@ -5657,6 +5686,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/BrinkmanPenalizationStrategy.cpp' object='../src/IB/libIBAMR3d_a-BrinkmanPenalizationStrategy.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR3d_a-BrinkmanPenalizationStrategy.obj `if test -f '../src/IB/BrinkmanPenalizationStrategy.cpp'; then $(CYGPATH_W) '../src/IB/BrinkmanPenalizationStrategy.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/BrinkmanPenalizationStrategy.cpp'; fi`
+
+../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.o: ../src/IB/CarmanKozenyDragForce.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.o -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR3d_a-CarmanKozenyDragForce.Tpo -c -o ../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.o `test -f '../src/IB/CarmanKozenyDragForce.cpp' || echo '$(srcdir)/'`../src/IB/CarmanKozenyDragForce.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR3d_a-CarmanKozenyDragForce.Tpo ../src/IB/$(DEPDIR)/libIBAMR3d_a-CarmanKozenyDragForce.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/CarmanKozenyDragForce.cpp' object='../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.o `test -f '../src/IB/CarmanKozenyDragForce.cpp' || echo '$(srcdir)/'`../src/IB/CarmanKozenyDragForce.cpp
+
+../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.obj: ../src/IB/CarmanKozenyDragForce.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.obj -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR3d_a-CarmanKozenyDragForce.Tpo -c -o ../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.obj `if test -f '../src/IB/CarmanKozenyDragForce.cpp'; then $(CYGPATH_W) '../src/IB/CarmanKozenyDragForce.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/CarmanKozenyDragForce.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR3d_a-CarmanKozenyDragForce.Tpo ../src/IB/$(DEPDIR)/libIBAMR3d_a-CarmanKozenyDragForce.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/CarmanKozenyDragForce.cpp' object='../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR3d_a-CarmanKozenyDragForce.obj `if test -f '../src/IB/CarmanKozenyDragForce.cpp'; then $(CYGPATH_W) '../src/IB/CarmanKozenyDragForce.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/CarmanKozenyDragForce.cpp'; fi`
 
 ../src/IB/libIBAMR3d_a-CIBMethod.o: ../src/IB/CIBMethod.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR3d_a-CIBMethod.o -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBMethod.Tpo -c -o ../src/IB/libIBAMR3d_a-CIBMethod.o `test -f '../src/IB/CIBMethod.cpp' || echo '$(srcdir)/'`../src/IB/CIBMethod.cpp
@@ -7989,6 +8032,7 @@ distclean: distclean-am
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStaggeredStokesOperator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStaggeredStokesSolver.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStrategy.Po
+	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-CarmanKozenyDragForce.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-ConstraintIBKinematics.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-ConstraintIBMethod.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-DirectMobilitySolver.Po
@@ -8059,6 +8103,7 @@ distclean: distclean-am
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStaggeredStokesOperator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStaggeredStokesSolver.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStrategy.Po
+	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-CarmanKozenyDragForce.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-ConstraintIBKinematics.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-ConstraintIBMethod.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-DirectMobilitySolver.Po
@@ -8345,6 +8390,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStaggeredStokesOperator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStaggeredStokesSolver.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-CIBStrategy.Po
+	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-CarmanKozenyDragForce.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-ConstraintIBKinematics.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-ConstraintIBMethod.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-DirectMobilitySolver.Po
@@ -8415,6 +8461,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStaggeredStokesOperator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStaggeredStokesSolver.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-CIBStrategy.Po
+	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-CarmanKozenyDragForce.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-ConstraintIBKinematics.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-ConstraintIBMethod.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-DirectMobilitySolver.Po

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,6 +135,7 @@ SET(CXX_SRC
   IB/IBInstrumentPanel.cpp
   IB/BrinkmanPenalizationStrategy.cpp
   IB/BrinkmanAdvDiffBcHelper.cpp
+  IB/CarmanKozenyDragForce.cpp
   IB/PenaltyIBMethod.cpp
   IB/GeneralizedIBMethod.cpp
   IB/IBLagrangianForceStrategy.cpp

--- a/src/IB/BrinkmanPenalizationRigidBodyDynamics.cpp
+++ b/src/IB/BrinkmanPenalizationRigidBodyDynamics.cpp
@@ -287,6 +287,9 @@ BrinkmanPenalizationRigidBodyDynamics::computeBrinkmanVelocity(int u_idx, double
     // Get the interpolated density variable
     const int rho_ins_idx = d_fluid_solver->getLinearOperatorRhoPatchDataIndex();
 
+    // Get the cell-centered viscosity patch data index. Returns mu_scratch with ghost cells filled.
+    const int mu_ins_idx = d_fluid_solver->getLinearOperatorMuPatchDataIndex();
+
     // Ghost fill the level set values.
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     const int ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
@@ -325,6 +328,7 @@ BrinkmanPenalizationRigidBodyDynamics::computeBrinkmanVelocity(int u_idx, double
         Pointer<CellData<NDIM, double> > ls_solid_data = patch->getPatchData(ls_scratch_idx);
         Pointer<SideData<NDIM, double> > u_data = patch->getPatchData(u_idx);
         Pointer<SideData<NDIM, double> > rho_data = patch->getPatchData(rho_ins_idx);
+        Pointer<CellData<NDIM, double> > mu_data = patch->getPatchData(mu_ins_idx);
         TBOX_ASSERT((ls_solid_data->getGhostCellWidth()).min() >= 1);
 
         for (unsigned int axis = 0; axis < NDIM; ++axis)
@@ -342,7 +346,22 @@ BrinkmanPenalizationRigidBodyDynamics::computeBrinkmanVelocity(int u_idx, double
                     const Eigen::Vector3d r = IBTK::IndexUtilities::getSideCenter<Eigen::Vector3d>(*patch, s_i);
                     const Eigen::Vector3d dr = r - d_center_of_mass_new;
                     const Eigen::Vector3d Wxdr = d_rot_vel_new.cross(dr);
-                    const double penalty = (*rho_data)(s_i) / dt;
+
+                    double penalty_rho_scale = 0.0, penalty_mu_scale = 0.0;
+                    if (d_use_rho_scale)
+                    {
+                        penalty_rho_scale = (*rho_data)(s_i) / dt;
+                    }
+
+                    const double mu_lower = (*mu_data)(s_i.toCell(0));
+                    const double mu_upper = (*mu_data)(s_i.toCell(1));
+                    const double mu = 0.5 * (mu_lower + mu_upper);
+                    if (d_use_mu_scale)
+                    {
+                        penalty_mu_scale = mu / std::pow(patch_dx[0], 2.0);
+                    }
+                    const double penalty = d_penalty_factor * (penalty_rho_scale + penalty_mu_scale);
+
                     (*u_data)(s_i) = d_trans_vel_new(axis) + Wxdr(axis);
                     (*u_data)(s_i) *= (1.0 - Hphi) * penalty;
                 }
@@ -366,6 +385,9 @@ BrinkmanPenalizationRigidBodyDynamics::demarcateBrinkmanZone(int u_idx, double t
 
     // Get the interpolated density variable
     const int rho_ins_idx = d_fluid_solver->getLinearOperatorRhoPatchDataIndex();
+
+    // Get the cell-centered viscosity patch data index. Returns mu_scratch with ghost cells filled.
+    const int mu_ins_idx = d_fluid_solver->getLinearOperatorMuPatchDataIndex();
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     const int ls_solid_idx = var_db->mapVariableAndContextToIndex(d_ls_solid_var, d_adv_diff_solver->getNewContext());
@@ -403,6 +425,7 @@ BrinkmanPenalizationRigidBodyDynamics::demarcateBrinkmanZone(int u_idx, double t
         Pointer<CellData<NDIM, double> > ls_solid_data = patch->getPatchData(ls_scratch_idx);
         Pointer<SideData<NDIM, double> > u_data = patch->getPatchData(u_idx);
         Pointer<SideData<NDIM, double> > rho_data = patch->getPatchData(rho_ins_idx);
+        Pointer<CellData<NDIM, double> > mu_data = patch->getPatchData(mu_ins_idx);
 
         for (unsigned int axis = 0; axis < NDIM; ++axis)
         {
@@ -416,7 +439,21 @@ BrinkmanPenalizationRigidBodyDynamics::demarcateBrinkmanZone(int u_idx, double t
                 const double Hphi = IBTK::smooth_heaviside(phi, alpha);
                 if (phi <= alpha)
                 {
-                    const double penalty = (*rho_data)(s_i) / dt;
+                    double penalty_rho_scale = 0.0, penalty_mu_scale = 0.0;
+                    if (d_use_rho_scale)
+                    {
+                        penalty_rho_scale = (*rho_data)(s_i) / dt;
+                    }
+
+                    const double mu_lower = (*mu_data)(s_i.toCell(0));
+                    const double mu_upper = (*mu_data)(s_i.toCell(1));
+                    const double mu = 0.5 * (mu_lower + mu_upper);
+                    if (d_use_mu_scale)
+                    {
+                        penalty_mu_scale = mu / std::pow(patch_dx[0], 2.0);
+                    }
+
+                    const double penalty = d_penalty_factor * (penalty_rho_scale + penalty_mu_scale);
                     (*u_data)(s_i) = (1.0 - Hphi) * penalty;
                 }
             }
@@ -458,6 +495,11 @@ BrinkmanPenalizationRigidBodyDynamics::putToDatabase(Pointer<Database> db)
     db->putDoubleArray(Q, &Q_coeffs[0], 4);
     db->putDouble(M, d_mass);
 
+    db->putDouble("d_num_interface_cells", d_num_interface_cells);
+    db->putDouble("d_penalty_factor", d_penalty_factor);
+    db->putBool("d_use_rho_scale", d_use_rho_scale);
+    db->putBool("d_use_mu_scale", d_use_mu_scale);
+
     return;
 } // postprocessComputeBrinkmanVelocity
 
@@ -479,20 +521,32 @@ BrinkmanPenalizationRigidBodyDynamics::getFromInput(Pointer<Database> input_db, 
         d_quaternion_current.normalize();
         d_quaternion_new = d_quaternion_current;
     }
-
-    if (input_db->keyExists("chi"))
+    if (!is_from_restart)
     {
-        d_chi = input_db->getDouble("chi");
-    }
+        if (input_db->keyExists("penalty_factor"))
+        {
+            d_penalty_factor = input_db->getDouble("penalty_factor");
+        }
 
-    if (input_db->keyExists("contour_level"))
-    {
-        d_contour_level = input_db->getDouble("contour_level");
-    }
+        if (input_db->keyExists("use_rho_scale"))
+        {
+            d_use_rho_scale = input_db->getBool("use_rho_scale");
+        }
 
-    if (input_db->keyExists("num_interface_cells"))
-    {
-        d_num_interface_cells = input_db->getDouble("num_interface_cells");
+        if (input_db->keyExists("use_mu_scale"))
+        {
+            d_use_mu_scale = input_db->getBool("use_mu_scale");
+        }
+
+        if (input_db->keyExists("contour_level"))
+        {
+            d_contour_level = input_db->getDouble("contour_level");
+        }
+
+        if (input_db->keyExists("num_interface_cells"))
+        {
+            d_num_interface_cells = input_db->getDouble("num_interface_cells");
+        }
     }
 
     return;
@@ -531,6 +585,11 @@ BrinkmanPenalizationRigidBodyDynamics::getFromRestart()
     d_quaternion_current.y() = Q_coeffs[2];
     d_quaternion_current.z() = Q_coeffs[3];
     d_quaternion_current.normalize();
+
+    d_num_interface_cells = db->getDouble("d_num_interface_cells");
+    d_penalty_factor = db->getDouble("d_penalty_factor");
+    d_use_rho_scale = db->getBool("d_use_rho_scale");
+    d_use_mu_scale = db->getBool("d_use_mu_scale");
 
     return;
 } // getFromRestart

--- a/src/IB/BrinkmanPenalizationStrategy.cpp
+++ b/src/IB/BrinkmanPenalizationStrategy.cpp
@@ -80,9 +80,18 @@ void BrinkmanPenalizationStrategy::putToDatabase(Pointer<Database> /*db*/)
 void
 BrinkmanPenalizationStrategy::setBrinkmanCoefficient(double chi)
 {
-    d_chi = chi;
+    IBTK_DEPRECATED_MEMBER_FUNCTION2(
+        "BrinkmanPenalizationStrategy", "setBrinkmanCoefficient", "setBrinkmanPenaltyFactor");
+    d_penalty_factor = chi;
     return;
 } // setBrinkmanCoefficient
+
+void
+BrinkmanPenalizationStrategy::setBrinkmanPenaltyFactor(double penalty_factor)
+{
+    d_penalty_factor = penalty_factor;
+    return;
+} // setBrinkmanPenaltyFactor
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 

--- a/src/IB/CarmanKozenyDragForce.cpp
+++ b/src/IB/CarmanKozenyDragForce.cpp
@@ -1,0 +1,377 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2019 - 2021 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include "ibamr/AdvDiffHierarchyIntegrator.h"
+#include "ibamr/BrinkmanPenalizationStrategy.h"
+#include "ibamr/CarmanKozenyDragForce.h"
+#include "ibamr/INSVCStaggeredHierarchyIntegrator.h"
+
+#include "ibtk/IndexUtilities.h"
+#include "ibtk/ibtk_utilities.h"
+
+#include "Box.h"
+#include "CartesianPatchGeometry.h"
+#include "CellData.h"
+#include "CellVariable.h"
+#include "HierarchyCellDataOpsReal.h"
+#include "IntVector.h"
+#include "Patch.h"
+#include "PatchHierarchy.h"
+#include "PatchLevel.h"
+#include "RefineAlgorithm.h"
+#include "RefineOperator.h"
+#include "RefineSchedule.h"
+#include "SideData.h"
+#include "SideGeometry.h"
+#include "SideIndex.h"
+#include "Variable.h"
+#include "VariableContext.h"
+#include "VariableDatabase.h"
+#include "tbox/Database.h"
+#include "tbox/MathUtilities.h"
+#include "tbox/Pointer.h"
+#include "tbox/RestartManager.h"
+#include "tbox/Utilities.h"
+
+#include <cmath>
+#include <string>
+#include <utility>
+
+#include "ibamr/app_namespaces.h" // IWYU pragma: keep
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace IBAMR
+{
+/////////////////////////////// PUBLIC //////////////////////////////////////
+CarmanKozenyDragForce::CarmanKozenyDragForce(std::string object_name,
+                                             Pointer<CellVariable<NDIM, double> > H_var,
+                                             Pointer<CellVariable<NDIM, double> > lf_var,
+                                             Pointer<AdvDiffHierarchyIntegrator> adv_diff_solver,
+                                             Pointer<INSVCStaggeredHierarchyIntegrator> fluid_solver,
+                                             Pointer<Database> input_db,
+                                             bool register_for_restart)
+    : BrinkmanPenalizationStrategy(std::move(object_name), register_for_restart),
+      d_adv_diff_solver(adv_diff_solver),
+      d_fluid_solver(fluid_solver),
+      d_H_var(H_var),
+      d_lf_var(lf_var)
+{
+    // Initialize object with data read from the input and restart databases.
+    bool from_restart = RestartManager::getManager()->isFromRestart();
+    if (from_restart) getFromRestart();
+    if (input_db) getFromInput(input_db, from_restart);
+
+    return;
+} // CarmanKozenyDragForce
+
+void
+CarmanKozenyDragForce::preprocessComputeBrinkmanPenalization(double current_time, double new_time, int num_cycles)
+{
+    BrinkmanPenalizationStrategy::preprocessComputeBrinkmanPenalization(current_time, new_time, num_cycles);
+    return;
+} // preprocessComputeBrinkmanPenalization
+
+void
+CarmanKozenyDragForce::computeBrinkmanVelocity(int u_idx, double time, int /*cycle_num*/)
+{
+#if !defined(NDEBUG)
+    TBOX_ASSERT(MathUtilities<double>::equalEps(time, d_new_time));
+#endif
+    const double dt = d_new_time - d_current_time;
+
+    // Get the interpolated density variable
+    const int rho_ins_idx = d_fluid_solver->getLinearOperatorRhoPatchDataIndex();
+
+    // Get the cell-centered viscosity patch data index. Returns mu_scratch with ghost cells filled.
+    const int mu_ins_idx = d_fluid_solver->getLinearOperatorMuPatchDataIndex();
+
+    // Ghost fill the heaviside and liquid fraction values.
+    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
+    const int H_idx = var_db->mapVariableAndContextToIndex(d_H_var, d_adv_diff_solver->getNewContext());
+    const int H_scratch_idx = var_db->mapVariableAndContextToIndex(d_H_var, d_adv_diff_solver->getScratchContext());
+
+    const int lf_new_idx = var_db->mapVariableAndContextToIndex(d_lf_var, d_adv_diff_solver->getNewContext());
+    const int lf_scratch_idx = var_db->mapVariableAndContextToIndex(d_lf_var, d_adv_diff_solver->getScratchContext());
+
+    Pointer<PatchHierarchy<NDIM> > patch_hierarchy = d_adv_diff_solver->getPatchHierarchy();
+    int finest_ln = patch_hierarchy->getFinestLevelNumber();
+    Pointer<PatchLevel<NDIM> > finest_level = patch_hierarchy->getPatchLevel(finest_ln);
+
+    typedef HierarchyGhostCellInterpolation::InterpolationTransactionComponent InterpolationTransactionComponent;
+    std::vector<InterpolationTransactionComponent> phi_transaction_comps(2);
+    phi_transaction_comps[0] = InterpolationTransactionComponent(H_scratch_idx,
+                                                                 H_idx,
+                                                                 "CONSERVATIVE_LINEAR_REFINE",
+                                                                 false,
+                                                                 "CONSERVATIVE_COARSEN",
+                                                                 "LINEAR",
+                                                                 false,
+                                                                 d_adv_diff_solver->getPhysicalBcCoefs(d_H_var));
+
+    // Using levelset bc for liquid fraction.
+    phi_transaction_comps[1] = InterpolationTransactionComponent(lf_scratch_idx,
+                                                                 lf_new_idx,
+                                                                 "CONSERVATIVE_LINEAR_REFINE",
+                                                                 false,
+                                                                 "CONSERVATIVE_COARSEN",
+                                                                 "LINEAR",
+                                                                 false,
+                                                                 d_adv_diff_solver->getPhysicalBcCoefs(d_H_var));
+
+    Pointer<HierarchyGhostCellInterpolation> hier_bdry_fill = new HierarchyGhostCellInterpolation();
+    hier_bdry_fill->initializeOperatorState(phi_transaction_comps, patch_hierarchy);
+    hier_bdry_fill->fillData(time);
+
+    // Set the rigid body velocity in u_idx
+    for (PatchLevel<NDIM>::Iterator p(finest_level); p; p++)
+    {
+        Pointer<Patch<NDIM> > patch = finest_level->getPatch(p());
+        const Box<NDIM>& patch_box = patch->getBox();
+        Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
+        const double* const patch_dx = patch_geom->getDx();
+
+        Pointer<CellData<NDIM, double> > H_data = patch->getPatchData(H_scratch_idx);
+        Pointer<CellData<NDIM, double> > lf_data = patch->getPatchData(lf_scratch_idx);
+        Pointer<SideData<NDIM, double> > u_data = patch->getPatchData(u_idx);
+        Pointer<SideData<NDIM, double> > rho_data = patch->getPatchData(rho_ins_idx);
+        Pointer<CellData<NDIM, double> > mu_data = patch->getPatchData(mu_ins_idx);
+
+        for (unsigned int axis = 0; axis < NDIM; ++axis)
+        {
+            for (Box<NDIM>::Iterator it(SideGeometry<NDIM>::toSideBox(patch_box, axis)); it; it++)
+            {
+                SideIndex<NDIM> s_i(it(), axis, SideIndex<NDIM>::Lower);
+
+                const double H_lower = (*H_data)(s_i.toCell(0));
+                const double H_upper = (*H_data)(s_i.toCell(1));
+                const double H = 0.5 * (H_lower + H_upper);
+
+                const double lf_lower = (*lf_data)(s_i.toCell(0));
+                const double lf_upper = (*lf_data)(s_i.toCell(1));
+                const double liquid_fraction = 0.5 * (lf_lower + lf_upper);
+
+                const double alpha_s = H * (1.0 - liquid_fraction);
+
+                double penalty_rho_scale = 0.0, penalty_mu_scale = 0.0;
+                if (d_use_rho_scale)
+                {
+                    penalty_rho_scale = (*rho_data)(s_i) / dt;
+                }
+
+                if (d_use_mu_scale)
+                {
+                    const double mu_lower = (*mu_data)(s_i.toCell(0));
+                    const double mu_upper = (*mu_data)(s_i.toCell(1));
+                    const double mu = 0.5 * (mu_lower + mu_upper);
+                    penalty_mu_scale = mu / std::pow(patch_dx[0], 2.0);
+                }
+                const double penalty = d_penalty_factor * (penalty_rho_scale + penalty_mu_scale);
+
+                const double solid_velocity = 0.0;
+
+                (*u_data)(s_i) = solid_velocity * penalty * alpha_s * alpha_s / (std::pow(1.0 - alpha_s, 3.0) + d_ed);
+            }
+        }
+    }
+
+    return;
+} // computeBrinkmanVelocity
+
+void
+CarmanKozenyDragForce::demarcateBrinkmanZone(int u_idx, double time, int /*cycle_num*/)
+{
+#if !defined(NDEBUG)
+    TBOX_ASSERT(MathUtilities<double>::equalEps(time, d_new_time));
+#else
+    NULL_USE(time);
+#endif
+
+    const double dt = d_new_time - d_current_time;
+
+    // Get the interpolated density variable
+    const int rho_ins_idx = d_fluid_solver->getLinearOperatorRhoPatchDataIndex();
+
+    // Get the cell-centered viscosity patch data index. Returns mu_scratch with ghost cells filled.
+    const int mu_ins_idx = d_fluid_solver->getLinearOperatorMuPatchDataIndex();
+
+    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
+    const int H_idx = var_db->mapVariableAndContextToIndex(d_H_var, d_adv_diff_solver->getNewContext());
+    const int H_scratch_idx = var_db->mapVariableAndContextToIndex(d_H_var, d_adv_diff_solver->getScratchContext());
+
+    const int lf_new_idx = var_db->mapVariableAndContextToIndex(d_lf_var, d_adv_diff_solver->getNewContext());
+    const int lf_scratch_idx = var_db->mapVariableAndContextToIndex(d_lf_var, d_adv_diff_solver->getScratchContext());
+
+    Pointer<PatchHierarchy<NDIM> > patch_hierarchy = d_adv_diff_solver->getPatchHierarchy();
+
+    // Ghost fill the level set values.
+    typedef HierarchyGhostCellInterpolation::InterpolationTransactionComponent InterpolationTransactionComponent;
+    std::vector<InterpolationTransactionComponent> phi_transaction_comps(2);
+    phi_transaction_comps[0] = InterpolationTransactionComponent(H_scratch_idx,
+                                                                 H_idx,
+                                                                 "CONSERVATIVE_LINEAR_REFINE",
+                                                                 false,
+                                                                 "CONSERVATIVE_COARSEN",
+                                                                 "LINEAR",
+                                                                 false,
+                                                                 d_adv_diff_solver->getPhysicalBcCoefs(d_H_var));
+
+    // Using levelset bc for liquid fraction.
+    phi_transaction_comps[1] = InterpolationTransactionComponent(lf_scratch_idx,
+                                                                 lf_new_idx,
+                                                                 "CONSERVATIVE_LINEAR_REFINE",
+                                                                 false,
+                                                                 "CONSERVATIVE_COARSEN",
+                                                                 "LINEAR",
+                                                                 false,
+                                                                 d_adv_diff_solver->getPhysicalBcCoefs(d_H_var));
+
+    Pointer<HierarchyGhostCellInterpolation> hier_bdry_fill = new HierarchyGhostCellInterpolation();
+    hier_bdry_fill->initializeOperatorState(phi_transaction_comps, patch_hierarchy);
+    hier_bdry_fill->fillData(time);
+
+    int finest_ln = patch_hierarchy->getFinestLevelNumber();
+    Pointer<PatchLevel<NDIM> > finest_level = patch_hierarchy->getPatchLevel(finest_ln);
+    for (PatchLevel<NDIM>::Iterator p(finest_level); p; p++)
+    {
+        Pointer<Patch<NDIM> > patch = finest_level->getPatch(p());
+        const Box<NDIM>& patch_box = patch->getBox();
+        Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
+        const double* const patch_dx = patch_geom->getDx();
+
+        Pointer<CellData<NDIM, double> > H_data = patch->getPatchData(H_scratch_idx);
+        Pointer<CellData<NDIM, double> > lf_data = patch->getPatchData(lf_scratch_idx);
+        Pointer<SideData<NDIM, double> > u_data = patch->getPatchData(u_idx);
+        Pointer<SideData<NDIM, double> > rho_data = patch->getPatchData(rho_ins_idx);
+        Pointer<CellData<NDIM, double> > mu_data = patch->getPatchData(mu_ins_idx);
+
+        for (unsigned int axis = 0; axis < NDIM; ++axis)
+        {
+            for (Box<NDIM>::Iterator it(SideGeometry<NDIM>::toSideBox(patch_box, axis)); it; it++)
+            {
+                SideIndex<NDIM> s_i(it(), axis, SideIndex<NDIM>::Lower);
+
+                const double H_lower = (*H_data)(s_i.toCell(0));
+                const double H_upper = (*H_data)(s_i.toCell(1));
+                const double H = 0.5 * (H_lower + H_upper);
+
+                const double lf_lower = (*lf_data)(s_i.toCell(0));
+                const double lf_upper = (*lf_data)(s_i.toCell(1));
+                const double liquid_fraction = 0.5 * (lf_lower + lf_upper);
+
+                const double alpha_s = H * (1.0 - liquid_fraction);
+                double penalty_rho_scale = 0.0, penalty_mu_scale = 0.0;
+                if (d_use_rho_scale)
+                {
+                    penalty_rho_scale = (*rho_data)(s_i) / dt;
+                }
+
+                if (d_use_mu_scale)
+                {
+                    const double mu_lower = (*mu_data)(s_i.toCell(0));
+                    const double mu_upper = (*mu_data)(s_i.toCell(1));
+                    const double mu = 0.5 * (mu_lower + mu_upper);
+                    penalty_mu_scale = mu / std::pow(patch_dx[0], 2.0);
+                }
+                const double penalty = d_penalty_factor * (penalty_rho_scale + penalty_mu_scale);
+                (*u_data)(s_i) = penalty * alpha_s * alpha_s / (std::pow(1.0 - alpha_s, 3.0) + d_ed);
+            }
+        }
+    }
+
+    return;
+} // demarcateBrinkmanZone
+
+void
+CarmanKozenyDragForce::postprocessComputeBrinkmanPenalization(double current_time, double new_time, int num_cycles)
+{
+    BrinkmanPenalizationStrategy::postprocessComputeBrinkmanPenalization(current_time, new_time, num_cycles);
+
+    return;
+} // postprocessComputeBrinkmanPenalization
+
+void
+CarmanKozenyDragForce::putToDatabase(Pointer<Database> db)
+{
+    db->putDouble("d_num_interface_cells", d_num_interface_cells);
+    db->putDouble("d_penalty_factor", d_penalty_factor);
+    db->putBool("d_use_rho_scale", d_use_rho_scale);
+    db->putBool("d_use_mu_scale", d_use_mu_scale);
+    db->putDouble("d_ed", d_ed);
+    return;
+} // postprocessComputeBrinkmanVelocity
+
+/////////////////////////////// PRIVATE //////////////////////////////////////
+
+void
+CarmanKozenyDragForce::getFromInput(Pointer<Database> input_db, bool is_from_restart)
+{
+    if (!is_from_restart)
+    {
+        if (input_db->keyExists("num_interface_cells"))
+        {
+            d_num_interface_cells = input_db->getDouble("num_interface_cells");
+        }
+
+        if (input_db->keyExists("penalty_factor"))
+        {
+            d_penalty_factor = input_db->getDouble("penalty_factor");
+        }
+
+        if (input_db->keyExists("use_rho_scale"))
+        {
+            d_use_rho_scale = input_db->getBool("use_rho_scale");
+        }
+
+        if (input_db->keyExists("use_mu_scale"))
+        {
+            d_use_mu_scale = input_db->getBool("use_mu_scale");
+        }
+
+        if (input_db->keyExists("division_by_zero_factor"))
+        {
+            d_ed = input_db->getDouble("division_by_zero_factor");
+        }
+    }
+    return;
+} // getFromInput
+
+void
+CarmanKozenyDragForce::getFromRestart()
+{
+    Pointer<Database> restart_db = RestartManager::getManager()->getRootDatabase();
+    Pointer<Database> db;
+    if (restart_db->isDatabase(d_object_name))
+    {
+        db = restart_db->getDatabase(d_object_name);
+    }
+    else
+    {
+        TBOX_ERROR(d_object_name << ":  Restart database corresponding to " << d_object_name
+                                 << " not found in restart file." << std::endl);
+    }
+    d_num_interface_cells = db->getDouble("d_num_interface_cells");
+    d_penalty_factor = db->getDouble("d_penalty_factor");
+    d_use_rho_scale = db->getBool("d_use_rho_scale");
+    d_use_mu_scale = db->getBool("d_use_mu_scale");
+    d_ed = db->getDouble("d_ed");
+    return;
+} // getFromRestart
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+} // namespace IBAMR
+
+//////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We're making some substantial simplifications to the advection-diffusion integrators in the other branch - meanwhile lets merge some unrelated things.

A few comments:
1. It looks like `H_var` is always the advection-diffusion source term. Is this correct? If so, lets just use `adv_diff->getSourceTerm()` to access the `CellVariable` instead of passing it in.
2. Similarly, which object is responsible for the liquid fraction? We should pass that object instead of passing the variable.
3. Lets add a simple test.

@amneetb want to pick one of your students to wrap this one up? Once its in we can rebase and update the other PRs.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?