### PR TITLE
Make get functions public in IBMethod.

### DIFF
--- a/ibtk/include/ibtk/ibtk_enums.h
+++ b/ibtk/include/ibtk/ibtk_enums.h
@@ -207,6 +207,34 @@ enum_to_string<NodeOutsidePatchCheckType>(NodeOutsidePatchCheckType val)
     return "UNKNOWN_NODE_OUTSIDE_PATCH_CHECK_TYPE";
 } // enum_to_string
 
+enum class TimePoint
+{
+    CURRENT_TIME,
+    HALF_TIME,
+    NEW_TIME,
+    UNKNOWN_TIME
+};
+
+template <>
+inline TimePoint
+string_to_enum<TimePoint>(const std::string& val)
+{
+    if (strcasecmp(val.c_str(), "CURRENT_TIME") == 0) return TimePoint::CURRENT_TIME;
+    if (strcasecmp(val.c_str(), "HALF_TIME") == 0) return TimePoint::HALF_TIME;
+    if (strcasecmp(val.c_str(), "NEW_TIME") == 0) return TimePoint::NEW_TIME;
+    return TimePoint::UNKNOWN_TIME;
+}
+
+template <>
+inline std::string
+enum_to_string<TimePoint>(TimePoint val)
+{
+    if (val == TimePoint::CURRENT_TIME) return "CURRENT_TIME";
+    if (val == TimePoint::HALF_TIME) return "HALF_TIME";
+    if (val == TimePoint::NEW_TIME) return "NEW_TIME";
+    return "UNKNOWN_TIME_POINT";
+}
+
 } // namespace IBTK
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/ibamr/IBMethod.h
+++ b/include/ibamr/IBMethod.h
@@ -28,6 +28,7 @@
 
 #include "ibtk/LInitStrategy.h"
 #include "ibtk/LSiloDataWriter.h"
+#include "ibtk/ibtk_enums.h"
 #include "ibtk/ibtk_utilities.h"
 
 #include "GriddingAlgorithm.h"
@@ -445,10 +446,46 @@ public:
     void putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
 
     /*!
+     * \brief Convert the enum TimePoint to it respective value.
+     *
+     * If TimePoint is not one of CURRENT_TIME, HALF_TIME, or NEW_TIME, this returns NaN.
+     */
+    double convertTimeEnumToDouble(IBTK::TimePoint time_pt);
+
+    /*!
+     * \brief Get the structure position data at the specified time point.
+     *
+     * The time point should be one of CURRENT_TIME, HALF_TIME, or NEW_TIME. If this condition is met, X_data is set
+     * to the data at that respective time, otherwise the X_data pointers are unchanged.
+     */
+    void getPositionData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** X_data,
+                         bool** X_needs_ghost_fill,
+                         IBTK::TimePoint time_pt);
+
+    /*!
+     * \brief Get the current structure velocity data at the specified time point.
+     *
+     * The time point should be one of CURRENT_TIME, HALF_TIME, or NEW_TIME. If this condition is met, U_data is set
+     * to the data at that respective time, otherwise the U_data pointers are unchanged.
+     */
+    void getVelocityData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** U_data, IBTK::TimePoint time_pt);
+
+    /*!
+     * \brief Get the current structure force data at the specified time point.
+     *
+     * The time point should be one of CURRENT_TIME, HALF_TIME, or NEW_TIME. If this condition is met, F_data is set
+     * to the data at that respective time, otherwise the F_data pointers are unchanged.
+     */
+    void getForceData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** F_data,
+                      bool** F_needs_ghost_fill,
+                      IBTK::TimePoint time_pt);
+
+protected:
+    /*!
      * Get the current structure position data.
      *
      * data_time must be equal to one of current time, new time, or half time. If this condition is met, X_data is set
-     * to the data at that respective time, otherwise the X_data is unchanged.
+     * to the data at that respective time, otherwise the X_data pointers are unchanged.
      */
     void getPositionData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** X_data,
                          bool** X_needs_ghost_fill,
@@ -478,7 +515,7 @@ public:
      * Get the current structure velocity data.
      *
      * data_time must be equal to one of current time, new time, or half time. If this condition is met, U_data is set
-     * to the data at that respective time, otherwise the U_data is unchanged.
+     * to the data at that respective time, otherwise the U_data pointers are unchanged.
      */
     void getVelocityData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** U_data, double data_time);
 
@@ -493,7 +530,7 @@ public:
      * Get the current structure force data.
      *
      * data_time must be equal to one of current time, new time, or half time. If this condition is met, F_data is set
-     * to the data at that respective time, otherwise the F_data is unchanged.
+     * to the data at that respective time, otherwise the F_data pointers are unchanged.
      */
     void getForceData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** F_data,
                       bool** F_needs_ghost_fill,
@@ -506,7 +543,6 @@ public:
      */
     void getLinearizedForceData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** F_data, bool** F_needs_ghost_fill);
 
-protected:
     /*!
      * Interpolate the current and new data to obtain values at the midpoint of
      * the time interval.

--- a/include/ibamr/IBMethod.h
+++ b/include/ibamr/IBMethod.h
@@ -444,9 +444,11 @@ public:
      */
     void putToDatabase(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
 
-protected:
     /*!
      * Get the current structure position data.
+     *
+     * data_time must be equal to one of current time, new time, or half time. If this condition is met, X_data is set
+     * to the data at that respective time, otherwise the X_data is unchanged.
      */
     void getPositionData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** X_data,
                          bool** X_needs_ghost_fill,
@@ -454,12 +456,19 @@ protected:
 
     /*!
      * Get the linearized structure position data.
+     *
+     * If the linearized position data does not exist, it will be created.
      */
     void getLinearizedPositionData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** X_data,
                                    bool** X_needs_ghost_fill);
 
     /*!
      * Get the current interpolation/spreading position data.
+     *
+     * data_time must be equal to one of current time, new time, or half time. If this condition is met, X_LE_data is
+     * set to the data at that respective time, otherwise the X_LE_data is unchanged.
+     *
+     * If this class is not set up to use fixed coupling, this returns data from getPositionData().
      */
     void getLECouplingPositionData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** X_LE_data,
                                    bool** X_LE_needs_ghost_fill,
@@ -467,16 +476,24 @@ protected:
 
     /*!
      * Get the current structure velocity data.
+     *
+     * data_time must be equal to one of current time, new time, or half time. If this condition is met, U_data is set
+     * to the data at that respective time, otherwise the U_data is unchanged.
      */
     void getVelocityData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** U_data, double data_time);
 
     /*!
      * Get the linearized structure velocity data.
+     *
+     * If the linearized velocity data does not exist, it will be created.
      */
     void getLinearizedVelocityData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** U_data);
 
     /*!
      * Get the current structure force data.
+     *
+     * data_time must be equal to one of current time, new time, or half time. If this condition is met, F_data is set
+     * to the data at that respective time, otherwise the F_data is unchanged.
      */
     void getForceData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** F_data,
                       bool** F_needs_ghost_fill,
@@ -484,9 +501,12 @@ protected:
 
     /*!
      * Get the linearized structure force data.
+     *
+     * If the linearized force data does not exist, it will be created.
      */
     void getLinearizedForceData(std::vector<SAMRAI::tbox::Pointer<IBTK::LData> >** F_data, bool** F_needs_ghost_fill);
 
+protected:
     /*!
      * Interpolate the current and new data to obtain values at the midpoint of
      * the time interval.

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -1712,6 +1712,8 @@ IBMethod::convertTimeEnumToDouble(TimePoint time_pt)
         return d_half_time;
     case TimePoint::NEW_TIME:
         return d_new_time;
+    default:
+        return std::numeric_limits<double>::quiet_NaN();
     }
     return std::numeric_limits<double>::quiet_NaN();
 }

--- a/src/IB/IBMethod.cpp
+++ b/src/IB/IBMethod.cpp
@@ -1701,6 +1701,42 @@ IBMethod::putToDatabase(Pointer<Database> db)
     return;
 } // putToDatabase
 
+double
+IBMethod::convertTimeEnumToDouble(TimePoint time_pt)
+{
+    switch (time_pt)
+    {
+    case TimePoint::CURRENT_TIME:
+        return d_current_time;
+    case TimePoint::HALF_TIME:
+        return d_half_time;
+    case TimePoint::NEW_TIME:
+        return d_new_time;
+    }
+    return std::numeric_limits<double>::quiet_NaN();
+}
+
+void
+IBMethod::getPositionData(std::vector<Pointer<LData> >** X_data, bool** X_needs_ghost_fill, TimePoint time_pt)
+{
+    double time = convertTimeEnumToDouble(time_pt);
+    getPositionData(X_data, X_needs_ghost_fill, time);
+}
+
+void
+IBMethod::getVelocityData(std::vector<Pointer<LData> >** U_data, TimePoint time_pt)
+{
+    double time = convertTimeEnumToDouble(time_pt);
+    getVelocityData(U_data, time);
+}
+
+void
+IBMethod::getForceData(std::vector<Pointer<LData> >** F_data, bool** F_needs_ghost_fill, TimePoint time_pt)
+{
+    double time = convertTimeEnumToDouble(time_pt);
+    getPositionData(F_data, F_needs_ghost_fill, time);
+}
+
 /////////////////////////////// PROTECTED ////////////////////////////////////
 
 void


### PR DESCRIPTION
Currently, the IB data in `IBMethod` during the middle of a time step is inaccessible outside of `IBMethod`. The data is owned by the class `IBMethod` and therefore can not be retrieved via `LDataManager`. This PR makes the get functions public.
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
