### PR TITLE
Introduce doIntegrateHierarchy() virtual function.

### DIFF
--- a/doc/news/changes/incompatibilities/20240123AaronBarrett
+++ b/doc/news/changes/incompatibilities/20240123AaronBarrett
@@ -1,0 +1,11 @@
+Incompatability: Changed HierarchyIntegrator::integrateHierarchy() to be
+non-virtual and introduced pure virtual function
+HierarchyIntegrator::integrateHierarchySpecialized().
+HierarchyIntegrator::integrateHierarchy() now calls
+integrateHierarchySpecialized() and then the integrateHierarchy() callback
+functions. Implementations of integrateHierarchy() should be moved to
+integrateHierarchySpecialized() and calls to
+executeIntegrateHierarchyCallbackFcns() should be removed from derived classes
+of HierarchyIntegrator.
+<br>
+(Aaron Barrett, 2024/01/23)

--- a/examples/IB/explicit/ex6/IBSimpleHierarchyIntegrator.cpp
+++ b/examples/IB/explicit/ex6/IBSimpleHierarchyIntegrator.cpp
@@ -80,10 +80,10 @@ IBSimpleHierarchyIntegrator::preprocessIntegrateHierarchy(const double current_t
 } // preprocessIntegrateHierarchy
 
 void
-IBSimpleHierarchyIntegrator::integrateHierarchy(const double current_time, const double new_time, const int cycle_num)
+IBSimpleHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                           const double new_time,
+                                                           const int /*cycle_num*/)
 {
-    IBHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
-
     const int finest_level_num = d_hierarchy->getFinestLevelNumber();
     PetscErrorCode ierr;
     const double dt = new_time - current_time;

--- a/examples/IB/explicit/ex6/IBSimpleHierarchyIntegrator.h
+++ b/examples/IB/explicit/ex6/IBSimpleHierarchyIntegrator.h
@@ -55,12 +55,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1);
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0);
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -74,6 +68,13 @@ public:
      */
     void initializeHierarchyIntegrator(Pointer<PatchHierarchy<NDIM> > hierarchy,
                                        Pointer<GriddingAlgorithm<NDIM> > gridding_alg);
+
+protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0);
 
 private:
     /*!

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -409,14 +409,10 @@ public:
     virtual void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1);
 
     /*!
-     * Pure virtual method to advance data from current_time to new_time.
-     *
-     * Implementations of this virtual function are not required to synchronize
-     * data on the patch hierarchy.  Data synchronization may be done
-     * (optionally) in a specialization of the public virtual member function
-     * postprocessIntegrateHierarchy().
+     * Advance data from current_time to new_time. The current implementation calls
+     * doIntegrateHierarchy() followed by executeIntegrateHierarchyCallbackFcns().
      */
-    virtual void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) = 0;
+    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0);
 
     /*!
      * Method to skip a cycle of the time integration scheme (e.g. for cases in
@@ -697,6 +693,21 @@ public:
     void putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
 
 protected:
+    /*!
+     * Pure virtual function that integrates the hierarchy from current_time to new_time.
+     *
+     * Implementations of this virtual function are not required to synchronize
+     * data on the patch hierarchy.  Data synchronization may be done
+     * (optionally) in a specialization of the public virtual member function
+     * postprocessIntegrateHierarchy().
+     *
+     * This function is called by integrateHierarchy() prior to the execution of callbacks.
+     *
+     * @note Inheriting classes should call their base class versions of this
+     * method.
+     */
+    virtual void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) = 0;
+
     /*!
      * Perform any necessary work relevant to data owned by the current
      * integrator prior to regridding (e.g., calculating divergences). An

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -666,11 +666,11 @@ HierarchyIntegrator::integrateHierarchy(const double current_time, const double 
     TBOX_ASSERT(IBTK::abs_equal_eps(d_current_dt, new_time - current_time));
     TBOX_ASSERT(d_current_cycle_num == cycle_num);
     TBOX_ASSERT(d_current_cycle_num < d_current_num_cycles);
-#else
-    NULL_USE(current_time);
-    NULL_USE(new_time);
-    NULL_USE(cycle_num);
 #endif
+
+    integrateHierarchySpecialized(current_time, new_time, cycle_num);
+
+    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
 } // integrateHierarchy
 
@@ -1211,6 +1211,14 @@ HierarchyIntegrator::putToDatabase(Pointer<Database> db)
 } // putToDatabase
 
 /////////////////////////////// PROTECTED ////////////////////////////////////
+void
+HierarchyIntegrator::integrateHierarchySpecialized(const double /*current_time*/,
+                                                   const double /*new_time*/,
+                                                   const int /*cycle_num*/)
+{
+    // intentionally blank
+    return;
+} // integrateHierarchySpecialized
 
 void
 HierarchyIntegrator::regridHierarchyBeginSpecialized()

--- a/include/ibamr/AdvDiffPredictorCorrectorHierarchyIntegrator.h
+++ b/include/ibamr/AdvDiffPredictorCorrectorHierarchyIntegrator.h
@@ -135,12 +135,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -149,6 +143,12 @@ public:
                                        int num_cycles = 1) override;
 
 protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
+
     /*!
      * Return the maximum stable time step size.
      */

--- a/include/ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h
+++ b/include/ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h
@@ -282,12 +282,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -296,6 +290,12 @@ public:
                                        int num_cycles = 1) override;
 
 protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
+
     /*!
      * Reset cached hierarchy dependent data.
      */

--- a/include/ibamr/BrinkmanAdvDiffSemiImplicitHierarchyIntegrator.h
+++ b/include/ibamr/BrinkmanAdvDiffSemiImplicitHierarchyIntegrator.h
@@ -124,12 +124,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -168,6 +162,12 @@ public:
                                              const bool output_Q = true) override;
 
 protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
+
     /*!
      * Additional variables required for Brinkman penalization
      */

--- a/include/ibamr/IBExplicitHierarchyIntegrator.h
+++ b/include/ibamr/IBExplicitHierarchyIntegrator.h
@@ -94,12 +94,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -146,6 +140,12 @@ public:
                                      const bool save_velocites = true) const;
 
 protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
+
     /*!
      * Perform necessary data movement, workload estimation, and logging prior
      * to regridding.

--- a/include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h
@@ -103,12 +103,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -135,6 +129,12 @@ public:
     int getNumberOfCycles() const override;
 
 protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
+
     /*!
      * Write out specialized object state to the given database.
      */

--- a/include/ibamr/IBInterpolantHierarchyIntegrator.h
+++ b/include/ibamr/IBInterpolantHierarchyIntegrator.h
@@ -80,12 +80,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -102,6 +96,12 @@ public:
                                   SAMRAI::tbox::Pointer<SAMRAI::mesh::GriddingAlgorithm<NDIM> > gridding_alg) override;
 
 protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
+
     /*!
      * Write out specialized object state to the given database.
      */

--- a/include/ibamr/INSCollocatedHierarchyIntegrator.h
+++ b/include/ibamr/INSCollocatedHierarchyIntegrator.h
@@ -158,12 +158,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -172,6 +166,12 @@ public:
                                        int num_cycles = 1) override;
 
 protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
+
     /*!
      * Determine the largest stable timestep on an individual patch.
      */

--- a/include/ibamr/INSStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSStaggeredHierarchyIntegrator.h
@@ -175,12 +175,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -215,6 +209,12 @@ public:
     void removeNullSpace(const SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double> >& sol_vec);
 
 protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
+
     /*!
      * L1 norm of the discrete divergence of the fluid velocity before regridding.
      */

--- a/include/ibamr/INSVCStaggeredConservativeHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredConservativeHierarchyIntegrator.h
@@ -113,12 +113,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -165,6 +159,12 @@ public:
     SAMRAI::tbox::Pointer<ConvectiveOperator> getConvectiveOperator() override;
 
 protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
+
     /*!
      * Initialize data on a new level after it is inserted into an AMR patch
      * hierarchy by the gridding algorithm.

--- a/include/ibamr/INSVCStaggeredNonConservativeHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredNonConservativeHierarchyIntegrator.h
@@ -114,12 +114,6 @@ public:
     void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
 
     /*!
-     * Synchronously advance each level in the hierarchy over the given time
-     * increment.
-     */
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
-
-    /*!
      * Clean up data following call(s) to integrateHierarchy().
      */
     void postprocessIntegrateHierarchy(double current_time,
@@ -152,6 +146,12 @@ public:
                                       unsigned int adv_diff_idx = 0);
 
 protected:
+    /*!
+     * Synchronously advance each level in the hierarchy over the given time
+     * increment.
+     */
+    void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
+
     /*!
      * Initialize data on a new level after it is inserted into an AMR patch
      * hierarchy by the gridding algorithm.

--- a/src/IB/IBExplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBExplicitHierarchyIntegrator.cpp
@@ -156,9 +156,11 @@ IBExplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const double current
 } // preprocessIntegrateHierarchy
 
 void
-IBExplicitHierarchyIntegrator::integrateHierarchy(const double current_time, const double new_time, const int cycle_num)
+IBExplicitHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                             const double new_time,
+                                                             const int cycle_num)
 {
-    IBHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
+    IBHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
     const double half_time = current_time + 0.5 * (new_time - current_time);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     const int u_current_idx = var_db->mapVariableAndContextToIndex(d_ins_hier_integrator->getVelocityVariable(),
@@ -357,8 +359,6 @@ IBExplicitHierarchyIntegrator::integrateHierarchy(const double current_time, con
                                              half_time);
     }
 
-    // Execute any registered callbacks.
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
 } // integrateHierarchy
 

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -239,10 +239,11 @@ IBImplicitStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
 } // preprocessIntegrateHierarchy
 
 void
-IBImplicitStaggeredHierarchyIntegrator::integrateHierarchy(const double current_time,
-                                                           const double new_time,
-                                                           const int cycle_num)
+IBImplicitStaggeredHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                                      const double new_time,
+                                                                      const int cycle_num)
 {
+    IBHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
     if (d_solve_for_position)
     {
         integrateHierarchy_position(current_time, new_time, cycle_num);

--- a/src/IB/IBInterpolantHierarchyIntegrator.cpp
+++ b/src/IB/IBInterpolantHierarchyIntegrator.cpp
@@ -117,12 +117,11 @@ IBInterpolantHierarchyIntegrator::preprocessIntegrateHierarchy(const double curr
 } // preprocessIntegrateHierarchy
 
 void
-IBInterpolantHierarchyIntegrator::integrateHierarchy(const double current_time,
-                                                     const double new_time,
-                                                     const int cycle_num)
+IBInterpolantHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                                const double new_time,
+                                                                const int cycle_num)
 {
-    IBHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
-
+    IBHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
     // Here we implement the following time integration scheme:
     //
     // (1) Update the interpolation mesh position to X^{n+1}.
@@ -150,9 +149,6 @@ IBInterpolantHierarchyIntegrator::integrateHierarchy(const double current_time,
 
     // Solve the INS equations.
     d_ins_hier_integrator->integrateHierarchy(current_time, new_time, cycle_num);
-
-    // Execute any registered callbacks.
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
 
     return;
 } // integrateHierarchy

--- a/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffPredictorCorrectorHierarchyIntegrator.cpp
@@ -284,11 +284,11 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::initializeHierarchyIntegrator(
 } // initializeHierarchyIntegrator
 
 void
-AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double current_time,
-                                                                 const double new_time,
-                                                                 const int cycle_num)
+AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                                            const double new_time,
+                                                                            const int cycle_num)
 {
-    AdvDiffHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
+    AdvDiffHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
     const double dt = new_time - current_time;
     const double half_time = current_time + 0.5 * dt;
     const int coarsest_ln = 0;
@@ -605,8 +605,6 @@ AdvDiffPredictorCorrectorHierarchyIntegrator::integrateHierarchy(const double cu
         }
     }
 
-    // Execute any registered callbacks.
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
 } // integrateHierarchy
 

--- a/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
+++ b/src/adv_diff/AdvDiffSemiImplicitHierarchyIntegrator.cpp
@@ -651,11 +651,11 @@ AdvDiffSemiImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
 } // preprocessIntegrateHierarchy
 
 void
-AdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchy(const double current_time,
-                                                           const double new_time,
-                                                           const int cycle_num)
+AdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                                      const double new_time,
+                                                                      const int cycle_num)
 {
-    AdvDiffHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
+    AdvDiffHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
     const double dt = new_time - current_time;
     const double half_time = current_time + 0.5 * dt;
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -907,8 +907,6 @@ AdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchy(const double current_
         }
     }
 
-    // Execute any registered callbacks.
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
 } // integrateHierarchy
 

--- a/src/adv_diff/BrinkmanAdvDiffSemiImplicitHierarchyIntegrator.cpp
+++ b/src/adv_diff/BrinkmanAdvDiffSemiImplicitHierarchyIntegrator.cpp
@@ -514,11 +514,11 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator::preprocessIntegrateHierarchy(con
 } // preprocessIntegrateHierarchy
 
 void
-BrinkmanAdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchy(const double current_time,
-                                                                   const double new_time,
-                                                                   const int cycle_num)
+BrinkmanAdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                                              const double new_time,
+                                                                              const int cycle_num)
 {
-    AdvDiffHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
+    AdvDiffHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
     const double dt = new_time - current_time;
     const double half_time = current_time + 0.5 * dt;
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -928,8 +928,6 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchy(const double 
         }
     }
 
-    // Execute any registered callbacks.
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
 } // integrateHierarchy
 

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1051,11 +1051,11 @@ INSCollocatedHierarchyIntegrator::preprocessIntegrateHierarchy(const double curr
 } // preprocessIntegrateHierarchy
 
 void
-INSCollocatedHierarchyIntegrator::integrateHierarchy(const double current_time,
-                                                     const double new_time,
-                                                     const int cycle_num)
+INSCollocatedHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                                const double new_time,
+                                                                const int cycle_num)
 {
-    INSHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
+    INSHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
     const double dt = new_time - current_time;
@@ -1435,8 +1435,6 @@ INSCollocatedHierarchyIntegrator::integrateHierarchy(const double current_time,
         }
     }
 
-    // Execute any registered callbacks.
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
 } // integrateHierarchy
 

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1239,12 +1239,11 @@ INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const double curre
 } // preprocessIntegrateHierarchy
 
 void
-INSStaggeredHierarchyIntegrator::integrateHierarchy(const double current_time,
-                                                    const double new_time,
-                                                    const int cycle_num)
+INSStaggeredHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                               const double new_time,
+                                                               const int cycle_num)
 {
-    INSHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
-
+    INSHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
     // Check to make sure that the number of cycles is what we expect it to be.
     const int expected_num_cycles = getNumberOfCycles();
     if (d_current_num_cycles != expected_num_cycles)

--- a/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
@@ -528,12 +528,11 @@ INSVCStaggeredConservativeHierarchyIntegrator::preprocessIntegrateHierarchy(cons
 } // preprocessIntegrateHierarchy
 
 void
-INSVCStaggeredConservativeHierarchyIntegrator::integrateHierarchy(const double current_time,
-                                                                  const double new_time,
-                                                                  const int cycle_num)
+INSVCStaggeredConservativeHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                                             const double new_time,
+                                                                             const int cycle_num)
 {
-    INSVCStaggeredHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
-
+    INSVCStaggeredHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
     // Get the coarsest and finest level numbers.
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
@@ -812,8 +811,6 @@ INSVCStaggeredConservativeHierarchyIntegrator::integrateHierarchy(const double c
         }
     }
 
-    // Execute any registered callbacks.
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
 } // integrateHierarchy
 

--- a/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredNonConservativeHierarchyIntegrator.cpp
@@ -551,12 +551,11 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::preprocessIntegrateHierarchy(c
 } // preprocessIntegrateHierarchy
 
 void
-INSVCStaggeredNonConservativeHierarchyIntegrator::integrateHierarchy(const double current_time,
-                                                                     const double new_time,
-                                                                     const int cycle_num)
+INSVCStaggeredNonConservativeHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                                                const double new_time,
+                                                                                const int cycle_num)
 {
-    INSVCStaggeredHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
-
+    INSVCStaggeredHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
     // Get the coarsest and finest level numbers.
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
@@ -843,8 +842,6 @@ INSVCStaggeredNonConservativeHierarchyIntegrator::integrateHierarchy(const doubl
         }
     }
 
-    // Execute any registered callbacks.
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
 } // integrateHierarchy
 

--- a/tests/IBTK/child_integrators.2_hierarchies.output
+++ b/tests/IBTK/child_integrators.2_hierarchies.output
@@ -42,11 +42,11 @@ INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing co
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing incompressible Stokes solver
-DummyAdvDiff: integrateHierarchy()
-DummyAdvDiff2: integrateHierarchy()
+DummyAdvDiff: integrateHierarchySpecialized()
+DummyAdvDiff2: integrateHierarchySpecialized()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
-DummyAdvDiff: integrateHierarchy()
-DummyAdvDiff2: integrateHierarchy()
+DummyAdvDiff: integrateHierarchySpecialized()
+DummyAdvDiff2: integrateHierarchySpecialized()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
 DummyAdvDiff: synchronizeHierarchyDataSpecialized()
 DummyAdvDiff2: synchronizeHierarchyDataSpecialized()
@@ -79,11 +79,11 @@ DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
 DummyAdvDiff2: getMaximumTimeStepSizeSpecialized()
 DummyAdvDiff: atRegridPointSpecialized()
 DummyAdvDiff2: atRegridPointSpecialized()
-DummyAdvDiff: integrateHierarchy()
-DummyAdvDiff2: integrateHierarchy()
+DummyAdvDiff: integrateHierarchySpecialized()
+DummyAdvDiff2: integrateHierarchySpecialized()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
-DummyAdvDiff: integrateHierarchy()
-DummyAdvDiff2: integrateHierarchy()
+DummyAdvDiff: integrateHierarchySpecialized()
+DummyAdvDiff2: integrateHierarchySpecialized()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
 DummyAdvDiff: synchronizeHierarchyDataSpecialized()
 DummyAdvDiff2: synchronizeHierarchyDataSpecialized()

--- a/tests/IBTK/child_integrators.cpp
+++ b/tests/IBTK/child_integrators.cpp
@@ -44,14 +44,12 @@ public:
 
     ~DummyAdvDiffIntegrator() = default;
 
-    void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override
-    {
-        plog << d_object_name << ": integrateHierarchy()\n";
-        HierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
-        return;
-    }
-
 protected:
+    void integrateHierarchySpecialized(double /*current_time*/, double /*new_time*/, int cycle_num = 0) override
+    {
+        NULL_USE(cycle_num);
+        plog << d_object_name << ": integrateHierarchySpecialized()\n";
+    }
     void regridHierarchyBeginSpecialized() override
     {
         plog << d_object_name << ": regridHierarchyBeginSpecialized()\n";

--- a/tests/IBTK/child_integrators.output
+++ b/tests/IBTK/child_integrators.output
@@ -28,9 +28,9 @@ INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing co
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver
 INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing incompressible Stokes solver
-DummyAdvDiff: integrateHierarchy()
+DummyAdvDiff: integrateHierarchySpecialized()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
-DummyAdvDiff: integrateHierarchy()
+DummyAdvDiff: integrateHierarchySpecialized()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
 DummyAdvDiff: synchronizeHierarchyDataSpecialized()
 DummyAdvDiff: resetTimeDependentHierarchyDataSpecialized()
@@ -55,9 +55,9 @@ DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
 DummyAdvDiff: getMinimumTimeStepSizeSpecialized()
 DummyAdvDiff: getMaximumTimeStepSizeSpecialized()
 DummyAdvDiff: atRegridPointSpecialized()
-DummyAdvDiff: integrateHierarchy()
+DummyAdvDiff: integrateHierarchySpecialized()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
-DummyAdvDiff: integrateHierarchy()
+DummyAdvDiff: integrateHierarchySpecialized()
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0
 DummyAdvDiff: synchronizeHierarchyDataSpecialized()
 DummyAdvDiff: resetTimeDependentHierarchyDataSpecialized()


### PR DESCRIPTION
Fixes #1636. This introduces a new protected pure virtual function `doIntegrateHierarchy()` in `HierarchyIntegrator`. Previously, `integrateHierarchy()` was designed to do two things: (1) perform an integration cycle and (2) execute post integration callbacks. The design principle was that the class furthest down the hierarchy ends up calling the post integration callbacks. This causes problems (e.g. in the phase change code from @amneetb and @Raamkrishnan) where child classes want to call the parent class's `integrateHierarchy()` to perform action (1) but not (2).

This changes the design principle so that the parent class `HierarchyIntegrator::integrateHierarchy()` executes post integration callbacks after `doIntegrateHierarchy()` is called. Child classes no longer need to execute the callbacks. I've left `integrateHierarchy()` as a virtual function in case some future application needs to modify the implementation, although I don't think this is necessary.

@boyceg This is the kind of change I was suggesting. This clearly delineates the two purposes of `integrateHierarchy()`. The function `doIntegrateHierarchy()` should _only_ integrate equations.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
