### PR TITLE
Add some more documentation on clang-format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Bugs and Other Issues
 
 Please use the GitHub issue tracking system to report bugs, feature requests, or other issues with IBAMR.
 
+Writing patches
+---------------
+
+IBAMR has a core group of developers but also regularly takes contributions from our students as well as outside users.
+All patches undergo a peer review process and are usually accepted after some minor revisions.
+To ensure style uniformity, we require that users run `make indent` (or make the fixes indicated by the continous integration run).
+For more information on how this process works see `scripts/formatting/README.md`.
+
 Acknowledgments
 ---------------
 

--- a/doc/pull_request_template.md
+++ b/doc/pull_request_template.md
@@ -9,7 +9,8 @@ code. Thanks in advance for helping to make IBAMR better!
 
 ### IBAMR Pull Request Checklist
 - [ ] Does the test suite pass?
-- [ ] Was clang-format (i.e., `make indent`) run?
+- [ ] Was clang-format (i.e., `make indent`) run? For more information see
+      `scripts/formatting/README.md`.
 - [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
       the issue automatically if we are fixing the problem.
 - [ ] Is this a change others will want to know about? If so, then has a


### PR DESCRIPTION
This makes things a little clearer. One thing we need to manually do now is make sure that all the outstanding PR authors are aware that they will need to run `make indent` since updating the checklist on `master` does not update it in their PRs.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

It's an infrastructure change so the normal checklist doesn't apply.