### PR TITLE
Add a check for ghost cell consistency in the PoissonFACPreconditionerStrategy

### DIFF
--- a/ibtk/include/ibtk/PoissonFACPreconditionerStrategy.h
+++ b/ibtk/include/ibtk/PoissonFACPreconditionerStrategy.h
@@ -86,6 +86,10 @@ namespace IBTK
  * FACPreconditionerStrategy implementing many of the operations required by
  * smoothers for the Poisson equation and related problems.
  *
+ * The parameter ghost_cell_width is the necessary ghost cell width for all operations required by this class and
+ derived classes. Such operations includes restricting, prolongation, computing residuals, and smoothing error. The
+ patch indices in the RHS vector must have ghost cell widths that are equal to this parameter.
+ *
  * Sample parameters for initialization from database (and their default
  * values): \verbatim
 
@@ -282,6 +286,9 @@ public:
      * - hierarchy configuration (hierarchy pointer and level range)
      * - number, type and alignment of vector component data
      * - ghost cell width of data in the solution (or solution-like) vector
+     *
+     * An unrecoverable error will occur if the rhs vector does not have consistent ghost cell width as that provided in
+     * the constructor.
      *
      * \param solution solution vector u
      * \param rhs right hand side vector f

--- a/ibtk/src/solvers/impls/PoissonFACPreconditionerStrategy.cpp
+++ b/ibtk/src/solvers/impls/PoissonFACPreconditionerStrategy.cpp
@@ -360,6 +360,19 @@ PoissonFACPreconditionerStrategy::initializeOperatorState(const SAMRAIVectorReal
     d_coarsest_ln = solution.getCoarsestLevelNumber();
     d_finest_ln = solution.getFinestLevelNumber();
 
+#if !defined(NDEBUG)
+    // To prevent very obtuse errors later on, we check that the rhs index has the correct ghost cell width.
+    Pointer<PatchDescriptor<NDIM> > pd = VariableDatabase<NDIM>::getDatabase()->getPatchDescriptor();
+    const IntVector<NDIM>& gcw = pd->getPatchDataFactory(rhs_idx)->getGhostCellWidth();
+    if (gcw != d_gcw)
+    {
+        TBOX_ERROR(
+            d_object_name +
+                "::initializeOperatorState(): RHS index does not have the correct ghost width. RHS has ghost width of "
+            << gcw << ". Expecting a ghost cell width of " << d_gcw << ".\n");
+    }
+#endif
+
     // Perform implementation-specific initialization.
     initializeOperatorStateSpecialized(solution, rhs, coarsest_reset_ln, finest_reset_ln);
 #if !defined(NDEBUG)


### PR DESCRIPTION
Currently, if the provided RHS patch index does not have the same ghost cell width as that provided in the constructor (or database), you get a very obtuse error message about `CoarsenSchedule` consistency. This adds a check in `initializeOperatorState()` to print a more helpful message.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
