### PR TITLE
Add an API for getting the CFL number.

### DIFF
--- a/doc/news/changes/incompatibilities/20231114DavidWells
+++ b/doc/news/changes/incompatibilities/20231114DavidWells
@@ -1,0 +1,7 @@
+Changed: IBAMR::INSHierarchyIntegrator now computes the current CFL number via
+IBAMR::INSHierarchyIntegrator::updateCurrentCFLNumber() and makes it available
+via IBAMR::INSHierarchyIntegrator::getCurrentCFLNumber(). Classes which inherit
+from INSHierarchyIntegrator need to implement updateCurrentCFLNumber() in a
+compatible way.
+<br>
+(David Wells, 2023/11/14)

--- a/include/ibamr/INSHierarchyIntegrator.h
+++ b/include/ibamr/INSHierarchyIntegrator.h
@@ -371,6 +371,21 @@ public:
      */
     int getNumberOfCycles() const override;
 
+    /*!
+     * Finish postprocessing the hierarchy by computing the current CFL number.
+     */
+    virtual void postprocessIntegrateHierarchy(double current_time,
+                                               double new_time,
+                                               bool skip_synchronize_new_state_data,
+                                               int num_cycles = 1) override;
+
+    /*!
+     * Return the current CFL number (i.e., the CFL number computed from the
+     * current velocity field). This is typically computed at the end of each
+     * time step.
+     */
+    virtual double getCurrentCFLNumber() const;
+
 protected:
     /*!
      * The constructor for class INSHierarchyIntegrator sets some default
@@ -421,6 +436,14 @@ protected:
      * Pure virtual method to project the velocity field following a regridding operation.
      */
     virtual void regridProjection() = 0;
+
+    /*!
+     * Update the current CFL number (i.e., at the end of a timestep).
+     *
+     * @note this method can handle both cell-centered and side-centered
+     * velocities.
+     */
+    virtual void updateCurrentCFLNumber(const int data_idx, const double dt);
 
     /*!
      * Return the maximum stable time step size.
@@ -476,6 +499,11 @@ protected:
      */
     std::vector<SAMRAI::tbox::Pointer<AdvDiffHierarchyIntegrator> > d_adv_diff_hier_integrators;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::FaceVariable<NDIM, double> > d_U_adv_diff_var;
+
+    /*!
+     * Current CFL number.
+     */
+    double d_cfl_current = std::numeric_limits<double>::quiet_NaN();
 
     /*!
      * The maximum CFL number.

--- a/src/IB/IBHierarchyIntegrator.cpp
+++ b/src/IB/IBHierarchyIntegrator.cpp
@@ -243,35 +243,7 @@ IBHierarchyIntegrator::postprocessIntegrateHierarchy(const double current_time,
         level->deallocatePatchData(d_ib_data);
     }
 
-    // Determine the CFL number.
-    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    const int u_new_idx = var_db->mapVariableAndContextToIndex(d_ins_hier_integrator->getVelocityVariable(),
-                                                               d_ins_hier_integrator->getNewContext());
-    const double dt = new_time - current_time;
-    double cfl_max = 0.0;
-    PatchCellDataOpsReal<NDIM, double> patch_cc_ops;
-    PatchSideDataOpsReal<NDIM, double> patch_sc_ops;
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
-        {
-            Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            const Box<NDIM>& patch_box = patch->getBox();
-            const Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
-            const double* const dx = pgeom->getDx();
-            const double dx_min = *(std::min_element(dx, dx + NDIM));
-            Pointer<CellData<NDIM, double> > u_cc_new_data = patch->getPatchData(u_new_idx);
-            Pointer<SideData<NDIM, double> > u_sc_new_data = patch->getPatchData(u_new_idx);
-            double u_max = 0.0;
-            if (u_cc_new_data) u_max = patch_cc_ops.maxNorm(u_cc_new_data, patch_box);
-            if (u_sc_new_data) u_max = patch_sc_ops.maxNorm(u_sc_new_data, patch_box);
-            cfl_max = std::max(cfl_max, u_max * dt / dx_min);
-        }
-    }
-
-    cfl_max = IBTK_MPI::maxReduction(cfl_max);
-    d_regrid_fluid_cfl_estimate += cfl_max;
+    d_regrid_fluid_cfl_estimate += d_ins_hier_integrator->getCurrentCFLNumber();
 
     // Not all IBStrategy objects implement this so make it optional (-1.0 is
     // the default value)
@@ -280,7 +252,9 @@ IBHierarchyIntegrator::postprocessIntegrateHierarchy(const double current_time,
 
     if (d_enable_logging)
     {
-        plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
+        plog << d_object_name
+             << "::postprocessIntegrateHierarchy(): CFL number = " << d_ins_hier_integrator->getCurrentCFLNumber()
+             << "\n";
         plog << d_object_name
              << "::postprocessIntegrateHierarchy(): Eulerian estimate of "
                 "upper bound on IB point displacement since last regrid = "

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1449,42 +1449,12 @@ INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(const double cur
     INSHierarchyIntegrator::postprocessIntegrateHierarchy(
         current_time, new_time, skip_synchronize_new_state_data, num_cycles);
 
-    const int coarsest_ln = 0;
-    const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    const double dt = new_time - current_time;
-
     // Synchronize new state data.
     if (!skip_synchronize_new_state_data)
     {
         if (d_enable_logging)
             plog << d_object_name << "::postprocessIntegrateHierarchy(): synchronizing updated data\n";
         synchronizeHierarchyData(NEW_DATA);
-    }
-
-    // Determine the CFL number.
-    if (!d_parent_integrator)
-    {
-        double cfl_max = 0.0;
-        PatchCellDataOpsReal<NDIM, double> patch_cc_ops;
-        for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
-        {
-            Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
-            {
-                Pointer<Patch<NDIM> > patch = level->getPatch(p());
-                const Box<NDIM>& patch_box = patch->getBox();
-                const Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
-                const double* const dx = pgeom->getDx();
-                const double dx_min = *(std::min_element(dx, dx + NDIM));
-                Pointer<CellData<NDIM, double> > u_cc_new_data = patch->getPatchData(d_U_new_idx);
-                double u_max = 0.0;
-                u_max = patch_cc_ops.maxNorm(u_cc_new_data, patch_box);
-                cfl_max = std::max(cfl_max, u_max * dt / dx_min);
-            }
-        }
-        cfl_max = IBTK_MPI::maxReduction(cfl_max);
-        if (d_enable_logging)
-            plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
     }
 
     // Compute max |Omega|_2.
@@ -1749,6 +1719,9 @@ INSCollocatedHierarchyIntegrator::resetHierarchyConfigurationSpecialized(
     d_convective_op_needs_init = true;
     d_velocity_solver_needs_init = true;
     d_pressure_solver_needs_init = true;
+
+    // Set the initial current CFL number.
+    updateCurrentCFLNumber(d_U_current_idx, getMaximumTimeStepSize());
     return;
 } // resetHierarchyConfigurationSpecialized
 

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1332,42 +1332,12 @@ INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double curr
     INSHierarchyIntegrator::postprocessIntegrateHierarchy(
         current_time, new_time, skip_synchronize_new_state_data, num_cycles);
 
-    const int coarsest_ln = 0;
-    const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    const double dt = new_time - current_time;
-
     // Synchronize new state data.
     if (!skip_synchronize_new_state_data)
     {
         if (d_enable_logging)
             plog << d_object_name << "::postprocessIntegrateHierarchy(): synchronizing updated data\n";
         synchronizeHierarchyData(NEW_DATA);
-    }
-
-    // Determine the CFL number.
-    if (!d_parent_integrator)
-    {
-        double cfl_max = 0.0;
-        PatchSideDataOpsReal<NDIM, double> patch_sc_ops;
-        for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
-        {
-            Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
-            {
-                Pointer<Patch<NDIM> > patch = level->getPatch(p());
-                const Box<NDIM>& patch_box = patch->getBox();
-                const Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
-                const double* const dx = pgeom->getDx();
-                const double dx_min = *(std::min_element(dx, dx + NDIM));
-                Pointer<SideData<NDIM, double> > u_sc_new_data = patch->getPatchData(d_U_new_idx);
-                double u_max = 0.0;
-                u_max = patch_sc_ops.maxNorm(u_sc_new_data, patch_box);
-                cfl_max = std::max(cfl_max, u_max * dt / dx_min);
-            }
-        }
-        cfl_max = IBTK_MPI::maxReduction(cfl_max);
-        if (d_enable_logging)
-            plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
     }
 
     // Compute max |Omega|_2.
@@ -1983,6 +1953,9 @@ INSStaggeredHierarchyIntegrator::resetHierarchyConfigurationSpecialized(
     d_velocity_solver_needs_init = true;
     d_pressure_solver_needs_init = true;
     d_stokes_solver_needs_init = true;
+
+    // Set the initial current CFL number.
+    updateCurrentCFLNumber(d_U_current_idx, getMaximumTimeStepSize());
     return;
 } // resetHierarchyConfigurationSpecialized
 

--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -1227,7 +1227,6 @@ INSVCStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double cu
 
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    const double dt = new_time - current_time;
 
     // Synchronize new state data.
     if (!skip_synchronize_new_state_data)
@@ -1235,32 +1234,6 @@ INSVCStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double cu
         if (d_enable_logging)
             plog << d_object_name << "::postprocessIntegrateHierarchy(): synchronizing updated data\n";
         synchronizeHierarchyData(NEW_DATA);
-    }
-
-    // Determine the CFL number.
-    if (!d_parent_integrator)
-    {
-        double cfl_max = 0.0;
-        PatchSideDataOpsReal<NDIM, double> patch_sc_ops;
-        for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
-        {
-            Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
-            {
-                Pointer<Patch<NDIM> > patch = level->getPatch(p());
-                const Box<NDIM>& patch_box = patch->getBox();
-                const Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
-                const double* const dx = pgeom->getDx();
-                const double dx_min = *(std::min_element(dx, dx + NDIM));
-                Pointer<SideData<NDIM, double> > u_sc_new_data = patch->getPatchData(d_U_new_idx);
-                double u_max = 0.0;
-                u_max = patch_sc_ops.maxNorm(u_sc_new_data, patch_box);
-                cfl_max = std::max(cfl_max, u_max * dt / dx_min);
-            }
-        }
-        cfl_max = IBTK_MPI::maxReduction(cfl_max);
-        if (d_enable_logging)
-            plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
     }
 
     // Compute max |Omega|_2.
@@ -1835,6 +1808,9 @@ INSVCStaggeredHierarchyIntegrator::resetHierarchyConfigurationSpecialized(
     d_velocity_solver_needs_init = true;
     d_pressure_solver_needs_init = true;
     d_stokes_solver_needs_init = true;
+
+    // Set the initial current CFL number.
+    updateCurrentCFLNumber(d_U_current_idx, getMaximumTimeStepSize());
     return;
 } // resetHierarchyConfigurationSpecialized
 

--- a/tests/IBTK/child_integrators.2_hierarchies.output
+++ b/tests/IBTK/child_integrators.2_hierarchies.output
@@ -1,6 +1,8 @@
 IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 DummyAdvDiff: initializeLevelDataSpecialized()
 DummyAdvDiff2: initializeLevelDataSpecialized()
+DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
+DummyAdvDiff2: getMaximumTimeStepSizeSpecialized()
 DummyAdvDiff: resetHierarchyConfigurationSpecialized()
 DummyAdvDiff2: resetHierarchyConfigurationSpecialized()
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():

--- a/tests/IBTK/child_integrators.output
+++ b/tests/IBTK/child_integrators.output
@@ -1,5 +1,6 @@
 IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 DummyAdvDiff: initializeLevelDataSpecialized()
+DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
 DummyAdvDiff: resetHierarchyConfigurationSpecialized()
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field


### PR DESCRIPTION
Presently, the CFL number is only available through the logfile. This PR consolidates where we calculate it (the INS solver is always responsible) and makes it available via `getCurrentCFLNumber()`.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
