### PR TITLE
Fix a compilation error.

### DIFF
--- a/src/IB/IBExplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBExplicitHierarchyIntegrator.cpp
@@ -525,7 +525,12 @@ IBExplicitHierarchyIntegrator::collectAllMarkers() const
     if (d_markers)
         return d_markers->collectAllMarkers();
     else
-        return {};
+    {
+        // Some older compilers cannot convert just '{}' into a std::pair so help it out
+        EigenAlignedVector<IBTK::Point> positions;
+        EigenAlignedVector<IBTK::Vector> velocities;
+        return std::make_pair(positions, velocities);
+    }
 } // collectAllMarkers
 
 void


### PR DESCRIPTION
Fixes #1592 (probably).

I cannot reproduce this (and our trusty gcc 4.8 CI tester is happy with the present version) but some older compilers have trouble converting `{}` into various aggregate types. Work around it by being explicit with what we return.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
