### PR TITLE
Cleanup basic inheritance

### DIFF
--- a/ibtk/include/ibtk/LDataManager.h
+++ b/ibtk/include/ibtk/LDataManager.h
@@ -171,7 +171,7 @@ namespace IBTK
  *
  * \see LMesh, LNode, LData
  */
-class LDataManager : public SAMRAI::tbox::Serializable, public SAMRAI::mesh::StandardTagAndInitStrategy<NDIM>
+class LDataManager : public SAMRAI::mesh::StandardTagAndInitStrategy<NDIM>, public SAMRAI::tbox::Serializable
 {
 public:
     /*!

--- a/include/ibamr/ConstraintIBKinematics.h
+++ b/include/ibamr/ConstraintIBKinematics.h
@@ -51,7 +51,7 @@ namespace IBAMR
  * \brief Class ConstraintIBKinematics encapsulates structure information and provides abstraction to get
  * kinematics (deformational or imposed) of immersed structure to ConstraintIBMethod class.
  */
-class ConstraintIBKinematics : public virtual SAMRAI::tbox::DescribedClass, public SAMRAI::tbox::Serializable
+class ConstraintIBKinematics : public SAMRAI::tbox::Serializable
 {
 public:
     class StructureParameters

--- a/include/ibamr/IBFEDirectForcingKinematics.h
+++ b/include/ibamr/IBFEDirectForcingKinematics.h
@@ -61,7 +61,7 @@ namespace IBAMR
  * \brief Class IBFEDirectForcingKinematics is a helper class that provides direct
  * forcing IBMethod functionality to the IBFEMethod class.
  */
-class IBFEDirectForcingKinematics : public virtual SAMRAI::tbox::DescribedClass, public SAMRAI::tbox::Serializable
+class IBFEDirectForcingKinematics : public SAMRAI::tbox::Serializable
 {
 public:
     /*!


### PR DESCRIPTION
`Serializable` inherits from `DescribedClass` so we don't need to do this. I also made the order of inheritance uniform (`Serializable is now always last).

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?