### PR TITLE
Only compute vorticity when we need it.

### DIFF
--- a/doc/news/changes/minor/20240515DavidWells
+++ b/doc/news/changes/minor/20240515DavidWells
@@ -1,0 +1,4 @@
+Improved: Classes derived from INSHierarchyIntegrator only compute the
+vorticity when they need to instead of at the end of every time step.
+<br>
+(David Wells, 2024/05/15)

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -825,6 +825,14 @@ HierarchyIntegrator::initializeLevelData(const Pointer<BasePatchHierarchy<NDIM> 
     // Initialize level data at the initial time.
     if (initial_time)
     {
+        // Initialize or reset the hierarchy math operations object.
+        d_hier_math_ops = buildHierarchyMathOps(hierarchy);
+        if (d_manage_hier_math_ops)
+        {
+            d_hier_math_ops->setPatchHierarchy(hierarchy);
+            d_hier_math_ops->resetLevels(0, std::max(level_number, hierarchy->getFinestLevelNumber()));
+        }
+
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         for (const auto& var : d_state_variables)
         {

--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -130,6 +130,7 @@ HierarchyIntegrator::HierarchyIntegrator(std::string object_name, Pointer<Databa
     d_current_context = var_db->getContext(d_object_name + "::CURRENT");
     d_new_context = var_db->getContext(d_object_name + "::NEW");
     d_scratch_context = var_db->getContext(d_object_name + "::SCRATCH");
+    d_plot_context = var_db->getContext(d_object_name + "::PLOT");
 
     // Create default communications algorithms.
     d_coarsen_algs[SYNCH_CURRENT_DATA_ALG] = new CoarsenAlgorithm<NDIM>();

--- a/include/ibamr/INSCollocatedHierarchyIntegrator.h
+++ b/include/ibamr/INSCollocatedHierarchyIntegrator.h
@@ -308,7 +308,6 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Div_U_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Div_u_ADV_var;
 
-    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Omega_Norm_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Grad_P_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Phi_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Grad_Phi_cc_var;
@@ -348,7 +347,7 @@ private:
      *
      * Scratch variables have only one context: scratch.
      */
-    int d_Omega_Norm_idx, d_Grad_P_idx, d_Phi_idx, d_Grad_Phi_cc_idx, d_Grad_Phi_fc_idx, d_F_div_idx;
+    int d_Grad_P_idx, d_Phi_idx, d_Grad_Phi_cc_idx, d_Grad_Phi_fc_idx, d_F_div_idx;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/INSHierarchyIntegrator.h
+++ b/include/ibamr/INSHierarchyIntegrator.h
@@ -453,6 +453,13 @@ protected:
     double getMaximumVorticityMagnitude(const int Omega_idx);
 
     /*!
+     * Tag cells based on the vorticity magnitude.
+     *
+     * @note This function is typically called by applyGradientDetectorSpecialized() in inheriting classes.
+     */
+    void tagCellsByVorticityMagnitude(const int level_number, const int Omega_idx, const int tag_idx);
+
+    /*!
      * Return the maximum stable time step size.
      */
     double getMaximumTimeStepSizeSpecialized() override;

--- a/include/ibamr/INSHierarchyIntegrator.h
+++ b/include/ibamr/INSHierarchyIntegrator.h
@@ -530,7 +530,6 @@ protected:
      */
     bool d_using_vorticity_tagging = false;
     SAMRAI::tbox::Array<double> d_Omega_rel_thresh, d_Omega_abs_thresh;
-    double d_Omega_max = 0.0;
 
     /*!
      * This boolean value determines whether the pressure is normalized to have

--- a/include/ibamr/INSHierarchyIntegrator.h
+++ b/include/ibamr/INSHierarchyIntegrator.h
@@ -446,6 +446,13 @@ protected:
     virtual void updateCurrentCFLNumber(const int data_idx, const double dt);
 
     /*!
+     * Compute the maximum vorticity magnitude at any given point.
+     *
+     * @note This function does not read ghost data from @p Omega_idx.
+     */
+    double getMaximumVorticityMagnitude(const int Omega_idx);
+
+    /*!
      * Return the maximum stable time step size.
      */
     double getMaximumTimeStepSizeSpecialized() override;

--- a/include/ibamr/INSStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSStaggeredHierarchyIntegrator.h
@@ -421,7 +421,6 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double> > d_Omega_nc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Div_U_var;
 
-    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Omega_Norm_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double> > d_U_regrid_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double> > d_U_src_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double> > d_indicator_var;
@@ -480,8 +479,8 @@ private:
      *
      * Scratch variables have only one context: scratch.
      */
-    int d_Omega_Norm_idx = IBTK::invalid_index, d_U_regrid_idx = IBTK::invalid_index, d_U_src_idx = IBTK::invalid_index,
-        d_indicator_idx = IBTK::invalid_index, d_F_div_idx = IBTK::invalid_index;
+    int d_U_regrid_idx = IBTK::invalid_index, d_U_src_idx = IBTK::invalid_index, d_indicator_idx = IBTK::invalid_index,
+        d_F_div_idx = IBTK::invalid_index;
 };
 } // namespace IBAMR
 

--- a/include/ibamr/INSVCStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSVCStaggeredHierarchyIntegrator.h
@@ -589,7 +589,6 @@ protected:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Omega_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Div_U_var;
 
-    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Omega_Norm_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double> > d_U_regrid_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double> > d_U_src_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double> > d_indicator_var;
@@ -683,7 +682,7 @@ protected:
      *
      * Scratch variables have only one context: scratch.
      */
-    int d_Omega_Norm_idx, d_U_regrid_idx, d_U_src_idx, d_indicator_idx, d_F_div_idx;
+    int d_U_regrid_idx, d_U_src_idx, d_indicator_idx, d_F_div_idx;
     int d_velocity_C_idx, d_velocity_L_idx, d_velocity_D_idx, d_velocity_D_cc_idx, d_pressure_D_idx;
     int d_velocity_rhs_C_idx, d_velocity_rhs_D_idx, d_pressure_rhs_D_idx;
     int d_mu_interp_idx;

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1448,12 +1448,11 @@ INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(const double cur
         synchronizeHierarchyData(NEW_DATA);
     }
 
-    // Compute max |Omega|_2.
+    // Compute Omega.
     if (d_using_vorticity_tagging)
     {
         d_hier_cc_data_ops->copyData(d_U_scratch_idx, d_U_new_idx);
         d_hier_math_ops->curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, new_time);
-        d_Omega_max = getMaximumVorticityMagnitude(d_Omega_idx);
     }
 
     // Deallocate scratch data.
@@ -1589,14 +1588,10 @@ INSCollocatedHierarchyIntegrator::initializeLevelDataSpecialized(
                              d_no_fill_op,
                              init_data_time);
 
-        // Initialize the maximum value of |Omega|_2 on the grid.
+        // Initialize Omega.
         if (d_using_vorticity_tagging)
         {
-            if (level_number == 0) d_Omega_max = 0.0;
-
-            // Compute max |Omega|_2.
             hier_math_ops.curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, init_data_time);
-            d_Omega_max = getMaximumVorticityMagnitude(d_Omega_idx);
         }
 
         // Deallocate scratch data.

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1701,65 +1701,16 @@ INSCollocatedHierarchyIntegrator::applyGradientDetectorSpecialized(const Pointer
                                                                    const bool /*uses_richardson_extrapolation_too*/)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(hierarchy);
+    TBOX_ASSERT(d_hierarchy == hierarchy);
     TBOX_ASSERT((level_number >= 0) && (level_number <= hierarchy->getFinestLevelNumber()));
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
 #endif
-    Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
 
-    // Tag cells based on the magnitude of the vorticity.
-    //
-    // Note that if either the relative or absolute threshold is zero for a
-    // particular level, no tagging is performed on that level.
     if (d_using_vorticity_tagging)
     {
-        double Omega_rel_thresh = 0.0;
-        if (d_Omega_rel_thresh.size() > 0)
-        {
-            Omega_rel_thresh = d_Omega_rel_thresh[std::max(std::min(level_number, d_Omega_rel_thresh.size() - 1), 0)];
-        }
-        double Omega_abs_thresh = 0.0;
-        if (d_Omega_abs_thresh.size() > 0)
-        {
-            Omega_abs_thresh = d_Omega_abs_thresh[std::max(std::min(level_number, d_Omega_abs_thresh.size() - 1), 0)];
-        }
-        if (Omega_rel_thresh > 0.0 || Omega_abs_thresh > 0.0)
-        {
-            double thresh = std::numeric_limits<double>::max();
-            if (Omega_rel_thresh > 0.0) thresh = std::min(thresh, Omega_rel_thresh * d_Omega_max);
-            if (Omega_abs_thresh > 0.0) thresh = std::min(thresh, Omega_abs_thresh);
-            thresh += std::sqrt(std::numeric_limits<double>::epsilon());
-            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
-            {
-                Pointer<Patch<NDIM> > patch = level->getPatch(p());
-                const Box<NDIM>& patch_box = patch->getBox();
-                Pointer<CellData<NDIM, int> > tags_data = patch->getPatchData(tag_index);
-                Pointer<CellData<NDIM, double> > Omega_data = patch->getPatchData(d_Omega_idx);
-                for (CellIterator<NDIM> ic(patch_box); ic; ic++)
-                {
-                    const hier::Index<NDIM>& i = ic();
-#if (NDIM == 2)
-                    if (std::abs((*Omega_data)(i)) > thresh)
-                    {
-                        (*tags_data)(i) = 1;
-                    }
-#endif
-#if (NDIM == 3)
-                    double norm_Omega_sq = 0.0;
-                    for (unsigned int d = 0; d < NDIM; ++d)
-                    {
-                        norm_Omega_sq += (*Omega_data)(i, d) * (*Omega_data)(i, d);
-                    }
-                    const double norm_Omega = std::sqrt(norm_Omega_sq);
-                    if (norm_Omega > thresh)
-                    {
-                        (*tags_data)(i) = 1;
-                    }
-#endif
-                }
-            }
-        }
+        tagCellsByVorticityMagnitude(level_number, d_Omega_idx, tag_index);
     }
+
     return;
 } // applyGradientDetectorSpecialized
 

--- a/src/navier_stokes/INSHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSHierarchyIntegrator.cpp
@@ -65,7 +65,7 @@ namespace IBAMR
 namespace
 {
 // Version of INSHierarchyIntegrator restart file data.
-static const int INS_HIERARCHY_INTEGRATOR_VERSION = 3;
+static const int INS_HIERARCHY_INTEGRATOR_VERSION = 4;
 } // namespace
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
@@ -613,6 +613,7 @@ void
 INSHierarchyIntegrator::tagCellsByVorticityMagnitude(const int level_number, const int Omega_idx, const int tag_idx)
 {
     Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(level_number);
+    const double Omega_max = getMaximumVorticityMagnitude(Omega_idx);
 
     // Tag cells based on the magnitude of the vorticity.
     //
@@ -631,7 +632,7 @@ INSHierarchyIntegrator::tagCellsByVorticityMagnitude(const int level_number, con
     if (Omega_rel_thresh > 0.0 || Omega_abs_thresh > 0.0)
     {
         double thresh = std::numeric_limits<double>::max();
-        if (Omega_rel_thresh > 0.0) thresh = std::min(thresh, Omega_rel_thresh * d_Omega_max);
+        if (Omega_rel_thresh > 0.0) thresh = std::min(thresh, Omega_rel_thresh * Omega_max);
         if (Omega_abs_thresh > 0.0) thresh = std::min(thresh, Omega_abs_thresh);
         thresh += std::sqrt(std::numeric_limits<double>::epsilon());
         for (PatchLevel<NDIM>::Iterator p(level); p; p++)
@@ -713,7 +714,6 @@ INSHierarchyIntegrator::putToDatabaseSpecialized(Pointer<Database> db)
     db->putBool("d_using_vorticity_tagging", d_using_vorticity_tagging);
     if (d_Omega_rel_thresh.size() > 0) db->putDoubleArray("d_Omega_rel_thresh", d_Omega_rel_thresh);
     if (d_Omega_abs_thresh.size() > 0) db->putDoubleArray("d_Omega_abs_thresh", d_Omega_abs_thresh);
-    db->putDouble("d_Omega_max", d_Omega_max);
     db->putBool("d_normalize_pressure", d_normalize_pressure);
     db->putBool("d_normalize_velocity", d_normalize_velocity);
     db->putString("d_convective_op_type", d_convective_op_type);
@@ -980,7 +980,6 @@ INSHierarchyIntegrator::getFromRestart()
         d_Omega_abs_thresh = db->getDoubleArray("d_Omega_abs_thresh");
     else
         d_Omega_abs_thresh.resizeArray(0);
-    d_Omega_max = db->getDouble("d_Omega_max");
     d_normalize_pressure = db->getBool("d_normalize_pressure");
     d_normalize_velocity = db->getBool("d_normalize_velocity");
     d_convective_op_type = db->getString("d_convective_op_type");

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1375,15 +1375,14 @@ INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double curr
         }
 
         d_hier_math_ops->curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, new_time);
-        if (d_Omega_Norm_idx != IBTK::invalid_index)
-            d_hier_math_ops->pointwiseL2Norm(d_Omega_Norm_idx, d_Omega_Norm_var, d_Omega_idx, d_Omega_var);
         const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
-        if (NDIM == 2)
+        if (d_Omega_Norm_idx == IBTK::invalid_index)
         {
             d_Omega_max = d_hier_cc_data_ops->maxNorm(d_Omega_idx, wgt_cc_idx);
         }
         else
         {
+            d_hier_math_ops->pointwiseL2Norm(d_Omega_Norm_idx, d_Omega_Norm_var, d_Omega_idx, d_Omega_var);
             d_Omega_max = d_hier_cc_data_ops->max(d_Omega_Norm_idx, wgt_cc_idx);
         }
     }
@@ -1928,15 +1927,14 @@ INSStaggeredHierarchyIntegrator::initializeLevelDataSpecialized(const Pointer<Ba
 
             HierarchyMathOps hier_math_ops(d_object_name + "::HierarchyLevelMathOps", d_hierarchy, 0, level_number);
             hier_math_ops.curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, init_data_time);
-            if (d_Omega_Norm_idx != IBTK::invalid_index)
-                hier_math_ops.pointwiseL2Norm(d_Omega_Norm_idx, d_Omega_Norm_var, d_Omega_idx, d_Omega_var);
             const int wgt_cc_idx = hier_math_ops.getCellWeightPatchDescriptorIndex();
-            if (NDIM == 2)
+            if (d_Omega_Norm_idx == IBTK::invalid_index)
             {
                 d_Omega_max = hier_cc_data_ops->maxNorm(d_Omega_idx, wgt_cc_idx);
             }
             else
             {
+                hier_math_ops.pointwiseL2Norm(d_Omega_Norm_idx, d_Omega_Norm_var, d_Omega_idx, d_Omega_var);
                 d_Omega_max = hier_cc_data_ops->max(d_Omega_Norm_idx, wgt_cc_idx);
             }
 

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -932,7 +932,7 @@ INSStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHier
     // Register scratch variables that are maintained by the
     // INSStaggeredHierarchyIntegrator.
     if (NDIM == 3)
-        registerVariable(d_Omega_Norm_idx, d_Omega_Norm_var, no_ghosts);
+        registerVariable(d_Omega_Norm_idx, d_Omega_Norm_var, no_ghosts, getScratchContext(), false);
     else
         d_Omega_Norm_idx = IBTK::invalid_index;
     registerVariable(d_U_regrid_idx, d_U_regrid_var, CartSideDoubleDivPreservingRefine::REFINE_OP_STENCIL_WIDTH);

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -920,7 +920,7 @@ INSStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHier
     {
         d_F_cc_idx = invalid_index;
     }
-    registerVariable(d_Omega_idx, d_Omega_var, no_ghosts, getCurrentContext(), false);
+    registerVariable(d_Omega_idx, d_Omega_var, no_ghosts, getScratchContext(), false);
     if (d_output_Omega)
     {
         registerVariable(d_Omega_nc_idx, d_Omega_nc_var, no_ghosts, getPlotContext());
@@ -1356,20 +1356,6 @@ INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double curr
         if (d_enable_logging)
             plog << d_object_name << "::postprocessIntegrateHierarchy(): synchronizing updated data\n";
         synchronizeHierarchyData(NEW_DATA);
-    }
-
-    // Compute Omega.
-    if (d_using_vorticity_tagging)
-    {
-        d_hier_sc_data_ops->copyData(d_U_scratch_idx, d_U_new_idx);
-
-        for (int ln = 0; ln <= d_hierarchy->getFinestLevelNumber(); ++ln)
-        {
-            Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-            if (!level->checkAllocated(d_Omega_idx)) level->allocatePatchData(d_Omega_idx);
-        }
-
-        d_hier_math_ops->curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, new_time);
     }
 
     // Deallocate scratch data.
@@ -1866,56 +1852,6 @@ INSStaggeredHierarchyIntegrator::initializeLevelDataSpecialized(const Pointer<Ba
         if (old_level) old_level->deallocatePatchData(scratch_data);
     }
 
-    // Initialize level data at the initial time.
-    if (initial_time)
-    {
-        // Initialize Omega.
-        if (d_using_vorticity_tagging)
-        {
-            // Allocate scratch data.
-            for (int ln = 0; ln <= level_number; ++ln)
-            {
-                hierarchy->getPatchLevel(ln)->allocatePatchData(d_U_scratch_idx, init_data_time);
-            }
-
-            // Fill ghost cells.
-            HierarchyDataOpsManager<NDIM>* hier_ops_manager = HierarchyDataOpsManager<NDIM>::getManager();
-            Pointer<HierarchyCellDataOpsReal<NDIM, double> > hier_cc_data_ops =
-                hier_ops_manager->getOperationsDouble(d_Omega_var, d_hierarchy, true);
-            Pointer<HierarchySideDataOpsReal<NDIM, double> > hier_sc_data_ops =
-                hier_ops_manager->getOperationsDouble(d_U_var, d_hierarchy, true);
-            hier_sc_data_ops->resetLevels(0, level_number);
-            hier_sc_data_ops->copyData(d_U_scratch_idx, d_U_current_idx);
-            using InterpolationTransactionComponent =
-                HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
-            InterpolationTransactionComponent U_bc_component(d_U_scratch_idx,
-                                                             DATA_REFINE_TYPE,
-                                                             USE_CF_INTERPOLATION,
-                                                             DATA_COARSEN_TYPE,
-                                                             d_bdry_extrap_type, // TODO: update variable name
-                                                             CONSISTENT_TYPE_2_BDRY,
-                                                             d_U_bc_coefs);
-            HierarchyGhostCellInterpolation U_bdry_bc_fill_op;
-            U_bdry_bc_fill_op.initializeOperatorState(U_bc_component, d_hierarchy, 0, level_number);
-            U_bdry_bc_fill_op.fillData(init_data_time);
-
-            // Compute max |Omega|_2.
-            for (int ln = 0; ln <= d_hierarchy->getFinestLevelNumber(); ++ln)
-            {
-                Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-                if (!level->checkAllocated(d_Omega_idx)) level->allocatePatchData(d_Omega_idx);
-            }
-
-            HierarchyMathOps hier_math_ops(d_object_name + "::HierarchyLevelMathOps", d_hierarchy, 0, level_number);
-            hier_math_ops.curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, init_data_time);
-
-            // Deallocate scratch data.
-            for (int ln = 0; ln <= level_number; ++ln)
-            {
-                hierarchy->getPatchLevel(ln)->deallocatePatchData(d_U_scratch_idx);
-            }
-        }
-    }
     return;
 } // initializeLevelDataSpecialized
 
@@ -2012,7 +1948,7 @@ INSStaggeredHierarchyIntegrator::resetHierarchyConfigurationSpecialized(
 void
 INSStaggeredHierarchyIntegrator::applyGradientDetectorSpecialized(const Pointer<BasePatchHierarchy<NDIM> > hierarchy,
                                                                   const int level_number,
-                                                                  const double /*error_data_time*/,
+                                                                  const double error_data_time,
                                                                   const int tag_index,
                                                                   const bool /*initial_time*/,
                                                                   const bool /*uses_richardson_extrapolation_too*/)
@@ -2025,7 +1961,26 @@ INSStaggeredHierarchyIntegrator::applyGradientDetectorSpecialized(const Pointer<
 
     if (d_using_vorticity_tagging)
     {
+        // To do tagging we may need to coarsen data to fill ghost values or
+        // prolong data to covered cells - i.e., even though we are given
+        // level_number, we need to compute across the whole hierarchy.
+        for (int ln = 0; ln <= d_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+            level->allocatePatchData(d_Omega_idx, error_data_time);
+            level->allocatePatchData(d_U_scratch_idx, error_data_time);
+        }
+
+        d_hier_sc_data_ops->copyData(d_U_scratch_idx, d_U_current_idx);
+        d_hier_math_ops->curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, error_data_time);
         tagCellsByVorticityMagnitude(level_number, d_Omega_idx, tag_index);
+
+        for (int ln = 0; ln <= d_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+            level->deallocatePatchData(d_Omega_idx);
+            level->deallocatePatchData(d_U_scratch_idx);
+        }
     }
 
     return;

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -2022,57 +2022,16 @@ INSStaggeredHierarchyIntegrator::applyGradientDetectorSpecialized(const Pointer<
                                                                   const bool /*uses_richardson_extrapolation_too*/)
 {
 #if !defined(NDEBUG)
-    TBOX_ASSERT(hierarchy);
+    TBOX_ASSERT(d_hierarchy == hierarchy);
     TBOX_ASSERT((level_number >= 0) && (level_number <= hierarchy->getFinestLevelNumber()));
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
 #endif
-    Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(level_number);
 
-    // Tag cells based on the magnitude of the vorticity.
-    //
-    // Note that if either the relative or absolute threshold is zero for a
-    // particular level, no tagging is performed on that level.
     if (d_using_vorticity_tagging)
     {
-        double Omega_rel_thresh = 0.0;
-        if (d_Omega_rel_thresh.size() > 0)
-        {
-            Omega_rel_thresh = d_Omega_rel_thresh[std::max(std::min(level_number, d_Omega_rel_thresh.size() - 1), 0)];
-        }
-        double Omega_abs_thresh = 0.0;
-        if (d_Omega_abs_thresh.size() > 0)
-        {
-            Omega_abs_thresh = d_Omega_abs_thresh[std::max(std::min(level_number, d_Omega_abs_thresh.size() - 1), 0)];
-        }
-        if (Omega_rel_thresh > 0.0 || Omega_abs_thresh > 0.0)
-        {
-            double thresh = std::numeric_limits<double>::max();
-            if (Omega_rel_thresh > 0.0) thresh = std::min(thresh, Omega_rel_thresh * d_Omega_max);
-            if (Omega_abs_thresh > 0.0) thresh = std::min(thresh, Omega_abs_thresh);
-            thresh += std::sqrt(std::numeric_limits<double>::epsilon());
-            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
-            {
-                Pointer<Patch<NDIM> > patch = level->getPatch(p());
-                const Box<NDIM>& patch_box = patch->getBox();
-                Pointer<CellData<NDIM, int> > tags_data = patch->getPatchData(tag_index);
-                Pointer<CellData<NDIM, double> > Omega_data = patch->getPatchData(d_Omega_idx);
-                for (CellIterator<NDIM> ic(patch_box); ic; ic++)
-                {
-                    const hier::Index<NDIM>& i = ic();
-                    double norm_Omega_sq = 0.0;
-                    for (unsigned int d = 0; d < (NDIM == 2 ? 1 : NDIM); ++d)
-                    {
-                        norm_Omega_sq += (*Omega_data)(i, d) * (*Omega_data)(i, d);
-                    }
-                    const double norm_Omega = std::sqrt(norm_Omega_sq);
-                    if (norm_Omega > thresh)
-                    {
-                        (*tags_data)(i) = 1;
-                    }
-                }
-            }
-        }
+        tagCellsByVorticityMagnitude(level_number, d_Omega_idx, tag_index);
     }
+
     return;
 } // applyGradientDetectorSpecialized
 

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1358,7 +1358,7 @@ INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double curr
         synchronizeHierarchyData(NEW_DATA);
     }
 
-    // Compute max |Omega|_2.
+    // Compute Omega.
     if (d_using_vorticity_tagging)
     {
         d_hier_sc_data_ops->copyData(d_U_scratch_idx, d_U_new_idx);
@@ -1370,7 +1370,6 @@ INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double curr
         }
 
         d_hier_math_ops->curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, new_time);
-        d_Omega_max = getMaximumVorticityMagnitude(d_Omega_idx);
     }
 
     // Deallocate scratch data.
@@ -1870,11 +1869,9 @@ INSStaggeredHierarchyIntegrator::initializeLevelDataSpecialized(const Pointer<Ba
     // Initialize level data at the initial time.
     if (initial_time)
     {
-        // Initialize the maximum value of |Omega|_2 on the grid.
+        // Initialize Omega.
         if (d_using_vorticity_tagging)
         {
-            if (level_number == 0) d_Omega_max = 0.0;
-
             // Allocate scratch data.
             for (int ln = 0; ln <= level_number; ++ln)
             {
@@ -1911,7 +1908,6 @@ INSStaggeredHierarchyIntegrator::initializeLevelDataSpecialized(const Pointer<Ba
 
             HierarchyMathOps hier_math_ops(d_object_name + "::HierarchyLevelMathOps", d_hierarchy, 0, level_number);
             hier_math_ops.curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, init_data_time);
-            d_Omega_max = getMaximumVorticityMagnitude(d_Omega_idx);
 
             // Deallocate scratch data.
             for (int ln = 0; ln <= level_number; ++ln)

--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -1230,12 +1230,11 @@ INSVCStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double cu
         synchronizeHierarchyData(NEW_DATA);
     }
 
-    // Compute max |Omega|_2.
+    // Compute Omega.
     if (d_using_vorticity_tagging)
     {
         d_hier_sc_data_ops->copyData(d_U_scratch_idx, d_U_new_idx);
         d_hier_math_ops->curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, new_time);
-        d_Omega_max = getMaximumVorticityMagnitude(d_Omega_idx);
     }
 
     // Deallocate scratch data.
@@ -1635,11 +1634,9 @@ INSVCStaggeredHierarchyIntegrator::initializeLevelDataSpecialized(
     // Initialize level data at the initial time.
     if (initial_time)
     {
-        // Initialize the maximum value of |Omega|_2 on the grid.
+        // Initialize Omega.
         if (d_using_vorticity_tagging)
         {
-            if (level_number == 0) d_Omega_max = 0.0;
-
             // Allocate scratch data.
             for (int ln = 0; ln <= level_number; ++ln)
             {
@@ -1670,7 +1667,6 @@ INSVCStaggeredHierarchyIntegrator::initializeLevelDataSpecialized(
             // Compute max |Omega|_2.
             HierarchyMathOps hier_math_ops(d_object_name + "::HierarchyLevelMathOps", d_hierarchy, 0, level_number);
             hier_math_ops.curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, init_data_time);
-            d_Omega_max = getMaximumVorticityMagnitude(d_Omega_idx);
 
             // Deallocate scratch data.
             for (int ln = 0; ln <= level_number; ++ln)

--- a/tests/navier_stokes/navier_stokes_01_2d.collocated.input
+++ b/tests/navier_stokes/navier_stokes_01_2d.collocated.input
@@ -1,0 +1,256 @@
+// physical parameters
+MU  = 1.0e-2                              // fluid viscosity
+RHO = 1.0                                 // fluid density
+L   = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// solver parameters
+SOLVER_TYPE        = "COLLOCATED"         // the fluid solver to use (STAGGERED or COLLOCATED)
+CFL_MAX            = 0.3                  // maximum CFL number
+DT_MAX             = 0.0625/NFINEST       // maximum timestep size
+START_TIME         = 0.0e0                // initial simulation time
+END_TIME           = 0.01                 // final simulation time
+GROW_DT            = 2.0e0                // growth factor for timesteps
+NUM_CYCLES         = 1                    // number of cycles of fixed-point iteration
+CONVECTIVE_TS_TYPE = "ADAMS_BASHFORTH"    // convective time stepping type
+CONVECTIVE_OP_TYPE = "PPM"                // convective differencing discretization type
+CONVECTIVE_FORM    = "ADVECTIVE"          // how to compute the convective terms
+NORMALIZE_PRESSURE = TRUE                 // whether to explicitly force the pressure to have mean zero
+VORTICITY_TAGGING  = FALSE                // whether to tag cells for refinement based on vorticity thresholds
+TAG_BUFFER         = 1                    // sized of tag buffer used by grid generation algorithm
+REGRID_INTERVAL    = 10000000             // effectively disable regridding
+OUTPUT_U           = TRUE
+OUTPUT_P           = TRUE
+OUTPUT_F           = FALSE
+OUTPUT_OMEGA       = TRUE
+OUTPUT_DIV_U       = TRUE
+ENABLE_LOGGING     = TRUE
+
+// collocated solver parameters
+PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
+SECOND_ORDER_PRESSURE_UPDATE = TRUE
+
+// exact solution function expressions
+U = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)"
+V = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)"
+P = "-(cos(4*PI*(X_0-t)) + cos(4*PI*(X_1-t)))*exp(-16*PI*PI*nu*t)"
+
+// normal tractions
+T_n_X_0 = "(cos(4*PI*(X_0-t))+cos(4*PI*(X_1-t)))*exp(-16*PI^2*nu*t)+8*nu*sin(2*PI*(X_0-t))*PI*sin(2*PI*(X_1-t))*exp(-8*PI^2*nu*t)"
+T_n_X_1 = "(cos(4*PI*(X_0-t))+cos(4*PI*(X_1-t)))*exp(-16*PI^2*nu*t)-8*nu*sin(2*PI*(X_0-t))*PI*sin(2*PI*(X_1-t))*exp(-8*PI^2*nu*t)"
+
+// tangential tractions
+T_t = "0.0"
+
+VelocityInitialConditions {
+   nu = MU/RHO
+   function_0 = U
+   function_1 = V
+}
+
+VelocityBcCoefs_0 {
+   nu = MU/RHO
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = U
+   gcoef_function_1 = U
+   gcoef_function_2 = U
+   gcoef_function_3 = U
+}
+
+VelocityBcCoefs_1 {
+   nu = MU/RHO
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = V
+   gcoef_function_1 = V
+   gcoef_function_2 = V
+   gcoef_function_3 = V
+}
+
+PressureInitialConditions {
+   nu = MU/RHO
+   function = P
+}
+
+INSCollocatedHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   num_cycles                    = NUM_CYCLES
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT_MAX
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_rel_thresh          = 0.25,0.125
+   tag_buffer                    = TAG_BUFFER
+   regrid_interval               = REGRID_INTERVAL
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+   projection_method_type        = PROJECTION_METHOD_TYPE
+   use_2nd_order_pressure_update = SECOND_ORDER_PRESSURE_UPDATE
+
+   velocity_solver_type = "PETSC_KRYLOV_SOLVER"
+   velocity_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   velocity_solver_db {
+      ksp_type = "fgmres"
+   }
+   velocity_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+
+   pressure_solver_type = "PETSC_KRYLOV_SOLVER"
+   pressure_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   pressure_solver_db {
+      ksp_type = "fgmres"
+   }
+   pressure_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+
+   regrid_projection_solver_type = "PETSC_KRYLOV_SOLVER"
+   regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   regrid_projection_solver_db {
+      ksp_type = "fgmres"
+   }
+   regrid_projection_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+}
+
+Main {
+   solver_type = SOLVER_TYPE
+
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = int(END_TIME/(3*DT_MAX))
+   viz_dump_dirname            = "viz_INS2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+//    level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+//    level_0 = [(0,0),(N/2 - 1,N/2 - 1)]
+      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/navier_stokes/navier_stokes_01_2d.collocated.output
+++ b/tests/navier_stokes/navier_stokes_01_2d.collocated.output
@@ -1,0 +1,643 @@
+INSCollocatedHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1
+INSCollocatedHierarchyIntegrator::regridProjection(): projection solve number of iterations = 7
+INSCollocatedHierarchyIntegrator::regridProjection(): projection solve residual norm        = 8.34761e-05
+Input database:
+input_db {
+   MU                           = 0.01                      // input used
+   RHO                          = 1                         // input used
+   L                            = 1                         // input used
+   MAX_LEVELS                   = 2                         // input used
+   REF_RATIO                    = 4                         // input used
+   N                            = 32                        // input used
+   NFINEST                      = 128                       // input used
+   SOLVER_TYPE                  = "COLLOCATED"              // input used
+   CFL_MAX                      = 0.3                       // input used
+   DT_MAX                       = 0.000488281               // input used
+   START_TIME                   = 0                         // input used
+   END_TIME                     = 0.01                      // input used
+   GROW_DT                      = 2                         // input used
+   NUM_CYCLES                   = 1                         // input used
+   CONVECTIVE_TS_TYPE           = "ADAMS_BASHFORTH"         // input used
+   CONVECTIVE_OP_TYPE           = "PPM"                     // input used
+   CONVECTIVE_FORM              = "ADVECTIVE"               // input used
+   NORMALIZE_PRESSURE           = TRUE                      // input used
+   VORTICITY_TAGGING            = FALSE                     // input used
+   TAG_BUFFER                   = 1                         // input used
+   REGRID_INTERVAL              = 10000000                  // input used
+   OUTPUT_U                     = TRUE                      // input used
+   OUTPUT_P                     = TRUE                      // input used
+   OUTPUT_F                     = FALSE                     // input used
+   OUTPUT_OMEGA                 = TRUE                      // input used
+   OUTPUT_DIV_U                 = TRUE                      // input used
+   ENABLE_LOGGING               = TRUE                      // input used
+   PROJECTION_METHOD_TYPE       = "PRESSURE_UPDATE"         // input used
+   SECOND_ORDER_PRESSURE_UPDATE = TRUE                      // input used
+   U                            = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+   V                            = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+   P                            = "-(cos(4*PI*(X_0-t)) + cos(4*PI*(X_1-t)))*exp(-16*PI*PI*nu*t)" // input used
+   T_n_X_0                      = "(cos(4*PI*(X_0-t))+cos(4*PI*(X_1-t)))*exp(-16*PI^2*nu*t)+8*nu*sin(2*PI*(X_0-t))*PI*sin(2*PI*(X_1-t))*exp(-8*PI^2*nu*t)" // input not used
+   T_n_X_1                      = "(cos(4*PI*(X_0-t))+cos(4*PI*(X_1-t)))*exp(-16*PI^2*nu*t)-8*nu*sin(2*PI*(X_0-t))*PI*sin(2*PI*(X_1-t))*exp(-8*PI^2*nu*t)" // input not used
+   T_t                          = "0.0"                     // input not used
+   VelocityInitialConditions {
+      nu         = 0.01                                     // input used
+      function_0 = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      function_1 = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+   }
+   VelocityBcCoefs_0 {
+      nu               = 0.01                               // input used
+      acoef_function_0 = "1.0"                              // input used
+      acoef_function_1 = "1.0"                              // input used
+      acoef_function_2 = "1.0"                              // input used
+      acoef_function_3 = "1.0"                              // input used
+      bcoef_function_0 = "0.0"                              // input used
+      bcoef_function_1 = "0.0"                              // input used
+      bcoef_function_2 = "0.0"                              // input used
+      bcoef_function_3 = "0.0"                              // input used
+      gcoef_function_0 = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_1 = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_2 = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_3 = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+   }
+   VelocityBcCoefs_1 {
+      nu               = 0.01                               // input used
+      acoef_function_0 = "1.0"                              // input used
+      acoef_function_1 = "1.0"                              // input used
+      acoef_function_2 = "1.0"                              // input used
+      acoef_function_3 = "1.0"                              // input used
+      bcoef_function_0 = "0.0"                              // input used
+      bcoef_function_1 = "0.0"                              // input used
+      bcoef_function_2 = "0.0"                              // input used
+      bcoef_function_3 = "0.0"                              // input used
+      gcoef_function_0 = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_1 = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_2 = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_3 = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+   }
+   PressureInitialConditions {
+      nu       = 0.01                                       // input used
+      function = "-(cos(4*PI*(X_0-t)) + cos(4*PI*(X_1-t)))*exp(-16*PI*PI*nu*t)" // input used
+   }
+   INSCollocatedHierarchyIntegrator {
+      mu                             = 0.01                 // input used
+      rho                            = 1                    // input used
+      start_time                     = 0                    // input used
+      end_time                       = 0.01                 // input used
+      grow_dt                        = 2                    // input used
+      num_cycles                     = 1                    // input used
+      convective_time_stepping_type  = "ADAMS_BASHFORTH"    // input used
+      convective_op_type             = "PPM"                // input used
+      convective_difference_form     = "ADVECTIVE"          // input used
+      normalize_pressure             = TRUE                 // input used
+      cfl                            = 0.3                  // input used
+      dt_max                         = 0.000488281          // input used
+      using_vorticity_tagging        = FALSE                // input used
+      vorticity_rel_thresh           = 0.25, 0.125          // input used
+      tag_buffer                     = 1                    // input used
+      regrid_interval                = 10000000             // input used
+      output_U                       = TRUE                 // input used
+      output_P                       = TRUE                 // input used
+      output_F                       = FALSE                // input used
+      output_Omega                   = TRUE                 // input used
+      output_Div_U                   = TRUE                 // input used
+      enable_logging                 = TRUE                 // input used
+      projection_method_type         = "PRESSURE_UPDATE"    // input used
+      use_2nd_order_pressure_update  = TRUE                 // input used
+      velocity_solver_type           = "PETSC_KRYLOV_SOLVER" // input used
+      velocity_precond_type          = "POINT_RELAXATION_FAC_PRECONDITIONER" // input used
+      pressure_solver_type           = "PETSC_KRYLOV_SOLVER" // input used
+      pressure_precond_type          = "POINT_RELAXATION_FAC_PRECONDITIONER" // input used
+      regrid_projection_solver_type  = "PETSC_KRYLOV_SOLVER" // input used
+      regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER" // input used
+      velocity_solver_db {
+         ksp_type = "fgmres"                                // input used
+      }
+      velocity_precond_db {
+         num_pre_sweeps                 = 0                 // input used
+         num_post_sweeps                = 3                 // input used
+         prolongation_method            = "LINEAR_REFINE"   // input used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input used
+         coarse_solver_rel_residual_tol = 1e-12             // input used
+         coarse_solver_abs_residual_tol = 1e-50             // input used
+         coarse_solver_max_iterations   = 1                 // input used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input used
+            num_pre_relax_steps  = 0                        // input used
+            num_post_relax_steps = 3                        // input used
+            enable_logging       = FALSE                    // input used
+         }
+      }
+      pressure_solver_db {
+         ksp_type = "fgmres"                                // input used
+      }
+      pressure_precond_db {
+         num_pre_sweeps                 = 0                 // input used
+         num_post_sweeps                = 3                 // input used
+         prolongation_method            = "LINEAR_REFINE"   // input used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input used
+         coarse_solver_rel_residual_tol = 1e-12             // input used
+         coarse_solver_abs_residual_tol = 1e-50             // input used
+         coarse_solver_max_iterations   = 1                 // input used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input used
+            num_pre_relax_steps  = 0                        // input used
+            num_post_relax_steps = 3                        // input used
+            enable_logging       = FALSE                    // input used
+         }
+      }
+      regrid_projection_solver_db {
+         ksp_type = "fgmres"                                // input used
+      }
+      regrid_projection_precond_db {
+         num_pre_sweeps                 = 0                 // input used
+         num_post_sweeps                = 3                 // input used
+         prolongation_method            = "LINEAR_REFINE"   // input used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input used
+         coarse_solver_rel_residual_tol = 1e-12             // input used
+         coarse_solver_abs_residual_tol = 1e-50             // input used
+         coarse_solver_max_iterations   = 1                 // input used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input used
+            num_pre_relax_steps  = 0                        // input used
+            num_post_relax_steps = 3                        // input used
+            enable_logging       = FALSE                    // input used
+         }
+      }
+   }
+   Main {
+      solver_type                 = "COLLOCATED"            // input used
+      log_file_name               = "output"                // input used
+      log_all_nodes               = FALSE                   // input used
+      viz_writer                  = "VisIt"                 // input used
+      viz_dump_interval           = 6                       // input used
+      viz_dump_dirname            = "viz_INS2d"             // input used
+      visit_number_procs_per_file = 1                       // input used
+      restart_dump_interval       = 0                       // input used
+      restart_dump_dirname        = "restart_INS2d"         // input used
+      timer_dump_interval         = 0                       // input used
+   }
+   CartesianGeometry {
+      domain_boxes       = [(0,0),(31,31)]                  // input used
+      x_lo               = 0, 0                             // input used
+      x_up               = 1, 1                             // input used
+      periodic_dimension = 0, 0                             // input used
+   }
+   GriddingAlgorithm {
+      max_levels                = 2                         // input used
+      efficiency_tolerance      = 0.85                      // input used
+      combine_efficiency        = 0.85                      // input used
+      check_nonrefined_tags     = 'w'                       // from default
+      check_overlapping_patches = 'i'                       // from default
+      extend_tags_to_bdry       = FALSE                     // from default
+      ratio_to_coarser {
+         level_1 = 4, 4                                     // input used
+         level_2 = 4, 4                                     // input not used
+         level_3 = 4, 4                                     // input not used
+      }
+      largest_patch_size {
+         level_0 = 512, 512                                 // input used
+      }
+      smallest_patch_size {
+         level_0 = 4, 4                                     // input used
+      }
+   }
+   StandardTagAndInitialize {
+      tagging_method = "REFINE_BOXES"                       // input used
+      RefineBoxes {
+         level_0 = [(8,8),(23,15)], [(8,16),(15,23)]        // input used
+      }
+   }
+   LoadBalancer {
+      bin_pack_method                      = "SPATIAL"      // input used
+      max_workload_factor                  = 1              // input used
+      ignore_level_box_union_is_single_box = FALSE          // from default
+   }
+   TimerManager {
+      print_exclusive = FALSE                               // input not used
+      print_total     = TRUE                                // input not used
+      print_threshold = 0.1                                 // input not used
+      timer_list      = "IBAMR::*::*", "IBTK::*::*", "*::*::*" // input not used
+   }
+}
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 0
+Simulation time is 0
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0,0.000488281], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): regridding prior to timestep 0
+INSCollocatedHierarchyIntegrator::regridProjection(): projection solve number of iterations = 6
+INSCollocatedHierarchyIntegrator::regridProjection(): projection solve residual norm        = 6.4657e-05
+INSCollocatedHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
+INSCollocatedHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
+INSCollocatedHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): executing cycle 1 of 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 3.08981e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 7
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.159829
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): executing cycle 2 of 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 0.00103055
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 6
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.0323571
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187448
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 0
+Simulation time is 0.000488281
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 1
+Simulation time is 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.000488281,0.000976562], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 8.52725e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 8
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.035621
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187411
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 1
+Simulation time is 0.000976562
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 2
+Simulation time is 0.000976562
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.000976562,0.00146484], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 5.6763e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 6
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00868518
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.18736
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 2
+Simulation time is 0.00146484
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 3
+Simulation time is 0.00146484
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00146484,0.00195312], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 5.37011e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.0220206
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187306
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 3
+Simulation time is 0.00195312
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 4
+Simulation time is 0.00195312
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00195312,0.00244141], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 5.05862e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.0160035
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187244
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 4
+Simulation time is 0.00244141
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 5
+Simulation time is 0.00244141
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00244141,0.00292969], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 4.75444e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.0122116
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187175
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 5
+Simulation time is 0.00292969
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 6
+Simulation time is 0.00292969
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00292969,0.00341797], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 4.47058e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.0104084
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187098
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 6
+Simulation time is 0.00341797
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 7
+Simulation time is 0.00341797
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00341797,0.00390625], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 4.21472e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00865317
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187015
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 7
+Simulation time is 0.00390625
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 8
+Simulation time is 0.00390625
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00390625,0.00439453], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 3.97959e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00758944
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.186927
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 8
+Simulation time is 0.00439453
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 9
+Simulation time is 0.00439453
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00439453,0.00488281], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 3.76413e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00782278
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.186876
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 9
+Simulation time is 0.00488281
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 10
+Simulation time is 0.00488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00488281,0.00537109], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 3.56713e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.0078739
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.186822
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 10
+Simulation time is 0.00537109
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 11
+Simulation time is 0.00537109
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00537109,0.00585938], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 3.37791e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00775284
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.186766
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 11
+Simulation time is 0.00585938
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 12
+Simulation time is 0.00585938
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00585938,0.00634766], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 3.21013e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00713459
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.186708
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 12
+Simulation time is 0.00634766
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 13
+Simulation time is 0.00634766
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00634766,0.00683594], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 3.06845e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00642
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.18665
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 13
+Simulation time is 0.00683594
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 14
+Simulation time is 0.00683594
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00683594,0.00732422], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 2.94397e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00592146
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.18659
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 14
+Simulation time is 0.00732422
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 15
+Simulation time is 0.00732422
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00732422,0.0078125], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 2.83457e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00594471
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.186544
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 15
+Simulation time is 0.0078125
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 16
+Simulation time is 0.0078125
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.0078125,0.00830078], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 2.73741e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00535738
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.186501
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 16
+Simulation time is 0.00830078
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 17
+Simulation time is 0.00830078
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00830078,0.00878906], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 2.65052e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00453168
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.186458
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 17
+Simulation time is 0.00878906
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 18
+Simulation time is 0.00878906
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00878906,0.00927734], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 2.5747e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00409059
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.186414
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 18
+Simulation time is 0.00927734
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 19
+Simulation time is 0.00927734
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00927734,0.00976562], dt = 0.000488281
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 2
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 2.51048e-05
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 5
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00365554
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.186368
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 19
+Simulation time is 0.00976562
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 20
+Simulation time is 0.00976562
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): time interval = [0.00976562,0.01], dt = 0.000234375
+INSCollocatedHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing velocity subdomain solver
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve number of iterations = 1
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): velocity solve residual norm        = 0.0694872
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve number of iterations = 7
+INSCollocatedHierarchyIntegrator::integrateHierarchy(): pressure solve residual norm        = 0.00326079
+INSCollocatedHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.0894468
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSCollocatedHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 20
+Simulation time is 0.01
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+Computing error norms.
+
+Error in u at time 0.01:
+  L1-norm:  0.03582682469
+  L2-norm:  0.04207514607
+  max-norm: 0.1760614113
+Error in p at time 0.0098828125:
+  L1-norm:  0.1780861854
+  L2-norm:  0.2677864089
+  max-norm: 1.335612869
++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Part of #1697.

This PR consolidates all the ways we handle computing the vorticity for tagging into two places instead of scattering them around the INS classes. I also added some tests for the collocated solver since, surprisingly, there were none in the test suite.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?