### PR TITLE
Run clang-format on everything.

### DIFF
--- a/examples/ConstraintIB/moving_plate/RigidBodyKinematics.cpp
+++ b/examples/ConstraintIB/moving_plate/RigidBodyKinematics.cpp
@@ -89,8 +89,7 @@ RigidBodyKinematics::putToDatabase(Pointer<Database> db)
 
 } // putToDatabase
 
-void
-RigidBodyKinematics::setImmersedBodyLayout(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/)
+void RigidBodyKinematics::setImmersedBodyLayout(Pointer<PatchHierarchy<NDIM> > /*patch_hierarchy*/)
 {
     const StructureParameters& struct_param = getStructureParameters();
     const int coarsest_ln = struct_param.getCoarsestLevelNumber();

--- a/examples/adv_diff/ex8/SetFluidProperties.h
+++ b/examples/adv_diff/ex8/SetFluidProperties.h
@@ -135,6 +135,6 @@ private:
      */
     double d_mu;
 
-};     // SetFluidProperties
+}; // SetFluidProperties
 
 #endif // #ifndef included_SetFluidProperties

--- a/examples/adv_diff/ex8/example.cpp
+++ b/examples/adv_diff/ex8/example.cpp
@@ -817,146 +817,145 @@ main(int argc, char* argv[])
             patch_hierarchy->getPatchLevel(ln)->deallocatePatchData(prop_counter_idx);
         }
 
-        } // cleanup dynamically allocated objects prior to shutdown
+    } // cleanup dynamically allocated objects prior to shutdown
 
-        SAMRAIManager::shutdown();
-        PetscFinalize();
-    } // main
+    SAMRAIManager::shutdown();
+    PetscFinalize();
+} // main
 
-    void
-    compute_T_profile(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
-                      Pointer<AdvDiffHierarchyIntegrator> adv_diff_integrator,
-                      Pointer<CellVariable<NDIM, double> > T_var,
-                      Pointer<CellVariable<NDIM, double> > phi_var,
-                      const double data_time,
-                      const string& data_dump_dirname)
-    {
+void
+compute_T_profile(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
+                  Pointer<AdvDiffHierarchyIntegrator> adv_diff_integrator,
+                  Pointer<CellVariable<NDIM, double> > T_var,
+                  Pointer<CellVariable<NDIM, double> > phi_var,
+                  const double data_time,
+                  const string& data_dump_dirname)
+{
 #if !defined(NDEBUG)
-        TBOX_ASSERT(NDIM == 2);
+    TBOX_ASSERT(NDIM == 2);
 #endif
-        const int coarsest_ln = 0;
-        const int finest_ln = patch_hierarchy->getFinestLevelNumber();
-        vector<double> pos_values;
-        VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-        const int T_current_idx = var_db->mapVariableAndContextToIndex(T_var, adv_diff_integrator->getCurrentContext());
-        const int phi_current_idx =
-            var_db->mapVariableAndContextToIndex(phi_var, adv_diff_integrator->getCurrentContext());
+    const int coarsest_ln = 0;
+    const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+    vector<double> pos_values;
+    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
+    const int T_current_idx = var_db->mapVariableAndContextToIndex(T_var, adv_diff_integrator->getCurrentContext());
+    const int phi_current_idx = var_db->mapVariableAndContextToIndex(phi_var, adv_diff_integrator->getCurrentContext());
 
-        // We need a phi var with single ghost cell width.
-        const int phi_scratch_idx =
-            var_db->registerVariableAndContext(phi_var, var_db->getContext("scratch"), IntVector<NDIM>(1));
+    // We need a phi var with single ghost cell width.
+    const int phi_scratch_idx =
+        var_db->registerVariableAndContext(phi_var, var_db->getContext("scratch"), IntVector<NDIM>(1));
 
-        for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+        level->allocatePatchData(phi_scratch_idx);
+    }
+    // Filling ghost cells for level set.
+    using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
+    std::vector<InterpolationTransactionComponent> adv_diff_bc_component(1);
+
+    adv_diff_bc_component[0] = InterpolationTransactionComponent(phi_scratch_idx,
+                                                                 phi_current_idx,
+                                                                 "CONSERVATIVE_LINEAR_REFINE",
+                                                                 false,
+                                                                 "CONSERVATIVE_COARSEN",
+                                                                 "LINEAR",
+                                                                 false,
+                                                                 adv_diff_integrator->getPhysicalBcCoefs(phi_var));
+
+    Pointer<HierarchyGhostCellInterpolation> hier_bdry_fill = new HierarchyGhostCellInterpolation();
+    hier_bdry_fill->initializeOperatorState(adv_diff_bc_component, patch_hierarchy);
+    hier_bdry_fill->fillData(data_time);
+
+    for (int ln = finest_ln; ln >= coarsest_ln; --ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
         {
-            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
-            level->allocatePatchData(phi_scratch_idx);
-        }
-        // Filling ghost cells for level set.
-        using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
-        std::vector<InterpolationTransactionComponent> adv_diff_bc_component(1);
+            Pointer<Patch<NDIM> > patch = level->getPatch(p());
+            const Box<NDIM>& patch_box = patch->getBox();
+            const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
+            const double* const patch_x_lower = patch_geom->getXLower();
+            const double* const patch_dx = patch_geom->getDx();
+            const hier::Index<NDIM>& patch_lower_idx = patch_box.lower();
+            Pointer<CellData<NDIM, double> > T_data = patch->getPatchData(T_current_idx);
+            Pointer<CellData<NDIM, double> > phi_data = patch->getPatchData(phi_scratch_idx);
 
-        adv_diff_bc_component[0] = InterpolationTransactionComponent(phi_scratch_idx,
-                                                                     phi_current_idx,
-                                                                     "CONSERVATIVE_LINEAR_REFINE",
-                                                                     false,
-                                                                     "CONSERVATIVE_COARSEN",
-                                                                     "LINEAR",
-                                                                     false,
-                                                                     adv_diff_integrator->getPhysicalBcCoefs(phi_var));
-
-        Pointer<HierarchyGhostCellInterpolation> hier_bdry_fill = new HierarchyGhostCellInterpolation();
-        hier_bdry_fill->initializeOperatorState(adv_diff_bc_component, patch_hierarchy);
-        hier_bdry_fill->fillData(data_time);
-
-        for (int ln = finest_ln; ln >= coarsest_ln; --ln)
-        {
-            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
-            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+            for (Box<NDIM>::Iterator it(patch_box); it; it++)
             {
-                Pointer<Patch<NDIM> > patch = level->getPatch(p());
-                const Box<NDIM>& patch_box = patch->getBox();
-                const Pointer<CartesianPatchGeometry<NDIM> > patch_geom = patch->getPatchGeometry();
-                const double* const patch_x_lower = patch_geom->getXLower();
-                const double* const patch_dx = patch_geom->getDx();
-                const hier::Index<NDIM>& patch_lower_idx = patch_box.lower();
-                Pointer<CellData<NDIM, double> > T_data = patch->getPatchData(T_current_idx);
-                Pointer<CellData<NDIM, double> > phi_data = patch->getPatchData(phi_scratch_idx);
+                CellIndex<NDIM> ci(it());
+                CellIndex<NDIM> ci_e = ci;
+                CellIndex<NDIM> ci_w = ci;
+                CellIndex<NDIM> ci_n = ci;
+                CellIndex<NDIM> ci_s = ci;
+                ci_e(0) += 1;
+                ci_w(0) -= 1;
+                ci_n(1) += 1;
+                ci_s(1) -= 1;
 
-                for (Box<NDIM>::Iterator it(patch_box); it; it++)
+                // Finding the interface cells.
+                const double phi_c_value = (*phi_data)(ci);
+                const double phi_e_value = (*phi_data)(ci_e);
+                const double phi_w_value = (*phi_data)(ci_w);
+                const double phi_n_value = (*phi_data)(ci_n);
+                const double phi_s_value = (*phi_data)(ci_s);
+                if ((phi_c_value * phi_e_value <= 0) || (phi_c_value * phi_w_value <= 0) ||
+                    (phi_c_value * phi_n_value <= 0) || (phi_c_value * phi_s_value <= 0))
                 {
-                    CellIndex<NDIM> ci(it());
-                    CellIndex<NDIM> ci_e = ci;
-                    CellIndex<NDIM> ci_w = ci;
-                    CellIndex<NDIM> ci_n = ci;
-                    CellIndex<NDIM> ci_s = ci;
-                    ci_e(0) += 1;
-                    ci_w(0) -= 1;
-                    ci_n(1) += 1;
-                    ci_s(1) -= 1;
-
-                    // Finding the interface cells.
-                    const double phi_c_value = (*phi_data)(ci);
-                    const double phi_e_value = (*phi_data)(ci_e);
-                    const double phi_w_value = (*phi_data)(ci_w);
-                    const double phi_n_value = (*phi_data)(ci_n);
-                    const double phi_s_value = (*phi_data)(ci_s);
-                    if ((phi_c_value * phi_e_value <= 0) || (phi_c_value * phi_w_value <= 0) ||
-                        (phi_c_value * phi_n_value <= 0) || (phi_c_value * phi_s_value <= 0))
+                    IBTK::VectorNd coord = IBTK::Vector::Zero();
+                    for (int d = 0; d < NDIM; ++d)
                     {
-                        IBTK::VectorNd coord = IBTK::Vector::Zero();
-                        for (int d = 0; d < NDIM; ++d)
-                        {
-                            coord[d] = patch_x_lower[d] +
-                                       patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
-                        }
-                        double radius = std::sqrt(coord[0] * coord[0] + coord[1] * coord[1]);
-                        if ((radius >= 1.0) && (coord[0] <= 0))
-                        {
-                            const double T = (*T_data)(ci);
-                            double angle = std::acos(coord[1] / radius);
-                            angle = angle * 180.0 / M_PI;
-                            pos_values.push_back(angle);
-                            pos_values.push_back(T);
-                        }
+                        coord[d] =
+                            patch_x_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
+                    }
+                    double radius = std::sqrt(coord[0] * coord[0] + coord[1] * coord[1]);
+                    if ((radius >= 1.0) && (coord[0] <= 0))
+                    {
+                        const double T = (*T_data)(ci);
+                        double angle = std::acos(coord[1] / radius);
+                        angle = angle * 180.0 / M_PI;
+                        pos_values.push_back(angle);
+                        pos_values.push_back(T);
                     }
                 }
             }
         }
-        for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
-        {
-            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
-            level->deallocatePatchData(phi_scratch_idx);
-        }
-
-        const int nprocs = SAMRAI_MPI::getNodes();
-        const int rank = SAMRAI_MPI::getRank();
-        vector<int> data_size(nprocs, 0);
-        data_size[rank] = static_cast<int>(pos_values.size());
-        SAMRAI_MPI::sumReduction(&data_size[0], nprocs);
-        int offset = 0;
-        offset = std::accumulate(&data_size[0], &data_size[rank], offset);
-        int size_array = 0;
-        size_array = std::accumulate(&data_size[0], &data_size[0] + nprocs, size_array);
-        // Write out the result in a file.
-        string file_name = data_dump_dirname + "/" + "temperature_angle_";
-        char temp_buf[128];
-        sprintf(temp_buf, "%.8f", data_time);
-        file_name += temp_buf;
-        MPI_Status status;
-        MPI_Offset mpi_offset;
-        MPI_File file;
-        MPI_File_open(MPI_COMM_WORLD, file_name.c_str(), MPI_MODE_CREATE | MPI_MODE_WRONLY, MPI_INFO_NULL, &file);
-
-        // First write the total size of the array.
-        if (rank == 0)
-        {
-            mpi_offset = 0;
-            MPI_File_seek(file, mpi_offset, MPI_SEEK_SET);
-            MPI_File_write(file, &size_array, 1, MPI_INT, &status);
-        }
-        mpi_offset = sizeof(double) * offset + sizeof(int);
-        MPI_File_seek(file, mpi_offset, MPI_SEEK_SET);
-        MPI_File_write(file, &pos_values[0], data_size[rank], MPI_DOUBLE, &status);
-        MPI_File_close(&file);
-        return;
     }
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+        level->deallocatePatchData(phi_scratch_idx);
+    }
+
+    const int nprocs = SAMRAI_MPI::getNodes();
+    const int rank = SAMRAI_MPI::getRank();
+    vector<int> data_size(nprocs, 0);
+    data_size[rank] = static_cast<int>(pos_values.size());
+    SAMRAI_MPI::sumReduction(&data_size[0], nprocs);
+    int offset = 0;
+    offset = std::accumulate(&data_size[0], &data_size[rank], offset);
+    int size_array = 0;
+    size_array = std::accumulate(&data_size[0], &data_size[0] + nprocs, size_array);
+    // Write out the result in a file.
+    string file_name = data_dump_dirname + "/" + "temperature_angle_";
+    char temp_buf[128];
+    sprintf(temp_buf, "%.8f", data_time);
+    file_name += temp_buf;
+    MPI_Status status;
+    MPI_Offset mpi_offset;
+    MPI_File file;
+    MPI_File_open(MPI_COMM_WORLD, file_name.c_str(), MPI_MODE_CREATE | MPI_MODE_WRONLY, MPI_INFO_NULL, &file);
+
+    // First write the total size of the array.
+    if (rank == 0)
+    {
+        mpi_offset = 0;
+        MPI_File_seek(file, mpi_offset, MPI_SEEK_SET);
+        MPI_File_write(file, &size_array, 1, MPI_INT, &status);
+    }
+    mpi_offset = sizeof(double) * offset + sizeof(int);
+    MPI_File_seek(file, mpi_offset, MPI_SEEK_SET);
+    MPI_File_write(file, &pos_values[0], data_size[rank], MPI_DOUBLE, &status);
+    MPI_File_close(&file);
+    return;
+}

--- a/ibtk/include/ibtk/FEDataManager.h
+++ b/ibtk/include/ibtk/FEDataManager.h
@@ -313,10 +313,10 @@ public:
         }
         else
         {
-            return std::find_if(d_map.begin(),
-                                d_map.end(),
-                                [&](const std::pair<libMesh::subdomain_id_type, int>& pair)
-                                { return pair.second == level_number; }) != d_map.end();
+            return std::find_if(
+                       d_map.begin(), d_map.end(), [&](const std::pair<libMesh::subdomain_id_type, int>& pair) {
+                           return pair.second == level_number;
+                       }) != d_map.end();
         }
     }
 

--- a/ibtk/include/ibtk/ibtk_enums.h
+++ b/ibtk/include/ibtk/ibtk_enums.h
@@ -43,8 +43,7 @@ string_to_enum(const std::string& /*val*/)
  * \brief Routine for converting enums to strings.
  */
 template <typename T>
-inline std::string
-enum_to_string(T /*val*/)
+inline std::string enum_to_string(T /*val*/)
 {
     TBOX_ERROR("UNSUPPORTED ENUM TYPE\n");
     return "UNKNOWN";

--- a/ibtk/include/ibtk/private/PartitioningBox-inl.h
+++ b/ibtk/include/ibtk/private/PartitioningBox-inl.h
@@ -64,16 +64,13 @@ inline PartitioningBoxes::PartitioningBoxes(const ForwardIterator begin, const F
         IBTK::Point top;
         for (unsigned int dim_n = 0; dim_n < NDIM; ++dim_n)
         {
-            bottom[dim_n] = std::min_element(begin,
-                                             end,
-                                             [=](const PartitioningBox& a, const PartitioningBox& b) -> bool
-                                             { return a.bottom()[dim_n] < b.bottom()[dim_n]; })
-                                ->bottom()[dim_n];
-            top[dim_n] = std::max_element(begin,
-                                          end,
-                                          [=](const PartitioningBox& a, const PartitioningBox& b) -> bool
-                                          { return a.top()[dim_n] < b.top()[dim_n]; })
-                             ->top()[dim_n];
+            bottom[dim_n] =
+                std::min_element(begin, end, [=](const PartitioningBox& a, const PartitioningBox& b) -> bool {
+                    return a.bottom()[dim_n] < b.bottom()[dim_n];
+                })->bottom()[dim_n];
+            top[dim_n] = std::max_element(begin, end, [=](const PartitioningBox& a, const PartitioningBox& b) -> bool {
+                             return a.top()[dim_n] < b.top()[dim_n];
+                         })->top()[dim_n];
         }
         d_bounding_partitioning_box = PartitioningBox(bottom, top);
     }

--- a/ibtk/src/lagrangian/BoxPartitioner.cpp
+++ b/ibtk/src/lagrangian/BoxPartitioner.cpp
@@ -165,8 +165,7 @@ BoxPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
     }
 
     const int current_rank = IBTK_MPI::getRank();
-    auto to_ibtk_point = [](const libMesh::Point& p) -> IBTK::Point
-    {
+    auto to_ibtk_point = [](const libMesh::Point& p) -> IBTK::Point {
         IBTK::Point point;
         for (unsigned int d = 0; d < NDIM; ++d) point[d] = p(d);
         return point;

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -306,8 +306,7 @@ FEData::getFromRestart()
 {
 } // getFromRestart
 
-void
-FEData::putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> /*db*/)
+void FEData::putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> /*db*/)
 {
 } // putToDatabase
 

--- a/ibtk/src/lagrangian/LEInteractor.cpp
+++ b/ibtk/src/lagrangian/LEInteractor.cpp
@@ -1573,8 +1573,7 @@ string_to_kernel(const std::string& kernel_fcn)
 double (*LEInteractor::s_kernel_fcn)(double r) = &ib4_kernel_fcn;
 int LEInteractor::s_kernel_fcn_stencil_size = 4;
 
-void
-LEInteractor::setFromDatabase(Pointer<Database> /*db*/)
+void LEInteractor::setFromDatabase(Pointer<Database> /*db*/)
 {
     // intentionally blank
     return;

--- a/ibtk/src/lagrangian/LMesh.cpp
+++ b/ibtk/src/lagrangian/LMesh.cpp
@@ -33,8 +33,7 @@ namespace IBTK
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
 LMesh::LMesh(std::string /*object_name*/, std::vector<LNode*> local_nodes, std::vector<LNode*> ghost_nodes)
-    : d_local_nodes(std::move(local_nodes)),
-      d_ghost_nodes(std::move(ghost_nodes))
+    : d_local_nodes(std::move(local_nodes)), d_ghost_nodes(std::move(ghost_nodes))
 {
     // intentionally blank
     return;

--- a/ibtk/src/lagrangian/StableCentroidPartitioner.cpp
+++ b/ibtk/src/lagrangian/StableCentroidPartitioner.cpp
@@ -77,12 +77,13 @@ StableCentroidPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
 
         centroids.push_back(std::make_pair(rounded_centroid, *it));
     }
-    std::stable_sort(
-        centroids.begin(),
-        centroids.end(),
-        [](const std::pair<std::array<float, LIBMESH_DIM>, libMesh::Elem*>& a,
-           const std::pair<std::array<float, LIBMESH_DIM>, libMesh::Elem*>& b)
-        { return std::lexicographical_compare(a.first.begin(), a.first.end(), b.first.begin(), b.first.end()); });
+    std::stable_sort(centroids.begin(),
+                     centroids.end(),
+                     [](const std::pair<std::array<float, LIBMESH_DIM>, libMesh::Elem*>& a,
+                        const std::pair<std::array<float, LIBMESH_DIM>, libMesh::Elem*>& b) {
+                         return std::lexicographical_compare(
+                             a.first.begin(), a.first.end(), b.first.begin(), b.first.end());
+                     });
 
     // proceed as libMesh would with CentroidPartitioner:
     const auto target_size = std::size_t(centroids.size() / n);

--- a/ibtk/src/math/HierarchyMathOps.cpp
+++ b/ibtk/src/math/HierarchyMathOps.cpp
@@ -3768,8 +3768,7 @@ HierarchyMathOps::enforceHangingNodeConstraints(const int dst_idx, Pointer<NodeV
     if (NDIM == 1) return;
 
     // Convert a BoundaryBox (which is implicitly cell-centered) into a nodal box.
-    auto boundary_to_nodal = [](const BoundaryBox<NDIM>& bbox)
-    {
+    auto boundary_to_nodal = [](const BoundaryBox<NDIM>& bbox) {
         // lower faces are even, upper faces are odd
         const int location = bbox.getLocationIndex();
         const bool is_lower_face = location % 2 == 0;

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -1403,8 +1403,7 @@ HierarchyIntegrator::applyGradientDetectorSpecialized(const Pointer<BasePatchHie
     return;
 } // applyGradientDetectorSpecialized
 
-void
-HierarchyIntegrator::putToDatabaseSpecialized(Pointer<Database> /*db*/)
+void HierarchyIntegrator::putToDatabaseSpecialized(Pointer<Database> /*db*/)
 {
     // intentionally blank
     return;

--- a/ibtk/src/utilities/MarkerPatchHierarchy.cpp
+++ b/ibtk/src/utilities/MarkerPatchHierarchy.cpp
@@ -356,8 +356,7 @@ MarkerPatchHierarchy::reinit(const EigenAlignedVector<IBTK::Point>& positions,
     unsigned int num_emplaced_markers = 0;
     std::vector<bool> marker_emplaced(positions.size());
 
-    auto insert_markers = [&](MarkerPatch& marker_patch)
-    {
+    auto insert_markers = [&](MarkerPatch& marker_patch) {
         for (unsigned int k = 0; k < positions.size(); ++k)
         {
             if (!marker_emplaced[k] && marker_patch.contains(positions[k]))
@@ -476,8 +475,7 @@ MarkerPatchHierarchy::putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database
     TBOX_ASSERT(d_num_markers <= std::numeric_limits<int>::max());
     db->putInteger("num_markers", int(d_num_markers));
 
-    auto put_marker_patch = [&](const MarkerPatch& marker_patch, const std::string& prefix)
-    {
+    auto put_marker_patch = [&](const MarkerPatch& marker_patch, const std::string& prefix) {
         db->putInteger(prefix + "_num_markers", static_cast<int>(marker_patch.d_indices.size()));
         // Yet another SAMRAI bug: we are not allowed to store zero-length
         // arrays in the database so we have to special-case that here ourselves
@@ -536,8 +534,7 @@ MarkerPatchHierarchy::writeH5Part(const std::string& filename,
 
     // Make these files also compatible with SAMRAI by encoding their types
     // in the manner perscribed by HDFDatabase.C
-    auto set_samrai_attribute = [](const hid_t dataset_id, const int type_key)
-    {
+    auto set_samrai_attribute = [](const hid_t dataset_id, const int type_key) {
         const hid_t attribute_id = H5Screate(H5S_SCALAR);
         TBOX_ASSERT(attribute_id >= 0);
         const auto samrai_attribute_type = H5T_STD_I8BE;
@@ -654,8 +651,7 @@ MarkerPatchHierarchy::getFromDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Databa
     d_num_markers = static_cast<std::size_t>(db->getInteger("num_markers"));
 
     int num_loaded_markers = 0;
-    auto get_marker_patch = [&](MarkerPatch& marker_patch, const std::string& prefix)
-    {
+    auto get_marker_patch = [&](MarkerPatch& marker_patch, const std::string& prefix) {
         const auto num_markers = static_cast<std::size_t>(db->getInteger(prefix + "_num_markers"));
         // No arrays are saved if num_markers == 0
         if (num_markers > 0)
@@ -713,8 +709,7 @@ MarkerPatchHierarchy::collectAllMarkers() const
     std::vector<double> local_velocities;
     std::vector<int> local_indices;
 
-    auto extract_markers = [&](const MarkerPatch& marker_patch)
-    {
+    auto extract_markers = [&](const MarkerPatch& marker_patch) {
         for (unsigned int k = 0; k < marker_patch.size(); ++k)
         {
             const auto marker_point = marker_patch[k];

--- a/ibtk/src/utilities/SnapshotCache.cpp
+++ b/ibtk/src/utilities/SnapshotCache.cpp
@@ -90,10 +90,9 @@ SnapshotCache::clearSnapshots()
 SnapshotCache::value_type
 SnapshotCache::getSnapshot(double time, double tol)
 {
-    auto it =
-        std::find_if(d_snapshots.begin(),
-                     d_snapshots.end(),
-                     [time, tol](const value_type& t) -> bool { return IBTK::abs_equal_eps(t.first, time, tol); });
+    auto it = std::find_if(d_snapshots.begin(), d_snapshots.end(), [time, tol](const value_type& t) -> bool {
+        return IBTK::abs_equal_eps(t.first, time, tol);
+    });
     if (it == d_snapshots.end())
         return std::make_pair(std::numeric_limits<double>::quiet_NaN(), nullptr);
     else
@@ -130,9 +129,9 @@ SnapshotCache::storeSnapshot(const int u_idx, const double time, Pointer<PatchHi
 
     // Store the index, time, hierarchy, and variable.
     // First determine where to store this index
-    auto it = std::find_if(d_snapshots.begin(),
-                           d_snapshots.end(),
-                           [time](const value_type& snapshot) -> bool { return time < snapshot.first; });
+    auto it = std::find_if(d_snapshots.begin(), d_snapshots.end(), [time](const value_type& snapshot) -> bool {
+        return time < snapshot.first;
+    });
     d_snapshots.insert(it, std::make_pair(time, snapshot_hierarchy));
 }
 

--- a/ibtk/src/utilities/snapshot_utilities.cpp
+++ b/ibtk/src/utilities/snapshot_utilities.cpp
@@ -151,11 +151,10 @@ fill_snapshot_at_time(SnapshotCache& cache,
     // Determine the correct snapshot index
     double snapshot_time_low = 0.0, snapshot_time_up = 0.0;
     double t_low = 0.0, t_up = 0.0;
-    auto it_up =
-        std::upper_bound(cache.begin(),
-                         cache.end(),
-                         time,
-                         [](const double a, const SnapshotCache::value_type& b) -> bool { return a < b.first; });
+    auto it_up = std::upper_bound(
+        cache.begin(), cache.end(), time, [](const double a, const SnapshotCache::value_type& b) -> bool {
+            return a < b.first;
+        });
     if (period == period && it_up == cache.end())
     {
         // Snapshot is storing periodic values, and the time value is between the last element and the first.

--- a/include/ibamr/ibamr_enums.h
+++ b/include/ibamr/ibamr_enums.h
@@ -43,8 +43,7 @@ string_to_enum(const std::string& /*val*/)
  * \brief Routine for converting enums to strings.
  */
 template <typename T>
-inline std::string
-enum_to_string(T /*val*/)
+inline std::string enum_to_string(T /*val*/)
 {
     TBOX_ERROR("UNSUPPORTED ENUM TYPE\n");
     return "UNKNOWN";

--- a/src/IB/BrinkmanPenalizationStrategy.cpp
+++ b/src/IB/BrinkmanPenalizationStrategy.cpp
@@ -72,8 +72,7 @@ BrinkmanPenalizationStrategy::postprocessComputeBrinkmanPenalization(double /*cu
     return;
 } // postprocessComputeBrinkmanPenalization
 
-void
-BrinkmanPenalizationStrategy::putToDatabase(Pointer<Database> /*db*/)
+void BrinkmanPenalizationStrategy::putToDatabase(Pointer<Database> /*db*/)
 {
     return;
 } // putToDatabase

--- a/src/IB/ConstraintIBKinematics.cpp
+++ b/src/IB/ConstraintIBKinematics.cpp
@@ -134,8 +134,7 @@ ConstraintIBKinematics::~ConstraintIBKinematics()
 
 } // ~ConstraintIBKinematics
 
-void
-ConstraintIBKinematics::putToDatabase(Pointer<Database> /*db*/)
+void ConstraintIBKinematics::putToDatabase(Pointer<Database> /*db*/)
 {
     // intentionally left blank
     return;

--- a/src/IB/FEMechanicsBase.cpp
+++ b/src/IB/FEMechanicsBase.cpp
@@ -911,22 +911,18 @@ FEMechanicsBase::assembleInteriorForceDensityRHS(PetscVector<double>& F_rhs_vec,
     // same quadrature rules and systems.
     const std::vector<PK1StressFcnData> all_pk1 = getPK1StressFunction(part);
     std::vector<PK1StressFcnData> remaining_pk1;
-    std::copy_if(all_pk1.begin(),
-                 all_pk1.end(),
-                 std::back_inserter(remaining_pk1),
-                 [](const PK1StressFcnData& data) { return data.fcn != nullptr; });
+    std::copy_if(all_pk1.begin(), all_pk1.end(), std::back_inserter(remaining_pk1), [](const PK1StressFcnData& data) {
+        return data.fcn != nullptr;
+    });
     while (remaining_pk1.size() > 0)
     {
         const PK1StressFcnData exemplar_pk1 = remaining_pk1.front();
         // Collect all PK1 functions that are sufficiently similar:
-        const auto next_group_start = std::partition(remaining_pk1.begin(),
-                                                     remaining_pk1.end(),
-                                                     [&](const PK1StressFcnData& pk1)
-                                                     {
-                                                         return pk1.system_data == exemplar_pk1.system_data &&
-                                                                pk1.quad_type == exemplar_pk1.quad_type &&
-                                                                pk1.quad_order == exemplar_pk1.quad_order;
-                                                     });
+        const auto next_group_start =
+            std::partition(remaining_pk1.begin(), remaining_pk1.end(), [&](const PK1StressFcnData& pk1) {
+                return pk1.system_data == exemplar_pk1.system_data && pk1.quad_type == exemplar_pk1.quad_type &&
+                       pk1.quad_order == exemplar_pk1.quad_order;
+            });
         std::vector<PK1StressFcnData> current_pk1(remaining_pk1.begin(), next_group_start);
         remaining_pk1.erase(remaining_pk1.begin(), next_group_start);
 

--- a/src/IB/IBExplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBExplicitHierarchyIntegrator.cpp
@@ -370,8 +370,7 @@ IBExplicitHierarchyIntegrator::postprocessIntegrateHierarchy(const double curren
 {
     auto ops = HierarchyDataOpsManager<NDIM>::getManager()->getOperationsDouble(d_u_var, d_hierarchy, true);
 
-    auto velocity_ghost_update = [&](const std::vector<int>& indices)
-    {
+    auto velocity_ghost_update = [&](const std::vector<int>& indices) {
         using ITC = IBTK::HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
         std::vector<ITC> ghostfills;
         for (const int& idx : indices)

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -1438,9 +1438,8 @@ IBFEMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const 
     return;
 } // addWorkloadEstimate
 
-void
-IBFEMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                    Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IBFEMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                         Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     IBAMR_TIMER_START(t_begin_data_redistribution);
     // clear some things that contain data specific to the current patch hierarchy
@@ -1484,9 +1483,8 @@ IBFEMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/
     return;
 } // beginDataRedistribution
 
-void
-IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                  Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IBFEMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                       Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     IBAMR_TIMER_START(t_end_data_redistribution);
     // if we are not initialized then there is nothing to do

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -1286,18 +1286,16 @@ IBFESurfaceMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy,
     return;
 } // addWorkloadEstimate
 
-void
-IBFESurfaceMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                           Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IBFESurfaceMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                                Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     // clear some things that contain data specific to the current patch hierarchy
     d_ghost_data_accumulator.reset();
     return;
 } // beginDataRedistribution
 
-void
-IBFESurfaceMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                         Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IBFESurfaceMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                              Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     if (d_is_initialized)
     {

--- a/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
@@ -449,7 +449,7 @@ IBHydrodynamicSurfaceForceEvaluator::fillPatchData(Pointer<PatchHierarchy<NDIM> 
     // Fill ghost cells for velocity
     Pointer<SideVariable<NDIM, double> > u_var = d_fluid_solver->getVelocityVariable();
     const int u_idx = use_current_ctx ?
-                          var_db->mapVariableAndContextToIndex(u_var, d_fluid_solver->getCurrentContext()) :
+                                    var_db->mapVariableAndContextToIndex(u_var, d_fluid_solver->getCurrentContext()) :
                       use_new_ctx ? var_db->mapVariableAndContextToIndex(u_var, d_fluid_solver->getNewContext()) :
                                     IBTK::invalid_index;
     InterpolationTransactionComponent u_transaction(d_u_idx,
@@ -491,7 +491,7 @@ IBHydrodynamicSurfaceForceEvaluator::fillPatchData(Pointer<PatchHierarchy<NDIM> 
         else if (mu_ins_var)
         {
             mu_idx = use_current_ctx ?
-                         var_db->mapVariableAndContextToIndex(mu_ins_var, d_fluid_solver->getCurrentContext()) :
+                                   var_db->mapVariableAndContextToIndex(mu_ins_var, d_fluid_solver->getCurrentContext()) :
                      use_new_ctx ? var_db->mapVariableAndContextToIndex(mu_ins_var, d_fluid_solver->getNewContext()) :
                                    IBTK::invalid_index;
             mu_bc_coef = p_vc_ins_hier_integrator->getViscosityBoundaryConditions();
@@ -519,7 +519,7 @@ IBHydrodynamicSurfaceForceEvaluator::fillPatchData(Pointer<PatchHierarchy<NDIM> 
     // Fill ghost cells for pressure
     Pointer<CellVariable<NDIM, double> > p_var = d_fluid_solver->getPressureVariable();
     const int p_idx = use_current_ctx ?
-                          var_db->mapVariableAndContextToIndex(p_var, d_fluid_solver->getCurrentContext()) :
+                                    var_db->mapVariableAndContextToIndex(p_var, d_fluid_solver->getCurrentContext()) :
                       use_new_ctx ? var_db->mapVariableAndContextToIndex(p_var, d_fluid_solver->getNewContext()) :
                                     IBTK::invalid_index;
     auto p_ins_bc_coef = dynamic_cast<INSStaggeredPressureBcCoef*>(d_fluid_solver->getPressureBoundaryConditions());

--- a/src/IB/IBInterpolantMethod.cpp
+++ b/src/IB/IBInterpolantMethod.cpp
@@ -675,17 +675,15 @@ IBInterpolantMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarch
     return;
 } // addWorkloadEstimate
 
-void
-IBInterpolantMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                             Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IBInterpolantMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                                  Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     d_l_data_manager->beginDataRedistribution();
     return;
 } // beginDataRedistribution
 
-void
-IBInterpolantMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                           Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IBInterpolantMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                                Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     d_l_data_manager->endDataRedistribution();
     return;

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -1487,9 +1487,8 @@ IBMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const in
     return;
 } // addWorkloadEstimate
 
-void
-IBMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                  Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IBMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                       Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     d_l_data_manager->beginDataRedistribution();
     return;

--- a/src/IB/IBStrategy.cpp
+++ b/src/IB/IBStrategy.cpp
@@ -270,17 +270,15 @@ IBStrategy::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/, co
     return;
 } // addWorkloadEstimate
 
-void
-IBStrategy::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                    Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IBStrategy::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                         Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     // intentionally blank
     return;
 } // beginDataRedistribution
 
-void
-IBStrategy::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                  Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IBStrategy::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                       Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     // intentionally blank
     return;
@@ -320,8 +318,7 @@ IBStrategy::applyGradientDetector(Pointer<BasePatchHierarchy<NDIM> > /*hierarchy
     return;
 } // applyGradientDetector
 
-void
-IBStrategy::putToDatabase(Pointer<Database> /*db*/)
+void IBStrategy::putToDatabase(Pointer<Database> /*db*/)
 {
     // intentionally blank
     return;

--- a/src/IB/IIMethod.cpp
+++ b/src/IB/IIMethod.cpp
@@ -536,17 +536,17 @@ IIMethod::preprocessIntegrateData(double current_time, double new_time, int /*nu
             }
             if (d_use_u_interp_correction)
             {
-               d_WSS_in_systems[part] = &d_equation_systems[part]->get_system(WSS_IN_SYSTEM_NAME);
-               d_WSS_in_half_vecs[part] =
-                  dynamic_cast<PetscVector<double>*>(d_WSS_in_systems[part]->current_local_solution.get());
-               d_WSS_in_IB_ghost_vecs[part] = dynamic_cast<PetscVector<double>*>(
-                   d_fe_data_managers[part]->buildGhostedSolutionVector(WSS_IN_SYSTEM_NAME, /*localize_data*/ false));
-                   
-               d_WSS_out_systems[part] = &d_equation_systems[part]->get_system(WSS_OUT_SYSTEM_NAME);
-               d_WSS_out_half_vecs[part] =
-                  dynamic_cast<PetscVector<double>*>(d_WSS_out_systems[part]->current_local_solution.get());
-               d_WSS_out_IB_ghost_vecs[part] = dynamic_cast<PetscVector<double>*>(
-                   d_fe_data_managers[part]->buildGhostedSolutionVector(WSS_OUT_SYSTEM_NAME, /*localize_data*/ false));
+                d_WSS_in_systems[part] = &d_equation_systems[part]->get_system(WSS_IN_SYSTEM_NAME);
+                d_WSS_in_half_vecs[part] =
+                    dynamic_cast<PetscVector<double>*>(d_WSS_in_systems[part]->current_local_solution.get());
+                d_WSS_in_IB_ghost_vecs[part] = dynamic_cast<PetscVector<double>*>(
+                    d_fe_data_managers[part]->buildGhostedSolutionVector(WSS_IN_SYSTEM_NAME, /*localize_data*/ false));
+
+                d_WSS_out_systems[part] = &d_equation_systems[part]->get_system(WSS_OUT_SYSTEM_NAME);
+                d_WSS_out_half_vecs[part] =
+                    dynamic_cast<PetscVector<double>*>(d_WSS_out_systems[part]->current_local_solution.get());
+                d_WSS_out_IB_ghost_vecs[part] = dynamic_cast<PetscVector<double>*>(
+                    d_fe_data_managers[part]->buildGhostedSolutionVector(WSS_OUT_SYSTEM_NAME, /*localize_data*/ false));
             }
         }
         if (d_use_velocity_jump_conditions && d_use_pressure_jump_conditions && d_use_u_interp_correction)
@@ -599,8 +599,8 @@ IIMethod::preprocessIntegrateData(double current_time, double new_time, int /*nu
             }
             if (d_use_u_interp_correction)
             {
-              *d_WSS_in_half_vecs[part] = *d_WSS_in_systems[part]->solution;
-              *d_WSS_out_half_vecs[part] = *d_WSS_out_systems[part]->solution;
+                *d_WSS_in_half_vecs[part] = *d_WSS_in_systems[part]->solution;
+                *d_WSS_out_half_vecs[part] = *d_WSS_out_systems[part]->solution;
             }
         }
         if (d_use_velocity_jump_conditions && d_use_pressure_jump_conditions && d_use_u_interp_correction)
@@ -694,10 +694,10 @@ IIMethod::postprocessIntegrateData(double /*current_time*/, double /*new_time*/,
             }
             if (d_use_u_interp_correction)
             {
-              *d_WSS_in_systems[part]->solution = *d_WSS_in_half_vecs[part];
-              *d_WSS_in_systems[part]->current_local_solution = *d_WSS_in_half_vecs[part];
-              *d_WSS_out_systems[part]->solution = *d_WSS_out_half_vecs[part];
-              *d_WSS_out_systems[part]->current_local_solution = *d_WSS_out_half_vecs[part];
+                *d_WSS_in_systems[part]->solution = *d_WSS_in_half_vecs[part];
+                *d_WSS_in_systems[part]->current_local_solution = *d_WSS_in_half_vecs[part];
+                *d_WSS_out_systems[part]->solution = *d_WSS_out_half_vecs[part];
+                *d_WSS_out_systems[part]->current_local_solution = *d_WSS_out_half_vecs[part];
             }
         }
         if (d_use_pressure_jump_conditions && d_use_velocity_jump_conditions && d_use_u_interp_correction)
@@ -784,8 +784,9 @@ IIMethod::interpolateVelocity(const int u_data_idx,
                               const double data_time)
 {
     if (!d_use_velocity_jump_conditions && d_use_u_interp_correction)
-      TBOX_ERROR(" use_velocity_jump_conditions must be also true "
-                   "whenever use_u_interp_correction = true...\n");
+        TBOX_ERROR(
+            " use_velocity_jump_conditions must be also true "
+            "whenever use_u_interp_correction = true...\n");
     IBAMR_TIMER_START(t_interpolate_velocity);
     const double mu = getINSHierarchyIntegrator()->getStokesSpecifications()->getMu();
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
@@ -2388,7 +2389,8 @@ IIMethod::extrapolatePressureForTraction(const int p_data_idx, const double data
 void
 IIMethod::calculateInterfacialFluidForces(const int p_data_idx, double data_time)
 {
-    if (d_compute_fluid_traction && (!d_use_pressure_jump_conditions || !d_use_velocity_jump_conditions || !d_use_u_interp_correction))
+    if (d_compute_fluid_traction &&
+        (!d_use_pressure_jump_conditions || !d_use_velocity_jump_conditions || !d_use_u_interp_correction))
     {
         TBOX_ERROR(d_object_name << ": To compute the traction all jump corrections need to be turned on!"
                                  << std::endl);
@@ -3072,8 +3074,8 @@ IIMethod::initializeFEEquationSystems()
                     vector_fe_family.push_back(d_viscous_jump_fe_family[part]);
                     vector_fe_order.push_back(d_viscous_jump_fe_order[part]);
                 }
-               if (d_use_u_interp_correction)
-               {
+                if (d_use_u_interp_correction)
+                {
                     vector_system_names.push_back(WSS_IN_SYSTEM_NAME);
                     vector_variable_prefixes.push_back("WSS_in");
                     vector_fe_family.push_back(d_viscous_jump_fe_family[part]);
@@ -3083,7 +3085,7 @@ IIMethod::initializeFEEquationSystems()
                     vector_variable_prefixes.push_back("WSS_out");
                     vector_fe_family.push_back(d_viscous_jump_fe_family[part]);
                     vector_fe_order.push_back(d_viscous_jump_fe_order[part]);
-				}
+                }
                 if (d_use_pressure_jump_conditions && d_use_u_interp_correction)
                 {
                     vector_system_names.push_back(TAU_IN_SYSTEM_NAME);
@@ -3205,13 +3207,13 @@ IIMethod::initializeFEData()
             }
             if (d_use_u_interp_correction)
             {
-              System& WSS_in_system = equation_systems->get_system<System>(WSS_IN_SYSTEM_NAME);
-              WSS_in_system.assemble_before_solve = false;
-              WSS_in_system.assemble();
+                System& WSS_in_system = equation_systems->get_system<System>(WSS_IN_SYSTEM_NAME);
+                WSS_in_system.assemble_before_solve = false;
+                WSS_in_system.assemble();
 
-              System& WSS_out_system = equation_systems->get_system<System>(WSS_OUT_SYSTEM_NAME);
-              WSS_out_system.assemble_before_solve = false;
-              WSS_out_system.assemble();
+                System& WSS_out_system = equation_systems->get_system<System>(WSS_OUT_SYSTEM_NAME);
+                WSS_out_system.assemble_before_solve = false;
+                WSS_out_system.assemble();
             }
         }
 
@@ -3288,9 +3290,8 @@ IIMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const in
     return;
 } // addWorkloadEstimate
 
-void
-IIMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                  Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IIMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                       Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     IBAMR_TIMER_START(t_begin_data_redistribution);
     // intentionally blank
@@ -3298,9 +3299,8 @@ IIMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
     return;
 } // beginDataRedistribution
 
-void
-IIMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IIMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                     Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     IBAMR_TIMER_START(t_end_data_redistribution);
     if (d_is_initialized)
@@ -4416,9 +4416,8 @@ IIMethod::getFromInput(Pointer<Database> db, bool /*is_from_restart*/)
     {
         d_use_velocity_jump_conditions = db->getBool("use_velocity_jump_conditions");
         d_use_u_interp_correction = true;
-	}
-    if (db->isBool("use_u_interp_correction"))
-        d_use_u_interp_correction = db->getBool("use_u_interp_correction");
+    }
+    if (db->isBool("use_u_interp_correction")) d_use_u_interp_correction = db->getBool("use_u_interp_correction");
     if (d_use_velocity_jump_conditions && d_use_u_interp_correction)
     {
         if (db->isDouble("wss_calc_width")) d_wss_calc_width = db->getDouble("wss_calc_width");
@@ -4433,8 +4432,7 @@ IIMethod::getFromInput(Pointer<Database> db, bool /*is_from_restart*/)
         if (db->isDouble("mesh_perturb_tol")) d_mesh_perturb_tol = db->getDouble("mesh_perturb_tol");
         if (db->isDouble("fuzzy_tol")) d_fuzzy_tol = db->getDouble("fuzzy_tol");
     }
-    
-    
+
     if (db->isBool("compute_fluid_traction")) d_compute_fluid_traction = db->getBool("compute_fluid_traction");
     if (d_compute_fluid_traction)
     {

--- a/src/IB/IMPInitializer.cpp
+++ b/src/IB/IMPInitializer.cpp
@@ -616,8 +616,7 @@ IMPInitializer::getVertexPosn(const std::pair<int, int>& point_index, const int 
     return d_vertex_posn[level_number][point_index.first][point_index.second];
 } // getVertexPosn
 
-void
-IMPInitializer::getFromInput(Pointer<Database> /*db*/)
+void IMPInitializer::getFromInput(Pointer<Database> /*db*/)
 {
     return;
 } // getFromInput

--- a/src/IB/IMPMethod.cpp
+++ b/src/IB/IMPMethod.cpp
@@ -967,17 +967,15 @@ IMPMethod::addWorkloadEstimate(Pointer<PatchHierarchy<NDIM> > hierarchy, const i
     return;
 } // addWorkloadEstimate
 
-void
-IMPMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                   Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IMPMethod::beginDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                        Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     d_l_data_manager->beginDataRedistribution();
     return;
 } // beginDataRedistribution
 
-void
-IMPMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
-                                 Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
+void IMPMethod::endDataRedistribution(Pointer<PatchHierarchy<NDIM> > /*hierarchy*/,
+                                      Pointer<GriddingAlgorithm<NDIM> > /*gridding_alg*/)
 {
     d_l_data_manager->endDataRedistribution();
     return;

--- a/src/IB/KrylovMobilitySolver.cpp
+++ b/src/IB/KrylovMobilitySolver.cpp
@@ -940,8 +940,7 @@ KrylovMobilitySolver::MatVecMult_KMInv(Mat A, Vec x, Vec y)
 } // MatVecMult_KMInv
 
 // Routine to apply DirectMobility preconditioner
-PetscErrorCode
-KrylovMobilitySolver::PCApply_KMInv(PC /*pc*/, Vec /*x*/, Vec /*y*/)
+PetscErrorCode KrylovMobilitySolver::PCApply_KMInv(PC /*pc*/, Vec /*x*/, Vec /*y*/)
 {
     PetscFunctionBeginUser;
     TBOX_ERROR(

--- a/src/adv_diff/BrinkmanAdvDiffSemiImplicitHierarchyIntegrator.cpp
+++ b/src/adv_diff/BrinkmanAdvDiffSemiImplicitHierarchyIntegrator.cpp
@@ -695,9 +695,9 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchySpecialized(co
                 break;
             default:
                 TBOX_ERROR(d_object_name << "::integrateHierarchy():\n"
-                                        << "  unsupported diffusion time stepping type: "
-                                        << enum_to_string<TimeSteppingType>(diffusion_time_stepping_type) << " \n"
-                                        << "  valid choices are: BACKWARD_EULER, "
+                                         << "  unsupported diffusion time stepping type: "
+                                         << enum_to_string<TimeSteppingType>(diffusion_time_stepping_type) << " \n"
+                                         << "  valid choices are: BACKWARD_EULER, "
                                             "FORWARD_EULER, TRAPEZOIDAL_RULE\n");
             }
             PoissonSpecifications solver_spec(d_object_name + "::solver_spec::" + Q_var->getName());
@@ -723,7 +723,7 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchySpecialized(co
                 const double kappa = d_Q_diffusion_coef[Q_var];
                 solver_spec.setDConstant(-K * kappa);
             }
-            
+
             // Initialize the linear solver.
             Pointer<PoissonSolver> helmholtz_solver = d_helmholtz_solvers[l];
             helmholtz_solver->setPoissonSpecifications(solver_spec);
@@ -738,7 +738,7 @@ BrinkmanAdvDiffSemiImplicitHierarchyIntegrator::integrateHierarchySpecialized(co
                 if (d_enable_logging)
                 {
                     plog << d_object_name << ": "
-                        << "Initializing Helmholtz solvers for variable number " << l << "\n";
+                         << "Initializing Helmholtz solvers for variable number " << l << "\n";
                 }
                 helmholtz_solver->initializeSolverState(*d_sol_vecs[l], *d_rhs_vecs[l]);
                 d_helmholtz_solvers_need_init[l] = false;

--- a/src/level_set/FESurfaceDistanceEvaluator.cpp
+++ b/src/level_set/FESurfaceDistanceEvaluator.cpp
@@ -670,8 +670,7 @@ FESurfaceDistanceEvaluator::checkIntersection2D(const IBTK::Vector3d& box_bl,
         return true;
     }
 
-    auto line_equation = [](const IBTK::Vector3d& coord, const libMesh::Point& n0, const libMesh::Point& n1)
-    {
+    auto line_equation = [](const IBTK::Vector3d& coord, const libMesh::Point& n0, const libMesh::Point& n1) {
         const double x0 = n0(0);
         const double y0 = n0(1);
         const double x1 = n1(0);

--- a/src/level_set/LSInitStrategy.cpp
+++ b/src/level_set/LSInitStrategy.cpp
@@ -74,8 +74,7 @@ LSInitStrategy::setReinitializeLSData(bool reinit_ls_data)
     return;
 } // setReinitializeLSData
 
-void
-LSInitStrategy::putToDatabase(Pointer<Database> /*db*/)
+void LSInitStrategy::putToDatabase(Pointer<Database> /*db*/)
 {
     // intentionally blank
     return;

--- a/src/navier_stokes/INSHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSHierarchyIntegrator.cpp
@@ -104,8 +104,9 @@ INSHierarchyIntegrator::registerAdvDiffHierarchyIntegrator(Pointer<AdvDiffHierar
 #if !defined(NDEBUG)
     TBOX_ASSERT(adv_diff_hier_integrator);
     // Bad things happen if the same integrator is registered twice.
-    auto pointer_compare = [adv_diff_hier_integrator](Pointer<AdvDiffHierarchyIntegrator> integrator) -> bool
-    { return adv_diff_hier_integrator.getPointer() == integrator.getPointer(); };
+    auto pointer_compare = [adv_diff_hier_integrator](Pointer<AdvDiffHierarchyIntegrator> integrator) -> bool {
+        return adv_diff_hier_integrator.getPointer() == integrator.getPointer();
+    };
     TBOX_ASSERT(std::find_if(d_adv_diff_hier_integrators.begin(), d_adv_diff_hier_integrators.end(), pointer_compare) ==
                 d_adv_diff_hier_integrators.end());
 #endif

--- a/src/navier_stokes/MarangoniSurfaceTensionForceFunction.cpp
+++ b/src/navier_stokes/MarangoniSurfaceTensionForceFunction.cpp
@@ -504,7 +504,7 @@ MarangoniSurfaceTensionForceFunction::setDataOnPatchSide(Pointer<SideData<NDIM, 
             .upper(1)
 #endif
 #if (NDIM == 3)
-        F_data->getPointer(0),
+                F_data->getPointer(0),
         F_data->getPointer(1),
         F_data->getPointer(2),
         F_data->getGhostCellWidth().max(),

--- a/src/navier_stokes/SurfaceTensionForceFunction.cpp
+++ b/src/navier_stokes/SurfaceTensionForceFunction.cpp
@@ -429,7 +429,7 @@ SurfaceTensionForceFunction::registerSurfaceTensionForceMasking(MaskSurfaceTensi
     d_mask_surface_tension_force_ctx = ctx;
 
     return;
-}// registerSurfaceTensionForceMasking
+} // registerSurfaceTensionForceMasking
 
 void
 SurfaceTensionForceFunction::registerSurfaceTensionCoefficientFunction(ComputeSurfaceTensionCoefficientPtr callback,
@@ -439,7 +439,7 @@ SurfaceTensionForceFunction::registerSurfaceTensionCoefficientFunction(ComputeSu
     d_compute_surface_tension_coef_ctx = ctx;
 
     return;
-}// registerSurfaceTensionCoefficientFunction
+} // registerSurfaceTensionCoefficientFunction
 
 /////////////////////////////// PROTECTED ////////////////////////////////////
 
@@ -669,7 +669,7 @@ SurfaceTensionForceFunction::setDataOnPatchSide(Pointer<SideData<NDIM, double> >
             .upper(1)
 #endif
 #if (NDIM == 3)
-        F_data->getPointer(0),
+                F_data->getPointer(0),
         F_data->getPointer(1),
         F_data->getPointer(2),
         F_data->getGhostCellWidth().max(),

--- a/tests/IBFE/explicit_ex4.cpp
+++ b/tests/IBFE/explicit_ex4.cpp
@@ -531,8 +531,7 @@ main(int argc, char** argv)
             other_manager->setPatchHierarchy(patch_hierarchy);
         }
 
-        auto add_markers = [&]()
-        {
+        auto add_markers = [&]() {
             System& X_system = equation_systems->get_system<System>(ib_method_ops->getCurrentCoordinatesSystemName());
             NumericVector<double>& X_vec = *X_system.solution.get();
             std::vector<double> X_vec_global(X_vec.size());

--- a/tests/IBFE/instrument_panel_01.cpp
+++ b/tests/IBFE/instrument_panel_01.cpp
@@ -416,8 +416,7 @@ main(int argc, char** argv)
             visit_data_writer->writePlotData(patch_hierarchy, 0, 0.0);
         }
 
-        auto do_instrument_panel = [&](const int data_time)
-        {
+        auto do_instrument_panel = [&](const int data_time) {
             // reallocate in case we regridded
             HierarchyMathOps hier_math_ops("HierarchyMathOps", patch_hierarchy);
             hier_math_ops.setPatchHierarchy(patch_hierarchy);

--- a/tests/IBTK/cf_interface.cpp
+++ b/tests/IBTK/cf_interface.cpp
@@ -75,8 +75,7 @@ main(int argc, char* argv[])
         else if (input_db->getString("CENTERING").compare("SIDE") == 0)
             Q_var = new SideVariable<NDIM, double>("Q");
 
-        auto Q_fcn = [](const VectorNd& x) -> double
-        {
+        auto Q_fcn = [](const VectorNd& x) -> double {
             double val = 1.0;
             for (int d = 0; d < NDIM; ++d) val += x[d] + x[d] * x[d];
             return val;

--- a/tests/IBTK/equal_eps.cpp
+++ b/tests/IBTK/equal_eps.cpp
@@ -38,8 +38,7 @@ main(int argc, char* argv[])
 
     std::ofstream out("output");
 
-    auto test = [&out](const double a, const double b, std::function<bool(double, double)> compare, std::string type)
-    {
+    auto test = [&out](const double a, const double b, std::function<bool(double, double)> compare, std::string type) {
         out.precision(std::numeric_limits<double>::max_digits10);
         out << type << " test:\n";
         out << "Testing a = " << a << " and b = " << b << "\n";
@@ -60,8 +59,7 @@ main(int argc, char* argv[])
     fcns.push_back(MathUtilities<double>::equalEps);
     std::vector<std::string> strs = { "Relative", "Absolute", "SAMRAI" };
 
-    auto loop_test = [&](const double a, const double b)
-    {
+    auto loop_test = [&](const double a, const double b) {
         for (unsigned int i = 0; i < fcns.size(); ++i)
         {
             test(a, b, fcns[i], strs[i]);

--- a/tests/adv_diff/SetFluidProperties.h
+++ b/tests/adv_diff/SetFluidProperties.h
@@ -135,6 +135,6 @@ private:
      */
     double d_mu;
 
-};     // SetFluidProperties
+}; // SetFluidProperties
 
 #endif // #ifndef included_SetFluidProperties

--- a/tests/adv_diff/adv_diff_convec_opers.cpp
+++ b/tests/adv_diff/adv_diff_convec_opers.cpp
@@ -169,8 +169,7 @@ main(int argc, char* argv[])
 #ifdef OUTPUT_VIZ_FILES
         int step = 0;
 #endif
-        auto do_test = [&](Pointer<ConvectiveOperator> convec_oper)
-        {
+        auto do_test = [&](Pointer<ConvectiveOperator> convec_oper) {
             convec_oper->initializeOperatorState(q_vec, q_vec);
             convec_oper->setAdvectionVelocity(u_idx);
             convec_oper->applyConvectiveOperator(q_idx, convec_idx);

--- a/tests/refine/rt0_refine_01.cpp
+++ b/tests/refine/rt0_refine_01.cpp
@@ -122,8 +122,7 @@ main(int argc, char* argv[])
         Pointer<VisItDataWriter<NDIM> > visit_writer = app_initializer->getVisItDataWriter();
 
         // The rest is just book-keeping, this is the actual test:
-        auto do_test = [&](const std::string& db_u_fcn_name, const int coarse_level_n)
-        {
+        auto do_test = [&](const std::string& db_u_fcn_name, const int coarse_level_n) {
             muParserCartGridFunction u_fcn(
                 db_u_fcn_name, app_initializer->getComponentDatabase(db_u_fcn_name), grid_geometry);
             u_fcn.setDataOnPatchHierarchy(u_sc_idx, u_sc_var, patch_hierarchy, 0.0);


### PR DESCRIPTION
Part of #1664.

It's just clang-format. The normal list doesn't apply. We'll be able to get rid of this step soon once we canonicalize our clang-format version (which I've done on most IBAMR projects now).