### PR TITLE
Add class to compute point-wise functions on the patch hierarchy.

### DIFF
--- a/ibtk/include/ibtk/CartGridPointwiseFunction.h
+++ b/ibtk/include/ibtk/CartGridPointwiseFunction.h
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2023 - 2023 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#ifndef included_IBTK_CartGridPointwiseFunction
+#define included_IBTK_CartGridPointwiseFunction
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include <ibtk/CartGridFunction.h>
+#include <ibtk/ibtk_utilities.h>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+namespace IBTK
+{
+/*!
+ * \brief Function signatures for CartGridPointwiseFunction
+ */
+namespace PointwiseFunctions
+{
+using ScalarFcn = std::function<double(double, const VectorNd&, double)>;
+using VectorFcn = std::function<VectorNd(const VectorNd&, const VectorNd&, double)>;
+using OtherFcn = std::function<VectorXd(const VectorXd&, const VectorNd&, double)>;
+using StaggeredFcn = std::function<double(double, const VectorNd&, double, int)>;
+} // namespace PointwiseFunctions
+
+/*!
+ * CartGridPointwiseFunction provides a lightweight class that can evaluate a function pointwise on the Cartesian grid.
+ * The constructor takes a function argument that will be applied to each index in the hierarchy.
+ *
+ * The valid function signature depends on the data centering and depth of the variable:
+ *
+ * For cell or node centered scalar quantities, the valid function signature must match PointwiseFunctions::ScalarFcn.
+ * For cell or node centered vector quantities, the valid function signature must match PointwiseFunctions::VectorFcn.
+ * For other cell or node centered quantities, the valid function signature must match PointwiseFunctions::OtherFcn.
+ * For side, face, or edge centered quantities, the valid function signature must match
+ * PointwiseFunctions::StaggeredFcn.
+ *
+ * The arguments given to the function include the current value stored on that index, the physical location of the
+ * point, and the time. For side, face, or edge centered quantities, the axis is also provided.
+ *
+ */
+template <typename F>
+class CartGridPointwiseFunction : public CartGridFunction
+{
+public:
+    /*!
+     * \brief Constructor. The function f must match on the signatures provided by PointwiseFunctions.
+     */
+    CartGridPointwiseFunction(std::string object_name, F f);
+
+    /*!
+     * \brief Does this function depend on time?
+     */
+    bool isTimeDependent() const override
+    {
+        return true;
+    }
+
+    /*!
+     * \brief Evaluate the function on the provided patch.
+     */
+    void setDataOnPatch(int data_idx,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM> > var,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM> > patch,
+                        double data_time,
+                        bool initial_time = false,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM> > patch_level =
+                            SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM> >(NULL)) override;
+
+private:
+    F d_f;
+};
+
+} // namespace IBTK
+
+#endif // #ifndef included_IBTK_CartGridPointwiseFunction

--- a/ibtk/lib/Makefile.am
+++ b/ibtk/lib/Makefile.am
@@ -150,6 +150,7 @@ DIM_DEPENDENT_SOURCES = \
 ../src/utilities/AppInitializer.cpp \
 ../src/utilities/CartGridFunction.cpp \
 ../src/utilities/CartGridFunctionSet.cpp \
+../src/utilities/CartGridPointwiseFunction.cpp \
 ../src/utilities/CellNoCornersFillPattern.cpp \
 ../src/utilities/CoarsenPatchStrategySet.cpp \
 ../src/utilities/CopyToRootSchedule.cpp \

--- a/ibtk/lib/Makefile.in
+++ b/ibtk/lib/Makefile.in
@@ -306,6 +306,7 @@ am__libIBTK2d_a_SOURCES_DIST =  \
 	../src/utilities/AppInitializer.cpp \
 	../src/utilities/CartGridFunction.cpp \
 	../src/utilities/CartGridFunctionSet.cpp \
+	../src/utilities/CartGridPointwiseFunction.cpp \
 	../src/utilities/CellNoCornersFillPattern.cpp \
 	../src/utilities/CoarsenPatchStrategySet.cpp \
 	../src/utilities/CopyToRootSchedule.cpp \
@@ -486,6 +487,7 @@ am__objects_4 = ../src/boundary/libIBTK2d_a-HierarchyGhostCellInterpolation.$(OB
 	../src/utilities/libIBTK2d_a-AppInitializer.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-CartGridFunction.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-CartGridFunctionSet.$(OBJEXT) \
+	../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-CellNoCornersFillPattern.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-CoarsenPatchStrategySet.$(OBJEXT) \
 	../src/utilities/libIBTK2d_a-CopyToRootSchedule.$(OBJEXT) \
@@ -636,6 +638,7 @@ am__libIBTK3d_a_SOURCES_DIST =  \
 	../src/utilities/AppInitializer.cpp \
 	../src/utilities/CartGridFunction.cpp \
 	../src/utilities/CartGridFunctionSet.cpp \
+	../src/utilities/CartGridPointwiseFunction.cpp \
 	../src/utilities/CellNoCornersFillPattern.cpp \
 	../src/utilities/CoarsenPatchStrategySet.cpp \
 	../src/utilities/CopyToRootSchedule.cpp \
@@ -814,6 +817,7 @@ am__objects_6 = ../src/boundary/libIBTK3d_a-HierarchyGhostCellInterpolation.$(OB
 	../src/utilities/libIBTK3d_a-AppInitializer.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-CartGridFunction.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-CartGridFunctionSet.$(OBJEXT) \
+	../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-CellNoCornersFillPattern.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-CoarsenPatchStrategySet.$(OBJEXT) \
 	../src/utilities/libIBTK3d_a-CopyToRootSchedule.$(OBJEXT) \
@@ -1092,6 +1096,7 @@ am__depfiles_remade = ../contrib/muparser/src/$(DEPDIR)/muParser.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-AppInitializer.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridFunction.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridFunctionSet.Po \
+	../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridPointwiseFunction.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-CellNoCornersFillPattern.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-CoarsenPatchStrategySet.Po \
 	../src/utilities/$(DEPDIR)/libIBTK2d_a-CopyToRootSchedule.Po \
@@ -1135,6 +1140,7 @@ am__depfiles_remade = ../contrib/muparser/src/$(DEPDIR)/muParser.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-AppInitializer.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunction.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunctionSet.Po \
+	../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridPointwiseFunction.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-CellNoCornersFillPattern.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-CoarsenPatchStrategySet.Po \
 	../src/utilities/$(DEPDIR)/libIBTK3d_a-CopyToRootSchedule.Po \
@@ -1757,6 +1763,7 @@ DIM_DEPENDENT_SOURCES =  \
 	../src/utilities/AppInitializer.cpp \
 	../src/utilities/CartGridFunction.cpp \
 	../src/utilities/CartGridFunctionSet.cpp \
+	../src/utilities/CartGridPointwiseFunction.cpp \
 	../src/utilities/CellNoCornersFillPattern.cpp \
 	../src/utilities/CoarsenPatchStrategySet.cpp \
 	../src/utilities/CopyToRootSchedule.cpp \
@@ -2301,6 +2308,9 @@ $(top_builddir)/src/utilities/fortran/averaging.$(OBJEXT):  \
 ../src/utilities/libIBTK2d_a-CartGridFunctionSet.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.$(OBJEXT):  \
+	../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 ../src/utilities/libIBTK2d_a-CellNoCornersFillPattern.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
@@ -2819,6 +2829,9 @@ libIBTK2d.a: $(libIBTK2d_a_OBJECTS) $(libIBTK2d_a_DEPENDENCIES) $(EXTRA_libIBTK2
 ../src/utilities/libIBTK3d_a-CartGridFunctionSet.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
+../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.$(OBJEXT):  \
+	../src/utilities/$(am__dirstamp) \
+	../src/utilities/$(DEPDIR)/$(am__dirstamp)
 ../src/utilities/libIBTK3d_a-CellNoCornersFillPattern.$(OBJEXT):  \
 	../src/utilities/$(am__dirstamp) \
 	../src/utilities/$(DEPDIR)/$(am__dirstamp)
@@ -3257,6 +3270,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-AppInitializer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridFunction.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridFunctionSet.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridPointwiseFunction.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-CellNoCornersFillPattern.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-CoarsenPatchStrategySet.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK2d_a-CopyToRootSchedule.Po@am__quote@ # am--include-marker
@@ -3300,6 +3314,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-AppInitializer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunction.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunctionSet.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridPointwiseFunction.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-CellNoCornersFillPattern.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-CoarsenPatchStrategySet.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/utilities/$(DEPDIR)/libIBTK3d_a-CopyToRootSchedule.Po@am__quote@ # am--include-marker
@@ -4630,6 +4645,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/CartGridFunctionSet.cpp' object='../src/utilities/libIBTK2d_a-CartGridFunctionSet.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-CartGridFunctionSet.obj `if test -f '../src/utilities/CartGridFunctionSet.cpp'; then $(CYGPATH_W) '../src/utilities/CartGridFunctionSet.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/CartGridFunctionSet.cpp'; fi`
+
+../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.o: ../src/utilities/CartGridPointwiseFunction.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridPointwiseFunction.Tpo -c -o ../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.o `test -f '../src/utilities/CartGridPointwiseFunction.cpp' || echo '$(srcdir)/'`../src/utilities/CartGridPointwiseFunction.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridPointwiseFunction.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridPointwiseFunction.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/CartGridPointwiseFunction.cpp' object='../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.o `test -f '../src/utilities/CartGridPointwiseFunction.cpp' || echo '$(srcdir)/'`../src/utilities/CartGridPointwiseFunction.cpp
+
+../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.obj: ../src/utilities/CartGridPointwiseFunction.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.obj -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridPointwiseFunction.Tpo -c -o ../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.obj `if test -f '../src/utilities/CartGridPointwiseFunction.cpp'; then $(CYGPATH_W) '../src/utilities/CartGridPointwiseFunction.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/CartGridPointwiseFunction.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridPointwiseFunction.Tpo ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridPointwiseFunction.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/CartGridPointwiseFunction.cpp' object='../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK2d_a-CartGridPointwiseFunction.obj `if test -f '../src/utilities/CartGridPointwiseFunction.cpp'; then $(CYGPATH_W) '../src/utilities/CartGridPointwiseFunction.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/CartGridPointwiseFunction.cpp'; fi`
 
 ../src/utilities/libIBTK2d_a-CellNoCornersFillPattern.o: ../src/utilities/CellNoCornersFillPattern.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK2d_a-CellNoCornersFillPattern.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK2d_a-CellNoCornersFillPattern.Tpo -c -o ../src/utilities/libIBTK2d_a-CellNoCornersFillPattern.o `test -f '../src/utilities/CellNoCornersFillPattern.cpp' || echo '$(srcdir)/'`../src/utilities/CellNoCornersFillPattern.cpp
@@ -6563,6 +6592,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-CartGridFunctionSet.obj `if test -f '../src/utilities/CartGridFunctionSet.cpp'; then $(CYGPATH_W) '../src/utilities/CartGridFunctionSet.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/CartGridFunctionSet.cpp'; fi`
 
+../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.o: ../src/utilities/CartGridPointwiseFunction.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridPointwiseFunction.Tpo -c -o ../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.o `test -f '../src/utilities/CartGridPointwiseFunction.cpp' || echo '$(srcdir)/'`../src/utilities/CartGridPointwiseFunction.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridPointwiseFunction.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridPointwiseFunction.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/CartGridPointwiseFunction.cpp' object='../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.o `test -f '../src/utilities/CartGridPointwiseFunction.cpp' || echo '$(srcdir)/'`../src/utilities/CartGridPointwiseFunction.cpp
+
+../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.obj: ../src/utilities/CartGridPointwiseFunction.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.obj -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridPointwiseFunction.Tpo -c -o ../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.obj `if test -f '../src/utilities/CartGridPointwiseFunction.cpp'; then $(CYGPATH_W) '../src/utilities/CartGridPointwiseFunction.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/CartGridPointwiseFunction.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridPointwiseFunction.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridPointwiseFunction.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/utilities/CartGridPointwiseFunction.cpp' object='../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/utilities/libIBTK3d_a-CartGridPointwiseFunction.obj `if test -f '../src/utilities/CartGridPointwiseFunction.cpp'; then $(CYGPATH_W) '../src/utilities/CartGridPointwiseFunction.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/utilities/CartGridPointwiseFunction.cpp'; fi`
+
 ../src/utilities/libIBTK3d_a-CellNoCornersFillPattern.o: ../src/utilities/CellNoCornersFillPattern.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBTK3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/utilities/libIBTK3d_a-CellNoCornersFillPattern.o -MD -MP -MF ../src/utilities/$(DEPDIR)/libIBTK3d_a-CellNoCornersFillPattern.Tpo -c -o ../src/utilities/libIBTK3d_a-CellNoCornersFillPattern.o `test -f '../src/utilities/CellNoCornersFillPattern.cpp' || echo '$(srcdir)/'`../src/utilities/CellNoCornersFillPattern.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/utilities/$(DEPDIR)/libIBTK3d_a-CellNoCornersFillPattern.Tpo ../src/utilities/$(DEPDIR)/libIBTK3d_a-CellNoCornersFillPattern.Po
@@ -7647,6 +7690,7 @@ distclean: distclean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-AppInitializer.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridFunction.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridFunctionSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridPointwiseFunction.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CellNoCornersFillPattern.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CoarsenPatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CopyToRootSchedule.Po
@@ -7690,6 +7734,7 @@ distclean: distclean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-AppInitializer.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunction.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunctionSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridPointwiseFunction.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CellNoCornersFillPattern.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CoarsenPatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CopyToRootSchedule.Po
@@ -7978,6 +8023,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-AppInitializer.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridFunction.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridFunctionSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CartGridPointwiseFunction.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CellNoCornersFillPattern.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CoarsenPatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK2d_a-CopyToRootSchedule.Po
@@ -8021,6 +8067,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-AppInitializer.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunction.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridFunctionSet.Po
+	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CartGridPointwiseFunction.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CellNoCornersFillPattern.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CoarsenPatchStrategySet.Po
 	-rm -f ../src/utilities/$(DEPDIR)/libIBTK3d_a-CopyToRootSchedule.Po

--- a/ibtk/src/CMakeLists.txt
+++ b/ibtk/src/CMakeLists.txt
@@ -214,6 +214,7 @@ SET(CXX_SRC
   utilities/PartitioningBox.cpp
   utilities/SnapshotCache.cpp
   utilities/snapshot_utilities.cpp
+  utilities/CartGridPointwiseFunction.cpp
   )
 
 IF(IBAMR_HAVE_LIBMESH)

--- a/ibtk/src/utilities/CartGridPointwiseFunction.cpp
+++ b/ibtk/src/utilities/CartGridPointwiseFunction.cpp
@@ -1,0 +1,275 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2023 - 2023 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#include "ibtk/CartGridPointwiseFunction.h"
+
+#include <CartesianPatchGeometry.h>
+
+#include "ibtk/app_namespaces.h"
+
+namespace IBTK
+{
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+template <typename F>
+CartGridPointwiseFunction<F>::CartGridPointwiseFunction(string object_name, F f)
+    : CartGridFunction(std::move(object_name)), d_f(f)
+{
+    // intentionally blank
+    return;
+} // CartGridPointwiseFunction
+
+template <>
+void
+CartGridPointwiseFunction<PointwiseFunctions::ScalarFcn>::setDataOnPatch(const int data_idx,
+                                                                         Pointer<Variable<NDIM> > var,
+                                                                         Pointer<Patch<NDIM> > patch,
+                                                                         const double data_time,
+                                                                         const bool initial_time,
+                                                                         Pointer<PatchLevel<NDIM> > /*patch_level*/)
+{
+    const Box<NDIM>& patch_box = patch->getBox();
+    const hier::Index<NDIM>& idx_low = patch_box.lower();
+    Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+
+    const double* const xlow = pgeom->getXLower();
+    const double* const dx = pgeom->getDx();
+
+    // Set the data in the patch.
+    Pointer<PatchData<NDIM> > data = patch->getPatchData(data_idx);
+#if !defined(NDEBUG)
+    TBOX_ASSERT(data);
+#endif
+    Pointer<CellData<NDIM, double> > cc_data = data;
+    Pointer<NodeData<NDIM, double> > nc_data = data;
+    if (cc_data)
+    {
+        for (CellIterator<NDIM> ci(patch_box); ci; ci++)
+        {
+            const CellIndex<NDIM>& idx = ci();
+
+            VectorNd x;
+            for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
+            (*cc_data)(idx) = d_f((*cc_data)(idx), x, data_time);
+        }
+    }
+    else if (nc_data)
+    {
+        for (NodeIterator<NDIM> ni(patch_box); ni; ni++)
+        {
+            const NodeIndex<NDIM>& idx = ni();
+            VectorNd x;
+            for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * static_cast<double>(idx(d) - idx_low(d));
+            (*nc_data)(idx) = d_f((*nc_data)(idx), x, data_time);
+        }
+    }
+    else
+    {
+        TBOX_ERROR("CartGridPointwiseFunction::setDataOnPatch(): unsupported patch data type encountered\n");
+    }
+}
+
+template <>
+void
+CartGridPointwiseFunction<PointwiseFunctions::VectorFcn>::setDataOnPatch(const int data_idx,
+                                                                         Pointer<Variable<NDIM> > var,
+                                                                         Pointer<Patch<NDIM> > patch,
+                                                                         const double data_time,
+                                                                         const bool initial_time,
+                                                                         Pointer<PatchLevel<NDIM> > /*patch_level*/)
+{
+    const Box<NDIM>& patch_box = patch->getBox();
+    const hier::Index<NDIM>& idx_low = patch_box.lower();
+    Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+
+    const double* const xlow = pgeom->getXLower();
+    const double* const dx = pgeom->getDx();
+
+    // Set the data in the patch.
+    Pointer<PatchData<NDIM> > data = patch->getPatchData(data_idx);
+#if !defined(NDEBUG)
+    TBOX_ASSERT(data);
+#endif
+    Pointer<CellData<NDIM, double> > cc_data = data;
+    Pointer<NodeData<NDIM, double> > nc_data = data;
+    if (cc_data)
+    {
+        for (CellIterator<NDIM> ci(patch_box); ci; ci++)
+        {
+            const CellIndex<NDIM>& idx = ci();
+
+            VectorNd x;
+            for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
+            // Vector values
+            Eigen::Map<const VectorNd> cc_val(&(*cc_data)(idx));
+            VectorNd ret_val = d_f(cc_val, x, data_time);
+            for (int d = 0; d < NDIM; ++d) (*cc_data)(idx, d) = ret_val[d];
+        }
+    }
+    else if (nc_data)
+    {
+        for (NodeIterator<NDIM> ni(patch_box); ni; ni++)
+        {
+            const NodeIndex<NDIM>& idx = ni();
+            VectorNd x;
+            for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * static_cast<double>(idx(d) - idx_low(d));
+            // Vector values
+            Eigen::Map<const VectorNd> nc_val(&(*nc_data)(idx));
+            VectorNd ret_val = d_f(nc_val, x, data_time);
+            for (int d = 0; d < NDIM; ++d) (*nc_data)(idx, d) = ret_val[d];
+        }
+    }
+    else
+    {
+        TBOX_ERROR("CartGridPointwiseFunction::setDataOnPatch(): unsupported patch data type encountered\n");
+    }
+}
+
+template <>
+void
+CartGridPointwiseFunction<PointwiseFunctions::OtherFcn>::setDataOnPatch(const int data_idx,
+                                                                        Pointer<Variable<NDIM> > var,
+                                                                        Pointer<Patch<NDIM> > patch,
+                                                                        const double data_time,
+                                                                        const bool initial_time,
+                                                                        Pointer<PatchLevel<NDIM> > /*patch_level*/)
+{
+    const Box<NDIM>& patch_box = patch->getBox();
+    const hier::Index<NDIM>& idx_low = patch_box.lower();
+    Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+
+    const double* const xlow = pgeom->getXLower();
+    const double* const dx = pgeom->getDx();
+
+    // Set the data in the patch.
+    Pointer<PatchData<NDIM> > data = patch->getPatchData(data_idx);
+#if !defined(NDEBUG)
+    TBOX_ASSERT(data);
+#endif
+    Pointer<CellData<NDIM, double> > cc_data = data;
+    Pointer<NodeData<NDIM, double> > nc_data = data;
+    if (cc_data)
+    {
+        const int depth = cc_data->getDepth();
+        for (CellIterator<NDIM> ci(patch_box); ci; ci++)
+        {
+            const CellIndex<NDIM>& idx = ci();
+
+            VectorNd x;
+            for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
+            Eigen::Map<const VectorXd> cc_val(&(*cc_data)(idx), depth);
+            VectorXd ret_val = d_f(cc_val, x, data_time);
+            for (int d = 0; d < depth; ++d) (*cc_data)(idx, d) = ret_val[d];
+        }
+    }
+    else if (nc_data)
+    {
+        const int depth = nc_data->getDepth();
+        for (NodeIterator<NDIM> ni(patch_box); ni; ni++)
+        {
+            const NodeIndex<NDIM>& idx = ni();
+            VectorNd x;
+            for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * static_cast<double>(idx(d) - idx_low(d));
+            Eigen::Map<const VectorXd> nc_val(&(*nc_data)(idx), depth);
+            VectorXd ret_val = d_f(nc_val, x, data_time);
+            for (int d = 0; d < depth; ++d) (*nc_data)(idx, d) = ret_val[d];
+        }
+    }
+    else
+    {
+        TBOX_ERROR("CartGridPointwiseFunction::setDataOnPatch(): unsupported patch data type encountered\n");
+    }
+}
+
+template <>
+void
+CartGridPointwiseFunction<PointwiseFunctions::StaggeredFcn>::setDataOnPatch(const int data_idx,
+                                                                            Pointer<Variable<NDIM> > var,
+                                                                            Pointer<Patch<NDIM> > patch,
+                                                                            const double data_time,
+                                                                            const bool initial_time,
+                                                                            Pointer<PatchLevel<NDIM> > /*patch_level*/)
+{
+    const Box<NDIM>& patch_box = patch->getBox();
+    const hier::Index<NDIM>& idx_low = patch_box.lower();
+    Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+
+    const double* const xlow = pgeom->getXLower();
+    const double* const dx = pgeom->getDx();
+
+    // Set the data in the patch.
+    Pointer<PatchData<NDIM> > data = patch->getPatchData(data_idx);
+#if !defined(NDEBUG)
+    TBOX_ASSERT(data);
+#endif
+    Pointer<FaceData<NDIM, double> > fc_data = data;
+    Pointer<SideData<NDIM, double> > sc_data = data;
+    Pointer<EdgeData<NDIM, double> > ec_data = data;
+    if (sc_data)
+    {
+        for (int axis = 0; axis < NDIM; ++axis)
+        {
+            for (SideIterator<NDIM> si(patch_box, axis); si; si++)
+            {
+                const SideIndex<NDIM>& idx = si();
+                VectorNd x;
+                for (int d = 0; d < NDIM; ++d)
+                    x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + (d == axis ? 0.0 : 0.5));
+
+                (*sc_data)(idx) = d_f((*sc_data)(idx), x, data_time, axis);
+            }
+        }
+    }
+    else if (fc_data)
+    {
+        for (int axis = 0; axis < NDIM; ++axis)
+        {
+            for (FaceIterator<NDIM> fi(patch_box, axis); fi; fi++)
+            {
+                const FaceIndex<NDIM>& idx = fi();
+                const CellIndex<NDIM>& cell_idx = idx.toCell(1);
+                VectorNd x;
+                for (int d = 0; d < NDIM; ++d)
+                    x[d] = xlow[d] + dx[d] * (static_cast<double>(cell_idx(d) - idx_low(d)) + (d == axis ? 0.0 : 0.5));
+
+                (*fc_data)(idx) = d_f((*fc_data)(idx), x, data_time, axis);
+            }
+        }
+    }
+    else if (ec_data)
+    {
+        for (int axis = 0; axis < NDIM; ++axis)
+        {
+            for (EdgeIterator<NDIM> ei(patch_box, axis); ei; ei++)
+            {
+                const EdgeIndex<NDIM>& idx = ei();
+                VectorNd x;
+                for (int d = 0; d < NDIM; ++d)
+                    x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + (d == axis ? 0.5 : 0.0));
+
+                (*ec_data)(idx) = d_f((*ec_data)(idx), x, data_time, axis);
+            }
+        }
+    }
+    else
+    {
+        TBOX_ERROR("CartGridPointwiseFunction::setDataOnPatch(): unsupported patch data type encountered\n");
+    }
+}
+
+// Instantiate valid templates
+template class CartGridPointwiseFunction<PointwiseFunctions::ScalarFcn>;
+template class CartGridPointwiseFunction<PointwiseFunctions::VectorFcn>;
+template class CartGridPointwiseFunction<PointwiseFunctions::OtherFcn>;
+template class CartGridPointwiseFunction<PointwiseFunctions::StaggeredFcn>;
+
+} // namespace IBTK

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -271,6 +271,7 @@ SETUP_2D(IBTK vc_viscous_solver.cpp)
 SETUP_2D(IBTK helmholtz.cpp)
 SETUP_2D(IBTK marker_points_01.cpp)
 SETUP_2D(IBTK marker_points_02.cpp)
+SETUP_2D(IBTK pointwise_function.cpp)
 
 IF(${IBAMR_HAVE_LIBMESH})
   SETUP_3D(IBTK bounding_boxes_01.cpp)
@@ -290,6 +291,7 @@ SETUP_3D(IBTK prolongation_mat.cpp)
 SETUP_3D(IBTK samraidatacache_01.cpp)
 SETUP_3D(IBTK vc_viscous_solver.cpp)
 SETUP_3D(IBTK helmholtz.cpp)
+SETUP_3D(IBTK pointwise_function.cpp)
 
 ADD_CUSTOM_COMMAND(TARGET tests
   POST_BUILD

--- a/tests/IBTK/Makefile.am
+++ b/tests/IBTK/Makefile.am
@@ -22,7 +22,8 @@ ghost_accumulation_01_2d ghost_accumulation_01_3d ghost_indices_01_2d \
 ghost_indices_01_3d ibtk_init hierarchy_callbacks ibtk_mpi equal_eps helmholtz_2d \
 helmholtz_3d secondary_hierarchy_01_2d child_integrators_2d version_macros \
 snapshot_cache_01_2d nodal_interpolation_01_2d nodal_interpolation_01_3d \
-curl_01_2d curl_01_3d marker_points_01_2d marker_points_02_2d
+curl_01_2d curl_01_3d marker_points_01_2d marker_points_02_2d \
+pointwise_function_2d pointwise_function_3d
 
 if LIBMESH_ENABLED
 EXTRA_PROGRAMS += elem_hmax_01 elem_hmax_02 jacobian_calc_01 bounding_boxes_01_2d \
@@ -261,6 +262,14 @@ version_macros_SOURCES = version_macros.cpp
 snapshot_cache_01_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 snapshot_cache_01_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 snapshot_cache_01_2d_SOURCES = snapshot_cache_01.cpp
+
+pointwise_function_2d_CXXFLAGS = $(AM_CXX_FLAGS) -DNDIM=2
+pointwise_function_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+pointwise_function_2d_SOURCES = pointwise_function.cpp
+
+pointwise_function_3d_CXXFLAGS = $(AM_CXX_FLAGS) -DNDIM=3
+pointwise_function_3d_LDADD = $(IBAMR_LD_FLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+pointwise_function_3d_SOURCES = pointwise_function.cpp
 
 tests: $(EXTRA_PROGRAMS)
 	if test "$(top_srcdir)" != "$(top_builddir)" ; then \

--- a/tests/IBTK/Makefile.in
+++ b/tests/IBTK/Makefile.in
@@ -108,7 +108,8 @@ EXTRA_PROGRAMS = mpi_type_wrappers$(EXEEXT) poisson_01_2d$(EXEEXT) \
 	nodal_interpolation_01_2d$(EXEEXT) \
 	nodal_interpolation_01_3d$(EXEEXT) curl_01_2d$(EXEEXT) \
 	curl_01_3d$(EXEEXT) marker_points_01_2d$(EXEEXT) \
-	marker_points_02_2d$(EXEEXT) $(am__EXEEXT_1)
+	marker_points_02_2d$(EXEEXT) pointwise_function_2d$(EXEEXT) \
+	pointwise_function_3d$(EXEEXT) $(am__EXEEXT_1)
 @LIBMESH_ENABLED_TRUE@am__append_1 = elem_hmax_01 elem_hmax_02 jacobian_calc_01 bounding_boxes_01_2d \
 @LIBMESH_ENABLED_TRUE@bounding_boxes_01_3d mapping_01 fe_values_01 fe_values_02 \
 @LIBMESH_ENABLED_TRUE@multilevel_fe_01_2d multilevel_fe_01_3d subdomain_level_translation_01 \
@@ -473,6 +474,22 @@ phys_boundary_ops_3d_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(phys_boundary_ops_3d_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
+am_pointwise_function_2d_OBJECTS =  \
+	pointwise_function_2d-pointwise_function.$(OBJEXT)
+pointwise_function_2d_OBJECTS = $(am_pointwise_function_2d_OBJECTS)
+pointwise_function_2d_DEPENDENCIES = $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+pointwise_function_2d_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
+	$(pointwise_function_2d_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
+	$(LDFLAGS) -o $@
+am_pointwise_function_3d_OBJECTS =  \
+	pointwise_function_3d-pointwise_function.$(OBJEXT)
+pointwise_function_3d_OBJECTS = $(am_pointwise_function_3d_OBJECTS)
+pointwise_function_3d_DEPENDENCIES = $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+pointwise_function_3d_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
+	$(pointwise_function_3d_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
+	$(LDFLAGS) -o $@
 am_poisson_01_2d_OBJECTS = poisson_01_2d-poisson_01.$(OBJEXT)
 poisson_01_2d_OBJECTS = $(am_poisson_01_2d_OBJECTS)
 poisson_01_2d_DEPENDENCIES = $(IBAMR2d_LIBS) $(IBAMR_LIBS)
@@ -626,6 +643,8 @@ am__depfiles_remade =  \
 	./$(DEPDIR)/nodal_interpolation_01_3d-nodal_interpolation_01.Po \
 	./$(DEPDIR)/phys_boundary_ops_2d-phys_boundary_ops.Po \
 	./$(DEPDIR)/phys_boundary_ops_3d-phys_boundary_ops.Po \
+	./$(DEPDIR)/pointwise_function_2d-pointwise_function.Po \
+	./$(DEPDIR)/pointwise_function_3d-pointwise_function.Po \
 	./$(DEPDIR)/poisson_01_2d-poisson_01.Po \
 	./$(DEPDIR)/poisson_01_3d-poisson_01.Po \
 	./$(DEPDIR)/prolongation_mat_2d-prolongation_mat.Po \
@@ -680,7 +699,9 @@ SOURCES = $(bounding_boxes_01_2d_SOURCES) \
 	$(nodal_interpolation_01_2d_SOURCES) \
 	$(nodal_interpolation_01_3d_SOURCES) \
 	$(phys_boundary_ops_2d_SOURCES) \
-	$(phys_boundary_ops_3d_SOURCES) $(poisson_01_2d_SOURCES) \
+	$(phys_boundary_ops_3d_SOURCES) \
+	$(pointwise_function_2d_SOURCES) \
+	$(pointwise_function_3d_SOURCES) $(poisson_01_2d_SOURCES) \
 	$(poisson_01_3d_SOURCES) $(prolongation_mat_2d_SOURCES) \
 	$(prolongation_mat_3d_SOURCES) \
 	$(samraidatacache_01_2d_SOURCES) \
@@ -716,7 +737,9 @@ DIST_SOURCES = $(am__bounding_boxes_01_2d_SOURCES_DIST) \
 	$(nodal_interpolation_01_2d_SOURCES) \
 	$(nodal_interpolation_01_3d_SOURCES) \
 	$(phys_boundary_ops_2d_SOURCES) \
-	$(phys_boundary_ops_3d_SOURCES) $(poisson_01_2d_SOURCES) \
+	$(phys_boundary_ops_3d_SOURCES) \
+	$(pointwise_function_2d_SOURCES) \
+	$(pointwise_function_3d_SOURCES) $(poisson_01_2d_SOURCES) \
 	$(poisson_01_3d_SOURCES) $(prolongation_mat_2d_SOURCES) \
 	$(prolongation_mat_3d_SOURCES) \
 	$(samraidatacache_01_2d_SOURCES) \
@@ -1171,6 +1194,12 @@ version_macros_SOURCES = version_macros.cpp
 snapshot_cache_01_2d_CXXFLAGS = $(AM_CXXFLAGS) -DNDIM=2
 snapshot_cache_01_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
 snapshot_cache_01_2d_SOURCES = snapshot_cache_01.cpp
+pointwise_function_2d_CXXFLAGS = $(AM_CXX_FLAGS) -DNDIM=2
+pointwise_function_2d_LDADD = $(IBAMR_LDFLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+pointwise_function_2d_SOURCES = pointwise_function.cpp
+pointwise_function_3d_CXXFLAGS = $(AM_CXX_FLAGS) -DNDIM=3
+pointwise_function_3d_LDADD = $(IBAMR_LD_FLAGS) $(IBAMR2d_LIBS) $(IBAMR_LIBS)
+pointwise_function_3d_SOURCES = pointwise_function.cpp
 all: all-am
 
 .SUFFIXES:
@@ -1366,6 +1395,14 @@ phys_boundary_ops_3d$(EXEEXT): $(phys_boundary_ops_3d_OBJECTS) $(phys_boundary_o
 	@rm -f phys_boundary_ops_3d$(EXEEXT)
 	$(AM_V_CXXLD)$(phys_boundary_ops_3d_LINK) $(phys_boundary_ops_3d_OBJECTS) $(phys_boundary_ops_3d_LDADD) $(LIBS)
 
+pointwise_function_2d$(EXEEXT): $(pointwise_function_2d_OBJECTS) $(pointwise_function_2d_DEPENDENCIES) $(EXTRA_pointwise_function_2d_DEPENDENCIES) 
+	@rm -f pointwise_function_2d$(EXEEXT)
+	$(AM_V_CXXLD)$(pointwise_function_2d_LINK) $(pointwise_function_2d_OBJECTS) $(pointwise_function_2d_LDADD) $(LIBS)
+
+pointwise_function_3d$(EXEEXT): $(pointwise_function_3d_OBJECTS) $(pointwise_function_3d_DEPENDENCIES) $(EXTRA_pointwise_function_3d_DEPENDENCIES) 
+	@rm -f pointwise_function_3d$(EXEEXT)
+	$(AM_V_CXXLD)$(pointwise_function_3d_LINK) $(pointwise_function_3d_OBJECTS) $(pointwise_function_3d_LDADD) $(LIBS)
+
 poisson_01_2d$(EXEEXT): $(poisson_01_2d_OBJECTS) $(poisson_01_2d_DEPENDENCIES) $(EXTRA_poisson_01_2d_DEPENDENCIES) 
 	@rm -f poisson_01_2d$(EXEEXT)
 	$(AM_V_CXXLD)$(poisson_01_2d_LINK) $(poisson_01_2d_OBJECTS) $(poisson_01_2d_LDADD) $(LIBS)
@@ -1460,6 +1497,8 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nodal_interpolation_01_3d-nodal_interpolation_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/phys_boundary_ops_2d-phys_boundary_ops.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/phys_boundary_ops_3d-phys_boundary_ops.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/pointwise_function_2d-pointwise_function.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/pointwise_function_3d-pointwise_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/poisson_01_2d-poisson_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/poisson_01_3d-poisson_01.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/prolongation_mat_2d-prolongation_mat.Po@am__quote@ # am--include-marker
@@ -2063,6 +2102,34 @@ phys_boundary_ops_3d-phys_boundary_ops.obj: phys_boundary_ops.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(phys_boundary_ops_3d_CXXFLAGS) $(CXXFLAGS) -c -o phys_boundary_ops_3d-phys_boundary_ops.obj `if test -f 'phys_boundary_ops.cpp'; then $(CYGPATH_W) 'phys_boundary_ops.cpp'; else $(CYGPATH_W) '$(srcdir)/phys_boundary_ops.cpp'; fi`
 
+pointwise_function_2d-pointwise_function.o: pointwise_function.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(pointwise_function_2d_CXXFLAGS) $(CXXFLAGS) -MT pointwise_function_2d-pointwise_function.o -MD -MP -MF $(DEPDIR)/pointwise_function_2d-pointwise_function.Tpo -c -o pointwise_function_2d-pointwise_function.o `test -f 'pointwise_function.cpp' || echo '$(srcdir)/'`pointwise_function.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/pointwise_function_2d-pointwise_function.Tpo $(DEPDIR)/pointwise_function_2d-pointwise_function.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='pointwise_function.cpp' object='pointwise_function_2d-pointwise_function.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(pointwise_function_2d_CXXFLAGS) $(CXXFLAGS) -c -o pointwise_function_2d-pointwise_function.o `test -f 'pointwise_function.cpp' || echo '$(srcdir)/'`pointwise_function.cpp
+
+pointwise_function_2d-pointwise_function.obj: pointwise_function.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(pointwise_function_2d_CXXFLAGS) $(CXXFLAGS) -MT pointwise_function_2d-pointwise_function.obj -MD -MP -MF $(DEPDIR)/pointwise_function_2d-pointwise_function.Tpo -c -o pointwise_function_2d-pointwise_function.obj `if test -f 'pointwise_function.cpp'; then $(CYGPATH_W) 'pointwise_function.cpp'; else $(CYGPATH_W) '$(srcdir)/pointwise_function.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/pointwise_function_2d-pointwise_function.Tpo $(DEPDIR)/pointwise_function_2d-pointwise_function.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='pointwise_function.cpp' object='pointwise_function_2d-pointwise_function.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(pointwise_function_2d_CXXFLAGS) $(CXXFLAGS) -c -o pointwise_function_2d-pointwise_function.obj `if test -f 'pointwise_function.cpp'; then $(CYGPATH_W) 'pointwise_function.cpp'; else $(CYGPATH_W) '$(srcdir)/pointwise_function.cpp'; fi`
+
+pointwise_function_3d-pointwise_function.o: pointwise_function.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(pointwise_function_3d_CXXFLAGS) $(CXXFLAGS) -MT pointwise_function_3d-pointwise_function.o -MD -MP -MF $(DEPDIR)/pointwise_function_3d-pointwise_function.Tpo -c -o pointwise_function_3d-pointwise_function.o `test -f 'pointwise_function.cpp' || echo '$(srcdir)/'`pointwise_function.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/pointwise_function_3d-pointwise_function.Tpo $(DEPDIR)/pointwise_function_3d-pointwise_function.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='pointwise_function.cpp' object='pointwise_function_3d-pointwise_function.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(pointwise_function_3d_CXXFLAGS) $(CXXFLAGS) -c -o pointwise_function_3d-pointwise_function.o `test -f 'pointwise_function.cpp' || echo '$(srcdir)/'`pointwise_function.cpp
+
+pointwise_function_3d-pointwise_function.obj: pointwise_function.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(pointwise_function_3d_CXXFLAGS) $(CXXFLAGS) -MT pointwise_function_3d-pointwise_function.obj -MD -MP -MF $(DEPDIR)/pointwise_function_3d-pointwise_function.Tpo -c -o pointwise_function_3d-pointwise_function.obj `if test -f 'pointwise_function.cpp'; then $(CYGPATH_W) 'pointwise_function.cpp'; else $(CYGPATH_W) '$(srcdir)/pointwise_function.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/pointwise_function_3d-pointwise_function.Tpo $(DEPDIR)/pointwise_function_3d-pointwise_function.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='pointwise_function.cpp' object='pointwise_function_3d-pointwise_function.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(pointwise_function_3d_CXXFLAGS) $(CXXFLAGS) -c -o pointwise_function_3d-pointwise_function.obj `if test -f 'pointwise_function.cpp'; then $(CYGPATH_W) 'pointwise_function.cpp'; else $(CYGPATH_W) '$(srcdir)/pointwise_function.cpp'; fi`
+
 poisson_01_2d-poisson_01.o: poisson_01.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(poisson_01_2d_CXXFLAGS) $(CXXFLAGS) -MT poisson_01_2d-poisson_01.o -MD -MP -MF $(DEPDIR)/poisson_01_2d-poisson_01.Tpo -c -o poisson_01_2d-poisson_01.o `test -f 'poisson_01.cpp' || echo '$(srcdir)/'`poisson_01.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/poisson_01_2d-poisson_01.Tpo $(DEPDIR)/poisson_01_2d-poisson_01.Po
@@ -2402,6 +2469,8 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/nodal_interpolation_01_3d-nodal_interpolation_01.Po
 	-rm -f ./$(DEPDIR)/phys_boundary_ops_2d-phys_boundary_ops.Po
 	-rm -f ./$(DEPDIR)/phys_boundary_ops_3d-phys_boundary_ops.Po
+	-rm -f ./$(DEPDIR)/pointwise_function_2d-pointwise_function.Po
+	-rm -f ./$(DEPDIR)/pointwise_function_3d-pointwise_function.Po
 	-rm -f ./$(DEPDIR)/poisson_01_2d-poisson_01.Po
 	-rm -f ./$(DEPDIR)/poisson_01_3d-poisson_01.Po
 	-rm -f ./$(DEPDIR)/prolongation_mat_2d-prolongation_mat.Po
@@ -2499,6 +2568,8 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/nodal_interpolation_01_3d-nodal_interpolation_01.Po
 	-rm -f ./$(DEPDIR)/phys_boundary_ops_2d-phys_boundary_ops.Po
 	-rm -f ./$(DEPDIR)/phys_boundary_ops_3d-phys_boundary_ops.Po
+	-rm -f ./$(DEPDIR)/pointwise_function_2d-pointwise_function.Po
+	-rm -f ./$(DEPDIR)/pointwise_function_3d-pointwise_function.Po
 	-rm -f ./$(DEPDIR)/poisson_01_2d-poisson_01.Po
 	-rm -f ./$(DEPDIR)/poisson_01_3d-poisson_01.Po
 	-rm -f ./$(DEPDIR)/prolongation_mat_2d-prolongation_mat.Po

--- a/tests/IBTK/pointwise_function.cpp
+++ b/tests/IBTK/pointwise_function.cpp
@@ -1,0 +1,238 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2023 - 2023 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/CartGridPointwiseFunction.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/muParserCartGridFunction.h>
+
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <GriddingAlgorithm.h>
+#include <LoadBalancer.h>
+#include <SAMRAI_config.h>
+#include <StandardTagAndInitialize.h>
+
+#include <ibtk/app_namespaces.h>
+
+/*******************************************************************************
+ * For each run, the input filename and restart information (if needed) must   *
+ * be given on the command line.  For non-restarted case, command line is:     *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ * For restarted run, command line is:                                         *
+ *                                                                             *
+ *    executable <input file name> <restart directory> <restart number>        *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize PETSc, MPI, and SAMRAI.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+
+    // Suppress a warning
+    SAMRAI::tbox::Logger::getInstance()->setWarning(false);
+
+    { // cleanup dynamically allocated objects prior to shutdown
+
+        // Parse command line options, set some standard options from the input
+        // file, initialize the restart database (if this is a restarted run),
+        // and enable file logging.
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "adv_diff.log");
+        Pointer<Database> input_db = app_initializer->getInputDatabase();
+        Pointer<Database> main_db = app_initializer->getComponentDatabase("Main");
+        const string reaction_exodus_filename = app_initializer->getExodusIIFilename("reaction");
+
+        // Get various standard options set in the input file.
+        const bool dump_postproc_data = app_initializer->dumpPostProcessingData();
+        const std::string postproc_data_dump_dirname = app_initializer->getPostProcessingDataDumpDirectory();
+        if (dump_postproc_data && !postproc_data_dump_dirname.empty())
+        {
+            Utilities::recursiveMkdir(postproc_data_dump_dirname);
+        }
+
+        // Create major algorithm and data objects that comprise the
+        // application.  These objects are configured from the input database
+        // and, if this is a restarted run, from the restart database.
+        Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<BergerRigoutsos<NDIM> > box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<StandardTagAndInitialize<NDIM> > error_detector = new StandardTagAndInitialize<NDIM>(
+            "StandardTagAndInitialize", NULL, app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<LoadBalancer<NDIM> > load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM> > gridding_algorithm =
+            new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                        app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                        error_detector,
+                                        box_generator,
+                                        load_balancer);
+
+        Pointer<CellVariable<NDIM, double> > cc_1_var = new CellVariable<NDIM, double>("cc_1");
+        Pointer<CellVariable<NDIM, double> > cc_d_var = new CellVariable<NDIM, double>("cc_d", NDIM);
+        Pointer<CellVariable<NDIM, double> > cc_d2_var = new CellVariable<NDIM, double>("cc_d2", NDIM * 2);
+        Pointer<NodeVariable<NDIM, double> > nc_var = new NodeVariable<NDIM, double>("nc");
+        Pointer<SideVariable<NDIM, double> > sc_var = new SideVariable<NDIM, double>("sc");
+        Pointer<FaceVariable<NDIM, double> > fc_var = new FaceVariable<NDIM, double>("fc");
+        Pointer<EdgeVariable<NDIM, double> > ec_var = new EdgeVariable<NDIM, double>("ec");
+
+        auto var_db = VariableDatabase<NDIM>::getDatabase();
+        Pointer<VariableContext> ctx = var_db->getContext("CTX");
+        IntVector<NDIM> no_ghosts(0);
+        const int cc_1_idx = var_db->registerVariableAndContext(cc_1_var, ctx, no_ghosts);
+        const int cc_1_cloned_idx = var_db->registerClonedPatchDataIndex(cc_1_var, cc_1_idx);
+        const int cc_d_idx = var_db->registerVariableAndContext(cc_d_var, ctx, no_ghosts);
+        const int cc_d_cloned_idx = var_db->registerClonedPatchDataIndex(cc_d_var, cc_d_idx);
+        const int cc_d2_idx = var_db->registerVariableAndContext(cc_d2_var, ctx, no_ghosts);
+        const int cc_d2_cloned_idx = var_db->registerClonedPatchDataIndex(cc_d2_var, cc_d2_idx);
+        const int nc_idx = var_db->registerVariableAndContext(nc_var, ctx, no_ghosts);
+        const int nc_cloned_idx = var_db->registerClonedPatchDataIndex(nc_var, nc_idx);
+        const int sc_idx = var_db->registerVariableAndContext(sc_var, ctx, no_ghosts);
+        const int sc_cloned_idx = var_db->registerClonedPatchDataIndex(sc_var, sc_idx);
+        const int fc_idx = var_db->registerVariableAndContext(fc_var, ctx, no_ghosts);
+        const int fc_cloned_idx = var_db->registerClonedPatchDataIndex(fc_var, fc_idx);
+        const int ec_idx = var_db->registerVariableAndContext(ec_var, ctx, no_ghosts);
+        const int ec_cloned_idx = var_db->registerClonedPatchDataIndex(ec_var, ec_idx);
+
+        ComponentSelector comps;
+        comps.setFlag(cc_1_idx);
+        comps.setFlag(cc_1_cloned_idx);
+        comps.setFlag(cc_d_idx);
+        comps.setFlag(cc_d_cloned_idx);
+        comps.setFlag(cc_d2_idx);
+        comps.setFlag(cc_d2_cloned_idx);
+        comps.setFlag(nc_idx);
+        comps.setFlag(nc_cloned_idx);
+        comps.setFlag(sc_idx);
+        comps.setFlag(sc_cloned_idx);
+        comps.setFlag(fc_idx);
+        comps.setFlag(fc_cloned_idx);
+        comps.setFlag(ec_idx);
+        comps.setFlag(ec_cloned_idx);
+
+        gridding_algorithm->makeCoarsestLevel(patch_hierarchy, 0.0);
+        int tag_buffer = 1;
+        int ln = 0;
+        bool done = false;
+        while (!done && (gridding_algorithm->levelCanBeRefined(ln)))
+        {
+            gridding_algorithm->makeFinerLevel(patch_hierarchy, 0.0, 0.0, tag_buffer);
+            done = !patch_hierarchy->finerLevelExists(ln);
+            ++ln;
+        }
+
+        // Read functions from input file
+        muParserCartGridFunction mu_scalar_fcn(
+            "scalar", app_initializer->getComponentDatabase("ScalarFcn"), grid_geometry);
+        muParserCartGridFunction mu_vector_fcn(
+            "vector", app_initializer->getComponentDatabase("VectorFcn"), grid_geometry);
+        muParserCartGridFunction mu_other_fcn(
+            "other", app_initializer->getComponentDatabase("OtherFcn"), grid_geometry);
+
+        PointwiseFunctions::ScalarFcn scalar_fcn = [](const double /*Q*/, const VectorNd& x, const double t) -> double
+        { return x(0) + x(1) + t; };
+
+        PointwiseFunctions::VectorFcn vector_fcn =
+            [](const VectorNd& /*Q*/, const VectorNd& x, const double t) -> VectorNd
+        {
+            VectorNd ret;
+            for (int d = 0; d < NDIM; ++d) ret[d] = x(0) + x(1) + t;
+            return ret;
+        };
+
+        PointwiseFunctions::OtherFcn other_fcn = [](const VectorXd& Q, const VectorNd& x, const double t) -> VectorXd
+        {
+            VectorXd ret = Q;
+            for (int d = 0; d < ret.rows(); ++d) ret[d] = x(0) + x(1) + t;
+            return ret;
+        };
+
+        PointwiseFunctions::StaggeredFcn vector_fcn_side =
+            [](const double /*Q*/, const VectorNd& x, const double t, const int /*axis*/) -> double
+        { return x(0) + x(1) + t; };
+
+        CartGridPointwiseFunction pt_scalar_fcn("scalar", scalar_fcn);
+        CartGridPointwiseFunction pt_vector_fcn("vector", vector_fcn);
+        CartGridPointwiseFunction pt_other_fcn("other", other_fcn);
+        CartGridPointwiseFunction pt_vector_side_fcn("vector_side", vector_fcn_side);
+
+        // Allocate data
+        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+            level->allocatePatchData(comps);
+        }
+
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(patch_hierarchy);
+        HierarchyNodeDataOpsReal<NDIM, double> hier_nc_data_ops(patch_hierarchy);
+        HierarchyFaceDataOpsReal<NDIM, double> hier_fc_data_ops(patch_hierarchy);
+        HierarchySideDataOpsReal<NDIM, double> hier_sc_data_ops(patch_hierarchy);
+        HierarchyEdgeDataOpsReal<NDIM, double> hier_ec_data_ops(patch_hierarchy);
+
+        const double time = 1.0;
+
+        plog << "Cell centered scalar\n";
+        mu_scalar_fcn.setDataOnPatchHierarchy(cc_1_idx, cc_1_var, patch_hierarchy, time, false);
+        pt_scalar_fcn.setDataOnPatchHierarchy(cc_1_cloned_idx, cc_1_var, patch_hierarchy, time, false);
+        hier_cc_data_ops.subtract(cc_1_idx, cc_1_idx, cc_1_cloned_idx);
+        plog << "Max difference: " << hier_cc_data_ops.maxNorm(cc_1_idx, IBTK::invalid_index) << "\n";
+
+        plog << "Cell centered vector\n";
+        mu_vector_fcn.setDataOnPatchHierarchy(cc_d_idx, cc_d_var, patch_hierarchy, time, false);
+        pt_vector_fcn.setDataOnPatchHierarchy(cc_d_cloned_idx, cc_d_var, patch_hierarchy, time, false);
+        hier_cc_data_ops.subtract(cc_d_idx, cc_d_idx, cc_d_cloned_idx);
+        plog << "Max difference: " << hier_cc_data_ops.maxNorm(cc_d_idx, IBTK::invalid_index) << "\n";
+
+        plog << "Cell centered other\n";
+        mu_other_fcn.setDataOnPatchHierarchy(cc_d2_idx, cc_d2_var, patch_hierarchy, time, false);
+        pt_other_fcn.setDataOnPatchHierarchy(cc_d2_cloned_idx, cc_d2_var, patch_hierarchy, time, false);
+        hier_cc_data_ops.subtract(cc_d2_idx, cc_d2_idx, cc_d2_cloned_idx);
+        plog << "Max difference: " << hier_cc_data_ops.maxNorm(cc_d2_idx, IBTK::invalid_index) << "\n";
+
+        plog << "Node centered\n";
+        mu_scalar_fcn.setDataOnPatchHierarchy(nc_idx, nc_var, patch_hierarchy, time, false);
+        pt_scalar_fcn.setDataOnPatchHierarchy(nc_cloned_idx, nc_var, patch_hierarchy, time, false);
+        hier_nc_data_ops.subtract(nc_idx, nc_idx, nc_cloned_idx);
+        plog << "Max difference: " << hier_nc_data_ops.maxNorm(nc_idx, IBTK::invalid_index) << "\n";
+
+        plog << "Side centered\n";
+        mu_vector_fcn.setDataOnPatchHierarchy(sc_idx, sc_var, patch_hierarchy, time, false);
+        pt_vector_side_fcn.setDataOnPatchHierarchy(sc_cloned_idx, sc_var, patch_hierarchy, time, false);
+        hier_sc_data_ops.subtract(sc_idx, sc_idx, sc_cloned_idx);
+        plog << "Max difference: " << hier_sc_data_ops.maxNorm(sc_idx, IBTK::invalid_index) << "\n";
+
+        plog << "Face centered\n";
+        mu_vector_fcn.setDataOnPatchHierarchy(fc_idx, fc_var, patch_hierarchy, time, false);
+        pt_vector_side_fcn.setDataOnPatchHierarchy(fc_cloned_idx, fc_var, patch_hierarchy, time, false);
+        hier_fc_data_ops.subtract(fc_idx, fc_idx, fc_cloned_idx);
+        plog << "Max difference: " << hier_fc_data_ops.maxNorm(fc_idx, IBTK::invalid_index) << "\n";
+
+        plog << "Edge centered\n";
+        mu_vector_fcn.setDataOnPatchHierarchy(ec_idx, ec_var, patch_hierarchy, time, false);
+        pt_vector_side_fcn.setDataOnPatchHierarchy(ec_cloned_idx, ec_var, patch_hierarchy, time, false);
+        hier_ec_data_ops.subtract(ec_idx, ec_idx, ec_cloned_idx);
+        plog << "Max difference: " << hier_ec_data_ops.maxNorm(ec_idx, IBTK::invalid_index) << "\n";
+
+        // Deallocate data
+        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+            level->deallocatePatchData(comps);
+        }
+
+    } // cleanup dynamically allocated objects prior to shutdown
+    return 0;
+} // main

--- a/tests/IBTK/pointwise_function_2d.input
+++ b/tests/IBTK/pointwise_function_2d.input
@@ -1,0 +1,68 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+N = 8                                    // coarsest grid spacing
+
+Main {
+
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt", "ExodusII"
+   viz_dump_interval           = 1
+   viz_dump_dirname            = "viz"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_adv_diff2d"
+
+   data_dump_interval          = 0
+   data_dump_dirname           = "hier_data_IB2d"
+
+   timer_dump_interval = 0
+}
+
+FCN = "X_0 + X_1 + t"
+
+ScalarFcn {
+   function = FCN
+}
+
+VectorFcn {
+   function_0 = FCN
+   function_1 = FCN
+}
+
+OtherFcn {
+   function_0 = FCN
+   function_1 = FCN
+   function_2 = FCN
+   function_3 = FCN
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = -1.0,-1.0
+   x_up = 1.0,1.0
+   periodic_dimension = 1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/IBTK/pointwise_function_2d.output
+++ b/tests/IBTK/pointwise_function_2d.output
@@ -1,0 +1,14 @@
+Cell centered scalar
+Max difference: -0
+Cell centered vector
+Max difference: -0
+Cell centered other
+Max difference: -0
+Node centered
+Max difference: -0
+Side centered
+Max difference: -0
+Face centered
+Max difference: -0
+Edge centered
+Max difference: -0

--- a/tests/IBTK/pointwise_function_3d.input
+++ b/tests/IBTK/pointwise_function_3d.input
@@ -1,0 +1,71 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+N = 8                                    // coarsest grid spacing
+
+Main {
+
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt", "ExodusII"
+   viz_dump_interval           = 1
+   viz_dump_dirname            = "viz"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_adv_diff2d"
+
+   data_dump_interval          = 0
+   data_dump_dirname           = "hier_data_IB2d"
+
+   timer_dump_interval = 0
+}
+
+FCN = "X_0 + X_1 + t"
+
+ScalarFcn {
+   function = FCN
+}
+
+VectorFcn {
+   function_0 = FCN
+   function_1 = FCN
+   function_2 = FCN
+}
+
+OtherFcn {
+   function_0 = FCN
+   function_1 = FCN
+   function_2 = FCN
+   function_3 = FCN
+   function_4 = FCN
+   function_5 = FCN
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = -1.0,-1.0,-1.0
+   x_up = 1.0,1.0,1.0
+   periodic_dimension = 1,1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4,  4  // all finer levels will use same values as level_0
+   }
+}
+
+StandardTagAndInitialize {
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/IBTK/pointwise_function_3d.output
+++ b/tests/IBTK/pointwise_function_3d.output
@@ -1,0 +1,14 @@
+Cell centered scalar
+Max difference: -0
+Cell centered vector
+Max difference: -0
+Cell centered other
+Max difference: -0
+Node centered
+Max difference: -0
+Side centered
+Max difference: -0
+Face centered
+Max difference: -0
+Edge centered
+Max difference: -0


### PR DESCRIPTION
This adds a class that can compute point-wise functions on the patch hierarchy. The functions can be used to modify patch data directly (i.e., you can compute `exp(Q_idx)` where `Q_idx` is a patch data index). The class is templated over the function definition, with different data centerings and depths requiring different function signatures. Fixes #1595.

In addition to the class, I think it would be good to add functions that can achieve the same result.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
