### PR TITLE
Simplify implicit solver implementation

### DIFF
--- a/examples/IB/explicit/ex0/example.cpp
+++ b/examples/IB/explicit/ex0/example.cpp
@@ -25,6 +25,7 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibamr/IBExplicitHierarchyIntegrator.h>
+#include <ibamr/IBImplicitHierarchyIntegrator.h>
 #include <ibamr/IBMethod.h>
 #include <ibamr/IBRedundantInitializer.h>
 #include <ibamr/IBStandardForceGen.h>
@@ -297,12 +298,27 @@ main(int argc, char* argv[])
             TBOX_ERROR("Unsupported solver type: " << solver_type << "\n"
                                                    << "Valid options are: COLLOCATED, STAGGERED");
         }
+
         Pointer<IBMethod> ib_method_ops = new IBMethod("IBMethod", app_initializer->getComponentDatabase("IBMethod"));
-        Pointer<IBHierarchyIntegrator> time_integrator =
-            new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
-                                              app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
-                                              ib_method_ops,
-                                              navier_stokes_integrator);
+        Pointer<IBHierarchyIntegrator> time_integrator;
+        const string ib_time_stepping_type =
+            app_initializer->getComponentDatabase("Main")->getStringWithDefault("ib_time_stepping_type", "EXPLICIT");
+        if (ib_time_stepping_type == "EXPLICIT")
+        {
+            time_integrator =
+                new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
+        else
+        {
+            time_integrator =
+                new IBImplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
         Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
             "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
         Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);

--- a/examples/IB/explicit/ex1/example.cpp
+++ b/examples/IB/explicit/ex1/example.cpp
@@ -24,7 +24,9 @@
 #include <StandardTagAndInitialize.h>
 
 // Headers for application-specific algorithm/data structure objects
+#include "ibamr/IBHierarchyIntegrator.h"
 #include <ibamr/IBExplicitHierarchyIntegrator.h>
+#include <ibamr/IBImplicitHierarchyIntegrator.h>
 #include <ibamr/IBMethod.h>
 #include <ibamr/IBStandardForceGen.h>
 #include <ibamr/IBStandardInitializer.h>
@@ -120,11 +122,25 @@ main(int argc, char* argv[])
                                                    << "Valid options are: COLLOCATED, STAGGERED");
         }
         Pointer<IBMethod> ib_method_ops = new IBMethod("IBMethod", app_initializer->getComponentDatabase("IBMethod"));
-        Pointer<IBHierarchyIntegrator> time_integrator =
-            new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
-                                              app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
-                                              ib_method_ops,
-                                              navier_stokes_integrator);
+        Pointer<IBHierarchyIntegrator> time_integrator;
+        const string ib_time_stepping_type =
+            app_initializer->getComponentDatabase("Main")->getStringWithDefault("ib_time_stepping_type", "EXPLICIT");
+        if (ib_time_stepping_type == "EXPLICIT")
+        {
+            time_integrator =
+                new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
+        else
+        {
+            time_integrator =
+                new IBImplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
         Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
             "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
         Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);

--- a/examples/IB/explicit/ex2/example.cpp
+++ b/examples/IB/explicit/ex2/example.cpp
@@ -25,6 +25,7 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibamr/IBExplicitHierarchyIntegrator.h>
+#include <ibamr/IBImplicitHierarchyIntegrator.h>
 #include <ibamr/IBMethod.h>
 #include <ibamr/IBStandardForceGen.h>
 #include <ibamr/IBStandardInitializer.h>
@@ -111,11 +112,25 @@ main(int argc, char* argv[])
                                                    << "Valid options are: COLLOCATED, STAGGERED");
         }
         Pointer<IBMethod> ib_method_ops = new IBMethod("IBMethod", app_initializer->getComponentDatabase("IBMethod"));
-        Pointer<IBHierarchyIntegrator> time_integrator =
-            new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
-                                              app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
-                                              ib_method_ops,
-                                              navier_stokes_integrator);
+        Pointer<IBHierarchyIntegrator> time_integrator;
+        const string ib_time_stepping_type =
+            app_initializer->getComponentDatabase("Main")->getStringWithDefault("ib_time_stepping_type", "EXPLICIT");
+        if (ib_time_stepping_type == "EXPLICIT")
+        {
+            time_integrator =
+                new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
+        else
+        {
+            time_integrator =
+                new IBImplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
         Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
             "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
         Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);

--- a/examples/IB/explicit/ex5/example.cpp
+++ b/examples/IB/explicit/ex5/example.cpp
@@ -25,6 +25,7 @@
 
 // Headers for application-specific algorithm/data structure objects
 #include <ibamr/IBExplicitHierarchyIntegrator.h>
+#include <ibamr/IBImplicitHierarchyIntegrator.h>
 #include <ibamr/IBMethod.h>
 #include <ibamr/IBStandardForceGen.h>
 #include <ibamr/IBStandardInitializer.h>
@@ -105,11 +106,25 @@ main(int argc, char* argv[])
             "INSStaggeredHierarchyIntegrator",
             app_initializer->getComponentDatabase("INSStaggeredHierarchyIntegrator"));
         Pointer<IBMethod> ib_method_ops = new IBMethod("IBMethod", app_initializer->getComponentDatabase("IBMethod"));
-        Pointer<IBHierarchyIntegrator> time_integrator =
-            new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
-                                              app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
-                                              ib_method_ops,
-                                              navier_stokes_integrator);
+        Pointer<IBHierarchyIntegrator> time_integrator;
+        const string ib_time_stepping_type =
+            app_initializer->getComponentDatabase("Main")->getStringWithDefault("ib_time_stepping_type", "EXPLICIT");
+        if (ib_time_stepping_type == "EXPLICIT")
+        {
+            time_integrator =
+                new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
+        else
+        {
+            time_integrator =
+                new IBImplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
         Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
             "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
         Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);

--- a/examples/IBFE/explicit/ex0/example.cpp
+++ b/examples/IBFE/explicit/ex0/example.cpp
@@ -34,6 +34,7 @@
 #include <ibamr/IBExplicitHierarchyIntegrator.h>
 #include <ibamr/IBFECentroidPostProcessor.h>
 #include <ibamr/IBFEMethod.h>
+#include <ibamr/IBImplicitHierarchyIntegrator.h>
 #include <ibamr/INSCollocatedHierarchyIntegrator.h>
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
@@ -219,11 +220,25 @@ main(int argc, char* argv[])
                            /*register_for_restart*/ true,
                            restart_read_dirname,
                            restart_restore_num);
-        Pointer<IBHierarchyIntegrator> time_integrator =
-            new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
-                                              app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
-                                              ib_method_ops,
-                                              navier_stokes_integrator);
+        Pointer<IBHierarchyIntegrator> time_integrator;
+        const string ib_time_stepping_type =
+            app_initializer->getComponentDatabase("Main")->getStringWithDefault("ib_time_stepping_type", "EXPLICIT");
+        if (ib_time_stepping_type == "EXPLICIT")
+        {
+            time_integrator =
+                new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
+        else
+        {
+            time_integrator =
+                new IBImplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
         Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
             "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
         Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);

--- a/examples/IBFE/explicit/ex1/example.cpp
+++ b/examples/IBFE/explicit/ex1/example.cpp
@@ -34,6 +34,7 @@
 #include <ibamr/IBExplicitHierarchyIntegrator.h>
 #include <ibamr/IBFECentroidPostProcessor.h>
 #include <ibamr/IBFEMethod.h>
+#include <ibamr/IBImplicitHierarchyIntegrator.h>
 #include <ibamr/INSCollocatedHierarchyIntegrator.h>
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
@@ -216,11 +217,25 @@ main(int argc, char* argv[])
                            /*register_for_restart*/ true,
                            restart_read_dirname,
                            restart_restore_num);
-        Pointer<IBHierarchyIntegrator> time_integrator =
-            new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
-                                              app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
-                                              ib_method_ops,
-                                              navier_stokes_integrator);
+        Pointer<IBHierarchyIntegrator> time_integrator;
+        const string ib_time_stepping_type =
+            app_initializer->getComponentDatabase("Main")->getStringWithDefault("ib_time_stepping_type", "EXPLICIT");
+        if (ib_time_stepping_type == "EXPLICIT")
+        {
+            time_integrator =
+                new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
+        else
+        {
+            time_integrator =
+                new IBImplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
         Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
             "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
         Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);

--- a/examples/IBFE/explicit/ex2/example.cpp
+++ b/examples/IBFE/explicit/ex2/example.cpp
@@ -34,6 +34,7 @@
 // Headers for application-specific algorithm/data structure objects
 #include <ibamr/IBExplicitHierarchyIntegrator.h>
 #include <ibamr/IBFEMethod.h>
+#include <ibamr/IBImplicitHierarchyIntegrator.h>
 #include <ibamr/INSCollocatedHierarchyIntegrator.h>
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
@@ -244,11 +245,25 @@ main(int argc, char* argv[])
                            /*register_for_restart*/ true,
                            restart_read_dirname,
                            restart_restore_num);
-        Pointer<IBHierarchyIntegrator> time_integrator =
-            new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
-                                              app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
-                                              ib_method_ops,
-                                              navier_stokes_integrator);
+        Pointer<IBHierarchyIntegrator> time_integrator;
+        const string ib_time_stepping_type =
+            app_initializer->getComponentDatabase("Main")->getStringWithDefault("ib_time_stepping_type", "EXPLICIT");
+        if (ib_time_stepping_type == "EXPLICIT")
+        {
+            time_integrator =
+                new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
+        else
+        {
+            time_integrator =
+                new IBImplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
         Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
             "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
         Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);

--- a/examples/IBFE/explicit/ex3/example.cpp
+++ b/examples/IBFE/explicit/ex3/example.cpp
@@ -34,6 +34,7 @@
 #include <ibamr/IBExplicitHierarchyIntegrator.h>
 #include <ibamr/IBFECentroidPostProcessor.h>
 #include <ibamr/IBFEMethod.h>
+#include <ibamr/IBImplicitHierarchyIntegrator.h>
 #include <ibamr/INSCollocatedHierarchyIntegrator.h>
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
 
@@ -227,11 +228,25 @@ main(int argc, char* argv[])
                            /*register_for_restart*/ true,
                            restart_read_dirname,
                            restart_restore_num);
-        Pointer<IBHierarchyIntegrator> time_integrator =
-            new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
-                                              app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
-                                              ib_method_ops,
-                                              navier_stokes_integrator);
+        Pointer<IBHierarchyIntegrator> time_integrator;
+        const string ib_time_stepping_type =
+            app_initializer->getComponentDatabase("Main")->getStringWithDefault("ib_time_stepping_type", "EXPLICIT");
+        if (ib_time_stepping_type == "EXPLICIT")
+        {
+            time_integrator =
+                new IBExplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
+        else
+        {
+            time_integrator =
+                new IBImplicitHierarchyIntegrator("IBHierarchyIntegrator",
+                                                  app_initializer->getComponentDatabase("IBHierarchyIntegrator"),
+                                                  ib_method_ops,
+                                                  navier_stokes_integrator);
+        }
         Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
             "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
         Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);

--- a/examples/IBFE/explicit/ex4/input2d.implicit
+++ b/examples/IBFE/explicit/ex4/input2d.implicit
@@ -1,0 +1,229 @@
+// physical parameters
+MU  = 0.01
+RHO = 1.0
+L   = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 1                                      // maximum number of levels in locally refined grid
+REF_RATIO  = 2                                      // refinement ratio between levels
+N = 64                                              // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N            // effective number of grid cells on finest   grid level
+DX0 = L/N                                           // mesh width on coarsest grid level
+DX  = L/NFINEST                                     // mesh width on finest   grid level
+MFAC = 2.0                                          // ratio of Lagrangian mesh width to Cartesian mesh width
+ELEM_TYPE = "TRI6"                                  // type of element to use for structure discretization
+PK1_DEV_QUAD_ORDER = "FIFTH"
+PK1_DIL_QUAD_ORDER = "THIRD"
+
+// model parameters
+U_MAX = 2.0
+C1_S = 100.0*0.625*5000.0
+P0_S = C1_S
+BETA_S = 1.0*(NFINEST/64.0)
+
+// solver parameters
+IB_DELTA_FUNCTION          = "IB_4"                 // the type of smoothed delta function to use for Lagrangian-Eulerian interaction
+SPLIT_FORCES               = FALSE                  // whether to split interior and boundary forces
+USE_JUMP_CONDITIONS        = FALSE                  // whether to impose pressure jumps at fluid-structure interfaces
+USE_CONSISTENT_MASS_MATRIX = TRUE                   // whether to use a consistent or lumped mass matrix
+IB_POINT_DENSITY           = 3.0                    // approximate density of IB quadrature points for Lagrangian-Eulerian interaction
+SOLVER_TYPE                = "STAGGERED"            // the fluid solver to use (STAGGERED or COLLOCATED)
+CFL_MAX                    = 0.1                    // maximum CFL number
+DT                         = 10.0*.25*CFL_MAX*DX/U_MAX  // maximum timestep size
+START_TIME                 = 0.0e0                  // initial simulation time
+END_TIME                   = 100.0                  // final simulation time
+GROW_DT                    = 2.0e0                  // growth factor for timesteps
+NUM_CYCLES                 = 1                      // number of cycles of fixed-point iteration
+CONVECTIVE_TS_TYPE         = "ADAMS_BASHFORTH"      // convective time stepping type
+CONVECTIVE_OP_TYPE         = "PPM"                  // convective differencing discretization type
+CONVECTIVE_FORM            = "ADVECTIVE"            // how to compute the convective terms
+NORMALIZE_PRESSURE         = FALSE                  // whether to explicitly force the pressure to have mean zero
+ERROR_ON_DT_CHANGE         = FALSE                  // whether to emit an error message if the time step size changes
+VORTICITY_TAGGING          = TRUE                   // whether to tag cells for refinement based on vorticity thresholds
+TAG_BUFFER                 = 1                      // size of tag buffer used by grid generation algorithm
+REGRID_CFL_INTERVAL        = 0.5                    // regrid whenever any material point could have moved 0.5 meshwidths since previous regrid
+OUTPUT_U                   = TRUE
+OUTPUT_P                   = TRUE
+OUTPUT_F                   = TRUE
+OUTPUT_OMEGA               = TRUE
+OUTPUT_DIV_U               = TRUE
+ENABLE_LOGGING             = TRUE
+
+// collocated solver parameters
+PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
+SECOND_ORDER_PRESSURE_UPDATE = TRUE
+
+VelocityBcCoefs_0 {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "1.0"
+}
+
+VelocityBcCoefs_1 {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+IBHierarchyIntegrator {
+   start_time          = START_TIME
+   end_time            = END_TIME
+   grow_dt             = GROW_DT
+   num_cycles          = NUM_CYCLES
+   regrid_cfl_interval = REGRID_CFL_INTERVAL
+   dt_init             = 0.001*DT
+   dt_max              = 100.0*DT
+   dt_min              = DT/1000.0
+   error_on_dt_change  = ERROR_ON_DT_CHANGE
+   enable_logging      = ENABLE_LOGGING
+
+   //time_stepping_type  = "BACKWARD_EULER"
+   solve_for_position  = TRUE
+   //eta                 = 100.0 * RHO / DT
+}
+
+IBFEMethod {
+   IB_delta_fcn               = IB_DELTA_FUNCTION
+   split_forces               = SPLIT_FORCES
+   use_jump_conditions        = USE_JUMP_CONDITIONS
+   use_consistent_mass_matrix = USE_CONSISTENT_MASS_MATRIX
+   IB_point_density           = IB_POINT_DENSITY
+}
+
+INSCollocatedHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_rel_thresh          = 0.01
+   tag_buffer                    = TAG_BUFFER
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+   projection_method_type        = PROJECTION_METHOD_TYPE
+   use_2nd_order_pressure_update = SECOND_ORDER_PRESSURE_UPDATE
+}
+
+INSStaggeredHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_rel_thresh          = 0.01
+   tag_buffer                    = TAG_BUFFER
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+}
+
+Main {
+   solver_type = SOLVER_TYPE
+   ib_time_stepping_type = "IMPLICIT"
+
+// log file parameters
+   log_file_name               = "IB2d.log"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt","ExodusII"
+   viz_dump_interval           = int(0.125/DT)
+   viz_dump_dirname            = "viz_IB2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_IB2d"
+
+// hierarchy data dump parameters
+   data_dump_interval          = 0
+   data_dump_dirname           = "hier_data_IB2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+      level_4 = REF_RATIO,REF_RATIO
+      level_5 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "GRADIENT_DETECTOR"
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/examples/IBFE/explicit/ex5/input2d.implicit
+++ b/examples/IBFE/explicit/ex5/input2d.implicit
@@ -1,0 +1,239 @@
+// physical parameters
+Re = 200.0
+MU = 1.0/Re
+RHO = 1.0
+
+// grid spacing parameters
+L = 16.0                                       // width of computational domain
+MAX_LEVELS = 5                                 // maximum number of levels in locally refined grid
+REF_RATIO  = 2                                 // refinement ratio between levels
+N = 16                                         // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N       // effective number of grid cells on finest   grid level
+DX0 = L/N                                      // mesh width on coarsest grid level
+DX  = L/NFINEST                                // mesh width on finest   grid level
+MFAC = 2.0                                     // ratio of Lagrangian mesh width to Cartesian mesh width
+ELEM_TYPE = "TRI3"                             // type of element to use for structure discretization
+PK1_DEV_QUAD_ORDER = "SEVENTH"
+PK1_DIL_QUAD_ORDER = "FIFTH"
+USE_BOUNDARY_MESH = TRUE
+
+// solver parameters
+IB_DELTA_FUNCTION          = "IB_4"            // the type of smoothed delta function to use for Lagrangian-Eulerian interaction
+SPLIT_FORCES               = FALSE             // whether to split interior and boundary forces
+USE_JUMP_CONDITIONS        = FALSE             // whether to impose pressure jumps at fluid-structure interfaces
+USE_CONSISTENT_MASS_MATRIX = TRUE              // whether to use a consistent or lumped mass matrix
+IB_POINT_DENSITY           = 4.0               // approximate density of IB quadrature points for Lagrangian-Eulerian interaction
+SOLVER_TYPE                = "STAGGERED"       // the fluid solver to use (STAGGERED or COLLOCATED)
+CFL_MAX                    = 0.9               // maximum CFL number
+DT                         = 0.25*CFL_MAX*DX   // maximum timestep size
+START_TIME                 = 0.0e0             // initial simulation time
+END_TIME                   = 100.0             // final simulation time
+GROW_DT                    = 2.0e0             // growth factor for timesteps
+CONVECTIVE_TS_TYPE         = "ADAMS_BASHFORTH" // convective time stepping type
+CONVECTIVE_OP_TYPE         = "PPM"             // convective differencing discretization type
+CONVECTIVE_FORM            = "ADVECTIVE"       // how to compute the convective terms
+NORMALIZE_PRESSURE         = FALSE             // whether to explicitly force the pressure to have mean zero
+ERROR_ON_DT_CHANGE         = TRUE              // whether to emit an error message if the time step size changes
+VORTICITY_TAGGING          = TRUE              // whether to tag cells for refinement based on vorticity thresholds
+TAG_BUFFER                 = 1                 // size of tag buffer used by grid generation algorithm
+REGRID_CFL_INTERVAL        = 0.5               // regrid whenever any material point could have moved 0.5 meshwidths since previous regrid
+OUTPUT_U                   = TRUE
+OUTPUT_P                   = TRUE
+OUTPUT_F                   = TRUE
+OUTPUT_OMEGA               = TRUE
+OUTPUT_DIV_U               = TRUE
+ENABLE_LOGGING             = TRUE
+
+// model parameters
+KAPPA_S = 2.5*DX/DT^2
+ETA_S = 1.5*DX/DT
+
+// tether penalty data
+C1_S = 1.0e5
+KAPPA_S_BODY = 1.0e6
+ETA_S_BODY = 0.0
+KAPPA_S_SURFACE = 1.0e6
+ETA_S_SURFACE = 0.0
+
+// collocated solver parameters
+PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
+SECOND_ORDER_PRESSURE_UPDATE = TRUE
+
+VelocityBcCoefs_0 {
+   t_half = 0.5
+   tau = 0.125
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "0.0"
+   acoef_function_2 = "0.0"
+   acoef_function_3 = "0.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "1.0"
+   bcoef_function_2 = "1.0"
+   bcoef_function_3 = "1.0"
+
+   gcoef_function_0 = "(tanh((t-t_half)/tau)+tanh(t_half/tau))/(1+tanh(t_half/tau))"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+VelocityBcCoefs_1 {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "0.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "1.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = "cos(pi*X_1/16.0)*exp(-2.0*t)"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+IBHierarchyIntegrator {
+   start_time          = START_TIME
+   end_time            = END_TIME
+   grow_dt             = GROW_DT
+   regrid_cfl_interval = REGRID_CFL_INTERVAL
+   dt_max              = DT
+   error_on_dt_change  = ERROR_ON_DT_CHANGE
+   enable_logging      = ENABLE_LOGGING
+
+   time_stepping_type  = "BACKWARD_EULER"
+   solve_for_position  = FALSE
+   eta                 = 100.0 * RHO / DT
+}
+
+IBFEMethod {
+   IB_delta_fcn                = IB_DELTA_FUNCTION
+   split_forces                = SPLIT_FORCES
+   use_jump_conditions         = USE_JUMP_CONDITIONS
+   use_consistent_mass_matrix  = USE_CONSISTENT_MASS_MATRIX
+   IB_point_density            = IB_POINT_DENSITY
+}
+
+INSCollocatedHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_abs_thresh          = 0.125,0.25,0.5,1,2
+   tag_buffer                    = TAG_BUFFER
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+   projection_method_type        = PROJECTION_METHOD_TYPE
+   use_2nd_order_pressure_update = SECOND_ORDER_PRESSURE_UPDATE
+}
+
+INSStaggeredHierarchyIntegrator {
+   creeping_flow = FALSE
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_abs_thresh          = 0.125,0.25,0.5,1,2
+   tag_buffer                    = TAG_BUFFER
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+}
+
+Main {
+   solver_type = SOLVER_TYPE
+   ib_time_stepping_type = "IMPLICIT"
+
+// log file parameters
+   log_file_name               = "IB2d.log"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt","ExodusII"
+   viz_dump_interval           = int(0.1/DT)
+   viz_dump_dirname            = "viz_IB2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_IB2d"
+
+// hierarchy data dump parameters
+   data_dump_interval          = 1
+   data_dump_dirname           = "hier_data_IB2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(2*N - 1,N - 1) ]
+   x_lo = -0.5*L,-0.5*L
+   x_up =  1.5*L, 0.5*L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+      level_4 = REF_RATIO,REF_RATIO
+      level_5 = REF_RATIO,REF_RATIO
+      level_6 = REF_RATIO,REF_RATIO
+      level_7 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   8,  8  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.80e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.80e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "GRADIENT_DETECTOR"
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total = TRUE
+   print_threshold = 0.1
+
+   timer_list = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -401,6 +401,12 @@ public:
     virtual double getCurrentTimeStepSize() const;
 
     /*!
+     * Skip enforcing that we do the prescribed number of cycles in each time
+     * step.
+     */
+    void setSkipEnforceNumCycles(bool set_skip_enforce_num_cycles = true);
+
+    /*!
      * Virtual method to prepare to advance data from current_time to new_time.
      *
      * A default implementation is provided that sets the current values of
@@ -1088,6 +1094,7 @@ protected:
      */
     int d_current_num_cycles = -1, d_current_cycle_num = -1;
     double d_current_dt = std::numeric_limits<double>::quiet_NaN();
+    bool d_skip_enforce_num_cycles = false;
 
     /*
      * The number of integration steps taken between invocations of the

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -141,9 +141,11 @@ public:
 
     /*!
      * Integrate data on all patches on all levels of the patch hierarchy over
-     * the specified time increment.
+     * the requested time increment.
+     *
+     * The actual time increment may be reduced to satisfy solver requirements.  The increment that was executed is returned.
      */
-    virtual void advanceHierarchy(double dt);
+    virtual double advanceHierarchy(double dt_requested);
 
     /*!
      * Return the current value of the minimum time step size for the integrator
@@ -1079,7 +1081,7 @@ protected:
     double d_integrator_time = std::numeric_limits<double>::quiet_NaN(), d_start_time = 0.0,
            d_end_time = std::numeric_limits<double>::max();
     double d_dt_init = std::numeric_limits<double>::max(), d_dt_min = 0.0,
-           d_dt_max = std::numeric_limits<double>::max(), d_dt_growth_factor = 2.0;
+           d_dt_max = std::numeric_limits<double>::max(), d_dt_growth_factor = 2.0, d_dt_shrink_factor = 0.5;
     int d_integrator_step = 0, d_max_integrator_steps = std::numeric_limits<int>::max();
     std::deque<double> d_dt_previous;
 
@@ -1095,6 +1097,7 @@ protected:
     int d_current_num_cycles = -1, d_current_cycle_num = -1;
     double d_current_dt = std::numeric_limits<double>::quiet_NaN();
     bool d_skip_enforce_num_cycles = false;
+    bool d_redo_time_step = false;
 
     /*
      * The number of integration steps taken between invocations of the

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -1686,6 +1686,8 @@ HierarchyIntegrator::getFromInput(Pointer<Database> db, bool is_from_restart)
     if (db->keyExists("dt_max")) d_dt_max = db->getDouble("dt_max");
     if (db->keyExists("grow_dt"))
         d_dt_growth_factor = db->getDouble("grow_dt");
+    if (db->keyExists("shrink_dt"))
+        d_dt_shrink_factor = db->getDouble("shrink_dt");
     else if (db->keyExists("dt_growth_factor"))
         d_dt_growth_factor = db->getDouble("dt_growth_factor");
     if (db->keyExists("max_integrator_steps")) d_max_integrator_steps = db->getInteger("max_integrator_steps");

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -644,6 +644,12 @@ HierarchyIntegrator::getCurrentTimeStepSize() const
 } // getCurrentTimeStepSize
 
 void
+HierarchyIntegrator::setSkipEnforceNumCycles(const bool skip_enforce_num_cycles)
+{
+    d_skip_enforce_num_cycles = skip_enforce_num_cycles;
+}
+
+void
 HierarchyIntegrator::preprocessIntegrateHierarchy(const double current_time,
                                                   const double new_time,
                                                   const int num_cycles)
@@ -664,8 +670,12 @@ HierarchyIntegrator::integrateHierarchy(const double current_time, const double 
     ++d_current_cycle_num;
 #if !defined(NDEBUG)
     TBOX_ASSERT(IBTK::abs_equal_eps(d_current_dt, new_time - current_time));
-    TBOX_ASSERT(d_current_cycle_num == cycle_num);
-    TBOX_ASSERT(d_current_cycle_num < d_current_num_cycles);
+    TBOX_ASSERT(d_skip_enforce_num_cycles || d_current_cycle_num == cycle_num);
+    TBOX_ASSERT(d_skip_enforce_num_cycles || d_current_cycle_num < d_current_num_cycles);
+#else
+    NULL_USE(current_time);
+    NULL_USE(new_time);
+    NULL_USE(cycle_num);
 #endif
 
     integrateHierarchySpecialized(current_time, new_time, cycle_num);
@@ -680,8 +690,8 @@ HierarchyIntegrator::skipCycle(const double current_time, const double new_time,
     ++d_current_cycle_num;
 #if !defined(NDEBUG)
     TBOX_ASSERT(IBTK::abs_equal_eps(d_current_dt, new_time - current_time));
-    TBOX_ASSERT(d_current_cycle_num == cycle_num);
-    TBOX_ASSERT(d_current_cycle_num < d_current_num_cycles);
+    TBOX_ASSERT(d_skip_enforce_num_cycles || d_current_cycle_num == cycle_num);
+    TBOX_ASSERT(d_skip_enforce_num_cycles || d_current_cycle_num < d_current_num_cycles);
 #else
     NULL_USE(current_time);
     NULL_USE(new_time);
@@ -698,8 +708,8 @@ HierarchyIntegrator::postprocessIntegrateHierarchy(const double current_time,
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(IBTK::abs_equal_eps(d_current_dt, new_time - current_time));
-    TBOX_ASSERT(num_cycles == d_current_num_cycles);
-    TBOX_ASSERT(d_current_cycle_num + 1 == d_current_num_cycles);
+    TBOX_ASSERT(d_skip_enforce_num_cycles || num_cycles == d_current_num_cycles);
+    TBOX_ASSERT(d_skip_enforce_num_cycles || d_current_cycle_num + 1 == d_current_num_cycles);
 #else
     NULL_USE(current_time);
     NULL_USE(new_time);

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -24,7 +24,7 @@
 
 #include "ibamr/FEMechanicsBase.h"
 #include "ibamr/IBFEDirectForcingKinematics.h"
-#include "ibamr/IBStrategy.h"
+#include "ibamr/IBImplicitStrategy.h"
 #include "ibamr/ibamr_enums.h"
 
 #include "ibtk/FEDataManager.h"
@@ -434,7 +434,7 @@ class IBFEDirectForcingKinematics;
  * is handled by the SAMRAI::tbox::RestartManager automatically to reinitiate
  * the IBFEMethod.
  */
-class IBFEMethod : public FEMechanicsBase, public IBStrategy
+class IBFEMethod : public FEMechanicsBase, public IBImplicitStrategy
 {
 public:
     IBTK_DEPRECATED("Use IBFEMethod::getSourceSystemName() to access the source system name.")
@@ -632,6 +632,12 @@ public:
     void forwardEulerStep(double current_time, double new_time) override;
 
     /*!
+     * Advance the positions of the Lagrangian structure using the backward Euler
+     * method.
+     */
+    void backwardEulerStep(double current_time, double new_time) override;
+
+    /*!
      * Advance the positions of the Lagrangian structure using the (explicit)
      * backward Euler method.
      */
@@ -685,6 +691,46 @@ public:
         IBTK::RobinPhysBdryPatchStrategy* q_phys_bdry_op,
         const std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::RefineSchedule<NDIM> > >& q_prolongation_scheds,
         double data_time) override;
+
+    /*!
+     * Create solution data.
+     */
+    void createSolutionVec(Vec* X_vec) override;
+
+    /*!
+     * Create solution and rhs data.
+     */
+    void createSolverVecs(Vec* X_vec, Vec* F_vec) override;
+
+    /*!
+     * Setup solution and rhs data.
+     */
+    void setupSolverVecs(Vec& X_vec, Vec& F_vec) override;
+
+    /*!
+     * Set the value of the updated position vector.
+     */
+    void setUpdatedPosition(Vec& X_new_vec) override;
+
+    /*!
+     * Get the value of the updated position vector.
+     */
+    void getUpdatedPosition(Vec& X_new_vec) override;
+
+    /*!
+     * Compute the nonlinear residual for backward Euler time stepping.
+     */
+    void computeResidualBackwardEuler(Vec& R_vec) override;
+
+    /*!
+     * Compute the nonlinear residual for midpoint rule time stepping.
+     */
+    void computeResidualMidpointRule(Vec& R_vec) override;
+
+    /*!
+     * Compute the nonlinear residual for trapezoidal rule time stepping.
+     */
+    void computeResidualTrapezoidalRule(Vec& R_vec) override;
 
     /*!
      * Get the default interpolation spec object used by the class.
@@ -1113,6 +1159,11 @@ private:
      * scratch hierarchy).
      */
     void reinitElementMappings();
+
+    /**
+     * Cached data for implicit solver.
+     */
+    std::vector<std::unique_ptr<libMesh::PetscVector<double> > > d_implicit_X_vecs, d_implicit_R_vecs;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -742,6 +742,12 @@ public:
     void computeResidualTrapezoidalRule(Vec& R_vec) override;
 
     /*!
+     * Update the positions used for the "fixed" interpolation and spreading
+     * operators.
+     */
+    void updateFixedLEOperators() override;
+
+    /*!
      * Get the default interpolation spec object used by the class.
      */
     IBTK::FEDataManager::InterpSpec getDefaultInterpSpec() const;

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -694,12 +694,12 @@ public:
     /*!
      * Create solution and rhs data.
      */
-    void createSolverVecs(Vec* X_vec, Vec* F_vec) override;
+    void createSolverVecs(Vec* X_vec, Vec* F_vec, Vec* R_vec) override;
 
     /*!
      * Setup solution and rhs data.
      */
-    void setupSolverVecs(Vec& X_vec, Vec& F_vec) override;
+    void setupSolverVecs(Vec& X_vec, Vec& F_vec, Vec& R_vec) override;
 
     /*!
      * Set the value of the updated position vector.
@@ -707,9 +707,24 @@ public:
     void setUpdatedPosition(Vec& X_new_vec) override;
 
     /*!
+     * Set the value of the updated force vector.
+     */
+    void setUpdatedForce(Vec& F_new_vec) override;
+
+    /*!
      * Get the value of the updated position vector.
      */
     void getUpdatedPosition(Vec& X_new_vec) override;
+
+    /*!
+     * Get the value of the updated velocity vector.
+     */
+    void getUpdatedVelocity(Vec& U_new_vec) override;
+
+    /*!
+     * Get the value of the updated force vector.
+     */
+    void getUpdatedForce(Vec& F_new_vec) override;
 
     /*!
      * Compute the nonlinear residual for backward Euler time stepping.
@@ -1157,7 +1172,8 @@ private:
     /**
      * Cached data for implicit solver.
      */
-    std::vector<std::unique_ptr<libMesh::PetscVector<double> > > d_implicit_X_vecs, d_implicit_R_vecs;
+    std::vector<std::unique_ptr<libMesh::PetscVector<double> > > d_implicit_X_vecs, d_implicit_F_vecs,
+        d_implicit_R_vecs;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBFEMethod.h
+++ b/include/ibamr/IBFEMethod.h
@@ -639,12 +639,6 @@ public:
 
     /*!
      * Advance the positions of the Lagrangian structure using the (explicit)
-     * backward Euler method.
-     */
-    void backwardEulerStep(double current_time, double new_time) override;
-
-    /*!
-     * Advance the positions of the Lagrangian structure using the (explicit)
      * midpoint rule.
      */
     void midpointStep(double current_time, double new_time) override;

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -157,6 +157,9 @@ protected:
 
     SAMRAI::tbox::Pointer<IBImplicitStrategy> d_ib_implicit_ops;
 
+    // The implicit solver approach. Current options are AITKEN or SNES.
+    std::string d_implicit_algorithm = "AITKEN";
+
     // Whether to use "frozen" LE operators.
     bool d_use_fixed_LE_operators = false;
 

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -34,6 +34,7 @@
 #include "petscsys.h"
 #include "petscvec.h"
 
+#include <limits>
 #include <string>
 
 namespace IBAMR
@@ -141,6 +142,12 @@ protected:
     // Whether to use "frozen" LE operators.
     bool d_use_fixed_LE_operators = false;
 
+    // Whether to solve for the position.
+    bool d_solve_for_position = false;
+
+    // Penalty factor used in direct forcing.
+    double d_eta = std::numeric_limits<double>::quiet_NaN();
+
 private:
     /*!
      * \brief Copy constructor.
@@ -175,13 +182,12 @@ private:
     /*!
      * Iterate the solution (e.g. for fixed-point iteration).
      */
-    void iterateSolution(Vec X_new);
+    void iterateSolution(Vec Y, Vec R, bool update_IB_state_vars, bool update_IB_residual);
 
     /*!
      * Static function for implicit formulation.
      */
-    static PetscErrorCode IBFunction_SAMRAI(SNES snes, Vec X, Vec R, void* ctx);
-    PetscErrorCode IBFunction(SNES snes, Vec X, Vec R);
+    static PetscErrorCode IBFunction(SNES snes, Vec Y, Vec R, void* ctx);
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -180,9 +180,9 @@ private:
     double d_current_time, d_new_time;
 
     /*!
-     * Update the solution (e.g. for fixed-point iteration) based on the current value of Y.
+     * Update the solution (e.g. for fixed-point iteration) based on the current value of Y and compute the residual.
      */
-    void updateSolution(Vec Y, Vec R, bool update_IB_state_vars, bool update_IB_residual);
+    void updateSolution(Vec Y, Vec R);
 
     /*!
      * Static function for implicit formulation.

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -1,0 +1,204 @@
+// Filename: IBImplicitHierarchyIntegrator.h
+// Created on 07 Apr 2012 by Boyce Griffith
+//
+// Copyright (c) 2002-2017, Boyce Griffith
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef included_IBAMR_IBImplicitHierarchyIntegrator
+#define included_IBAMR_IBImplicitHierarchyIntegrator
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include "ibamr/IBHierarchyIntegrator.h"
+#include "ibamr/IBImplicitStrategy.h"
+#include "ibamr/StaggeredStokesFACPreconditioner.h"
+#include "ibamr/StaggeredStokesIBLevelRelaxationFACOperator.h"
+#include "ibamr/StaggeredStokesOperator.h"
+#include "ibamr/StaggeredStokesSolver.h"
+
+#include "IntVector.h"
+#include "SAMRAIVectorReal.h"
+#include "tbox/Pointer.h"
+
+#include "petscksp.h"
+#include "petscmat.h"
+#include "petscpc.h"
+#include "petscsnes.h"
+#include "petscsys.h"
+#include "petscvec.h"
+
+#include <string>
+
+namespace IBAMR
+{
+class INSStaggeredHierarchyIntegrator;
+} // namespace IBAMR
+namespace SAMRAI
+{
+namespace hier
+{
+template <int DIM>
+class PatchHierarchy;
+} // namespace hier
+namespace mesh
+{
+template <int DIM>
+class GriddingAlgorithm;
+} // namespace mesh
+namespace solv
+{
+class PoissonSpecifications;
+} // namespace solv
+namespace tbox
+{
+class Database;
+} // namespace tbox
+} // namespace SAMRAI
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+namespace IBAMR
+{
+/*!
+ * \brief Class IBImplicitHierarchyIntegrator is an implementation of a
+ * formally second-order accurate, nonlinearly-implicit version of the immersed
+ * boundary method.
+ */
+class IBImplicitHierarchyIntegrator : public IBHierarchyIntegrator
+{
+public:
+    /*!
+     * The constructor for class IBImplicitHierarchyIntegrator sets
+     * some default values, reads in configuration information from input and
+     * restart databases, and registers the integrator object with the restart
+     * manager when requested.
+     */
+    IBImplicitHierarchyIntegrator(const std::string& object_name,
+                                  SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db,
+                                  SAMRAI::tbox::Pointer<IBImplicitStrategy> ib_method_ops,
+                                  SAMRAI::tbox::Pointer<INSStaggeredHierarchyIntegrator> ins_hier_integrator,
+                                  bool register_for_restart = true);
+
+    /*!
+     * The destructor for class IBImplicitHierarchyIntegrator
+     * unregisters the integrator object with the restart manager when the
+     * object is so registered.
+     */
+    ~IBImplicitHierarchyIntegrator() = default;
+
+    /*!
+     * Prepare to advance the data from current_time to new_time.
+     */
+    void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
+
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
+
+    /*!
+     * Clean up data following call(s) to integrateHierarchy().
+     */
+    void postprocessIntegrateHierarchy(double current_time,
+                                       double new_time,
+                                       bool skip_synchronize_new_state_data,
+                                       int num_cycles = 1) override;
+
+    /*!
+     * Initialize the variables, basic communications algorithms, solvers, and
+     * other data structures used by this time integrator object.
+     *
+     * This method is called automatically by initializePatchHierarchy() prior
+     * to the construction of the patch hierarchy.  It is also possible for
+     * users to make an explicit call to initializeHierarchyIntegrator() prior
+     * to calling initializePatchHierarchy().
+     */
+    void
+    initializeHierarchyIntegrator(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                                  SAMRAI::tbox::Pointer<SAMRAI::mesh::GriddingAlgorithm<NDIM> > gridding_alg) override;
+
+    /*!
+     * Returns the number of cycles to perform for the present time step.
+     */
+    int getNumberOfCycles() const override;
+
+protected:
+    /*!
+     * Write out specialized object state to the given database.
+     */
+    void putToDatabaseSpecialized(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
+
+    SAMRAI::tbox::Pointer<IBImplicitStrategy> d_ib_implicit_ops;
+
+    // Whether to use "frozen" LE operators.
+    bool d_use_fixed_LE_operators = false;
+
+private:
+    /*!
+     * \brief Copy constructor.
+     *
+     * \note This constructor is not implemented and should not be used.
+     *
+     * \param from The value to copy to this object.
+     */
+    IBImplicitHierarchyIntegrator(const IBImplicitHierarchyIntegrator& from) = delete;
+
+    /*!
+     * \brief Assignment operator.
+     *
+     * \note This operator is not implemented and should not be used.
+     *
+     * \param that The value to assign to this object.
+     *
+     * \return A reference to this object.
+     */
+    IBImplicitHierarchyIntegrator& operator=(const IBImplicitHierarchyIntegrator& that) = delete;
+
+    /*!
+     * Read object state from the restart file and initialize class data
+     * members.
+     */
+    void getFromRestart();
+
+    /// Solver state data.
+    int d_cycle_num, d_ins_cycle_num;
+    double d_current_time, d_new_time;
+
+    /*!
+     * Static function for implicit formulation.
+     */
+    static PetscErrorCode IBFunction_SAMRAI(SNES snes, Vec X, Vec R, void* ctx);
+    PetscErrorCode IBFunction(SNES snes, Vec X, Vec R);
+};
+} // namespace IBAMR
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif //#ifndef included_IBAMR_IBImplicitHierarchyIntegrator

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -18,50 +18,8 @@
 
 #include "ibamr/IBHierarchyIntegrator.h"
 #include "ibamr/IBImplicitStrategy.h"
-#include "ibamr/StaggeredStokesFACPreconditioner.h"
-#include "ibamr/StaggeredStokesIBLevelRelaxationFACOperator.h"
-#include "ibamr/StaggeredStokesOperator.h"
-#include "ibamr/StaggeredStokesSolver.h"
 
-#include "IntVector.h"
-#include "SAMRAIVectorReal.h"
-#include "tbox/Pointer.h"
-
-#include "petscksp.h"
-#include "petscmat.h"
-#include "petscpc.h"
 #include "petscsnes.h"
-#include "petscsys.h"
-#include "petscvec.h"
-
-#include <limits>
-#include <string>
-
-namespace IBAMR
-{
-class INSStaggeredHierarchyIntegrator;
-} // namespace IBAMR
-namespace SAMRAI
-{
-namespace hier
-{
-template <int DIM>
-class PatchHierarchy;
-} // namespace hier
-namespace mesh
-{
-template <int DIM>
-class GriddingAlgorithm;
-} // namespace mesh
-namespace solv
-{
-class PoissonSpecifications;
-} // namespace solv
-namespace tbox
-{
-class Database;
-} // namespace tbox
-} // namespace SAMRAI
 
 /////////////////////////////// CLASS DEFINITION /////////////////////////////
 
@@ -84,7 +42,7 @@ public:
     IBImplicitHierarchyIntegrator(const std::string& object_name,
                                   SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db,
                                   SAMRAI::tbox::Pointer<IBImplicitStrategy> ib_method_ops,
-                                  SAMRAI::tbox::Pointer<INSStaggeredHierarchyIntegrator> ins_hier_integrator,
+                                  SAMRAI::tbox::Pointer<INSHierarchyIntegrator> ins_hier_integrator,
                                   bool register_for_restart = true);
 
     /*!
@@ -133,6 +91,11 @@ public:
 
 protected:
     /*!
+     * Determine the maximum time step size.
+     */
+    double getMaximumTimeStepSizeSpecialized() override;
+
+    /*!
      * Write out specialized object state to the given database.
      */
     void putToDatabaseSpecialized(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
@@ -177,7 +140,8 @@ private:
 
     /// Solver state data.
     int d_cycle_num, d_ins_cycle_num;
-    double d_current_time, d_new_time;
+    int d_snes_f_evals, d_snes_f_evals_previous, d_snes_f_evals_target_min = 5, d_snes_f_evals_target_max = 10;
+    double d_current_time, d_new_time, d_cfl_max_tol = 1.1;
 
     /*!
      * Update the solution (e.g. for fixed-point iteration) based on the current value of Y and compute the residual.
@@ -193,4 +157,4 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
-#endif //#ifndef included_IBAMR_IBImplicitHierarchyIntegrator
+#endif // #ifndef included_IBAMR_IBImplicitHierarchyIntegrator

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -157,7 +157,7 @@ protected:
 
     SAMRAI::tbox::Pointer<IBImplicitStrategy> d_ib_implicit_ops;
 
-    // The implicit solver approach. Current options are AITKEN or SNES.
+    // The implicit solver approach. Current options are AITKEN, ANDERSON, or SNES.
     std::string d_implicit_algorithm = "AITKEN";
 
     // Whether to use "frozen" LE operators.

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -157,8 +157,12 @@ protected:
 
     SAMRAI::tbox::Pointer<IBImplicitStrategy> d_ib_implicit_ops;
 
-    // The implicit solver approach. Current options are AITKEN, ANDERSON, or SNES.
+    // The implicit solver approach. Current options are AITKEN, ANDERSON, IRONS-TUCK, or SNES.
     std::string d_implicit_algorithm = "AITKEN";
+
+    // Relaxation parameter for IRONS-TUCK.
+    double d_omega_n = 0.5;
+    double d_omega_max = 0.5;
 
     // Whether to use "frozen" LE operators.
     bool d_use_fixed_LE_operators = false;

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -192,6 +192,11 @@ private:
     double d_current_time, d_new_time;
 
     /*!
+     * Iterate the solution (e.g. for fixed-point iteration).
+     */
+    void iterateSolution(Vec X_new);
+
+    /*!
      * Static function for implicit formulation.
      */
     static PetscErrorCode IBFunction_SAMRAI(SNES snes, Vec X, Vec R, void* ctx);

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -138,13 +138,6 @@ protected:
 
     SAMRAI::tbox::Pointer<IBImplicitStrategy> d_ib_implicit_ops;
 
-    // The implicit solver approach. Current options are AITKEN, ANDERSON, IRONS-TUCK, or SNES.
-    std::string d_implicit_algorithm = "AITKEN";
-
-    // Relaxation parameter for IRONS-TUCK.
-    double d_omega_n = 0.5;
-    double d_omega_max = 0.5;
-
     // Whether to use "frozen" LE operators.
     bool d_use_fixed_LE_operators = false;
 

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -1,34 +1,15 @@
-// Filename: IBImplicitHierarchyIntegrator.h
-// Created on 07 Apr 2012 by Boyce Griffith
+// ---------------------------------------------------------------------
 //
-// Copyright (c) 2002-2017, Boyce Griffith
+// Copyright (c) 2014 - 2019 by the IBAMR developers
 // All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
+// This file is part of IBAMR.
 //
-//    * Redistributions of source code must retain the above copyright notice,
-//      this list of conditions and the following disclaimer.
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
 //
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of The University of North Carolina nor the names of
-//      its contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// ---------------------------------------------------------------------
 
 #ifndef included_IBAMR_IBImplicitHierarchyIntegrator
 #define included_IBAMR_IBImplicitHierarchyIntegrator

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -180,9 +180,9 @@ private:
     double d_current_time, d_new_time;
 
     /*!
-     * Iterate the solution (e.g. for fixed-point iteration).
+     * Update the solution (e.g. for fixed-point iteration) based on the current value of Y.
      */
-    void iterateSolution(Vec Y, Vec R, bool update_IB_state_vars, bool update_IB_residual);
+    void updateSolution(Vec Y, Vec R, bool update_IB_state_vars, bool update_IB_residual);
 
     /*!
      * Static function for implicit formulation.

--- a/include/ibamr/IBImplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitHierarchyIntegrator.h
@@ -57,12 +57,14 @@ public:
      */
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
+protected:
     /*!
      * Synchronously advance each level in the hierarchy over the given time
      * increment.
      */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
 
+public:
     /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
@@ -105,9 +107,6 @@ protected:
     // Whether to use "frozen" LE operators.
     bool d_use_fixed_LE_operators = false;
 
-    // Whether to solve for the position.
-    bool d_solve_for_position = false;
-
     // Penalty factor used in direct forcing.
     double d_eta = std::numeric_limits<double>::quiet_NaN();
 
@@ -141,17 +140,18 @@ private:
     /// Solver state data.
     int d_cycle_num, d_ins_cycle_num;
     int d_snes_f_evals, d_snes_f_evals_previous, d_snes_f_evals_target_min = 5, d_snes_f_evals_target_max = 10;
-    double d_current_time, d_new_time, d_cfl_max_tol = 1.1;
+    double d_current_time, d_new_time, d_cfl_max_tol = 1.2;
+    bool d_skip_final_update_solution = false;
 
     /*!
      * Update the solution (e.g. for fixed-point iteration) based on the current value of Y and compute the residual.
      */
-    void updateSolution(Vec Y, Vec R);
+    void updateSolution(Vec X, Vec R);
 
     /*!
      * Static function for implicit formulation.
      */
-    static PetscErrorCode IBFunction(SNES snes, Vec Y, Vec R, void* ctx);
+    static PetscErrorCode IBFunction(SNES snes, Vec X, Vec R, void* ctx);
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBImplicitStrategy.h
+++ b/include/ibamr/IBImplicitStrategy.h
@@ -76,12 +76,12 @@ public:
     /*!
      * Create solution and rhs data.
      */
-    virtual void createSolverVecs(Vec* X_vec, Vec* F_vec) = 0;
+    virtual void createSolverVecs(Vec* X_vec, Vec* F_vec, Vec* R_vec) = 0;
 
     /*!
      * Setup solution and rhs data.
      */
-    virtual void setupSolverVecs(Vec& X_vec, Vec& F_vec) = 0;
+    virtual void setupSolverVecs(Vec& X_vec, Vec& F_vec, Vec& R_vec) = 0;
 
     /*!
      * Set the value of the updated position vector.
@@ -89,9 +89,24 @@ public:
     virtual void setUpdatedPosition(Vec& X_new_vec) = 0;
 
     /*!
+     * Set the value of the updated position vector.
+     */
+    virtual void setUpdatedForce(Vec& F_new_vec) = 0;
+
+    /*!
      * Get the value of the updated position vector.
      */
     virtual void getUpdatedPosition(Vec& X_new_vec) = 0;
+
+    /*!
+     * Get the value of the updated velocity vector.
+     */
+    virtual void getUpdatedVelocity(Vec& U_new_vec) = 0;
+
+    /*!
+     * Get the value of the updated force vector.
+     */
+    virtual void getUpdatedForce(Vec& F_new_vec) = 0;
 
     /*!
      * Compute the nonlinear residual for backward Euler time stepping.

--- a/include/ibamr/IBImplicitStrategy.h
+++ b/include/ibamr/IBImplicitStrategy.h
@@ -84,6 +84,11 @@ public:
     virtual void setUpdatedPosition(Vec& X_new_vec) = 0;
 
     /*!
+     * Get the value of the updated position vector.
+     */
+    virtual void getUpdatedPosition(Vec& X_new_vec) = 0;
+
+    /*!
      * Compute the nonlinear residual for backward Euler time stepping.
      */
     virtual void computeResidualBackwardEuler(Vec& R_vec) = 0;

--- a/include/ibamr/IBImplicitStrategy.h
+++ b/include/ibamr/IBImplicitStrategy.h
@@ -84,63 +84,19 @@ public:
     virtual void setUpdatedPosition(Vec& X_new_vec) = 0;
 
     /*!
-     * Set the value of the intermediate position vector used in evaluating the
-     * linearized problem.
+     * Compute the nonlinear residual for backward Euler time stepping.
      */
-    virtual void setLinearizedPosition(Vec& X_vec, double data_time) = 0;
+    virtual void computeResidualBackwardEuler(Vec& R_vec) = 0;
 
     /*!
-     * Compute the nonlinear residual.
+     * Compute the nonlinear residual for midpoint rule time stepping.
      */
-    virtual void computeResidual(Vec& R_vec) = 0;
+    virtual void computeResidualMidpointRule(Vec& R_vec) = 0;
 
     /*!
-     * Compute the linearized residual for the given intermediate position
-     * vector.
+     * Compute the nonlinear residual for trapezoidal rule time stepping.
      */
-    virtual void computeLinearizedResidual(Vec& X_vec, Vec& R_vec) = 0;
-
-    /*!
-     * Interpolate the Eulerian velocity to the curvilinear mesh at the
-     * specified time within the current time interval for use in evaluating the
-     * residual of the linearized problem.
-     */
-    virtual void interpolateLinearizedVelocity(
-        int u_data_idx,
-        const std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenSchedule<NDIM> > >& u_synch_scheds,
-        const std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::RefineSchedule<NDIM> > >& u_ghost_fill_scheds,
-        double data_time) = 0;
-
-    /*!
-     * Compute the Lagrangian force of the linearized problem for the specified
-     * configuration of the updated position vector.
-     */
-    virtual void computeLinearizedLagrangianForce(Vec& X_vec, double data_time) = 0;
-
-    /*!
-     * Construct the linearized Lagrangian force Jacobian.
-     */
-    virtual void constructLagrangianForceJacobian(Mat& A, MatType mat_type, double data_time) = 0;
-
-    /*!
-     * Spread the Lagrangian force of the linearized problem to the Cartesian
-     * grid at the specified time within the current time interval.
-     */
-    virtual void spreadLinearizedForce(
-        int f_data_idx,
-        IBTK::RobinPhysBdryPatchStrategy* f_phys_bdry_op,
-        const std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::RefineSchedule<NDIM> > >& f_prolongation_scheds,
-        double data_time) = 0;
-
-    /*!
-     * Construct the IB interpolation operator.
-     */
-    virtual void constructInterpOp(Mat& J,
-                                   void (*spread_fnc)(const double, double*),
-                                   int stencil_width,
-                                   const std::vector<int>& num_dofs_per_proc,
-                                   int dof_index_idx,
-                                   double data_time) = 0;
+    virtual void computeResidualTrapezoidalRule(Vec& R_vec) = 0;
 
 protected:
 private:

--- a/include/ibamr/IBImplicitStrategy.h
+++ b/include/ibamr/IBImplicitStrategy.h
@@ -69,6 +69,11 @@ public:
     virtual ~IBImplicitStrategy() = default;
 
     /*!
+     * Create solution data.
+     */
+    virtual void createSolutionVec(Vec* X_vec) = 0;
+
+    /*!
      * Create solution and rhs data.
      */
     virtual void createSolverVecs(Vec* X_vec, Vec* F_vec) = 0;
@@ -76,7 +81,7 @@ public:
     /*!
      * Setup solution and rhs data.
      */
-    virtual void setupSolverVecs(Vec* X_vec, Vec* F_vec) = 0;
+    virtual void setupSolverVecs(Vec& X_vec, Vec& F_vec) = 0;
 
     /*!
      * Set the value of the updated position vector.

--- a/include/ibamr/IBMethod.h
+++ b/include/ibamr/IBMethod.h
@@ -196,13 +196,13 @@ public:
      * Create solution and rhs data on the specified level of the patch
      * hierarchy.
      */
-    void createSolverVecs(Vec* X_vec, Vec* F_vec) override;
+    void createSolverVecs(Vec* X_vec, Vec* F_vec, Vec* R_vec) override;
 
     /*!
      * Setup solution and rhs data on the specified level of the patch
      * hierarchy.
      */
-    void setupSolverVecs(Vec& X_vec, Vec& F_vec) override;
+    void setupSolverVecs(Vec& X_vec, Vec& F_vec, Vec& R_vec) override;
 
     /*!
      * Set the value of the updated position vector.
@@ -210,9 +210,24 @@ public:
     void setUpdatedPosition(Vec& X_new_vec) override;
 
     /*!
+     * Set the value of the updated force vector.
+     */
+    void setUpdatedForce(Vec& F_new_vec) override;
+
+    /*!
      * Get the value of the updated position vector.
      */
     void getUpdatedPosition(Vec& X_new_vec) override;
+
+    /*!
+     * Get the value of the updated velocity vector.
+     */
+    void getUpdatedVelocity(Vec& U_new_vec) override;
+
+    /*!
+     * Get the value of the updated force vector.
+     */
+    void getUpdatedForce(Vec& F_new_vec) override;
 
     /*!
      * Compute the nonlinear residual for backward Euler time stepping.

--- a/include/ibamr/IBMethod.h
+++ b/include/ibamr/IBMethod.h
@@ -204,21 +204,19 @@ public:
     void setUpdatedPosition(Vec& X_new_vec) override;
 
     /*!
-     * Set the value of the intermediate position vector used in evaluating the
-     * linearized problem.
+     * Compute the nonlinear residual for backward Euler time stepping.
      */
-    void setLinearizedPosition(Vec& X_vec, double data_time) override;
+    void computeResidualBackwardEuler(Vec& R_vec) override;
 
     /*!
-     * Compute the residual on the specified level of the patch hierarchy.
+     * Compute the nonlinear residual for midpoint rule time stepping.
      */
-    void computeResidual(Vec& R_vec) override;
+    void computeResidualMidpointRule(Vec& R_vec) override;
 
     /*!
-     * Compute the linearized residual for the given intermediate position
-     * vector.
+     * Compute the nonlinear residual for trapezoidal rule time stepping.
      */
-    void computeLinearizedResidual(Vec& X_vec, Vec& R_vec) override;
+    void computeResidualTrapezoidalRule(Vec& R_vec) override;
 
     /*!
      * Update the positions used for the "fixed" interpolation and spreading
@@ -231,17 +229,6 @@ public:
      * specified time within the current time interval.
      */
     void interpolateVelocity(
-        int u_data_idx,
-        const std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenSchedule<NDIM> > >& u_synch_scheds,
-        const std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::RefineSchedule<NDIM> > >& u_ghost_fill_scheds,
-        double data_time) override;
-
-    /*!
-     * Interpolate the Eulerian velocity to the curvilinear mesh at the
-     * specified time within the current time interval for use in evaluating the
-     * residual of the linearized problem.
-     */
-    void interpolateLinearizedVelocity(
         int u_data_idx,
         const std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenSchedule<NDIM> > >& u_synch_scheds,
         const std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::RefineSchedule<NDIM> > >& u_ghost_fill_scheds,
@@ -277,17 +264,6 @@ public:
     void computeLagrangianForce(double data_time) override;
 
     /*!
-     * Compute the Lagrangian force of the linearized problem for the specified
-     * configuration of the updated position vector.
-     */
-    void computeLinearizedLagrangianForce(Vec& X_vec, double data_time) override;
-
-    /*!
-     * Construct the linearized Lagrangian force Jacobian.
-     */
-    void constructLagrangianForceJacobian(Mat& A, MatType mat_type, double data_time) override;
-
-    /*!
      * Spread the Lagrangian force to the Cartesian grid at the specified time
      * within the current time interval.
      */
@@ -298,16 +274,6 @@ public:
                 double data_time) override;
 
     /*!
-     * Spread the Lagrangian force of the linearized problem to the Cartesian
-     * grid at the specified time within the current time interval.
-     */
-    void spreadLinearizedForce(
-        int f_data_idx,
-        IBTK::RobinPhysBdryPatchStrategy* f_phys_bdry_op,
-        const std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::RefineSchedule<NDIM> > >& f_prolongation_scheds,
-        double data_time) override;
-
-    /*!
      * Construct the IB interpolation operator.
      */
     void constructInterpOp(Mat& J,
@@ -315,7 +281,7 @@ public:
                            int stencil_width,
                            const std::vector<int>& num_dofs_per_proc,
                            int dof_index_idx,
-                           double data_time) override;
+                           double data_time);
 
     /*!
      * Indicate whether there are any internal fluid sources/sinks.
@@ -453,12 +419,6 @@ protected:
                          double data_time);
 
     /*!
-     * Get the linearized structure position data.
-     */
-    void getLinearizedPositionData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** X_data,
-                                   bool** X_needs_ghost_fill);
-
-    /*!
      * Get the current interpolation/spreading position data.
      */
     void getLECouplingPositionData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** X_LE_data,
@@ -471,21 +431,11 @@ protected:
     void getVelocityData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** U_data, double data_time);
 
     /*!
-     * Get the linearized structure velocity data.
-     */
-    void getLinearizedVelocityData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** U_data);
-
-    /*!
      * Get the current structure force data.
      */
     void getForceData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** F_data,
                       bool** F_needs_ghost_fill,
                       double data_time);
-
-    /*!
-     * Get the linearized structure force data.
-     */
-    void getLinearizedForceData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** F_data, bool** F_needs_ghost_fill);
 
     /*!
      * Interpolate the current and new data to obtain values at the midpoint of
@@ -501,13 +451,6 @@ protected:
      */
     void
     resetAnchorPointValues(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> > U_data, int coarsest_ln, int finest_ln);
-
-    /*
-     * PETSc function for evaluating Lagrangian force.
-     */
-    static PetscErrorCode computeForce_SAMRAI(void* ctx, Vec X, Vec F);
-
-    PetscErrorCode computeForce(Vec X, Vec F);
 
     /*
      * Indicates whether the integrator should output logging messages.
@@ -533,9 +476,8 @@ protected:
      * reinitialized.
      */
     bool d_X_current_needs_ghost_fill = true, d_X_new_needs_ghost_fill = true, d_X_half_needs_ghost_fill = true,
-         d_X_jac_needs_ghost_fill = true, d_X_LE_new_needs_ghost_fill = true, d_X_LE_half_needs_ghost_fill = true;
-    bool d_F_current_needs_ghost_fill = true, d_F_new_needs_ghost_fill = true, d_F_half_needs_ghost_fill = true,
-         d_F_jac_needs_ghost_fill = true;
+         d_X_LE_new_needs_ghost_fill = true, d_X_LE_half_needs_ghost_fill = true;
+    bool d_F_current_needs_ghost_fill = true, d_F_new_needs_ghost_fill = true, d_F_half_needs_ghost_fill = true;
 
     /*
      * The LDataManager is used to coordinate the distribution of Lagrangian
@@ -549,10 +491,10 @@ protected:
     /*
      * Lagrangian variables.
      */
-    std::vector<SAMRAI::tbox::Pointer<IBTK::LData> > d_X_current_data, d_X_new_data, d_X_half_data, d_X_jac_data,
-        d_X_LE_new_data, d_X_LE_half_data;
-    std::vector<SAMRAI::tbox::Pointer<IBTK::LData> > d_U_current_data, d_U_new_data, d_U_half_data, d_U_jac_data;
-    std::vector<SAMRAI::tbox::Pointer<IBTK::LData> > d_F_current_data, d_F_new_data, d_F_half_data, d_F_jac_data;
+    std::vector<SAMRAI::tbox::Pointer<IBTK::LData> > d_X_current_data, d_X_new_data, d_X_half_data, d_X_LE_new_data,
+        d_X_LE_half_data;
+    std::vector<SAMRAI::tbox::Pointer<IBTK::LData> > d_U_current_data, d_U_new_data, d_U_half_data;
+    std::vector<SAMRAI::tbox::Pointer<IBTK::LData> > d_F_current_data, d_F_new_data, d_F_half_data;
 
     /*
      * List of local indices of local anchor points.
@@ -673,13 +615,6 @@ private:
      * members.
      */
     void getFromRestart();
-
-    /*!
-     * Jacobian data.
-     */
-    bool d_force_jac_mffd = false;
-    Mat d_force_jac = nullptr;
-    double d_force_jac_data_time;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/IBMethod.h
+++ b/include/ibamr/IBMethod.h
@@ -204,6 +204,11 @@ public:
     void setUpdatedPosition(Vec& X_new_vec) override;
 
     /*!
+     * Get the value of the updated position vector.
+     */
+    void getUpdatedPosition(Vec& X_new_vec) override;
+
+    /*!
      * Compute the nonlinear residual for backward Euler time stepping.
      */
     void computeResidualBackwardEuler(Vec& R_vec) override;

--- a/include/ibamr/IBMethod.h
+++ b/include/ibamr/IBMethod.h
@@ -187,6 +187,12 @@ public:
     void postprocessIntegrateData(double current_time, double new_time, int num_cycles) override;
 
     /*!
+     * Create solution data on the specified level of the patch
+     * hierarchy.
+     */
+    void createSolutionVec(Vec* X_vec) override;
+
+    /*!
      * Create solution and rhs data on the specified level of the patch
      * hierarchy.
      */
@@ -196,7 +202,7 @@ public:
      * Setup solution and rhs data on the specified level of the patch
      * hierarchy.
      */
-    void setupSolverVecs(Vec* X_vec, Vec* F_vec) override;
+    void setupSolverVecs(Vec& X_vec, Vec& F_vec) override;
 
     /*!
      * Set the value of the updated position vector.

--- a/include/ibamr/INSHierarchyIntegrator.h
+++ b/include/ibamr/INSHierarchyIntegrator.h
@@ -78,6 +78,12 @@ public:
     ~INSHierarchyIntegrator();
 
     /*!
+     * Compute the current CFL number for the given velocity field and time step size.
+     */
+    static double
+    compute_CFL_number(const int data_idx, const double dt, const SAMRAI::hier::PatchHierarchy<NDIM>* patch_hierarchy);
+
+    /*!
      * Set the type of viscous time integration scheme being employed by the
      * incompressible flow solver.
      *
@@ -370,6 +376,11 @@ public:
      * Returns the number of cycles to perform for the present time step.
      */
     int getNumberOfCycles() const override;
+
+    /*!
+     * Returns the maximum CFL number.
+     */
+    double getMaximumCFLNumber() const { return d_cfl_max; }
 
     /*!
      * Finish postprocessing the hierarchy by computing the current CFL number.

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -69,7 +69,7 @@ DIM_INDEPENDENT_SOURCES = \
 ../src/IB/IBExplicitHierarchyIntegrator.cpp \
 ../src/IB/IBHierarchyIntegrator.cpp \
 ../src/IB/IBHydrodynamicForceEvaluator.cpp \
-../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp \
+../src/IB/IBImplicitHierarchyIntegrator.cpp \
 ../src/IB/IBInstrumentPanel.cpp \
 ../src/IB/IBInstrumentationSpec.cpp \
 ../src/IB/IBInstrumentationSpecFactory.cpp \
@@ -250,7 +250,7 @@ pkg_include_HEADERS += \
 ../include/ibamr/IBExplicitHierarchyIntegrator.h \
 ../include/ibamr/IBHierarchyIntegrator.h \
 ../include/ibamr/IBHydrodynamicForceEvaluator.h \
-../include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h \
+../include/ibamr/IBImplicitHierarchyIntegrator.h \
 ../include/ibamr/IBImplicitStrategy.h \
 ../include/ibamr/IBInstrumentPanel.h \
 ../include/ibamr/IBInstrumentationSpec.h \

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -216,7 +216,7 @@ am__libIBAMR2d_a_SOURCES_DIST = ../src/IB/BrinkmanAdvDiffBcHelper.cpp \
 	../src/IB/IBExplicitHierarchyIntegrator.cpp \
 	../src/IB/IBHierarchyIntegrator.cpp \
 	../src/IB/IBHydrodynamicForceEvaluator.cpp \
-	../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp \
+	../src/IB/IBImplicitHierarchyIntegrator.cpp \
 	../src/IB/IBInstrumentPanel.cpp \
 	../src/IB/IBInstrumentationSpec.cpp \
 	../src/IB/IBInstrumentationSpecFactory.cpp \
@@ -402,7 +402,7 @@ am__objects_2 =  \
 	../src/IB/libIBAMR2d_a-IBExplicitHierarchyIntegrator.$(OBJEXT) \
 	../src/IB/libIBAMR2d_a-IBHierarchyIntegrator.$(OBJEXT) \
 	../src/IB/libIBAMR2d_a-IBHydrodynamicForceEvaluator.$(OBJEXT) \
-	../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.$(OBJEXT) \
+	../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.$(OBJEXT) \
 	../src/IB/libIBAMR2d_a-IBInstrumentPanel.$(OBJEXT) \
 	../src/IB/libIBAMR2d_a-IBInstrumentationSpec.$(OBJEXT) \
 	../src/IB/libIBAMR2d_a-IBInstrumentationSpecFactory.$(OBJEXT) \
@@ -570,7 +570,7 @@ am__libIBAMR3d_a_SOURCES_DIST = ../src/IB/BrinkmanAdvDiffBcHelper.cpp \
 	../src/IB/IBExplicitHierarchyIntegrator.cpp \
 	../src/IB/IBHierarchyIntegrator.cpp \
 	../src/IB/IBHydrodynamicForceEvaluator.cpp \
-	../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp \
+	../src/IB/IBImplicitHierarchyIntegrator.cpp \
 	../src/IB/IBInstrumentPanel.cpp \
 	../src/IB/IBInstrumentationSpec.cpp \
 	../src/IB/IBInstrumentationSpecFactory.cpp \
@@ -756,7 +756,7 @@ am__objects_4 =  \
 	../src/IB/libIBAMR3d_a-IBExplicitHierarchyIntegrator.$(OBJEXT) \
 	../src/IB/libIBAMR3d_a-IBHierarchyIntegrator.$(OBJEXT) \
 	../src/IB/libIBAMR3d_a-IBHydrodynamicForceEvaluator.$(OBJEXT) \
-	../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.$(OBJEXT) \
+	../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.$(OBJEXT) \
 	../src/IB/libIBAMR3d_a-IBInstrumentPanel.$(OBJEXT) \
 	../src/IB/libIBAMR3d_a-IBInstrumentationSpec.$(OBJEXT) \
 	../src/IB/libIBAMR3d_a-IBInstrumentationSpecFactory.$(OBJEXT) \
@@ -949,7 +949,7 @@ am__depfiles_remade = ../src/$(DEPDIR)/dummy.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHierarchyIntegrator.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHydrodynamicForceEvaluator.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHydrodynamicSurfaceForceEvaluator.Po \
-	../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.Po \
+	../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitHierarchyIntegrator.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentPanel.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentationSpec.Po \
 	../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentationSpecFactory.Po \
@@ -1019,7 +1019,7 @@ am__depfiles_remade = ../src/$(DEPDIR)/dummy.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHierarchyIntegrator.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHydrodynamicForceEvaluator.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHydrodynamicSurfaceForceEvaluator.Po \
-	../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.Po \
+	../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitHierarchyIntegrator.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentPanel.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentationSpec.Po \
 	../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentationSpecFactory.Po \
@@ -1344,7 +1344,7 @@ am__pkg_include_HEADERS_DIST = ../include/ibamr/app_namespaces.h \
 	../include/ibamr/IBExplicitHierarchyIntegrator.h \
 	../include/ibamr/IBHierarchyIntegrator.h \
 	../include/ibamr/IBHydrodynamicForceEvaluator.h \
-	../include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h \
+	../include/ibamr/IBImplicitHierarchyIntegrator.h \
 	../include/ibamr/IBImplicitStrategy.h \
 	../include/ibamr/IBInstrumentPanel.h \
 	../include/ibamr/IBInstrumentationSpec.h \
@@ -1772,7 +1772,7 @@ pkg_include_HEADERS = ../include/ibamr/app_namespaces.h \
 	../include/ibamr/IBExplicitHierarchyIntegrator.h \
 	../include/ibamr/IBHierarchyIntegrator.h \
 	../include/ibamr/IBHydrodynamicForceEvaluator.h \
-	../include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h \
+	../include/ibamr/IBImplicitHierarchyIntegrator.h \
 	../include/ibamr/IBImplicitStrategy.h \
 	../include/ibamr/IBInstrumentPanel.h \
 	../include/ibamr/IBInstrumentationSpec.h \
@@ -1885,7 +1885,7 @@ DIM_INDEPENDENT_SOURCES = ../src/IB/BrinkmanAdvDiffBcHelper.cpp \
 	../src/IB/IBExplicitHierarchyIntegrator.cpp \
 	../src/IB/IBHierarchyIntegrator.cpp \
 	../src/IB/IBHydrodynamicForceEvaluator.cpp \
-	../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp \
+	../src/IB/IBImplicitHierarchyIntegrator.cpp \
 	../src/IB/IBInstrumentPanel.cpp \
 	../src/IB/IBInstrumentationSpec.cpp \
 	../src/IB/IBInstrumentationSpecFactory.cpp \
@@ -2180,7 +2180,7 @@ libIBAMR.a: $(libIBAMR_a_OBJECTS) $(libIBAMR_a_DEPENDENCIES) $(EXTRA_libIBAMR_a_
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
 ../src/IB/libIBAMR2d_a-IBHydrodynamicForceEvaluator.$(OBJEXT):  \
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
-../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.$(OBJEXT):  \
+../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.$(OBJEXT):  \
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
 ../src/IB/libIBAMR2d_a-IBInstrumentPanel.$(OBJEXT):  \
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
@@ -2727,7 +2727,7 @@ libIBAMR2d.a: $(libIBAMR2d_a_OBJECTS) $(libIBAMR2d_a_DEPENDENCIES) $(EXTRA_libIB
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
 ../src/IB/libIBAMR3d_a-IBHydrodynamicForceEvaluator.$(OBJEXT):  \
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
-../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.$(OBJEXT):  \
+../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.$(OBJEXT):  \
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
 ../src/IB/libIBAMR3d_a-IBInstrumentPanel.$(OBJEXT):  \
 	../src/IB/$(am__dirstamp) ../src/IB/$(DEPDIR)/$(am__dirstamp)
@@ -3211,7 +3211,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHierarchyIntegrator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHydrodynamicForceEvaluator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHydrodynamicSurfaceForceEvaluator.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitHierarchyIntegrator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentPanel.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentationSpec.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentationSpecFactory.Po@am__quote@ # am--include-marker
@@ -3281,7 +3281,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHierarchyIntegrator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHydrodynamicForceEvaluator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHydrodynamicSurfaceForceEvaluator.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitHierarchyIntegrator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentPanel.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentationSpec.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentationSpecFactory.Po@am__quote@ # am--include-marker
@@ -3839,19 +3839,19 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR2d_a-IBHydrodynamicForceEvaluator.obj `if test -f '../src/IB/IBHydrodynamicForceEvaluator.cpp'; then $(CYGPATH_W) '../src/IB/IBHydrodynamicForceEvaluator.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/IBHydrodynamicForceEvaluator.cpp'; fi`
 
-../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.o: ../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.o -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.Tpo -c -o ../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.o `test -f '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp' || echo '$(srcdir)/'`../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.Tpo ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp' object='../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.o' libtool=no @AMDEPBACKSLASH@
+../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.o: ../src/IB/IBImplicitHierarchyIntegrator.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.o -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitHierarchyIntegrator.Tpo -c -o ../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.o `test -f '../src/IB/IBImplicitHierarchyIntegrator.cpp' || echo '$(srcdir)/'`../src/IB/IBImplicitHierarchyIntegrator.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitHierarchyIntegrator.Tpo ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitHierarchyIntegrator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/IBImplicitHierarchyIntegrator.cpp' object='../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.o `test -f '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp' || echo '$(srcdir)/'`../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.o `test -f '../src/IB/IBImplicitHierarchyIntegrator.cpp' || echo '$(srcdir)/'`../src/IB/IBImplicitHierarchyIntegrator.cpp
 
-../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.obj: ../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.obj -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.Tpo -c -o ../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.obj `if test -f '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; then $(CYGPATH_W) '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.Tpo ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp' object='../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.obj' libtool=no @AMDEPBACKSLASH@
+../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.obj: ../src/IB/IBImplicitHierarchyIntegrator.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.obj -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitHierarchyIntegrator.Tpo -c -o ../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.obj `if test -f '../src/IB/IBImplicitHierarchyIntegrator.cpp'; then $(CYGPATH_W) '../src/IB/IBImplicitHierarchyIntegrator.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/IBImplicitHierarchyIntegrator.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitHierarchyIntegrator.Tpo ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitHierarchyIntegrator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/IBImplicitHierarchyIntegrator.cpp' object='../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.obj `if test -f '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; then $(CYGPATH_W) '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR2d_a-IBImplicitHierarchyIntegrator.obj `if test -f '../src/IB/IBImplicitHierarchyIntegrator.cpp'; then $(CYGPATH_W) '../src/IB/IBImplicitHierarchyIntegrator.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/IBImplicitHierarchyIntegrator.cpp'; fi`
 
 ../src/IB/libIBAMR2d_a-IBInstrumentPanel.o: ../src/IB/IBInstrumentPanel.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR2d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR2d_a-IBInstrumentPanel.o -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentPanel.Tpo -c -o ../src/IB/libIBAMR2d_a-IBInstrumentPanel.o `test -f '../src/IB/IBInstrumentPanel.cpp' || echo '$(srcdir)/'`../src/IB/IBInstrumentPanel.cpp
@@ -6079,19 +6079,19 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR3d_a-IBHydrodynamicForceEvaluator.obj `if test -f '../src/IB/IBHydrodynamicForceEvaluator.cpp'; then $(CYGPATH_W) '../src/IB/IBHydrodynamicForceEvaluator.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/IBHydrodynamicForceEvaluator.cpp'; fi`
 
-../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.o: ../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.o -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.Tpo -c -o ../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.o `test -f '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp' || echo '$(srcdir)/'`../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.Tpo ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp' object='../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.o' libtool=no @AMDEPBACKSLASH@
+../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.o: ../src/IB/IBImplicitHierarchyIntegrator.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.o -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitHierarchyIntegrator.Tpo -c -o ../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.o `test -f '../src/IB/IBImplicitHierarchyIntegrator.cpp' || echo '$(srcdir)/'`../src/IB/IBImplicitHierarchyIntegrator.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitHierarchyIntegrator.Tpo ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitHierarchyIntegrator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/IBImplicitHierarchyIntegrator.cpp' object='../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.o `test -f '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp' || echo '$(srcdir)/'`../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.o `test -f '../src/IB/IBImplicitHierarchyIntegrator.cpp' || echo '$(srcdir)/'`../src/IB/IBImplicitHierarchyIntegrator.cpp
 
-../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.obj: ../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.obj -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.Tpo -c -o ../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.obj `if test -f '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; then $(CYGPATH_W) '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.Tpo ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp' object='../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.obj' libtool=no @AMDEPBACKSLASH@
+../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.obj: ../src/IB/IBImplicitHierarchyIntegrator.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.obj -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitHierarchyIntegrator.Tpo -c -o ../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.obj `if test -f '../src/IB/IBImplicitHierarchyIntegrator.cpp'; then $(CYGPATH_W) '../src/IB/IBImplicitHierarchyIntegrator.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/IBImplicitHierarchyIntegrator.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitHierarchyIntegrator.Tpo ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitHierarchyIntegrator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='../src/IB/IBImplicitHierarchyIntegrator.cpp' object='../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.obj `if test -f '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; then $(CYGPATH_W) '../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -c -o ../src/IB/libIBAMR3d_a-IBImplicitHierarchyIntegrator.obj `if test -f '../src/IB/IBImplicitHierarchyIntegrator.cpp'; then $(CYGPATH_W) '../src/IB/IBImplicitHierarchyIntegrator.cpp'; else $(CYGPATH_W) '$(srcdir)/../src/IB/IBImplicitHierarchyIntegrator.cpp'; fi`
 
 ../src/IB/libIBAMR3d_a-IBInstrumentPanel.o: ../src/IB/IBInstrumentPanel.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libIBAMR3d_a_CXXFLAGS) $(CXXFLAGS) -MT ../src/IB/libIBAMR3d_a-IBInstrumentPanel.o -MD -MP -MF ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentPanel.Tpo -c -o ../src/IB/libIBAMR3d_a-IBInstrumentPanel.o `test -f '../src/IB/IBInstrumentPanel.cpp' || echo '$(srcdir)/'`../src/IB/IBInstrumentPanel.cpp
@@ -8236,7 +8236,7 @@ distclean: distclean-am
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHierarchyIntegrator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHydrodynamicForceEvaluator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHydrodynamicSurfaceForceEvaluator.Po
-	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.Po
+	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitHierarchyIntegrator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentPanel.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentationSpec.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentationSpecFactory.Po
@@ -8306,7 +8306,7 @@ distclean: distclean-am
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHierarchyIntegrator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHydrodynamicForceEvaluator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHydrodynamicSurfaceForceEvaluator.Po
-	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.Po
+	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitHierarchyIntegrator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentPanel.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentationSpec.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentationSpecFactory.Po
@@ -8602,7 +8602,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHierarchyIntegrator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHydrodynamicForceEvaluator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBHydrodynamicSurfaceForceEvaluator.Po
-	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitStaggeredHierarchyIntegrator.Po
+	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBImplicitHierarchyIntegrator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentPanel.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentationSpec.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR2d_a-IBInstrumentationSpecFactory.Po
@@ -8672,7 +8672,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHierarchyIntegrator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHydrodynamicForceEvaluator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBHydrodynamicSurfaceForceEvaluator.Po
-	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitStaggeredHierarchyIntegrator.Po
+	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBImplicitHierarchyIntegrator.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentPanel.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentationSpec.Po
 	-rm -f ../src/IB/$(DEPDIR)/libIBAMR3d_a-IBInstrumentationSpecFactory.Po

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,7 +150,7 @@ SET(CXX_SRC
   IB/CIBStaggeredStokesSolver.cpp
   IB/IBKirchhoffRodForceGen.cpp
   IB/IBAnchorPointSpec.cpp
-  IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+  IB/IBImplicitHierarchyIntegrator.cpp
   IB/IBRedundantInitializer.cpp
   IB/IBAnchorPointSpecFactory.cpp
   IB/CIBStrategy.cpp

--- a/src/IB/IBExplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBExplicitHierarchyIntegrator.cpp
@@ -125,7 +125,7 @@ IBExplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const double current
         d_ib_method_ops->spreadForce(
             d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), current_time);
         d_u_phys_bdry_op->setHomogeneousBc(false);
-        if (d_f_current_idx != invalid_index) d_hier_velocity_data_ops->copyData(d_f_current_idx, d_f_idx);
+        d_hier_velocity_data_ops->copyData(d_f_current_idx, d_f_idx);
         break;
     case MIDPOINT_RULE:
         // intentionally blank

--- a/src/IB/IBExplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBExplicitHierarchyIntegrator.cpp
@@ -125,7 +125,7 @@ IBExplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const double current
         d_ib_method_ops->spreadForce(
             d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), current_time);
         d_u_phys_bdry_op->setHomogeneousBc(false);
-        d_hier_velocity_data_ops->copyData(d_f_current_idx, d_f_idx);
+        if (d_f_current_idx != invalid_index) d_hier_velocity_data_ops->copyData(d_f_current_idx, d_f_idx);
         break;
     case MIDPOINT_RULE:
         // intentionally blank

--- a/src/IB/IBExplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBExplicitHierarchyIntegrator.cpp
@@ -216,6 +216,8 @@ IBExplicitHierarchyIntegrator::integrateHierarchySpecialized(const double curren
 
     // Compute the Lagrangian source/sink strengths and spread them to the
     // Eulerian grid.
+    //
+    // TODO: Should this be "half_time" or "new_time"?
     if (d_ib_method_ops->hasFluidSources())
     {
         if (d_enable_logging)

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1235,6 +1235,168 @@ IBFEMethod::spreadFluidSource(const int q_data_idx,
     return;
 } // spreadFluidSource
 
+void
+IBFEMethod::createSolutionVec(Vec* X_vec)
+{
+    // TODO: Don't rebuild these vectors each time.
+    d_implicit_X_vecs.clear();
+    std::vector<Vec> X_vecs;
+    for (unsigned int part = 0; part < d_num_parts; ++part)
+    {
+        d_implicit_X_vecs.push_back(std::unique_ptr<PetscVector<double> >(
+            dynamic_cast<PetscVector<double>*>(d_X_new_vecs[part]->clone().release())));
+        X_vecs.push_back(d_implicit_X_vecs[part]->vec());
+    }
+    PetscErrorCode ierr;
+    ierr = VecCreateNest(PETSC_COMM_WORLD, d_num_parts, nullptr, X_vecs.data(), X_vec);
+    IBTK_CHKERRQ(ierr);
+}
+
+void
+IBFEMethod::createSolverVecs(Vec* X_vec, Vec* R_vec)
+{
+    // TODO: Don't rebuild these vectors each time.
+    d_implicit_X_vecs.clear();
+    d_implicit_R_vecs.clear();
+    std::vector<Vec> X_vecs, R_vecs;
+    for (unsigned int part = 0; part < d_num_parts; ++part)
+    {
+        d_implicit_X_vecs.push_back(std::unique_ptr<PetscVector<double> >(
+            dynamic_cast<PetscVector<double>*>(d_X_new_vecs[part]->clone().release())));
+        X_vecs.push_back(d_implicit_X_vecs[part]->vec());
+
+        d_implicit_R_vecs.push_back(std::unique_ptr<PetscVector<double> >(
+            dynamic_cast<PetscVector<double>*>(d_X_rhs_vecs[part]->zero_clone().release())));
+        R_vecs.push_back(d_implicit_R_vecs[part]->vec());
+    }
+    PetscErrorCode ierr;
+    ierr = VecCreateNest(PETSC_COMM_WORLD, d_num_parts, nullptr, X_vecs.data(), X_vec);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecCreateNest(PETSC_COMM_WORLD, d_num_parts, nullptr, R_vecs.data(), R_vec);
+    IBTK_CHKERRQ(ierr);
+}
+
+void
+IBFEMethod::setupSolverVecs(Vec& X_vec, Vec& R_vec)
+{
+    PetscErrorCode ierr;
+    PetscInt N;
+    Vec *X_sub_vecs, *R_sub_vecs;
+    ierr = VecNestGetSubVecs(X_vec, &N, &X_sub_vecs);
+    IBTK_CHKERRQ(ierr);
+    TBOX_ASSERT(static_cast<unsigned int>(N) == d_num_parts);
+    ierr = VecNestGetSubVecs(R_vec, &N, &R_sub_vecs);
+    IBTK_CHKERRQ(ierr);
+    TBOX_ASSERT(static_cast<unsigned int>(N) == d_num_parts);
+    for (unsigned int part = 0; part < d_num_parts; ++part)
+    {
+        auto X_new_petsc_vec = d_X_new_vecs[part];
+        ierr = VecCopy(X_new_petsc_vec->vec(), X_sub_vecs[part]);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecZeroEntries(R_sub_vecs[part]);
+        IBTK_CHKERRQ(ierr);
+    }
+}
+
+void
+IBFEMethod::setUpdatedPosition(Vec& X_new_vec)
+{
+    PetscErrorCode ierr;
+    PetscInt N;
+    Vec* X_new_sub_vecs;
+    ierr = VecNestGetSubVecs(X_new_vec, &N, &X_new_sub_vecs);
+    IBTK_CHKERRQ(ierr);
+    TBOX_ASSERT(static_cast<unsigned int>(N) == d_num_parts);
+    for (unsigned int part = 0; part < d_num_parts; ++part)
+    {
+        ierr = VecCopy(X_new_sub_vecs[part], d_X_new_vecs[part]->vec());
+        IBTK_CHKERRQ(ierr);
+        ierr = VecAXPBYPCZ(
+            d_X_half_vecs[part]->vec(), 0.5, 0.5, 0.0, d_X_current_vecs[part]->vec(), d_X_new_vecs[part]->vec());
+        IBTK_CHKERRQ(ierr);
+    }
+    return;
+} // setUpdatedPosition
+
+void
+IBFEMethod::getUpdatedPosition(Vec& X_new_vec)
+{
+    PetscErrorCode ierr;
+    PetscInt N;
+    Vec* X_new_sub_vecs;
+    ierr = VecNestGetSubVecs(X_new_vec, &N, &X_new_sub_vecs);
+    IBTK_CHKERRQ(ierr);
+    TBOX_ASSERT(static_cast<unsigned int>(N) == d_num_parts);
+    for (unsigned int part = 0; part < d_num_parts; ++part)
+    {
+        ierr = VecCopy(d_X_new_vecs[part]->vec(), X_new_sub_vecs[part]);
+        IBTK_CHKERRQ(ierr);
+    }
+    return;
+} // getUpdatedPosition
+
+void
+IBFEMethod::computeResidualBackwardEuler(Vec& R_vec)
+{
+    PetscErrorCode ierr;
+    PetscInt N;
+    Vec* R_sub_vecs;
+    ierr = VecNestGetSubVecs(R_vec, &N, &R_sub_vecs);
+    IBTK_CHKERRQ(ierr);
+    TBOX_ASSERT(static_cast<unsigned int>(N) == d_num_parts);
+    for (unsigned int part = 0; part < d_num_parts; ++part)
+    {
+        const double dt = d_new_time - d_current_time;
+        ierr = VecWAXPY(R_sub_vecs[part], -dt, d_U_new_vecs[part]->vec(), d_X_new_vecs[part]->vec());
+        IBTK_CHKERRQ(ierr);
+        ierr = VecAXPY(R_sub_vecs[part], -1.0, d_X_current_vecs[part]->vec());
+        IBTK_CHKERRQ(ierr);
+    }
+    return;
+} // computeResidualBackwardEuler
+
+void
+IBFEMethod::computeResidualMidpointRule(Vec& R_vec)
+{
+    PetscErrorCode ierr;
+    PetscInt N;
+    Vec* R_sub_vecs;
+    ierr = VecNestGetSubVecs(R_vec, &N, &R_sub_vecs);
+    IBTK_CHKERRQ(ierr);
+    TBOX_ASSERT(static_cast<unsigned int>(N) == d_num_parts);
+    for (unsigned int part = 0; part < d_num_parts; ++part)
+    {
+        const double dt = d_new_time - d_current_time;
+        ierr = VecWAXPY(R_sub_vecs[part], -dt, d_U_half_vecs[part]->vec(), d_X_new_vecs[part]->vec());
+        IBTK_CHKERRQ(ierr);
+        ierr = VecAXPY(R_sub_vecs[part], -1.0, d_X_current_vecs[part]->vec());
+        IBTK_CHKERRQ(ierr);
+    }
+    return;
+} // computeResidualMidpointRule
+
+void
+IBFEMethod::computeResidualTrapezoidalRule(Vec& R_vec)
+{
+    PetscErrorCode ierr;
+    PetscInt N;
+    Vec* R_sub_vecs;
+    ierr = VecNestGetSubVecs(R_vec, &N, &R_sub_vecs);
+    IBTK_CHKERRQ(ierr);
+    TBOX_ASSERT(static_cast<unsigned int>(N) == d_num_parts);
+    for (unsigned int part = 0; part < d_num_parts; ++part)
+    {
+        const double dt = d_new_time - d_current_time;
+        ierr = VecWAXPY(R_sub_vecs[part], -0.5 * dt, d_U_current_vecs[part]->vec(), d_X_new_vecs[part]->vec());
+        IBTK_CHKERRQ(ierr);
+        ierr = VecAXPY(R_sub_vecs[part], -0.5 * dt, d_U_new_vecs[part]->vec());
+        IBTK_CHKERRQ(ierr);
+        ierr = VecAXPY(R_sub_vecs[part], -1.0, d_X_current_vecs[part]->vec());
+        IBTK_CHKERRQ(ierr);
+    }
+    return;
+} // computeResidualTrapezoidalRule
+
 FEDataManager::InterpSpec
 IBFEMethod::getDefaultInterpSpec() const
 {

--- a/src/IB/IBImplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitHierarchyIntegrator.cpp
@@ -262,12 +262,13 @@ IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
         double tol = 1.0e-5;
         int max_its = 100;
         bool converged = false;
+
+        iterateSolution(X0);
+        d_ib_implicit_ops->getUpdatedPosition(X1);
+        ++n_solves;
+
         for (k = 0; k < max_its && !converged; ++k)
         {
-            iterateSolution(X0);
-            d_ib_implicit_ops->getUpdatedPosition(X1);
-            ++n_solves;
-
             iterateSolution(X1);
             d_ib_implicit_ops->getUpdatedPosition(X2);
             ++n_solves;

--- a/src/IB/IBImplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitHierarchyIntegrator.cpp
@@ -1,0 +1,603 @@
+// Filename: IBImplicitHierarchyIntegrator.cpp
+// Created on 07 Apr 2012 by Boyce Griffith
+//
+// Copyright (c) 2002-2017, Boyce Griffith
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of The University of North Carolina nor the names of
+//      its contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include "ibamr/IBHierarchyIntegrator.h"
+#include "ibamr/IBImplicitHierarchyIntegrator.h"
+#include "ibamr/IBImplicitStrategy.h"
+#include "ibamr/IBStrategy.h"
+#include "ibamr/INSHierarchyIntegrator.h"
+#include "ibamr/INSStaggeredHierarchyIntegrator.h"
+#include "ibamr/StaggeredStokesOperator.h"
+#include "ibamr/StaggeredStokesPETScVecUtilities.h"
+#include "ibamr/StaggeredStokesSolver.h"
+#include "ibamr/ibamr_enums.h"
+#include "ibamr/namespaces.h" // IWYU pragma: keep
+
+#include "ibtk/HierarchyMathOps.h"
+#include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/KrylovLinearSolver.h"
+#include "ibtk/PETScSAMRAIVectorReal.h"
+#include "ibtk/RobinPhysBdryPatchStrategy.h"
+#include "ibtk/ibtk_enums.h"
+
+#include "CartesianPatchGeometry.h"
+#include "CellData.h"
+#include "GriddingAlgorithm.h"
+#include "HierarchyDataOpsReal.h"
+#include "IntVector.h"
+#include "Patch.h"
+#include "PatchCellDataOpsReal.h"
+#include "PatchHierarchy.h"
+#include "PatchLevel.h"
+#include "PatchSideDataOpsReal.h"
+#include "PoissonSpecifications.h"
+#include "SAMRAIVectorReal.h"
+#include "SideData.h"
+#include "Variable.h"
+#include "VariableContext.h"
+#include "VariableDatabase.h"
+#include "tbox/Database.h"
+#include "tbox/PIO.h"
+#include "tbox/Pointer.h"
+#include "tbox/RestartManager.h"
+#include "tbox/SAMRAI_MPI.h"
+#include "tbox/Utilities.h"
+
+#include "petscerror.h"
+#include "petscksp.h"
+#include "petscmat.h"
+#include "petscpc.h"
+#include "petscsnes.h"
+#include "petscsys.h"
+#include "petscsystypes.h"
+#include "petscvec.h"
+
+#include <algorithm>
+#include <ostream>
+#include <string>
+
+namespace IBAMR
+{
+} // namespace IBAMR
+namespace SAMRAI
+{
+namespace hier
+{
+template <int DIM>
+class Box;
+} // namespace hier
+namespace xfer
+{
+} // namespace xfer
+} // namespace SAMRAI
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace IBAMR
+{
+/////////////////////////////// STATIC ///////////////////////////////////////
+
+namespace
+{
+// Version of IBImplicitHierarchyIntegrator restart file data.
+static const int IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION = 1;
+} // namespace
+
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+
+IBImplicitHierarchyIntegrator::IBImplicitHierarchyIntegrator(
+    const std::string& object_name,
+    Pointer<Database> input_db,
+    Pointer<IBImplicitStrategy> ib_implicit_ops,
+    Pointer<INSStaggeredHierarchyIntegrator> ins_hier_integrator,
+    bool register_for_restart)
+    : IBHierarchyIntegrator(object_name, input_db, ib_implicit_ops, ins_hier_integrator, register_for_restart),
+      d_ib_implicit_ops(ib_implicit_ops)
+{
+    // Set default configuration options.
+    d_use_structure_predictor = true;
+    d_use_fixed_LE_operators = false;
+
+    // Set options from input.
+    if (input_db)
+    {
+        if (input_db->keyExists("use_structure_predictor"))
+            d_use_structure_predictor = input_db->getBool("use_structure_predictor");
+        if (input_db->keyExists("use_fixed_LE_operators"))
+            d_use_fixed_LE_operators = input_db->getBool("use_fixed_LE_operators");
+    }
+    d_ib_implicit_ops->setUseFixedLEOperators(d_use_fixed_LE_operators);
+
+    // Initialize object with data read from the input and restart databases.
+    bool from_restart = RestartManager::getManager()->isFromRestart();
+    if (from_restart) getFromRestart();
+    return;
+} // IBImplicitHierarchyIntegrator
+
+void
+IBImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const double current_time,
+                                                            const double new_time,
+                                                            const int num_cycles)
+{
+    IBHierarchyIntegrator::preprocessIntegrateHierarchy(current_time, new_time, num_cycles);
+
+    switch (d_time_stepping_type)
+    {
+    case BACKWARD_EULER:
+    case TRAPEZOIDAL_RULE:
+    case MIDPOINT_RULE:
+        break;
+    default:
+        TBOX_ERROR("IBImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(): time_stepping_type = "
+                   << enum_to_string<TimeSteppingType>(d_time_stepping_type) << "\n"
+                   << "  only supported time_stepping_types are:\n"
+                   << "    " << enum_to_string<TimeSteppingType>(BACKWARD_EULER) << "\n"
+                   << "    " << enum_to_string<TimeSteppingType>(TRAPEZOIDAL_RULE) << "\n"
+                   << "    " << enum_to_string<TimeSteppingType>(MIDPOINT_RULE) << "\n");
+    }
+
+    const int coarsest_ln = 0;
+    const int finest_ln = d_hierarchy->getFinestLevelNumber();
+
+    // Allocate Eulerian scratch and new data.
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        level->allocatePatchData(d_u_idx, current_time);
+        level->allocatePatchData(d_f_idx, current_time);
+        if (d_f_current_idx != -1) level->allocatePatchData(d_f_current_idx, current_time);
+        level->allocatePatchData(d_scratch_data, current_time);
+        level->allocatePatchData(d_new_data, new_time);
+    }
+
+    // Initialize IB data.
+    d_ib_implicit_ops->preprocessIntegrateData(current_time, new_time, num_cycles);
+
+    // Initialize the fluid solver.
+    const int ins_num_cycles = d_ins_hier_integrator->getNumberOfCycles();
+    d_ins_hier_integrator->preprocessIntegrateHierarchy(current_time, new_time, ins_num_cycles);
+    d_ins_hier_integrator->setSkipEnforceNumCycles();
+
+    // Compute the Lagrangian forces and spread them to the Eulerian grid.
+    switch (d_time_stepping_type)
+    {
+    case TRAPEZOIDAL_RULE:
+        if (d_enable_logging) plog << d_object_name << "::preprocessIntegrateHierarchy(): computing Lagrangian force\n";
+        d_ib_method_ops->computeLagrangianForce(current_time);
+        if (d_enable_logging)
+            plog << d_object_name
+                 << "::preprocessIntegrateHierarchy(): spreading Lagrangian force "
+                    "to the Eulerian grid\n";
+        d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0);
+        d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
+        d_u_phys_bdry_op->setHomogeneousBc(true);
+        d_ib_method_ops->spreadForce(
+            d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), current_time);
+        d_u_phys_bdry_op->setHomogeneousBc(false);
+        d_hier_velocity_data_ops->copyData(d_f_current_idx, d_f_idx);
+        break;
+    case BACKWARD_EULER:
+    case MIDPOINT_RULE:
+        // intentionally blank
+        break;
+    default:
+        TBOX_ERROR(
+            d_object_name << "::preprocessIntegrateHierarchy():\n"
+                          << "  unsupported time stepping type: "
+                          << enum_to_string<TimeSteppingType>(d_time_stepping_type) << "\n"
+                          << "  supported time stepping types are: BACKWARD_EULER, MIDPOINT_RULE, TRAPEZOIDAL_RULE\n");
+    }
+
+    // Compute an initial prediction of the updated positions of the Lagrangian
+    // structure.
+    //
+    // NOTE: The velocity should already have been interpolated to the
+    // curvilinear mesh and should not need to be re-interpolated.
+    if (d_use_structure_predictor)
+    {
+        if (d_enable_logging)
+            plog << d_object_name << "::preprocessIntegrateHierarchy(): performing Lagrangian forward Euler step\n";
+        d_ib_implicit_ops->forwardEulerStep(current_time, new_time);
+    }
+
+    // Execute any registered callbacks.
+    executePreprocessIntegrateHierarchyCallbackFcns(current_time, new_time, num_cycles);
+    return;
+} // preprocessIntegrateHierarchy
+
+void
+IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, const double new_time, const int cycle_num)
+{
+    IBHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
+    d_current_time = current_time;
+    d_new_time = new_time;
+    d_cycle_num = cycle_num;
+
+    // Setup Lagrangian vectors used in solving the implicit IB equations.
+    PetscErrorCode ierr;
+    Vec X, R, R_work;
+    d_ib_implicit_ops->createSolverVecs(&X, &R);
+    d_ib_implicit_ops->setupSolverVecs(&X, &R);
+    ierr = VecDuplicate(R, &R_work);
+    IBTK_CHKERRQ(ierr);
+
+    if (d_use_fixed_LE_operators)
+    {
+        // Indicate that the current approximation to position of the structure
+        // should be used for Lagrangian-Eulerian coupling.
+        d_ib_implicit_ops->updateFixedLEOperators();
+    }
+
+    // Solve the implicit IB equations.
+    d_ins_cycle_num = 0;
+
+    SNES snes;
+    ierr = SNESCreate(PETSC_COMM_WORLD, &snes);
+    IBTK_CHKERRQ(ierr);
+    ierr = SNESSetFunction(snes, R_work, IBFunction_SAMRAI, this);
+    IBTK_CHKERRQ(ierr);
+    ierr = SNESSetOptionsPrefix(snes, "ib_");
+    IBTK_CHKERRQ(ierr);
+    ierr = SNESSetFromOptions(snes);
+    IBTK_CHKERRQ(ierr);
+    ierr = SNESSolve(snes, R, X);
+    IBTK_CHKERRQ(ierr);
+    ierr = SNESDestroy(&snes);
+    IBTK_CHKERRQ(ierr);
+
+    // Ensure that the INS variables are consistent with the final structure configuration.
+    //
+    // TODO: Can we skip this?
+    d_ib_implicit_ops->setUpdatedPosition(X);
+    IBFunction(snes, X, R);
+
+    // Deallocate temporary data.
+    ierr = VecDestroy(&X);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&R);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&R_work);
+    IBTK_CHKERRQ(ierr);
+
+    // Execute any registered callbacks.
+    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
+} // integrateHierarchy
+
+void
+IBImplicitHierarchyIntegrator::postprocessIntegrateHierarchy(const double current_time,
+                                                             const double new_time,
+                                                             const bool skip_synchronize_new_state_data,
+                                                             const int num_cycles)
+{
+    IBHierarchyIntegrator::postprocessIntegrateHierarchy(
+        current_time, new_time, skip_synchronize_new_state_data, num_cycles);
+
+    const int coarsest_ln = 0;
+    const int finest_ln = d_hierarchy->getFinestLevelNumber();
+    const double dt = new_time - current_time;
+    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
+    const int u_new_idx = var_db->mapVariableAndContextToIndex(d_ins_hier_integrator->getVelocityVariable(),
+                                                               d_ins_hier_integrator->getNewContext());
+
+    // Interpolate the Eulerian velocity to the curvilinear mesh.
+    d_hier_velocity_data_ops->copyData(d_u_idx, u_new_idx);
+    if (d_enable_logging)
+        plog << d_object_name
+             << "::postprocessIntegrateHierarchy(): interpolating Eulerian "
+                "velocity to the Lagrangian mesh\n";
+    d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
+    d_u_phys_bdry_op->setHomogeneousBc(false);
+    d_ib_implicit_ops->interpolateVelocity(d_u_idx,
+                                           getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
+                                           getGhostfillRefineSchedules(d_object_name + "::u"),
+                                           new_time);
+
+    // Synchronize new state data.
+    if (!skip_synchronize_new_state_data)
+    {
+        if (d_enable_logging)
+            plog << d_object_name << "::postprocessIntegrateHierarchy(): synchronizing updated data\n";
+        synchronizeHierarchyData(NEW_DATA);
+    }
+
+    // Determine the CFL number.
+    double cfl_max = 0.0;
+    PatchCellDataOpsReal<NDIM, double> patch_cc_ops;
+    PatchSideDataOpsReal<NDIM, double> patch_sc_ops;
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM> > patch = level->getPatch(p());
+            const Box<NDIM>& patch_box = patch->getBox();
+            const Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+            const double* const dx = pgeom->getDx();
+            const double dx_min = *(std::min_element(dx, dx + NDIM));
+            Pointer<CellData<NDIM, double> > u_cc_new_data = patch->getPatchData(u_new_idx);
+            Pointer<SideData<NDIM, double> > u_sc_new_data = patch->getPatchData(u_new_idx);
+            double u_max = 0.0;
+            if (u_cc_new_data) u_max = patch_cc_ops.maxNorm(u_cc_new_data, patch_box);
+            if (u_sc_new_data) u_max = patch_sc_ops.maxNorm(u_sc_new_data, patch_box);
+            cfl_max = std::max(cfl_max, u_max * dt / dx_min);
+        }
+    }
+    cfl_max = SAMRAI_MPI::maxReduction(cfl_max);
+    d_regrid_cfl_estimate += cfl_max;
+    if (d_enable_logging)
+        plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
+    if (d_enable_logging)
+        plog << d_object_name
+             << "::postprocessIntegrateHierarchy(): estimated upper bound on IB "
+                "point displacement since last regrid = "
+             << d_regrid_cfl_estimate << "\n";
+
+    // Deallocate the fluid solver.
+    const int ins_num_cycles = d_ins_hier_integrator->getNumberOfCycles();
+    d_ins_hier_integrator->postprocessIntegrateHierarchy(
+        current_time, new_time, skip_synchronize_new_state_data, ins_num_cycles);
+
+    // Deallocate IB data.
+    d_ib_implicit_ops->postprocessIntegrateData(current_time, new_time, num_cycles);
+
+    // Deallocate Eulerian scratch data.
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        level->deallocatePatchData(d_u_idx);
+        level->deallocatePatchData(d_f_idx);
+        if (d_f_current_idx != -1) level->deallocatePatchData(d_f_current_idx);
+    }
+
+    // Execute any registered callbacks.
+    executePostprocessIntegrateHierarchyCallbackFcns(
+        current_time, new_time, skip_synchronize_new_state_data, num_cycles);
+    return;
+} // postprocessIntegrateHierarchy
+
+void
+IBImplicitHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHierarchy<NDIM> > hierarchy,
+                                                             Pointer<GriddingAlgorithm<NDIM> > gridding_alg)
+{
+    if (d_integrator_is_initialized) return;
+
+    // Register body force function with INSHierarchyIntegrator
+    d_ins_hier_integrator->registerBodyForceFunction(new IBEulerianForceFunction(this));
+
+    // Finish initializing the hierarchy integrator.
+    IBHierarchyIntegrator::initializeHierarchyIntegrator(hierarchy, gridding_alg);
+    return;
+} // initializeHierarchyIntegrator
+
+int
+IBImplicitHierarchyIntegrator::getNumberOfCycles() const
+{
+    return d_ins_hier_integrator->getNumberOfCycles();
+} // getNumberOfCycles
+
+/////////////////////////////// PROTECTED ////////////////////////////////////
+
+void
+IBImplicitHierarchyIntegrator::putToDatabaseSpecialized(Pointer<Database> db)
+{
+    IBHierarchyIntegrator::putToDatabaseSpecialized(db);
+    db->putInteger("IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION",
+                   IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION);
+    return;
+} // putToDatabaseSpecialized
+
+/////////////////////////////// PRIVATE //////////////////////////////////////
+
+void
+IBImplicitHierarchyIntegrator::getFromRestart()
+{
+    Pointer<Database> restart_db = RestartManager::getManager()->getRootDatabase();
+    Pointer<Database> db;
+    if (restart_db->isDatabase(d_object_name))
+    {
+        db = restart_db->getDatabase(d_object_name);
+    }
+    else
+    {
+        TBOX_ERROR(d_object_name << ":  Restart database corresponding to " << d_object_name
+                                 << " not found in restart file." << std::endl);
+    }
+    int ver = db->getInteger("IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION");
+    if (ver != IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION)
+    {
+        TBOX_ERROR(d_object_name << ":  Restart file version different than class version." << std::endl);
+    }
+    return;
+} // getFromRestart
+
+PetscErrorCode
+IBImplicitHierarchyIntegrator::IBFunction_SAMRAI(SNES snes, Vec X, Vec R, void* ctx)
+{
+    auto integrator = static_cast<IBImplicitHierarchyIntegrator*>(ctx);
+    return integrator->IBFunction(snes, X, R);
+}
+
+PetscErrorCode
+IBImplicitHierarchyIntegrator::IBFunction(SNES /*snes*/, Vec X, Vec R)
+{
+    const double current_time = d_current_time;
+    const double new_time = d_new_time;
+    const double half_time = current_time + 0.5 * (new_time - current_time);
+    const int cycle_num = d_cycle_num;
+
+    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
+    const int u_current_idx = var_db->mapVariableAndContextToIndex(d_ins_hier_integrator->getVelocityVariable(),
+                                                                   d_ins_hier_integrator->getCurrentContext());
+    const int u_new_idx = var_db->mapVariableAndContextToIndex(d_ins_hier_integrator->getVelocityVariable(),
+                                                               d_ins_hier_integrator->getNewContext());
+
+    // Set the current position data.
+    d_ib_implicit_ops->setUpdatedPosition(X);
+
+    // Compute the Lagrangian forces and spread them to the Eulerian grid.
+    switch (d_time_stepping_type)
+    {
+    case FORWARD_EULER:
+        // intentionally blank
+        break;
+    case BACKWARD_EULER:
+        if (d_enable_logging) plog << d_object_name << "::integrateHierarchy(): computing Lagrangian force\n";
+        d_ib_method_ops->computeLagrangianForce(d_new_time);
+        if (d_enable_logging)
+            plog << d_object_name << "::integrateHierarchy(): spreading Lagrangian force to the Eulerian grid\n";
+        d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0);
+        d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
+        d_u_phys_bdry_op->setHomogeneousBc(true);
+        d_ib_method_ops->spreadForce(
+            d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), new_time);
+        d_u_phys_bdry_op->setHomogeneousBc(false);
+        break;
+    case MIDPOINT_RULE:
+        if (d_enable_logging) plog << d_object_name << "::integrateHierarchy(): computing Lagrangian force\n";
+        d_ib_method_ops->computeLagrangianForce(half_time);
+        if (d_enable_logging)
+            plog << d_object_name << "::integrateHierarchy(): spreading Lagrangian force to the Eulerian grid\n";
+        d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0);
+        d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
+        d_u_phys_bdry_op->setHomogeneousBc(true);
+        d_ib_method_ops->spreadForce(
+            d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), half_time);
+        d_u_phys_bdry_op->setHomogeneousBc(false);
+        break;
+    case TRAPEZOIDAL_RULE:
+        if (d_enable_logging) plog << d_object_name << "::integrateHierarchy(): computing Lagrangian force\n";
+        d_ib_method_ops->computeLagrangianForce(new_time);
+        if (d_enable_logging)
+            plog << d_object_name << "::integrateHierarchy(): spreading Lagrangian force to the Eulerian grid\n";
+        d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0);
+        d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
+        d_u_phys_bdry_op->setHomogeneousBc(true);
+        d_ib_method_ops->spreadForce(
+            d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), new_time);
+        d_u_phys_bdry_op->setHomogeneousBc(false);
+        d_hier_velocity_data_ops->linearSum(d_f_idx, 0.5, d_f_current_idx, 0.5, d_f_idx);
+        break;
+    default:
+        TBOX_ERROR(
+            d_object_name << "::integrateHierarchy():\n"
+                          << "  unsupported time stepping type: "
+                          << enum_to_string<TimeSteppingType>(d_time_stepping_type) << "\n"
+                          << "  supported time stepping types are: BACKWARD_EULER, MIDPOINT_RULE, TRAPEZOIDAL_RULE\n");
+    }
+
+    // Solve the incompressible Navier-Stokes equations.
+    if (d_enable_logging)
+        plog << d_object_name << "::integrateHierarchy(): solving the incompressible Navier-Stokes equations\n";
+    d_ib_method_ops->preprocessSolveFluidEquations(current_time, new_time, cycle_num);
+    d_ins_hier_integrator->integrateHierarchy(current_time, new_time, d_ins_cycle_num);
+    d_ins_cycle_num++;
+    d_ib_method_ops->postprocessSolveFluidEquations(current_time, new_time, cycle_num);
+
+    // Interpolate the Eulerian velocity to the curvilinear mesh.
+    switch (d_time_stepping_type)
+    {
+    case BACKWARD_EULER:
+        d_hier_velocity_data_ops->copyData(d_u_idx, u_new_idx);
+        if (d_enable_logging)
+            plog << d_object_name
+                 << "::integrateHierarchy(): interpolating Eulerian velocity to "
+                    "the Lagrangian mesh\n";
+        d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
+        d_u_phys_bdry_op->setHomogeneousBc(false);
+        d_ib_method_ops->interpolateVelocity(d_u_idx,
+                                             getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
+                                             getGhostfillRefineSchedules(d_object_name + "::u"),
+                                             new_time);
+        break;
+    case MIDPOINT_RULE:
+        d_hier_velocity_data_ops->linearSum(d_u_idx, 0.5, u_current_idx, 0.5, u_new_idx);
+        if (d_enable_logging)
+            plog << d_object_name
+                 << "::integrateHierarchy(): interpolating Eulerian velocity to "
+                    "the Lagrangian mesh\n";
+        d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
+        d_u_phys_bdry_op->setHomogeneousBc(false);
+        d_ib_method_ops->interpolateVelocity(d_u_idx,
+                                             getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
+                                             getGhostfillRefineSchedules(d_object_name + "::u"),
+                                             half_time);
+        break;
+    case TRAPEZOIDAL_RULE:
+        d_hier_velocity_data_ops->copyData(d_u_idx, u_new_idx);
+        if (d_enable_logging)
+            plog << d_object_name
+                 << "::integrateHierarchy(): interpolating Eulerian velocity to "
+                    "the Lagrangian mesh\n";
+        d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
+        d_u_phys_bdry_op->setHomogeneousBc(false);
+        d_ib_method_ops->interpolateVelocity(d_u_idx,
+                                             getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
+                                             getGhostfillRefineSchedules(d_object_name + "::u"),
+                                             new_time);
+        break;
+    default:
+        TBOX_ERROR(
+            d_object_name << "::integrateHierarchy():\n"
+                          << "  unsupported time stepping type: "
+                          << enum_to_string<TimeSteppingType>(d_time_stepping_type) << "\n"
+                          << "  supported time stepping types are: BACKWARD_EULER, MIDPOINT_RULE, TRAPEZOIDAL_RULE\n");
+    }
+
+    // Compute the residual.
+    switch (d_time_stepping_type)
+    {
+    case BACKWARD_EULER:
+        d_ib_implicit_ops->computeResidualBackwardEuler(R);
+        break;
+    case MIDPOINT_RULE:
+        d_ib_implicit_ops->computeResidualMidpointRule(R);
+        break;
+    case TRAPEZOIDAL_RULE:
+        d_ib_implicit_ops->computeResidualTrapezoidalRule(R);
+        break;
+    default:
+        TBOX_ERROR(d_object_name << "::integrateHierarchy():\n"
+                                 << "  unsupported time stepping type: "
+                                 << enum_to_string<TimeSteppingType>(d_time_stepping_type) << "\n"
+                                 << "  supported time stepping types are: BACKWARD_EULER, "
+                                    "MIDPOINT_RULE, TRAPEZOIDAL_RULE\n");
+    }
+    return 0;
+}
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+} // namespace IBAMR
+
+//////////////////////////////////////////////////////////////////////////////

--- a/src/IB/IBImplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitHierarchyIntegrator.cpp
@@ -341,13 +341,15 @@ IBImplicitHierarchyIntegrator::getMaximumTimeStepSizeSpecialized()
     if (initial_time) return dt_max;
     if (d_snes_f_evals_previous < d_snes_f_evals_target_min)
     {
-        pout << "BELOW TARGET!!!\n";
         dt_max = std::min(dt_max, std::max(1.0, d_dt_growth_factor) * d_dt_previous[0]);
     }
-    if (d_snes_f_evals_previous > d_snes_f_evals_target_max)
+    else if (d_snes_f_evals_previous > d_snes_f_evals_target_max)
     {
-        pout << "ABOVE TARGET!!!\n";
         dt_max = std::min(dt_max, std::min(1.0, d_dt_shrink_factor) * d_dt_previous[0]);
+    }
+    else
+    {
+        dt_max = std::min(dt_max, d_dt_previous[0]);
     }
     return dt_max;
 } // getMaximumTimeStepSizeSpecialized

--- a/src/IB/IBImplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitHierarchyIntegrator.cpp
@@ -251,7 +251,7 @@ IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
         //
         // See Pg. 21 of https://hal-cea.archives-ouvertes.fr/cea-01403292/document.
         PetscErrorCode ierr;
-        Vec X_nm1, X_n, X_np1, GX_nm1, GX_n, DX_nm1, DX_n, DX_np1, DDX_n, DGX_n;
+        Vec X_nm1, X_n, X_np1, GX_nm1, GX_n, DX_nm1, DX_n, DDX_n, DGX_n;
         d_ib_implicit_ops->createSolutionVec(&X_nm1);
         d_ib_implicit_ops->createSolutionVec(&X_n);
         d_ib_implicit_ops->createSolutionVec(&X_np1);
@@ -259,7 +259,6 @@ IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
         d_ib_implicit_ops->createSolutionVec(&GX_n);
         d_ib_implicit_ops->createSolutionVec(&DX_nm1);
         d_ib_implicit_ops->createSolutionVec(&DX_n);
-        d_ib_implicit_ops->createSolutionVec(&DX_np1);
         d_ib_implicit_ops->createSolutionVec(&DDX_n);
         d_ib_implicit_ops->createSolutionVec(&DGX_n);
 
@@ -341,11 +340,9 @@ IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
                 IBTK_CHKERRQ(ierr);
             }
 
-            // Check to see if ||G(X_{n}) - X_{n+1}||_2 is sufficiently small to declare convergence.
-            ierr = VecWAXPY(DX_np1, -1.0, X_np1, GX_n);
-            IBTK_CHKERRQ(ierr);
+            // Check to see if ||G(X_{n}) - X_{n}||_2 is sufficiently small to declare convergence.
             double D;
-            ierr = VecNorm(DX_np1, NORM_2, &D);
+            ierr = VecNorm(DX_n, NORM_2, &D);
             IBTK_CHKERRQ(ierr);
             if (D < tol * D0)
             {
@@ -386,8 +383,6 @@ IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
         ierr = VecDestroy(&DX_nm1);
         IBTK_CHKERRQ(ierr);
         ierr = VecDestroy(&DX_n);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&DX_np1);
         IBTK_CHKERRQ(ierr);
         ierr = VecDestroy(&DDX_n);
         IBTK_CHKERRQ(ierr);

--- a/src/IB/IBImplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitHierarchyIntegrator.cpp
@@ -74,14 +74,7 @@
 #include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 
-#include "petscerror.h"
-#include "petscksp.h"
-#include "petscmat.h"
-#include "petscpc.h"
 #include "petscsnes.h"
-#include "petscsys.h"
-#include "petscsystypes.h"
-#include "petscvec.h"
 
 #include <algorithm>
 #include <ostream>

--- a/src/IB/IBImplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitHierarchyIntegrator.cpp
@@ -430,9 +430,6 @@ IBImplicitHierarchyIntegrator::iterateSolution(Vec X_new)
     // Compute the Lagrangian forces and spread them to the Eulerian grid.
     switch (d_time_stepping_type)
     {
-    case FORWARD_EULER:
-        // intentionally blank
-        break;
     case BACKWARD_EULER:
         if (d_enable_logging) plog << d_object_name << "::integrateHierarchy(): computing Lagrangian force\n";
         d_ib_method_ops->computeLagrangianForce(d_new_time);
@@ -585,9 +582,6 @@ IBImplicitHierarchyIntegrator::IBFunction(SNES /*snes*/, Vec X, Vec R)
     // Compute the Lagrangian forces and spread them to the Eulerian grid.
     switch (d_time_stepping_type)
     {
-    case FORWARD_EULER:
-        // intentionally blank
-        break;
     case BACKWARD_EULER:
         if (d_enable_logging) plog << d_object_name << "::integrateHierarchy(): computing Lagrangian force\n";
         d_ib_method_ops->computeLagrangianForce(d_new_time);

--- a/src/IB/IBImplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitHierarchyIntegrator.cpp
@@ -1,39 +1,21 @@
-// Filename: IBImplicitHierarchyIntegrator.cpp
-// Created on 07 Apr 2012 by Boyce Griffith
+// ---------------------------------------------------------------------
 //
-// Copyright (c) 2002-2017, Boyce Griffith
+// Copyright (c) 2014 - 2019 by the IBAMR developers
 // All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
+// This file is part of IBAMR.
 //
-//    * Redistributions of source code must retain the above copyright notice,
-//      this list of conditions and the following disclaimer.
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
 //
-//    * Redistributions in binary form must reproduce the above copyright
-//      notice, this list of conditions and the following disclaimer in the
-//      documentation and/or other materials provided with the distribution.
-//
-//    * Neither the name of The University of North Carolina nor the names of
-//      its contributors may be used to endorse or promote products derived from
-//      this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// ---------------------------------------------------------------------
+
+#include "ibamr/IBImplicitHierarchyIntegrator.h"
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include "ibamr/IBHierarchyIntegrator.h"
-#include "ibamr/IBImplicitHierarchyIntegrator.h"
 #include "ibamr/IBImplicitStrategy.h"
 #include "ibamr/IBStrategy.h"
 #include "ibamr/INSHierarchyIntegrator.h"

--- a/src/IB/IBImplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitHierarchyIntegrator.cpp
@@ -75,6 +75,7 @@
 #include "tbox/Utilities.h"
 
 #include "petscsnes.h"
+#include "petscvec.h"
 
 #include <algorithm>
 #include <ostream>
@@ -242,20 +243,30 @@ IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
 
     if (d_implicit_algorithm == "AITKEN")
     {
-        // Use Aitken extrapolation following Eq. 24 and 25 of TECHNIQUES FOR ACCELERATING ITERATIVE METHODS FOR THE
-        // SOLUTION OF MATHEMATICAL PROBLEMS by S. R. Capehart, 1989.
+        // Use the crossed secant method (Aitken extrapolation).
+        //
+        // Ref: Isabelle Ramière, Thomas Helfer. Iterative residual-based vector methods to accelerate fixed point
+        // iterations. Computers and Mathematics with Applications, Elsevier, 2015, 70, pp. 2210 - 2226.
+        //
+        // See Pg. 21 of https://hal-cea.archives-ouvertes.fr/cea-01403292/document.
         PetscErrorCode ierr;
-        Vec X0, X1, X2, Y, Z;
-        d_ib_implicit_ops->createSolutionVec(&X0);
-        d_ib_implicit_ops->createSolutionVec(&X1);
-        d_ib_implicit_ops->createSolutionVec(&X2);
-        d_ib_implicit_ops->createSolutionVec(&Y);
-        d_ib_implicit_ops->createSolutionVec(&Z);
+        Vec X_nm1, X_n, X_np1, GX_nm1, GX_n, DX_nm1, DX_n, DX_np1, DDX_n, DGX_n;
+        d_ib_implicit_ops->createSolutionVec(&X_nm1);
+        d_ib_implicit_ops->createSolutionVec(&X_n);
+        d_ib_implicit_ops->createSolutionVec(&X_np1);
+        d_ib_implicit_ops->createSolutionVec(&GX_nm1);
+        d_ib_implicit_ops->createSolutionVec(&GX_n);
+        d_ib_implicit_ops->createSolutionVec(&DX_nm1);
+        d_ib_implicit_ops->createSolutionVec(&DX_n);
+        d_ib_implicit_ops->createSolutionVec(&DX_np1);
+        d_ib_implicit_ops->createSolutionVec(&DDX_n);
+        d_ib_implicit_ops->createSolutionVec(&DGX_n);
 
-        d_ib_implicit_ops->getUpdatedPosition(X0);
+        // Initialize X_{n-1}:
+        d_ib_implicit_ops->getUpdatedPosition(X_nm1);
 
         double D0;
-        ierr = VecNorm(X0, NORM_2, &D0);
+        ierr = VecNorm(X_nm1, NORM_2, &D0);
         IBTK_CHKERRQ(ierr);
 
         int k = 0, n_solves = 0;
@@ -263,65 +274,72 @@ IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
         int max_its = 100;
         bool converged = false;
 
-        iterateSolution(X0);
-        d_ib_implicit_ops->getUpdatedPosition(X1);
+        // Initialize X_{n} = G(X_{n-1}):
+        iterateSolution(X_nm1);
+        d_ib_implicit_ops->getUpdatedPosition(GX_nm1);
         ++n_solves;
+        ierr = VecCopy(GX_nm1, X_n);
+        IBTK_CHKERRQ(ierr);
+
+        // Initialize DX_{n-1} := G(X_{n-1}) - X_{n-1}:
+        ierr = VecWAXPY(DX_nm1, -1.0, X_nm1, GX_nm1);
+        IBTK_CHKERRQ(ierr);
 
         for (k = 0; k < max_its && !converged; ++k)
         {
-            iterateSolution(X1);
-            d_ib_implicit_ops->getUpdatedPosition(X2);
+            // G(X_{n}):
+            iterateSolution(X_n);
+            d_ib_implicit_ops->getUpdatedPosition(GX_n);
             ++n_solves;
 
-            // Y := X2 - X1
-            ierr = VecWAXPY(Y, -1.0, X1, X2);
+            // DX_{n} := G(X_{n}) - X_{n}:
+            ierr = VecWAXPY(DX_n, -1.0, X_n, GX_n);
             IBTK_CHKERRQ(ierr);
 
-            // Z := X2 - 2*X1 + X0
-            ierr = VecWAXPY(Z, -2.0, X1, X0);
-            IBTK_CHKERRQ(ierr);
-            ierr = VecAXPY(Z, 1.0, X2);
+            // DGX_{n} := G(X_{n}) - G(X_{n-1}):
+            ierr = VecWAXPY(DGX_n, -1.0, GX_nm1, GX_n);
             IBTK_CHKERRQ(ierr);
 
-            // Q1 := dot(Z, Y)
+            // DDX_{n} := DX_{n} - DX_{n-1}:
+            ierr = VecWAXPY(DDX_n, -1.0, DX_nm1, DX_n);
+            IBTK_CHKERRQ(ierr);
+
+            // X_{n+1} := G(X_{n}) - Q DX_{n}
+            //
+            // with Q = dot(G(X_{n}) - G(X_{n-1}, DX_{n} - DX_{n-1})/||DX_{n} - DX_{n-1}||^2
+            //        = dot(DGX_{n}, DDX_{n})/||DDX_{n}||^2
+
             double Q1;
-            ierr = VecDot(Z, Y, &Q1);
+            ierr = VecDot(DGX_n, DDX_n, &Q1);
             IBTK_CHKERRQ(ierr);
-
-            // Q2 := dot(Z, Z)
             double Q2;
-            ierr = VecDot(Z, Z, &Q2);
+            ierr = VecDot(DDX_n, DDX_n, &Q2);
             IBTK_CHKERRQ(ierr);
 
-            // Q := dot(X2 - 2*X1 + X0 , X1 - X2) / ||X2 - 2*X1 + X0||_2
-            const double Q = -Q1 / Q2;
-
-            // Y := X2 + Q*(X2 - X1)
-            ierr = VecAYPX(Y, Q, X2);
+            const double Q = Q1 / Q2;
+            ierr = VecWAXPY(X_np1, -Q, DX_n, GX_n);
             IBTK_CHKERRQ(ierr);
 
-            // Z := X2 - Y
-            ierr = VecWAXPY(Z, -1.0, Y, X2);
+            // Check to see if ||G(X_{n}) - X_{n+1}||_2 is sufficiently small to declare convergence.
+            ierr = VecWAXPY(DX_np1, -1.0, X_np1, GX_n);
             IBTK_CHKERRQ(ierr);
             double D;
-            ierr = VecNorm(Z, NORM_2, &D);
+            ierr = VecNorm(DX_np1, NORM_2, &D);
             IBTK_CHKERRQ(ierr);
-
-            // Check to see if ||X2 - Y||_2 is sufficiently small to declare convergence.
             if (D < tol * D0)
             {
                 converged = true;
             }
             else
             {
-                // If we haven't converged, get an updated solution, reset X0 and X1, and repeat.
-                iterateSolution(Y);
-                d_ib_implicit_ops->getUpdatedPosition(Z);
-                ++n_solves;
-
-                ierr = VecCopy(Y, X0);
+                // If we haven't converged, get an updated solution, reset values and repeat.
+                ierr = VecCopy(X_n, X_nm1);
                 IBTK_CHKERRQ(ierr);
-                ierr = VecCopy(Z, X1);
+                ierr = VecCopy(X_np1, X_n);
+                IBTK_CHKERRQ(ierr);
+                ierr = VecCopy(GX_n, GX_nm1);
+                IBTK_CHKERRQ(ierr);
+                ierr = VecCopy(DX_n, DX_nm1);
                 IBTK_CHKERRQ(ierr);
             }
         }
@@ -334,15 +352,158 @@ IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
              << "  AITKEN extrapolation " << (converged ? "CONVERGED" : "DIVERGED") << "\n"
              << "  requiring in " << k << " iterations and " << n_solves << " total Navier-Stokes solves\n";
 
-        ierr = VecDestroy(&X0);
+        ierr = VecDestroy(&X_nm1);
         IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&X1);
+        ierr = VecDestroy(&X_n);
         IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&X2);
+        ierr = VecDestroy(&X_np1);
         IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&Y);
+        ierr = VecDestroy(&GX_nm1);
         IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&Z);
+        ierr = VecDestroy(&GX_n);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&DX_nm1);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&DX_n);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&DX_np1);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&DDX_n);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&DGX_n);
+        IBTK_CHKERRQ(ierr);
+    }
+    else if (d_implicit_algorithm == "ANDERSON")
+    {
+        // Use the alternate secant method (Anderson extrapolation with M = 1).
+        //
+        // Ref: Isabelle Ramière, Thomas Helfer. Iterative residual-based vector methods to accelerate fixed point
+        // iterations. Computers and Mathematics with Applications, Elsevier, 2015, 70, pp. 2210 - 2226.
+        //
+        // See Pg. 21 of https://hal-cea.archives-ouvertes.fr/cea-01403292/document.
+        PetscErrorCode ierr;
+        Vec X_nm1, X_n, X_np1, GX_nm1, GX_n, DX_nm1, DX_n, DX_np1, DDX_n, DGX_n;
+        d_ib_implicit_ops->createSolutionVec(&X_nm1);
+        d_ib_implicit_ops->createSolutionVec(&X_n);
+        d_ib_implicit_ops->createSolutionVec(&X_np1);
+        d_ib_implicit_ops->createSolutionVec(&GX_nm1);
+        d_ib_implicit_ops->createSolutionVec(&GX_n);
+        d_ib_implicit_ops->createSolutionVec(&DX_nm1);
+        d_ib_implicit_ops->createSolutionVec(&DX_n);
+        d_ib_implicit_ops->createSolutionVec(&DX_np1);
+        d_ib_implicit_ops->createSolutionVec(&DDX_n);
+        d_ib_implicit_ops->createSolutionVec(&DGX_n);
+
+        // Initialize X_{n-1}:
+        d_ib_implicit_ops->getUpdatedPosition(X_nm1);
+
+        double D0;
+        ierr = VecNorm(X_nm1, NORM_2, &D0);
+        IBTK_CHKERRQ(ierr);
+
+        int k = 0, n_solves = 0;
+        double tol = 1.0e-5;
+        int max_its = 100;
+        bool converged = false;
+
+        // Initialize X_{n} = G(X_{n-1}):
+        iterateSolution(X_nm1);
+        d_ib_implicit_ops->getUpdatedPosition(GX_nm1);
+        ++n_solves;
+        ierr = VecCopy(GX_nm1, X_n);
+        IBTK_CHKERRQ(ierr);
+
+        // Initialize DX_{n-1} := G(X_{n-1}) - X_{n-1}:
+        ierr = VecWAXPY(DX_nm1, -1.0, X_nm1, GX_nm1);
+        IBTK_CHKERRQ(ierr);
+
+        for (k = 0; k < max_its && !converged; ++k)
+        {
+            // G(X_{n}):
+            iterateSolution(X_n);
+            d_ib_implicit_ops->getUpdatedPosition(GX_n);
+            ++n_solves;
+
+            // DX_{n} := G(X_{n}) - X_{n}:
+            ierr = VecWAXPY(DX_n, -1.0, X_n, GX_n);
+            IBTK_CHKERRQ(ierr);
+
+            // DGX_{n} := G(X_{n}) - G(X_{n-1}):
+            ierr = VecWAXPY(DGX_n, -1.0, GX_nm1, GX_n);
+            IBTK_CHKERRQ(ierr);
+
+            // DDX_{n} := DX_{n} - DX_{n-1}:
+            ierr = VecWAXPY(DDX_n, -1.0, DX_nm1, DX_n);
+            IBTK_CHKERRQ(ierr);
+
+            // X_{n+1} := G(X_{n}) - Q (G(X_{n}) - G(X_{n-1}))
+            //          = G(X_{n}) - Q DGX_{n}
+            //
+            // with Q = dot(DX_{n} - DX_{n-1}, DX_{n})/||DX_{n} - DX_{n-1}||^2
+            //        = dot(DDX_{n}, DX_{n})/||DDX_{n}||^2
+
+            double Q1;
+            ierr = VecDot(DDX_n, DX_n, &Q1);
+            IBTK_CHKERRQ(ierr);
+            double Q2;
+            ierr = VecDot(DDX_n, DDX_n, &Q2);
+            IBTK_CHKERRQ(ierr);
+
+            const double Q = Q1 / Q2;
+            ierr = VecWAXPY(X_np1, -Q, DGX_n, GX_n);
+            IBTK_CHKERRQ(ierr);
+
+            // Check to see if ||G(X_{n}) - X_{n+1}||_2 is sufficiently small to declare convergence.
+            ierr = VecWAXPY(DX_np1, -1.0, X_np1, GX_n);
+            IBTK_CHKERRQ(ierr);
+            double D;
+            ierr = VecNorm(DX_np1, NORM_2, &D);
+            IBTK_CHKERRQ(ierr);
+            if (D < tol * D0)
+            {
+                converged = true;
+            }
+            else
+            {
+                // If we haven't converged, get an updated solution, reset values and repeat.
+                ierr = VecCopy(X_n, X_nm1);
+                IBTK_CHKERRQ(ierr);
+                ierr = VecCopy(X_np1, X_n);
+                IBTK_CHKERRQ(ierr);
+                ierr = VecCopy(GX_n, GX_nm1);
+                IBTK_CHKERRQ(ierr);
+                ierr = VecCopy(DX_n, DX_nm1);
+                IBTK_CHKERRQ(ierr);
+            }
+        }
+
+        if (!converged)
+        {
+            pout << "WARNING: ANDERSON extrapolation DIVERGED\n";
+        }
+        plog << d_object_name << "::integrateHierarchy():\n"
+             << "  ANDERSON extrapolation " << (converged ? "CONVERGED" : "DIVERGED") << "\n"
+             << "  requiring in " << k << " iterations and " << n_solves << " total Navier-Stokes solves\n";
+
+        ierr = VecDestroy(&X_nm1);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&X_n);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&X_np1);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&GX_nm1);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&GX_n);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&DX_nm1);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&DX_n);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&DX_np1);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&DDX_n);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&DGX_n);
         IBTK_CHKERRQ(ierr);
     }
     else if (d_implicit_algorithm == "SNES")
@@ -387,7 +548,7 @@ IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
     {
         TBOX_ERROR(d_object_name << "::integrateHierarchy():\n"
                                  << "  unsupported solver algorithm: " << d_implicit_algorithm << "\n"
-                                 << "  supported time stepping types are: AITKEN, SNES\n");
+                                 << "  supported time stepping types are: AITKEN, ANDERSON, SNES\n");
     }
 
     // Execute any registered callbacks.

--- a/src/IB/IBImplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitHierarchyIntegrator.cpp
@@ -24,7 +24,6 @@
 #include "ibamr/StaggeredStokesPETScVecUtilities.h"
 #include "ibamr/StaggeredStokesSolver.h"
 #include "ibamr/ibamr_enums.h"
-#include "ibamr/namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/HierarchyMathOps.h"
 #include "ibtk/IBTK_CHKERRQ.h"
@@ -62,6 +61,8 @@
 #include <algorithm>
 #include <ostream>
 #include <string>
+
+#include "ibamr/namespaces.h" // IWYU pragma: keep
 
 namespace IBAMR
 {
@@ -112,7 +113,6 @@ IBImplicitHierarchyIntegrator::IBImplicitHierarchyIntegrator(
             d_use_structure_predictor = input_db->getBool("use_structure_predictor");
         if (input_db->keyExists("use_fixed_LE_operators"))
             d_use_fixed_LE_operators = input_db->getBool("use_fixed_LE_operators");
-        if (input_db->keyExists("implicit_algorithm")) d_implicit_algorithm = input_db->getString("implicit_algorithm");
     }
     d_ib_implicit_ops->setUseFixedLEOperators(d_use_fixed_LE_operators);
 
@@ -223,219 +223,41 @@ IBImplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
 
     if (d_use_fixed_LE_operators) d_ib_implicit_ops->updateFixedLEOperators();
 
-    if (d_implicit_algorithm == "AITKEN" || d_implicit_algorithm == "ANDERSON" || d_implicit_algorithm == "IRONS-TUCK")
-    {
-        // Use the crossed secant method (Aitken extrapolation) or the alternate secant method (Anderson extrapolation
-        // with M = 1).
-        //
-        // Ref: Isabelle Ramière, Thomas Helfer. Iterative residual-based vector methods to accelerate fixed point
-        // iterations. Computers and Mathematics with Applications, Elsevier, 2015, 70, pp. 2210 - 2226.
-        //
-        // See Pg. 21 of https://hal-cea.archives-ouvertes.fr/cea-01403292/document.
-        PetscErrorCode ierr;
-        Vec X_nm1, X_n, X_np1, GX_nm1, GX_n, DX_nm1, DX_n, DDX_n, DGX_n;
-        d_ib_implicit_ops->createSolutionVec(&X_nm1);
-        d_ib_implicit_ops->createSolutionVec(&X_n);
-        d_ib_implicit_ops->createSolutionVec(&X_np1);
-        d_ib_implicit_ops->createSolutionVec(&GX_nm1);
-        d_ib_implicit_ops->createSolutionVec(&GX_n);
-        d_ib_implicit_ops->createSolutionVec(&DX_nm1);
-        d_ib_implicit_ops->createSolutionVec(&DX_n);
-        d_ib_implicit_ops->createSolutionVec(&DDX_n);
-        d_ib_implicit_ops->createSolutionVec(&DGX_n);
+    // Setup Lagrangian vectors used in solving the implicit IB equations.
+    PetscErrorCode ierr;
+    Vec X, R, R_work;
+    d_ib_implicit_ops->createSolverVecs(&X, &R);
+    d_ib_implicit_ops->setupSolverVecs(X, R);
+    ierr = VecDuplicate(R, &R_work);
+    IBTK_CHKERRQ(ierr);
 
-        // Initialize X_{n-1}:
-        d_ib_implicit_ops->getUpdatedPosition(X_nm1);
+    // Solve the implicit IB equations.
+    d_ins_cycle_num = 0;
 
-        double D0;
-        ierr = VecNorm(X_nm1, NORM_2, &D0);
-        IBTK_CHKERRQ(ierr);
+    SNES snes;
+    ierr = SNESCreate(PETSC_COMM_WORLD, &snes);
+    IBTK_CHKERRQ(ierr);
+    ierr = SNESSetFunction(snes, R_work, IBFunction_SAMRAI, this);
+    IBTK_CHKERRQ(ierr);
+    ierr = SNESSetOptionsPrefix(snes, "ib_");
+    IBTK_CHKERRQ(ierr);
+    ierr = SNESSetFromOptions(snes);
+    IBTK_CHKERRQ(ierr);
+    ierr = SNESSolve(snes, R, X);
+    IBTK_CHKERRQ(ierr);
+    ierr = SNESDestroy(&snes);
+    IBTK_CHKERRQ(ierr);
 
-        int k = 0, n_solves = 0;
-        double tol = 1.0e-5;
-        int max_its = 100;
-        bool converged = false;
+    // Ensure that the INS variables are consistent with the final structure configuration.
+    iterateSolution(X);
 
-        // Initialize X_{n} = G(X_{n-1}):
-        iterateSolution(X_nm1);
-        d_ib_implicit_ops->getUpdatedPosition(GX_nm1);
-        ++n_solves;
-        ierr = VecCopy(GX_nm1, X_n);
-        IBTK_CHKERRQ(ierr);
-
-        // Initialize DX_{n-1} := G(X_{n-1}) - X_{n-1}:
-        ierr = VecWAXPY(DX_nm1, -1.0, X_nm1, GX_nm1);
-        IBTK_CHKERRQ(ierr);
-
-        // Initialize omega_{n-1}:
-        double omega_nm1 = std::min(d_omega_n, d_omega_max);
-
-        for (k = 0; k < max_its && !converged; ++k)
-        {
-            // G(X_{n}):
-            iterateSolution(X_n);
-            d_ib_implicit_ops->getUpdatedPosition(GX_n);
-            ++n_solves;
-
-            // DX_{n} := G(X_{n}) - X_{n}:
-            ierr = VecWAXPY(DX_n, -1.0, X_n, GX_n);
-            IBTK_CHKERRQ(ierr);
-
-            // DGX_{n} := G(X_{n}) - G(X_{n-1}):
-            ierr = VecWAXPY(DGX_n, -1.0, GX_nm1, GX_n);
-            IBTK_CHKERRQ(ierr);
-
-            // DDX_{n} := DX_{n} - DX_{n-1}:
-            ierr = VecWAXPY(DDX_n, -1.0, DX_nm1, DX_n);
-            IBTK_CHKERRQ(ierr);
-
-            if (d_implicit_algorithm == "AITKEN")
-            {
-                // X_{n+1} := G(X_{n}) - Q DX_{n}
-                //
-                // with Q = dot(DX_{n-1}, DX_{n} - DX_{n-1})/||DX_{n} - DX_{n-1}||^2
-                //        = dot(DX_{n}, DDX_{n})/||DDX_{n}||^2
-                double Q1;
-                ierr = VecDot(DX_n, DDX_n, &Q1);
-                IBTK_CHKERRQ(ierr);
-                double Q2;
-                ierr = VecDot(DDX_n, DDX_n, &Q2);
-                IBTK_CHKERRQ(ierr);
-
-                const double Q = Q1 / Q2;
-                ierr = VecWAXPY(X_np1, -Q, DX_n, GX_n);
-                IBTK_CHKERRQ(ierr);
-            }
-            else if (d_implicit_algorithm == "ANDERSON")
-            {
-                // X_{n+1} := G(X_{n}) - Q (G(X_{n}) - G(X_{n-1}))
-                //          = G(X_{n}) - Q DGX_{n}
-                //
-                // with Q = dot(DX_{n} - DX_{n-1}, DX_{n})/||DX_{n} - DX_{n-1}||^2
-                //        = dot(DDX_{n}, DX_{n})/||DDX_{n}||^2
-                double Q1;
-                ierr = VecDot(DDX_n, DX_n, &Q1);
-                IBTK_CHKERRQ(ierr);
-                double Q2;
-                ierr = VecDot(DDX_n, DDX_n, &Q2);
-                IBTK_CHKERRQ(ierr);
-
-                const double Q = Q1 / Q2;
-                ierr = VecWAXPY(X_np1, -Q, DGX_n, GX_n);
-                IBTK_CHKERRQ(ierr);
-            }
-            else if (d_implicit_algorithm == "IRONS-TUCK")
-            {
-                // X_{n+1} := omega_{n} G(X_n) + (1.0-omega_{n}) X_n
-                //
-                // with omega_{n} = -omega_{n-1} dot(DX_{n-1}, DX_{n} - DX_{n-1})/||DX_{n} - DX_{n-1}||^2
-                //                = -omega_{n-1} dot(DX_{n-1}, DDX_{n})/||DDX_{n}||^2
-                double Q1;
-                ierr = VecDot(DX_nm1, DDX_n, &Q1);
-                IBTK_CHKERRQ(ierr);
-                double Q2;
-                ierr = VecDot(DDX_n, DDX_n, &Q2);
-                IBTK_CHKERRQ(ierr);
-
-                d_omega_n = -omega_nm1 * Q1 / Q2;
-                ierr = VecAXPBYPCZ(X_np1, d_omega_n, 1.0 - d_omega_n, 0.0, GX_n, X_n);
-                IBTK_CHKERRQ(ierr);
-                omega_nm1 = d_omega_n;
-            }
-
-            // Check to see if ||G(X_{n}) - X_{n}||_2 is sufficiently small to declare convergence.
-            double D;
-            ierr = VecNorm(DX_n, NORM_2, &D);
-            IBTK_CHKERRQ(ierr);
-            if (D < tol * D0)
-            {
-                converged = true;
-            }
-            else
-            {
-                // If we haven't converged, get an updated solution, reset values and repeat.
-                ierr = VecCopy(X_n, X_nm1);
-                IBTK_CHKERRQ(ierr);
-                ierr = VecCopy(X_np1, X_n);
-                IBTK_CHKERRQ(ierr);
-                ierr = VecCopy(GX_n, GX_nm1);
-                IBTK_CHKERRQ(ierr);
-                ierr = VecCopy(DX_n, DX_nm1);
-                IBTK_CHKERRQ(ierr);
-            }
-        }
-
-        if (!converged)
-        {
-            pout << "WARNING: " << d_implicit_algorithm << " extrapolation DIVERGED\n";
-        }
-        plog << d_object_name << "::integrateHierarchy():\n"
-             << "  " << d_implicit_algorithm << " extrapolation " << (converged ? "CONVERGED" : "DIVERGED") << "\n"
-             << "  requiring in " << k << " iterations and " << n_solves << " total Navier-Stokes solves\n";
-
-        ierr = VecDestroy(&X_nm1);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&X_n);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&X_np1);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&GX_nm1);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&GX_n);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&DX_nm1);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&DX_n);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&DDX_n);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&DGX_n);
-        IBTK_CHKERRQ(ierr);
-    }
-    else if (d_implicit_algorithm == "SNES")
-    {
-        // Setup Lagrangian vectors used in solving the implicit IB equations.
-        PetscErrorCode ierr;
-        Vec X, R, R_work;
-        d_ib_implicit_ops->createSolverVecs(&X, &R);
-        d_ib_implicit_ops->setupSolverVecs(X, R);
-        ierr = VecDuplicate(R, &R_work);
-        IBTK_CHKERRQ(ierr);
-
-        // Solve the implicit IB equations.
-        d_ins_cycle_num = 0;
-
-        SNES snes;
-        ierr = SNESCreate(PETSC_COMM_WORLD, &snes);
-        IBTK_CHKERRQ(ierr);
-        ierr = SNESSetFunction(snes, R_work, IBFunction_SAMRAI, this);
-        IBTK_CHKERRQ(ierr);
-        ierr = SNESSetOptionsPrefix(snes, "ib_");
-        IBTK_CHKERRQ(ierr);
-        ierr = SNESSetFromOptions(snes);
-        IBTK_CHKERRQ(ierr);
-        ierr = SNESSolve(snes, R, X);
-        IBTK_CHKERRQ(ierr);
-        ierr = SNESDestroy(&snes);
-        IBTK_CHKERRQ(ierr);
-
-        // Ensure that the INS variables are consistent with the final structure configuration.
-        iterateSolution(X);
-
-        // Deallocate temporary data.
-        ierr = VecDestroy(&X);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&R);
-        IBTK_CHKERRQ(ierr);
-        ierr = VecDestroy(&R_work);
-        IBTK_CHKERRQ(ierr);
-    }
-    else
-    {
-        TBOX_ERROR(d_object_name << "::integrateHierarchy():\n"
-                                 << "  unsupported solver algorithm: " << d_implicit_algorithm << "\n"
-                                 << "  supported time stepping types are: AITKEN, ANDERSON, IRONS-TUCK, SNES\n");
-    }
+    // Deallocate temporary data.
+    ierr = VecDestroy(&X);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&R);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&R_work);
+    IBTK_CHKERRQ(ierr);
 
     // Execute any registered callbacks.
     executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
@@ -501,14 +323,14 @@ IBImplicitHierarchyIntegrator::postprocessIntegrateHierarchy(const double curren
         }
     }
     cfl_max = SAMRAI_MPI::maxReduction(cfl_max);
-    d_regrid_cfl_estimate += cfl_max;
+    d_regrid_fluid_cfl_estimate += cfl_max;
     if (d_enable_logging)
         plog << d_object_name << "::postprocessIntegrateHierarchy(): CFL number = " << cfl_max << "\n";
     if (d_enable_logging)
         plog << d_object_name
              << "::postprocessIntegrateHierarchy(): estimated upper bound on IB "
                 "point displacement since last regrid = "
-             << d_regrid_cfl_estimate << "\n";
+             << d_regrid_fluid_cfl_estimate << "\n";
 
     // Deallocate the fluid solver.
     const int ins_num_cycles = d_ins_hier_integrator->getNumberOfCycles();

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -558,7 +558,7 @@ IBMethod::computeResidualBackwardEuler(Vec& R_vec)
     ierr = VecAXPY(R_vec, -1.0, d_X_current_data[level_num]->getVec());
     IBTK_CHKERRQ(ierr);
     return;
-} // computeResidual
+} // computeResidualBackwardEuler
 
 void
 IBMethod::computeResidualMidpointRule(Vec& R_vec)
@@ -571,7 +571,7 @@ IBMethod::computeResidualMidpointRule(Vec& R_vec)
     ierr = VecAXPY(R_vec, -1.0, d_X_current_data[level_num]->getVec());
     IBTK_CHKERRQ(ierr);
     return;
-} // computeResidual
+} // computeResidualMidpointRule
 
 void
 IBMethod::computeResidualTrapezoidalRule(Vec& R_vec)
@@ -586,7 +586,7 @@ IBMethod::computeResidualTrapezoidalRule(Vec& R_vec)
     ierr = VecAXPY(R_vec, -1.0, d_X_current_data[level_num]->getVec());
     IBTK_CHKERRQ(ierr);
     return;
-} // computeResidual
+} // computeResidualTrapezoidalRule
 
 void
 IBMethod::updateFixedLEOperators()

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -470,6 +470,19 @@ IBMethod::postprocessIntegrateData(double current_time, double new_time, int /*n
 } // postprocessIntegrateData
 
 void
+IBMethod::createSolutionVec(Vec* X_vec)
+{
+    PetscErrorCode ierr;
+    const int level_num = d_hierarchy->getFinestLevelNumber();
+    if (X_vec != nullptr)
+    {
+        ierr = VecDuplicate(d_X_current_data[level_num]->getVec(), X_vec);
+        IBTK_CHKERRQ(ierr);
+    }
+    return;
+} // createSolutionVec
+
+void
 IBMethod::createSolverVecs(Vec* X_vec, Vec* F_vec)
 {
     PetscErrorCode ierr;
@@ -488,18 +501,18 @@ IBMethod::createSolverVecs(Vec* X_vec, Vec* F_vec)
 } // createSolverVecs
 
 void
-IBMethod::setupSolverVecs(Vec* X_vec, Vec* F_vec)
+IBMethod::setupSolverVecs(Vec& X_vec, Vec& F_vec)
 {
     PetscErrorCode ierr;
     const int level_num = d_hierarchy->getFinestLevelNumber();
     if (X_vec != nullptr)
     {
-        ierr = VecCopy(d_X_current_data[level_num]->getVec(), *X_vec);
+        ierr = VecCopy(d_X_current_data[level_num]->getVec(), X_vec);
         IBTK_CHKERRQ(ierr);
     }
     if (F_vec != nullptr)
     {
-        ierr = VecSet(*F_vec, 0.0);
+        ierr = VecSet(F_vec, 0.0);
         IBTK_CHKERRQ(ierr);
     }
     return;

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -525,6 +525,16 @@ IBMethod::setUpdatedPosition(Vec& X_new_vec)
 } // setUpdatedPosition
 
 void
+IBMethod::getUpdatedPosition(Vec& X_new_vec)
+{
+    PetscErrorCode ierr;
+    const int level_num = d_hierarchy->getFinestLevelNumber();
+    ierr = VecCopy(d_X_new_data[level_num]->getVec(), X_new_vec);
+    IBTK_CHKERRQ(ierr);
+    return;
+} // getUpdatedPosition
+
+void
 IBMethod::computeResidualBackwardEuler(Vec& R_vec)
 {
     PetscErrorCode ierr;

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -1532,6 +1532,10 @@ IBMethod::getLECouplingPositionData(std::vector<Pointer<LData> >** X_LE_data,
         *X_LE_data = &d_X_LE_new_data;
         *X_LE_needs_ghost_fill = &d_X_LE_new_needs_ghost_fill;
     }
+    else
+    {
+        *X_LE_data = nullptr;
+    }
     return;
 } // getLECouplingPositionData
 
@@ -1549,6 +1553,10 @@ IBMethod::getVelocityData(std::vector<Pointer<LData> >** U_data, double data_tim
     else if (IBTK::rel_equal_eps(data_time, d_new_time))
     {
         *U_data = &d_U_new_data;
+    }
+    else
+    {
+        *U_data = nullptr;
     }
     return;
 } // getVelocityData
@@ -1577,6 +1585,10 @@ IBMethod::getForceData(std::vector<Pointer<LData> >** F_data, bool** F_needs_gho
         }
         *F_data = &d_F_new_data;
         *F_needs_ghost_fill = &d_F_new_needs_ghost_fill;
+    }
+    else
+    {
+        *F_data = nullptr;
     }
     return;
 } // getForceData

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -184,12 +184,6 @@ IBMethod::~IBMethod()
         RestartManager::getManager()->unregisterRestartItem(d_object_name);
         d_registered_for_restart = false;
     }
-    if (d_force_jac)
-    {
-        PetscErrorCode ierr;
-        ierr = MatDestroy(&d_force_jac);
-        IBTK_CHKERRQ(ierr);
-    }
     return;
 } // ~IBMethod
 
@@ -353,15 +347,12 @@ IBMethod::preprocessIntegrateData(double current_time, double new_time, int /*nu
     d_X_current_data.resize(finest_ln + 1);
     d_X_new_data.resize(finest_ln + 1);
     d_X_half_data.resize(finest_ln + 1);
-    d_X_jac_data.resize(finest_ln + 1);
     d_U_current_data.resize(finest_ln + 1);
     d_U_new_data.resize(finest_ln + 1);
     d_U_half_data.resize(finest_ln + 1);
-    d_U_jac_data.resize(finest_ln + 1);
     d_F_current_data.resize(finest_ln + 1);
     d_F_new_data.resize(finest_ln + 1);
     d_F_half_data.resize(finest_ln + 1);
-    d_F_jac_data.resize(finest_ln + 1);
     if (d_use_fixed_coupling_ops)
     {
         d_X_LE_new_data.resize(finest_ln + 1);
@@ -462,17 +453,14 @@ IBMethod::postprocessIntegrateData(double current_time, double new_time, int /*n
     d_X_current_data.clear();
     d_X_new_data.clear();
     d_X_half_data.clear();
-    d_X_jac_data.clear();
     d_X_LE_new_data.clear();
     d_X_LE_half_data.clear();
     d_U_current_data.clear();
     d_U_new_data.clear();
     d_U_half_data.clear();
-    d_U_jac_data.clear();
     d_F_current_data.clear();
     d_F_new_data.clear();
     d_F_half_data.clear();
-    d_F_jac_data.clear();
 
     // Reset the current time step interval.
     d_current_time = std::numeric_limits<double>::quiet_NaN();
@@ -537,90 +525,20 @@ IBMethod::setUpdatedPosition(Vec& X_new_vec)
 } // setUpdatedPosition
 
 void
-IBMethod::setLinearizedPosition(Vec& X_vec, const double data_time)
+IBMethod::computeResidualBackwardEuler(Vec& R_vec)
 {
     PetscErrorCode ierr;
     const int level_num = d_hierarchy->getFinestLevelNumber();
-    std::vector<Pointer<LData> >* X_jac_data;
-    bool* X_jac_needs_ghost_fill;
-    getLinearizedPositionData(&X_jac_data, &X_jac_needs_ghost_fill);
-    ierr = VecCopy(X_vec, (*X_jac_data)[level_num]->getVec());
+    const double dt = d_new_time - d_current_time;
+    ierr = VecWAXPY(R_vec, -dt, d_U_new_data[level_num]->getVec(), d_X_new_data[level_num]->getVec());
     IBTK_CHKERRQ(ierr);
-    *X_jac_needs_ghost_fill = true;
-
-    if (d_force_jac)
-    {
-        ierr = MatDestroy(&d_force_jac);
-        IBTK_CHKERRQ(ierr);
-        d_force_jac = nullptr;
-    }
-    d_force_jac_data_time = data_time;
-    int n_local, n_global;
-    ierr = VecGetLocalSize(X_vec, &n_local);
+    ierr = VecAXPY(R_vec, -1.0, d_X_current_data[level_num]->getVec());
     IBTK_CHKERRQ(ierr);
-    ierr = VecGetSize(X_vec, &n_global);
-    IBTK_CHKERRQ(ierr);
-
-    if (d_force_jac_mffd)
-    {
-        ierr = MatCreateMFFD(PETSC_COMM_WORLD, n_local, n_local, n_global, n_global, &d_force_jac);
-        IBTK_CHKERRQ(ierr);
-        ierr = MatMFFDSetFunction(d_force_jac, computeForce_SAMRAI, this);
-        IBTK_CHKERRQ(ierr);
-        ierr = MatSetOptionsPrefix(d_force_jac, "ib_jac_");
-        IBTK_CHKERRQ(ierr);
-        ierr = MatSetFromOptions(d_force_jac);
-        IBTK_CHKERRQ(ierr);
-        ierr = MatMFFDSetBase(d_force_jac, (*X_jac_data)[level_num]->getVec(), nullptr);
-        IBTK_CHKERRQ(ierr);
-        ierr = MatAssemblyBegin(d_force_jac, MAT_FINAL_ASSEMBLY);
-        IBTK_CHKERRQ(ierr);
-        ierr = MatAssemblyEnd(d_force_jac, MAT_FINAL_ASSEMBLY);
-        IBTK_CHKERRQ(ierr);
-    }
-    else
-    {
-        std::vector<int> d_nnz, o_nnz;
-        d_ib_force_fcn->computeLagrangianForceJacobianNonzeroStructure(
-            d_nnz, o_nnz, d_hierarchy, level_num, d_l_data_manager);
-        std::vector<int> d_nnz_unblocked(NDIM * d_nnz.size()), o_nnz_unblocked(NDIM * o_nnz.size());
-        for (unsigned int k = 0; k < d_nnz.size(); ++k)
-        {
-            for (unsigned int d = 0; d < NDIM; ++d)
-            {
-                d_nnz_unblocked[NDIM * k + d] = NDIM * d_nnz[k];
-                o_nnz_unblocked[NDIM * k + d] = NDIM * o_nnz[k];
-            }
-        }
-        ierr = MatCreateAIJ(PETSC_COMM_WORLD,
-                            n_local,
-                            n_local,
-                            n_global,
-                            n_global,
-                            0,
-                            n_local ? &d_nnz_unblocked[0] : nullptr,
-                            0,
-                            n_local ? &o_nnz_unblocked[0] : nullptr,
-                            &d_force_jac);
-        IBTK_CHKERRQ(ierr);
-        ierr = MatSetBlockSize(d_force_jac, NDIM);
-        IBTK_CHKERRQ(ierr);
-        d_ib_force_fcn->computeLagrangianForceJacobian(d_force_jac,
-                                                       MAT_FINAL_ASSEMBLY,
-                                                       1.0,
-                                                       (*X_jac_data)[level_num],
-                                                       0.0,
-                                                       Pointer<IBTK::LData>(nullptr),
-                                                       d_hierarchy,
-                                                       level_num,
-                                                       data_time,
-                                                       d_l_data_manager);
-    }
     return;
-} // setLinearizedPosition
+} // computeResidual
 
 void
-IBMethod::computeResidual(Vec& R_vec)
+IBMethod::computeResidualMidpointRule(Vec& R_vec)
 {
     PetscErrorCode ierr;
     const int level_num = d_hierarchy->getFinestLevelNumber();
@@ -633,15 +551,19 @@ IBMethod::computeResidual(Vec& R_vec)
 } // computeResidual
 
 void
-IBMethod::computeLinearizedResidual(Vec& X_vec, Vec& R_vec)
+IBMethod::computeResidualTrapezoidalRule(Vec& R_vec)
 {
     PetscErrorCode ierr;
     const int level_num = d_hierarchy->getFinestLevelNumber();
     const double dt = d_new_time - d_current_time;
-    ierr = VecWAXPY(R_vec, -dt, d_U_jac_data[level_num]->getVec(), X_vec);
+    ierr = VecWAXPY(R_vec, -0.5 * dt, d_U_current_data[level_num]->getVec(), d_X_new_data[level_num]->getVec());
+    IBTK_CHKERRQ(ierr);
+    ierr = VecAXPY(R_vec, -0.5 * dt, d_U_new_data[level_num]->getVec());
+    IBTK_CHKERRQ(ierr);
+    ierr = VecAXPY(R_vec, -1.0, d_X_current_data[level_num]->getVec());
     IBTK_CHKERRQ(ierr);
     return;
-} // computeLinearizedResidual
+} // computeResidual
 
 void
 IBMethod::updateFixedLEOperators()
@@ -691,23 +613,6 @@ IBMethod::interpolateVelocity(const int u_data_idx,
 
     return;
 } // interpolateVelocity
-
-void
-IBMethod::interpolateLinearizedVelocity(const int u_data_idx,
-                                        const std::vector<Pointer<CoarsenSchedule<NDIM> > >& u_synch_scheds,
-                                        const std::vector<Pointer<RefineSchedule<NDIM> > >& u_ghost_fill_scheds,
-                                        const double data_time)
-{
-    std::vector<Pointer<LData> >*U_jac_data, *X_LE_data;
-    bool* X_LE_needs_ghost_fill;
-    getLinearizedVelocityData(&U_jac_data);
-    getLECouplingPositionData(&X_LE_data, &X_LE_needs_ghost_fill, data_time);
-    d_l_data_manager->interp(u_data_idx, *U_jac_data, *X_LE_data, u_synch_scheds, u_ghost_fill_scheds, data_time);
-    resetAnchorPointValues(*U_jac_data,
-                           /*coarsest_ln*/ 0,
-                           /*finest_ln*/ d_hierarchy->getFinestLevelNumber());
-    return;
-} // interpolateLinearizedVelocity
 
 void
 IBMethod::forwardEulerStep(const double current_time, const double new_time)
@@ -856,118 +761,6 @@ IBMethod::computeLagrangianForce(const double data_time)
 } // computeLagrangianForce
 
 void
-IBMethod::computeLinearizedLagrangianForce(Vec& X_vec, const double /*data_time*/)
-{
-    PetscErrorCode ierr;
-    const int level_num = d_hierarchy->getFinestLevelNumber();
-    std::vector<Pointer<LData> >* F_jac_data;
-    bool* F_jac_needs_ghost_fill;
-    getLinearizedForceData(&F_jac_data, &F_jac_needs_ghost_fill);
-    Vec F_vec = (*F_jac_data)[level_num]->getVec();
-    ierr = MatMult(d_force_jac, X_vec, F_vec);
-    IBTK_CHKERRQ(ierr);
-    *F_jac_needs_ghost_fill = true;
-    IBTK_CHKERRQ(ierr);
-    return;
-} // computeLinearizedLagrangianForce
-
-void
-IBMethod::constructLagrangianForceJacobian(Mat& A, MatType mat_type, const double data_time)
-{
-    const int finest_ln = d_hierarchy->getFinestLevelNumber();
-
-    if (!std::strcmp(mat_type, MATMFFD) || !std::strcmp(mat_type, MATSHELL))
-    {
-        if (!d_force_jac)
-        {
-            Vec X_current = d_X_current_data[finest_ln]->getVec();
-            setLinearizedPosition(X_current, data_time);
-        }
-        A = d_force_jac;
-    }
-    else
-    {
-        int ierr;
-        if (A)
-        {
-            ierr = MatDestroy(&A);
-            IBTK_CHKERRQ(ierr);
-        }
-
-        // Get the "frozen" position for Lagrangian structure.
-        std::vector<Pointer<LData> >* X_LE_data;
-        bool* X_LE_needs_ghost_fill;
-        getLECouplingPositionData(&X_LE_data, &X_LE_needs_ghost_fill, data_time);
-
-        TBOX_ASSERT(d_ib_force_fcn);
-
-        // Build the Jacobian matrix.
-        const int num_local_nodes = d_l_data_manager->getNumberOfLocalNodes(finest_ln);
-        std::vector<int> d_nnz, o_nnz;
-        d_ib_force_fcn->computeLagrangianForceJacobianNonzeroStructure(
-            d_nnz, o_nnz, d_hierarchy, finest_ln, d_l_data_manager);
-        if (!std::strcmp(mat_type, MATBAIJ) || !std::strcmp(mat_type, MATMPIBAIJ))
-        {
-            ierr = MatCreateBAIJ(PETSC_COMM_WORLD,
-                                 NDIM,
-                                 NDIM * num_local_nodes,
-                                 NDIM * num_local_nodes,
-                                 PETSC_DETERMINE,
-                                 PETSC_DETERMINE,
-                                 0,
-                                 num_local_nodes ? &d_nnz[0] : nullptr,
-                                 0,
-                                 num_local_nodes ? &o_nnz[0] : nullptr,
-                                 &A);
-            IBTK_CHKERRQ(ierr);
-        }
-        else if (!std::strcmp(mat_type, MATAIJ) || !std::strcmp(mat_type, MATMPIAIJ))
-        {
-            std::vector<int> d_nnz_unblocked(NDIM * d_nnz.size()), o_nnz_unblocked(NDIM * o_nnz.size());
-            for (unsigned int k = 0; k < d_nnz.size(); ++k)
-            {
-                for (unsigned int d = 0; d < NDIM; ++d)
-                {
-                    d_nnz_unblocked[NDIM * k + d] = NDIM * d_nnz[k];
-                    o_nnz_unblocked[NDIM * k + d] = NDIM * o_nnz[k];
-                }
-            }
-            ierr = MatCreateAIJ(PETSC_COMM_WORLD,
-                                NDIM * num_local_nodes,
-                                NDIM * num_local_nodes,
-                                PETSC_DETERMINE,
-                                PETSC_DETERMINE,
-                                0,
-                                num_local_nodes ? &d_nnz_unblocked[0] : nullptr,
-                                0,
-                                num_local_nodes ? &o_nnz_unblocked[0] : nullptr,
-                                &A);
-            IBTK_CHKERRQ(ierr);
-        }
-        else
-        {
-            TBOX_ERROR(d_object_name + "::getLagrangianForceJacobian()."
-                       << "Matrix of the type " << mat_type << " given. Supported types are " << MATSHELL << "/"
-                       << MATMFFD << " , " << MATBAIJ << "/" << MATMPIBAIJ << " , " << MATAIJ << "/" << MATMPIAIJ
-                       << std::endl);
-        }
-        ierr = MatSetBlockSize(A, NDIM);
-        IBTK_CHKERRQ(ierr);
-        d_ib_force_fcn->computeLagrangianForceJacobian(A,
-                                                       MAT_FINAL_ASSEMBLY,
-                                                       1.0,
-                                                       (*X_LE_data)[finest_ln],
-                                                       0.0,
-                                                       Pointer<IBTK::LData>(nullptr),
-                                                       d_hierarchy,
-                                                       finest_ln,
-                                                       data_time,
-                                                       d_l_data_manager);
-    }
-    return;
-} // getLagrangianForceJacobian
-
-void
 IBMethod::spreadForce(const int f_data_idx,
                       RobinPhysBdryPatchStrategy* f_phys_bdry_op,
                       const std::vector<Pointer<RefineSchedule<NDIM> > >& f_prolongation_scheds,
@@ -992,32 +785,6 @@ IBMethod::spreadForce(const int f_data_idx,
     *X_LE_needs_ghost_fill = false;
     return;
 } // spreadForce
-
-void
-IBMethod::spreadLinearizedForce(const int f_data_idx,
-                                RobinPhysBdryPatchStrategy* f_phys_bdry_op,
-                                const std::vector<Pointer<RefineSchedule<NDIM> > >& f_prolongation_scheds,
-                                const double data_time)
-{
-    std::vector<Pointer<LData> >*F_jac_data, *X_LE_data;
-    bool *F_jac_needs_ghost_fill, *X_LE_needs_ghost_fill;
-    getLinearizedForceData(&F_jac_data, &F_jac_needs_ghost_fill);
-    getLECouplingPositionData(&X_LE_data, &X_LE_needs_ghost_fill, data_time);
-    resetAnchorPointValues(*F_jac_data,
-                           /*coarsest_ln*/ 0,
-                           /*finest_ln*/ d_hierarchy->getFinestLevelNumber());
-    d_l_data_manager->spread(f_data_idx,
-                             *F_jac_data,
-                             *X_LE_data,
-                             f_phys_bdry_op,
-                             f_prolongation_scheds,
-                             data_time,
-                             *F_jac_needs_ghost_fill,
-                             *X_LE_needs_ghost_fill);
-    *F_jac_needs_ghost_fill = false;
-    *X_LE_needs_ghost_fill = false;
-    return;
-} // spreadLinearizedForce
 
 void
 IBMethod::constructInterpOp(Mat& J,
@@ -1456,14 +1223,6 @@ IBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy,
     // Indicate that the force and source strategies need to be re-initialized.
     d_ib_force_fcn_needs_init = true;
     d_ib_source_fcn_needs_init = true;
-
-    // Deallocate any previously allocated Jacobian data structures.
-    if (d_force_jac)
-    {
-        PetscErrorCode ierr;
-        ierr = MatDestroy(&d_force_jac);
-        IBTK_CHKERRQ(ierr);
-    }
     return;
 } // initializePatchHierarchy
 
@@ -1725,25 +1484,6 @@ IBMethod::getPositionData(std::vector<Pointer<LData> >** X_data, bool** X_needs_
 } // getPositionData
 
 void
-IBMethod::getLinearizedPositionData(std::vector<Pointer<LData> >** X_jac_data, bool** X_jac_needs_ghost_fill)
-{
-    const int coarsest_ln = 0;
-    const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
-    {
-        if (!d_l_data_manager->levelContainsLagrangianData(ln)) continue;
-        if (!d_X_jac_data[ln])
-        {
-            d_X_jac_data[ln] = d_l_data_manager->createLData("X_jac", ln, NDIM);
-            d_X_jac_needs_ghost_fill = true;
-        }
-    }
-    *X_jac_data = &d_X_jac_data;
-    *X_jac_needs_ghost_fill = &d_X_jac_needs_ghost_fill;
-    return;
-} // getLinearizedPositionData
-
-void
 IBMethod::getLECouplingPositionData(std::vector<Pointer<LData> >** X_LE_data,
                                     bool** X_LE_needs_ghost_fill,
                                     double data_time)
@@ -1791,23 +1531,6 @@ IBMethod::getVelocityData(std::vector<Pointer<LData> >** U_data, double data_tim
 } // getVelocityData
 
 void
-IBMethod::getLinearizedVelocityData(std::vector<Pointer<LData> >** U_jac_data)
-{
-    const int coarsest_ln = 0;
-    const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
-    {
-        if (!d_l_data_manager->levelContainsLagrangianData(ln)) continue;
-        if (!d_U_jac_data[ln])
-        {
-            d_U_jac_data[ln] = d_l_data_manager->createLData("U_jac", ln, NDIM);
-        }
-    }
-    *U_jac_data = &d_U_jac_data;
-    return;
-} // getLinearizedVelocityData
-
-void
 IBMethod::getForceData(std::vector<Pointer<LData> >** F_data, bool** F_needs_ghost_fill, double data_time)
 {
     const int coarsest_ln = 0;
@@ -1834,25 +1557,6 @@ IBMethod::getForceData(std::vector<Pointer<LData> >** F_data, bool** F_needs_gho
     }
     return;
 } // getForceData
-
-void
-IBMethod::getLinearizedForceData(std::vector<Pointer<LData> >** F_jac_data, bool** F_jac_needs_ghost_fill)
-{
-    const int coarsest_ln = 0;
-    const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
-    {
-        if (!d_l_data_manager->levelContainsLagrangianData(ln)) continue;
-        if (!d_F_jac_data[ln])
-        {
-            d_F_jac_data[ln] = d_l_data_manager->createLData("F_jac", ln, NDIM);
-            d_F_jac_needs_ghost_fill = true;
-        }
-    }
-    *F_jac_data = &d_F_jac_data;
-    *F_jac_needs_ghost_fill = &d_F_jac_needs_ghost_fill;
-    return;
-} // getLinearizedForceData
 
 void
 IBMethod::reinitMidpointData(const std::vector<Pointer<LData> >& current_data,
@@ -2025,7 +1729,6 @@ IBMethod::getFromInput(Pointer<Database> db, bool is_from_restart)
     TBOX_ASSERT(LEInteractor::isKnownKernel(d_spread_kernel_fcn));
     if (db->keyExists("error_if_points_leave_domain"))
         d_error_if_points_leave_domain = db->getBool("error_if_points_leave_domain");
-    if (db->keyExists("force_jac_mffd")) d_force_jac_mffd = db->getBool("force_jac_mffd");
     if (db->keyExists("do_log"))
         d_do_log = db->getBool("do_log");
     else if (db->keyExists("enable_logging"))
@@ -2102,37 +1805,6 @@ IBMethod::getFromRestart()
     d_normalize_source_strength = db->getBool("d_normalize_source_strength");
     return;
 } // getFromRestart
-
-PetscErrorCode
-IBMethod::computeForce_SAMRAI(void* ctx, Vec X, Vec F)
-{
-    PetscErrorCode ierr;
-    auto ib_method_ops = static_cast<IBMethod*>(ctx);
-    ierr = ib_method_ops->computeForce(X, F);
-    CHKERRQ(ierr);
-    return ierr;
-} // computeForce_SAMRAI
-
-PetscErrorCode
-IBMethod::computeForce(Vec X, Vec F)
-{
-    PetscErrorCode ierr;
-    std::vector<Pointer<LData> >*F_data, *X_data;
-    bool *F_needs_ghost_fill, *X_needs_ghost_fill;
-    getForceData(&F_data, &F_needs_ghost_fill, d_force_jac_data_time);
-    getPositionData(&X_data, &X_needs_ghost_fill, d_force_jac_data_time);
-    const int level_num = d_hierarchy->getFinestLevelNumber();
-    ierr = VecSwap(X, (*X_data)[level_num]->getVec());
-    CHKERRQ(ierr);
-    ierr = VecSwap(F, (*F_data)[level_num]->getVec());
-    CHKERRQ(ierr);
-    computeLagrangianForce(d_force_jac_data_time);
-    ierr = VecSwap(X, (*X_data)[level_num]->getVec());
-    CHKERRQ(ierr);
-    ierr = VecSwap(F, (*F_data)[level_num]->getVec());
-    CHKERRQ(ierr);
-    return ierr;
-} // computeForce
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1408,45 +1408,49 @@ INSStaggeredHierarchyIntegrator::setupSolverVectors(const Pointer<SAMRAIVectorRe
     // Account for the convective acceleration term.
     if (!d_creeping_flow)
     {
+        const int N_idx = d_N_vec->getComponentDescriptorIndex(0);
         const TimeSteppingType convective_time_stepping_type = getConvectiveTimeSteppingType(cycle_num);
-        if (cycle_num > 0)
+        if (cycle_num == 0 && convective_time_stepping_type == ADAMS_BASHFORTH)
+        {
+            TBOX_ASSERT(cycle_num == 0);
+            const double omega = dt / d_dt_previous[0];
+            d_hier_sc_data_ops->linearSum(N_idx, 1.0 + 0.5 * omega, N_idx, -0.5 * omega, d_N_old_current_idx);
+        }
+        else if (cycle_num > 0)
         {
             const int U_adv_idx = d_U_adv_vec->getComponentDescriptorIndex(0);
             double apply_time = std::numeric_limits<double>::quiet_NaN();
+            bool update_convective_term = false;
             if (convective_time_stepping_type == MIDPOINT_RULE)
             {
+                update_convective_term = true;
                 d_hier_sc_data_ops->linearSum(U_adv_idx, 0.5, d_U_current_idx, 0.5, d_U_new_idx);
                 apply_time = half_time;
             }
             else if (convective_time_stepping_type == TRAPEZOIDAL_RULE)
             {
+                update_convective_term = true;
                 d_hier_sc_data_ops->copyData(U_adv_idx, d_U_new_idx);
                 apply_time = new_time;
             }
-            for (int ln = finest_ln; ln > coarsest_ln; --ln)
+            if (update_convective_term)
             {
-                Pointer<CoarsenAlgorithm<NDIM> > coarsen_alg = new CoarsenAlgorithm<NDIM>();
-                Pointer<CartesianGridGeometry<NDIM> > grid_geom = d_hierarchy->getGridGeometry();
-                Pointer<CoarsenOperator<NDIM> > coarsen_op =
-                    grid_geom->lookupCoarsenOperator(d_U_var, d_U_coarsen_type);
-                coarsen_alg->registerCoarsen(U_adv_idx, U_adv_idx, coarsen_op);
-                coarsen_alg->resetSchedule(getCoarsenSchedules(d_object_name + "::CONVECTIVE_OP")[ln]);
-                getCoarsenSchedules(d_object_name + "::CONVECTIVE_OP")[ln]->coarsenData();
-                getCoarsenAlgorithm(d_object_name + "::CONVECTIVE_OP")
-                    ->resetSchedule(getCoarsenSchedules(d_object_name + "::CONVECTIVE_OP")[ln]);
+                for (int ln = finest_ln; ln > coarsest_ln; --ln)
+                {
+                    Pointer<CoarsenAlgorithm<NDIM> > coarsen_alg = new CoarsenAlgorithm<NDIM>();
+                    Pointer<CartesianGridGeometry<NDIM> > grid_geom = d_hierarchy->getGridGeometry();
+                    Pointer<CoarsenOperator<NDIM> > coarsen_op =
+                        grid_geom->lookupCoarsenOperator(d_U_var, d_U_coarsen_type);
+                    coarsen_alg->registerCoarsen(U_adv_idx, U_adv_idx, coarsen_op);
+                    coarsen_alg->resetSchedule(getCoarsenSchedules(d_object_name + "::CONVECTIVE_OP")[ln]);
+                    getCoarsenSchedules(d_object_name + "::CONVECTIVE_OP")[ln]->coarsenData();
+                    getCoarsenAlgorithm(d_object_name + "::CONVECTIVE_OP")
+                        ->resetSchedule(getCoarsenSchedules(d_object_name + "::CONVECTIVE_OP")[ln]);
+                }
+                d_convective_op->setAdvectionVelocity(d_U_adv_vec->getComponentDescriptorIndex(0));
+                d_convective_op->setSolutionTime(apply_time);
+                d_convective_op->apply(*d_U_adv_vec, *d_N_vec);
             }
-            d_convective_op->setAdvectionVelocity(d_U_adv_vec->getComponentDescriptorIndex(0));
-            d_convective_op->setSolutionTime(apply_time);
-            d_convective_op->apply(*d_U_adv_vec, *d_N_vec);
-        }
-        const int N_idx = d_N_vec->getComponentDescriptorIndex(0);
-        if (convective_time_stepping_type == ADAMS_BASHFORTH)
-        {
-#if !defined(NDEBUG)
-            TBOX_ASSERT(cycle_num == 0);
-#endif
-            const double omega = dt / d_dt_previous[0];
-            d_hier_sc_data_ops->linearSum(N_idx, 1.0 + 0.5 * omega, N_idx, -0.5 * omega, d_N_old_current_idx);
         }
         if (convective_time_stepping_type == ADAMS_BASHFORTH || convective_time_stepping_type == MIDPOINT_RULE)
         {
@@ -2764,31 +2768,15 @@ INSStaggeredHierarchyIntegrator::computeDivSourceTerm(const int F_idx, const int
 } // computeDivSourceTerm
 
 TimeSteppingType
-INSStaggeredHierarchyIntegrator::getConvectiveTimeSteppingType(const int cycle_num)
+INSStaggeredHierarchyIntegrator::getConvectiveTimeSteppingType(const int /*cycle_num*/)
 {
     TimeSteppingType convective_time_stepping_type = d_convective_time_stepping_type;
     if (is_multistep_time_stepping_type(convective_time_stepping_type))
     {
-#if !defined(NDEBUG)
         TBOX_ASSERT(convective_time_stepping_type == ADAMS_BASHFORTH);
-#endif
         if (getIntegratorStep() == 0)
         {
             convective_time_stepping_type = d_init_convective_time_stepping_type;
-        }
-        else if (cycle_num > 0)
-        {
-            convective_time_stepping_type = MIDPOINT_RULE;
-            IBAMR_DO_ONCE({
-                pout << "INSStaggeredHierarchyIntegrator::integrateHierarchy():\n"
-                     << "  WARNING: convective_time_stepping_type = "
-                     << enum_to_string<TimeSteppingType>(d_convective_time_stepping_type)
-                     << " but num_cycles = " << d_current_num_cycles << " > 1.\n"
-                     << "           using " << enum_to_string<TimeSteppingType>(d_convective_time_stepping_type)
-                     << " only for the first cycle in each time step;\n"
-                     << "           using " << enum_to_string<TimeSteppingType>(convective_time_stepping_type)
-                     << " for subsequent cycles.\n";
-            });
         }
     }
     return convective_time_stepping_type;


### PR DESCRIPTION
This PR updates and simplifies the implementation of implicit solvers of the form:
```
rho [(u(n+1) - u(n))/dt + A(n+1/2)] = - G p(n+1/2) + mu L (u(n+1) + u(n))/2 + S F[X(n+1)]
D u(n+1) = 0
(X(n+1)-X(n))/dt = J u(n+1)
```
with
```
A(n+1/2) = time step-centered approximation to the convective term
S = IB spreading operator
J = IB interpolation operator
F[X] = IB force evaluated using IB positions X
```
as well as the "direct forcing" form:
```
rho [(u(n+1) - u(n))/dt + A(n+1/2)] = - G p(n+1/2) + mu L (u(n+1) + u(n))/2 + S F(n+1)
D u(n+1) = 0
F(n+1) = -eta J u(n+1)
```
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [ ] Was clang-format run?
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
