### PR TITLE
Remove sprintf().

### DIFF
--- a/include/ibamr/IBInstrumentPanel.h
+++ b/include/ibamr/IBInstrumentPanel.h
@@ -61,8 +61,6 @@ namespace IBAMR
 /*!
  * \brief Class IBInstrumentPanel provides support for flow meters and pressure
  * gauges.
- *
- * \note Use of class IBInstrumentPanel requires the Blitz++ array library.
  */
 class IBInstrumentPanel : public virtual SAMRAI::tbox::DescribedClass
 {

--- a/src/IB/IBInstrumentPanel.cpp
+++ b/src/IB/IBInstrumentPanel.cpp
@@ -1209,14 +1209,14 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
     const int mpi_nodes = IBTK_MPI::getNodes();
 
     // Create the working directory.
-    sprintf(temp_buf, "%06d", d_instrument_read_timestep_num);
+    snprintf(temp_buf, sizeof(temp_buf), "%06d", d_instrument_read_timestep_num);
     std::string current_dump_directory_name = SILO_DUMP_DIR_PREFIX + temp_buf;
     std::string dump_dirname = d_plot_directory_name + "/" + current_dump_directory_name;
 
     Utilities::recursiveMkdir(dump_dirname);
 
     // Create one local DBfile per MPI process.
-    sprintf(temp_buf, "%04d", mpi_rank);
+    snprintf(temp_buf, sizeof(temp_buf), "%04d", mpi_rank);
     current_file_name = dump_dirname + "/" + SILO_PROCESSOR_FILE_PREFIX;
     current_file_name += temp_buf;
     current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
@@ -1248,7 +1248,7 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
     {
         // Create and initialize the multimesh Silo database on the root MPI
         // process.
-        sprintf(temp_buf, "%06d", d_instrument_read_timestep_num);
+        snprintf(temp_buf, sizeof(temp_buf), "%06d", d_instrument_read_timestep_num);
         std::string summary_file_name =
             dump_dirname + "/" + SILO_SUMMARY_FILE_PREFIX + temp_buf + SILO_SUMMARY_FILE_POSTFIX;
         if (!(dbfile = DBCreate(summary_file_name.c_str(), DB_CLOBBER, DB_LOCAL, nullptr, DB_PDB)))
@@ -1270,7 +1270,7 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
         for (unsigned int meter = 0; meter < d_num_meters; ++meter)
         {
             const int proc = meter % mpi_nodes;
-            sprintf(temp_buf, "%04d", proc);
+            snprintf(temp_buf, sizeof(temp_buf), "%04d", proc);
             current_file_name = SILO_PROCESSOR_FILE_PREFIX;
             current_file_name += temp_buf;
             current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
@@ -1303,7 +1303,7 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
         // Create or update the dumps file on the root MPI process.
         static bool summary_file_opened = false;
         std::string path = d_plot_directory_name + "/" + VISIT_DUMPS_FILENAME;
-        sprintf(temp_buf, "%06d", d_instrument_read_timestep_num);
+        snprintf(temp_buf, sizeof(temp_buf), "%06d", d_instrument_read_timestep_num);
         std::string file =
             current_dump_directory_name + "/" + SILO_SUMMARY_FILE_PREFIX + temp_buf + SILO_SUMMARY_FILE_POSTFIX;
         if (!summary_file_opened)


### PR DESCRIPTION
There's no reason to use this instead of snprintf().

To the best of my knowledge, this class isn't finished (e.g., there is no way to actually specify the locations of meters) so I did not add any tests. We should include this in the release since some platforms are finally deprecating sprintf().

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?