### PR TITLE
CI: update to checkout v3.

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -50,7 +50,7 @@ jobs:
       CMAKE_GENERATOR: Unix Makefiles
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         id: git
       - name: Create keys
         id: keys
@@ -157,7 +157,7 @@ jobs:
       CMAKE_GENERATOR: Unix Makefiles
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         id: git
       - name: Create keys
         id: keys
@@ -227,7 +227,7 @@ jobs:
       SCCACHE_CACHE_SIZE: 500M
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         id: git
       - name: Create keys
         id: keys
@@ -304,7 +304,7 @@ jobs:
       CMAKE_GENERATOR: Unix Makefiles
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         id: git
       - name: Create keys
         id: keys
@@ -373,7 +373,7 @@ jobs:
       CMAKE_GENERATOR: Unix Makefiles
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         id: git
       - name: Create keys
         id: keys


### PR DESCRIPTION
This version of `checkout` also fixed some silly bugs with paths - let's keep the workarounds for now since they are more robust.