### PR TITLE
Clean up restart db

### DIFF
--- a/doc/news/changes/major/20240311DavidWells
+++ b/doc/news/changes/major/20240311DavidWells
@@ -1,0 +1,4 @@
+Improved: Many quantities which did not need to be in the restart database have been removed from it.
+This decreases the size of the restart files by over 50%.
+<br>
+(David Wells, 2024/03/11)

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -608,6 +608,13 @@ public:
     SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext> getScratchContext() const;
 
     /*!
+     * Return a pointer to the "plot" variable context used by integrator. Plot
+     * data is only read from by the VisItDataWriter and is allocated by
+     * setupPlotData() and deallocated by regridHierarchyBegin().
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext> getPlotContext() const;
+
+    /*!
      * Check whether a patch data index corresponds to allocated data over the
      * specified range of patch level numbers.
      *
@@ -1154,14 +1161,15 @@ protected:
     std::list<SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM> > > d_copy_scratch_to_current_fast;
     std::list<SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM> > > d_copy_scratch_to_current_slow;
 
-    SAMRAI::hier::ComponentSelector d_current_data, d_new_data, d_scratch_data;
+    SAMRAI::hier::ComponentSelector d_current_data, d_new_data, d_scratch_data, d_plot_data;
 
     std::map<SAMRAI::hier::Variable<NDIM>*, SAMRAI::tbox::Pointer<CartGridFunction> > d_state_var_init_fcns;
 
     /*!
      * Variable contexts.
      */
-    SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext> d_current_context, d_new_context, d_scratch_context;
+    SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext> d_current_context, d_new_context, d_scratch_context,
+        d_plot_context;
 
     /*!
      * Names of special coarsen algorithms/schedules.

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -684,7 +684,8 @@ public:
                           SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM> > variable,
                           const SAMRAI::hier::IntVector<NDIM>& ghosts = SAMRAI::hier::IntVector<NDIM>(0),
                           SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext> ctx =
-                              SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext>(NULL));
+                              SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext>(NULL),
+                          const bool register_for_restart = true);
 
     ///
     ///  Implementations of functions declared in the SAMRAI::tbox::Serializable

--- a/ibtk/include/ibtk/HierarchyIntegrator.h
+++ b/ibtk/include/ibtk/HierarchyIntegrator.h
@@ -670,7 +670,8 @@ public:
                      const SAMRAI::hier::IntVector<NDIM>& scratch_ghosts = SAMRAI::hier::IntVector<NDIM>(0),
                      const std::string& coarsen_name = "NO_COARSEN",
                      const std::string& refine_name = "NO_REFINE",
-                     SAMRAI::tbox::Pointer<CartGridFunction> init_fcn = SAMRAI::tbox::Pointer<CartGridFunction>(NULL));
+                     SAMRAI::tbox::Pointer<CartGridFunction> init_fcn = SAMRAI::tbox::Pointer<CartGridFunction>(NULL),
+                     const bool register_for_restart = true);
 
     /*!
      * Register a variable with the integrator that may not be maintained from

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -1306,6 +1306,8 @@ HierarchyIntegrator::resetTimeDependentHierarchyDataSpecialized(const double new
                 Pointer<PatchData<NDIM> > src_data = patch->getPatchData(src_idx);
                 Pointer<PatchData<NDIM> > dst_data = patch->getPatchData(dst_idx);
 #if !defined(NDEBUG)
+                TBOX_ASSERT(src_data);
+                TBOX_ASSERT(dst_data);
                 TBOX_ASSERT(src_data->getBox() == dst_data->getBox());
                 TBOX_ASSERT(src_data->getGhostCellWidth() == dst_data->getGhostCellWidth());
 #endif

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -1148,7 +1148,8 @@ void
 HierarchyIntegrator::registerVariable(int& idx,
                                       const Pointer<Variable<NDIM> > variable,
                                       const IntVector<NDIM>& ghosts,
-                                      Pointer<VariableContext> ctx)
+                                      Pointer<VariableContext> ctx,
+                                      const bool register_for_restart)
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(variable);
@@ -1166,7 +1167,7 @@ HierarchyIntegrator::registerVariable(int& idx,
     if (*ctx == *getCurrentContext())
     {
         d_current_data.setFlag(idx);
-        if (d_registered_for_restart)
+        if (d_registered_for_restart && register_for_restart)
         {
             var_db->registerPatchDataForRestart(idx);
         }
@@ -1306,8 +1307,7 @@ HierarchyIntegrator::resetTimeDependentHierarchyDataSpecialized(const double new
             // If a variable is in the current context but not registered for
             // restarts, then it will not be allocated at this point, so
             // double-check that dst is allocated:
-            if (!level->checkAllocated(dst_idx))
-                level->allocatePatchData(dst_idx);
+            if (!level->checkAllocated(dst_idx)) level->allocatePatchData(dst_idx);
             for (PatchLevel<NDIM>::Iterator p(level); p; p++)
             {
                 Pointer<Patch<NDIM> > patch = level->getPatch(p());
@@ -1421,7 +1421,8 @@ HierarchyIntegrator::applyGradientDetectorSpecialized(const Pointer<BasePatchHie
     return;
 } // applyGradientDetectorSpecialized
 
-void HierarchyIntegrator::putToDatabaseSpecialized(Pointer<Database> /*db*/)
+void
+HierarchyIntegrator::putToDatabaseSpecialized(Pointer<Database> /*db*/)
 {
     // intentionally blank
     return;

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -1025,6 +1025,12 @@ HierarchyIntegrator::getScratchContext() const
     return d_scratch_context;
 } // getScratchContext
 
+Pointer<VariableContext>
+HierarchyIntegrator::getPlotContext() const
+{
+    return d_plot_context;
+} // getPlotContext
+
 bool
 HierarchyIntegrator::isAllocatedPatchData(const int data_idx, int coarsest_ln, int finest_ln) const
 {
@@ -1168,6 +1174,8 @@ HierarchyIntegrator::registerVariable(int& idx,
         d_scratch_data.setFlag(idx);
     else if (*ctx == *getNewContext())
         d_new_data.setFlag(idx);
+    else if (*ctx == *getPlotContext())
+        d_plot_data.setFlag(idx);
     else
     {
         TBOX_ERROR(d_object_name << "::registerVariable():\n"

--- a/include/ibamr/INSStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSStaggeredHierarchyIntegrator.h
@@ -454,14 +454,25 @@ private:
         d_N_old_scratch_idx = IBTK::invalid_index;
 
     /*
+     * Patch data descriptor for state variables which are only present in the current context.
+     */
+    int d_Div_U_idx = IBTK::invalid_index, d_Omega_idx = IBTK::invalid_index;
+
+    /*
      * Patch data descriptor indices for all "plot" variables managed by the
-     * integrator.
+     * integrator. These are only used for directly computing graphical output.
+     * In particular, this list does *not* contain some scratch variables used
+     * to generate graphical output. d_Div_U_idx is also directly plotted.
      *
-     * Plot variables have one context: current.
+     * Plot variables have one context: plot.
      */
     int d_U_nc_idx = IBTK::invalid_index, d_P_nc_idx = IBTK::invalid_index, d_F_cc_idx = IBTK::invalid_index,
-        d_Omega_idx = IBTK::invalid_index, d_Omega_nc_idx = IBTK::invalid_index, d_Div_U_idx = IBTK::invalid_index,
-        d_EE_idx = IBTK::invalid_index;
+        d_Omega_nc_idx = IBTK::invalid_index, d_EE_idx = IBTK::invalid_index;
+
+    /**
+     * Vector of all such plot-only data indices.
+     */
+    std::vector<int> d_plot_indices;
 
     /*
      * Patch data descriptor indices for all "scratch" variables managed by the

--- a/include/ibamr/INSStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSStaggeredHierarchyIntegrator.h
@@ -256,6 +256,11 @@ protected:
     double getStableTimestep(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM> > patch) const override;
 
     /*!
+     * Write out specialized object state to the given database.
+     */
+    void putToDatabaseSpecialized(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
+
+    /*!
      * Prepare the current hierarchy for regridding. Here we calculate the divergence.
      */
     void regridHierarchyBeginSpecialized() override;
@@ -341,6 +346,12 @@ private:
      * \return A reference to this object.
      */
     INSStaggeredHierarchyIntegrator& operator=(const INSStaggeredHierarchyIntegrator& that) = delete;
+
+    /*!
+     * Read object state from the restart file and initialize class data
+     * members.
+     */
+    void getFromRestart();
 
     /*!
      * Compute the appropriate source term that must be added to the momentum

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -2086,7 +2086,6 @@ INSStaggeredHierarchyIntegrator::setupPlotDataSpecialized()
     if (d_output_U)
     {
         const int U_sc_idx = var_db->mapVariableAndContextToIndex(d_U_var, ctx);
-        const int U_nc_idx = var_db->mapVariableAndContextToIndex(d_U_nc_var, ctx);
 
         // We need updated ghost values to interpolate from side data:
         using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
@@ -2105,7 +2104,7 @@ INSStaggeredHierarchyIntegrator::setupPlotDataSpecialized()
         }
 
         // synch both the src and dst data:
-        d_hier_math_ops->interp(U_nc_idx,
+        d_hier_math_ops->interp(d_U_nc_idx,
                                 d_U_nc_var,
                                 synch_cf_interface,
                                 d_U_scratch_idx,
@@ -2119,7 +2118,6 @@ INSStaggeredHierarchyIntegrator::setupPlotDataSpecialized()
     if (d_output_P)
     {
         const int P_cc_idx = var_db->mapVariableAndContextToIndex(d_P_var, ctx);
-        const int P_nc_idx = var_db->mapVariableAndContextToIndex(d_P_nc_var, ctx);
 
         // We need updated ghost values to interpolate from side data:
         using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
@@ -2139,14 +2137,13 @@ INSStaggeredHierarchyIntegrator::setupPlotDataSpecialized()
 
         // synch both the src and dst data:
         d_hier_math_ops->interp(
-            P_nc_idx, d_P_nc_var, synch_cf_interface, d_P_scratch_idx, d_P_var, d_no_fill_op, d_integrator_time);
+            d_P_nc_idx, d_P_nc_var, synch_cf_interface, d_P_scratch_idx, d_P_var, d_no_fill_op, d_integrator_time);
     }
     if (d_F_fcn && d_output_F)
     {
         const int F_sc_idx = var_db->mapVariableAndContextToIndex(d_F_var, ctx);
-        const int F_cc_idx = var_db->mapVariableAndContextToIndex(d_F_cc_var, ctx);
         d_hier_math_ops->interp(
-            F_cc_idx, d_F_cc_var, F_sc_idx, d_F_var, d_no_fill_op, d_integrator_time, synch_cf_interface);
+            d_F_cc_idx, d_F_cc_var, F_sc_idx, d_F_var, d_no_fill_op, d_integrator_time, synch_cf_interface);
     }
 
     // Compute Omega = curl U.

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -844,6 +844,8 @@ INSStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHier
                      d_U_refine_type,
                      d_U_init);
 
+    // We use d_P_current_idx as the initial guess for d_P_new_idx, so the
+    // pressure should always be in the restart database.
     registerVariable(d_P_current_idx,
                      d_P_new_idx,
                      d_P_scratch_idx,
@@ -855,6 +857,10 @@ INSStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHier
 
     if (d_F_fcn)
     {
+        // Work around a common bug in examples and tests - they print graphical
+        // output prior to timestepping whether or not the run is restarted.
+        // Hence, in that case, we need F to be in the restart database to
+        // generate valid output.
         registerVariable(d_F_current_idx,
                          d_F_new_idx,
                          d_F_scratch_idx,
@@ -862,7 +868,8 @@ INSStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHier
                          side_ghosts,
                          d_F_coarsen_type,
                          d_F_refine_type,
-                         d_F_fcn);
+                         d_F_fcn,
+                         d_output_F);
     }
     else
     {
@@ -889,6 +896,8 @@ INSStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHier
         d_Q_scratch_idx = invalid_index;
     }
 
+    // We need previous values of N for Adams-Bashforth so keep it in the
+    // restart database.
     registerVariable(d_N_old_current_idx,
                      d_N_old_new_idx,
                      d_N_old_scratch_idx,


### PR DESCRIPTION
Follow-up to a conversation I had with @marshallrdavey - it turns out that most of the stuff we store in a restart database is never actually read. Removing things we don't ever use, like plot-only variables, shrinks its size by about 50%.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format run?
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?