### PR TITLE
add IMEX-BDF2-type time stepping

### DIFF
--- a/include/ibamr/INSStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/INSStaggeredHierarchyIntegrator.h
@@ -371,6 +371,11 @@ private:
     TimeSteppingType getConvectiveTimeSteppingType(int cycle_num);
 
     /*!
+     * Determine the time step size ratio.
+     */
+    double getTimeStepSizeRatio() const;
+
+    /*!
      * Hierarchy operations objects.
      */
     SAMRAI::tbox::Pointer<SAMRAI::math::HierarchyCellDataOpsReal<NDIM, double> > d_hier_cc_data_ops;
@@ -416,6 +421,7 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_F_cc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Q_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double> > d_N_old_var;
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double> > d_U_old_var;
 
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double> > d_Omega_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double> > d_Omega_nc_var;
@@ -451,6 +457,8 @@ private:
     int d_Q_current_idx = IBTK::invalid_index, d_Q_new_idx = IBTK::invalid_index, d_Q_scratch_idx = IBTK::invalid_index;
     int d_N_old_current_idx = IBTK::invalid_index, d_N_old_new_idx = IBTK::invalid_index,
         d_N_old_scratch_idx = IBTK::invalid_index;
+    int d_U_old_current_idx = IBTK::invalid_index, d_U_old_new_idx = IBTK::invalid_index,
+        d_U_old_scratch_idx = IBTK::invalid_index;
 
     /*
      * Patch data descriptor for state variables which are only present in the current context.

--- a/include/ibamr/ibamr_enums.h
+++ b/include/ibamr/ibamr_enums.h
@@ -284,6 +284,7 @@ enum TimeSteppingType
 {
     ADAMS_BASHFORTH,
     BACKWARD_EULER,
+    BDF2,
     FORWARD_EULER,
     MIDPOINT_RULE,
     TRAPEZOIDAL_RULE,
@@ -298,6 +299,8 @@ string_to_enum<TimeSteppingType>(const std::string& val)
 {
     if (strcasecmp(val.c_str(), "ADAMS_BASHFORTH") == 0) return ADAMS_BASHFORTH;
     if (strcasecmp(val.c_str(), "BACKWARD_EULER") == 0) return BACKWARD_EULER;
+    if (strcasecmp(val.c_str(), "BDF1") == 0) return BACKWARD_EULER;
+    if (strcasecmp(val.c_str(), "BDF2") == 0) return BDF2;
     if (strcasecmp(val.c_str(), "FORWARD_EULER") == 0) return FORWARD_EULER;
     if (strcasecmp(val.c_str(), "MIDPOINT_RULE") == 0) return MIDPOINT_RULE;
     if (strcasecmp(val.c_str(), "TRAPEZOIDAL_RULE") == 0) return TRAPEZOIDAL_RULE;
@@ -314,6 +317,7 @@ enum_to_string<TimeSteppingType>(TimeSteppingType val)
 {
     if (val == ADAMS_BASHFORTH) return "ADAMS_BASHFORTH";
     if (val == BACKWARD_EULER) return "BACKWARD_EULER";
+    if (val == BDF2) return "BDF2";
     if (val == FORWARD_EULER) return "FORWARD_EULER";
     if (val == MIDPOINT_RULE) return "MIDPOINT_RULE";
     if (val == TRAPEZOIDAL_RULE) return "TRAPEZOIDAL_RULE";
@@ -328,6 +332,7 @@ is_multistep_time_stepping_type(TimeSteppingType val)
     switch (val)
     {
     case ADAMS_BASHFORTH:
+    case BDF2:
         return true;
     case BACKWARD_EULER:
     case FORWARD_EULER:
@@ -339,6 +344,19 @@ is_multistep_time_stepping_type(TimeSteppingType val)
         return false;
     }
 } // is_multistep_time_stepping_type
+
+inline bool
+is_bdf_time_stepping_type(TimeSteppingType val)
+{
+    switch (val)
+    {
+    case BACKWARD_EULER:
+    case BDF2:
+        return true;
+    default:
+        return false;
+    }
+} // is_bdf_time_stepping_type
 
 /*!
  * \brief Enumerated type for different types of traction boundary conditions.

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -475,6 +475,7 @@ INSStaggeredHierarchyIntegrator::INSStaggeredHierarchyIntegrator(std::string obj
     switch (d_viscous_time_stepping_type)
     {
     case BACKWARD_EULER:
+    case BDF2:
     case FORWARD_EULER:
     case TRAPEZOIDAL_RULE:
         break;
@@ -482,7 +483,7 @@ INSStaggeredHierarchyIntegrator::INSStaggeredHierarchyIntegrator(std::string obj
         TBOX_ERROR(d_object_name << "::INSStaggeredHierarchyIntegrator():\n"
                                  << "  unsupported viscous time stepping type: "
                                  << enum_to_string<TimeSteppingType>(d_viscous_time_stepping_type) << " \n"
-                                 << "  valid choices are: BACKWARD_EULER, FORWARD_EULER, "
+                                 << "  valid choices are: BACKWARD_EULER, BDF2, FORWARD_EULER, "
                                     "TRAPEZOIDAL_RULE\n");
     }
     switch (d_convective_time_stepping_type)
@@ -573,6 +574,7 @@ INSStaggeredHierarchyIntegrator::INSStaggeredHierarchyIntegrator(std::string obj
     d_F_var = INSHierarchyIntegrator::d_F_var;
     d_Q_var = INSHierarchyIntegrator::d_Q_var;
     d_N_old_var = new SideVariable<NDIM, double>(d_object_name + "::N_old");
+    d_U_old_var = new SideVariable<NDIM, double>(d_object_name + "::U_old");
 
     // with our convention fine_boundary_represents_var = false means that will
     // use a conforming discretization (the solution, with bilinear/trilinear
@@ -897,13 +899,27 @@ INSStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHier
 
     // We need previous values of N for Adams-Bashforth so keep it in the
     // restart database.
-    registerVariable(d_N_old_current_idx,
-                     d_N_old_new_idx,
-                     d_N_old_scratch_idx,
-                     d_N_old_var,
-                     side_ghosts,
-                     d_N_coarsen_type,
-                     d_N_refine_type);
+    if (is_multistep_time_stepping_type(d_convective_time_stepping_type))
+    {
+        registerVariable(d_N_old_current_idx,
+                         d_N_old_new_idx,
+                         d_N_old_scratch_idx,
+                         d_N_old_var,
+                         side_ghosts,
+                         d_N_coarsen_type,
+                         d_N_refine_type);
+    }
+
+    if (is_multistep_time_stepping_type(d_viscous_time_stepping_type))
+    {
+        registerVariable(d_U_old_current_idx,
+                         d_U_old_new_idx,
+                         d_U_old_scratch_idx,
+                         d_U_old_var,
+                         side_ghosts,
+                         d_U_coarsen_type,
+                         d_U_refine_type);
+    }
 
     registerVariable(d_U_nc_idx, d_U_nc_var, no_ghosts, getPlotContext());
     d_plot_indices.push_back(d_U_nc_idx);
@@ -1129,37 +1145,68 @@ INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const double curre
     const double rho = d_problem_coefs.getRho();
     const double mu = d_problem_coefs.getMu();
     const double lambda = d_problem_coefs.getLambda();
-    double K_rhs = 0.0;
-    switch (d_viscous_time_stepping_type)
+    if (is_multistep_time_stepping_type(d_viscous_time_stepping_type))
     {
-    case BACKWARD_EULER:
-        K_rhs = 0.0;
-        break;
-    case FORWARD_EULER:
-        K_rhs = 1.0;
-        break;
-    case TRAPEZOIDAL_RULE:
-        K_rhs = 0.5;
-        break;
-    default:
-        TBOX_ERROR("this statment should not be reached");
+        const int U_rhs_idx = d_U_rhs_vec->getComponentDescriptorIndex(0);
+        switch (d_viscous_time_stepping_type)
+        {
+        case BDF2:
+        {
+            if (getIntegratorStep() == 0)
+            {
+                d_hier_sc_data_ops->scale(U_rhs_idx, rho / dt, d_U_current_idx);
+            }
+            else
+            {
+                const double omega = getTimeStepSizeRatio();
+                const double a1 = (1.0 + omega) * rho / dt;
+                const double a2 = -(omega * omega / (1.0 + omega)) * rho / dt;
+                d_hier_sc_data_ops->linearSum(U_rhs_idx, a1, d_U_current_idx, a2, d_U_old_current_idx);
+            }
+            break;
+        }
+        default:
+            TBOX_ERROR("this statement should not be reached");
+        }
+        d_hier_sc_data_ops->copyData(d_U_old_new_idx, d_U_current_idx);
     }
-    PoissonSpecifications U_rhs_problem_coefs(d_object_name + "::U_rhs_problem_coefs");
-    U_rhs_problem_coefs.setCConstant((rho / dt) - K_rhs * lambda);
-    U_rhs_problem_coefs.setDConstant(+K_rhs * mu);
-    const int U_rhs_idx = d_U_rhs_vec->getComponentDescriptorIndex(0);
-    const Pointer<SideVariable<NDIM, double> > U_rhs_var = d_U_rhs_vec->getComponentVariable(0);
-    d_hier_sc_data_ops->copyData(d_U_scratch_idx, d_U_current_idx);
-    StaggeredStokesPhysicalBoundaryHelper::setupBcCoefObjects(d_U_bc_coefs,
-                                                              /*P_bc_coef*/ nullptr,
-                                                              d_U_scratch_idx,
-                                                              /*P_data_idx*/ -1,
-                                                              /*homogeneous_bc*/ false);
-    d_U_bdry_bc_fill_op->fillData(current_time);
-    StaggeredStokesPhysicalBoundaryHelper::resetBcCoefObjects(d_U_bc_coefs,
-                                                              /*P_bc_coef*/ nullptr);
-    d_hier_math_ops->laplace(
-        U_rhs_idx, U_rhs_var, U_rhs_problem_coefs, d_U_scratch_idx, d_U_var, d_no_fill_op, current_time);
+    else
+    {
+        double K1_rhs = 1.0, K2_rhs = 0.0;
+        switch (d_viscous_time_stepping_type)
+        {
+        case BACKWARD_EULER:
+            K1_rhs = 1.0;
+            K2_rhs = 0.0;
+            break;
+        case FORWARD_EULER:
+            K1_rhs = 1.0;
+            K2_rhs = 1.0;
+            break;
+        case TRAPEZOIDAL_RULE:
+            K1_rhs = 1.0;
+            K2_rhs = 0.5;
+            break;
+        default:
+            TBOX_ERROR("this statment should not be reached");
+        }
+        PoissonSpecifications U_rhs_problem_coefs(d_object_name + "::U_rhs_problem_coefs");
+        U_rhs_problem_coefs.setCConstant(K1_rhs * rho / dt - K2_rhs * lambda);
+        U_rhs_problem_coefs.setDConstant(K2_rhs * mu);
+        const int U_rhs_idx = d_U_rhs_vec->getComponentDescriptorIndex(0);
+        const Pointer<SideVariable<NDIM, double> > U_rhs_var = d_U_rhs_vec->getComponentVariable(0);
+        d_hier_sc_data_ops->copyData(d_U_scratch_idx, d_U_current_idx);
+        StaggeredStokesPhysicalBoundaryHelper::setupBcCoefObjects(d_U_bc_coefs,
+                                                                  /*P_bc_coef*/ nullptr,
+                                                                  d_U_scratch_idx,
+                                                                  /*P_data_idx*/ -1,
+                                                                  /*homogeneous_bc*/ false);
+        d_U_bdry_bc_fill_op->fillData(current_time);
+        StaggeredStokesPhysicalBoundaryHelper::resetBcCoefObjects(d_U_bc_coefs,
+                                                                  /*P_bc_coef*/ nullptr);
+        d_hier_math_ops->laplace(
+            U_rhs_idx, U_rhs_var, U_rhs_problem_coefs, d_U_scratch_idx, d_U_var, d_no_fill_op, current_time);
+    }
     d_hier_sc_data_ops->copyData(d_U_src_idx,
                                  d_U_scratch_idx,
                                  /*interior_only*/ false);
@@ -1235,7 +1282,10 @@ INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const double curre
         d_convective_op->setSolutionTime(current_time);
         d_convective_op->apply(*d_U_adv_vec, *d_N_vec);
         const int N_idx = d_N_vec->getComponentDescriptorIndex(0);
-        d_hier_sc_data_ops->copyData(d_N_old_new_idx, N_idx);
+        if (is_multistep_time_stepping_type(d_convective_time_stepping_type))
+        {
+            d_hier_sc_data_ops->copyData(d_N_old_new_idx, N_idx);
+        }
         if (convective_time_stepping_type == FORWARD_EULER)
         {
             d_hier_sc_data_ops->axpy(d_rhs_vec->getComponentDescriptorIndex(0),
@@ -1440,15 +1490,28 @@ INSStaggeredHierarchyIntegrator::setupSolverVectors(const Pointer<SAMRAIVectorRe
             d_convective_op->setSolutionTime(apply_time);
             d_convective_op->apply(*d_U_adv_vec, *d_N_vec);
         }
+
         const int N_idx = d_N_vec->getComponentDescriptorIndex(0);
         if (convective_time_stepping_type == ADAMS_BASHFORTH)
         {
 #if !defined(NDEBUG)
             TBOX_ASSERT(cycle_num == 0);
 #endif
-            const double omega = dt / d_dt_previous[0];
-            d_hier_sc_data_ops->linearSum(N_idx, 1.0 + 0.5 * omega, N_idx, -0.5 * omega, d_N_old_current_idx);
+            const double omega = getTimeStepSizeRatio();
+            double beta1, beta2;
+            if (is_bdf_time_stepping_type(d_viscous_time_stepping_type))
+            {
+                beta1 = 1.0 + omega;
+                beta2 = -omega;
+            }
+            else
+            {
+                beta1 = 1.0 + 0.5 * omega;
+                beta2 = -0.5 * omega;
+            }
+            d_hier_sc_data_ops->linearSum(N_idx, beta1, N_idx, beta2, d_N_old_current_idx);
         }
+
         if (convective_time_stepping_type == ADAMS_BASHFORTH || convective_time_stepping_type == MIDPOINT_RULE)
         {
             d_hier_sc_data_ops->axpy(
@@ -1464,7 +1527,16 @@ INSStaggeredHierarchyIntegrator::setupSolverVectors(const Pointer<SAMRAIVectorRe
     // Account for body forcing terms.
     if (d_F_fcn)
     {
-        d_F_fcn->setDataOnPatchHierarchy(d_F_scratch_idx, d_F_var, d_hierarchy, half_time);
+        double data_time;
+        if (is_bdf_time_stepping_type(d_viscous_time_stepping_type))
+        {
+            data_time = new_time;
+        }
+        else
+        {
+            data_time = half_time;
+        }
+        d_F_fcn->setDataOnPatchHierarchy(d_F_scratch_idx, d_F_var, d_hierarchy, data_time);
         d_hier_sc_data_ops->add(
             rhs_vec->getComponentDescriptorIndex(0), rhs_vec->getComponentDescriptorIndex(0), d_F_scratch_idx);
     }
@@ -1472,15 +1544,40 @@ INSStaggeredHierarchyIntegrator::setupSolverVectors(const Pointer<SAMRAIVectorRe
     // Account for internal source/sink distributions.
     if (d_Q_fcn)
     {
-        d_Q_fcn->setDataOnPatchHierarchy(d_Q_current_idx, d_Q_var, d_hierarchy, current_time);
-        d_Q_fcn->setDataOnPatchHierarchy(d_Q_new_idx, d_Q_var, d_hierarchy, new_time);
-        d_hier_cc_data_ops->linearSum(d_Q_scratch_idx, 0.5, d_Q_current_idx, 0.5, d_Q_new_idx);
-        d_Q_bdry_bc_fill_op->fillData(half_time);
+        if (is_bdf_time_stepping_type(d_viscous_time_stepping_type))
+        {
+            d_Q_fcn->setDataOnPatchHierarchy(d_Q_new_idx, d_Q_var, d_hierarchy, new_time);
+            d_hier_cc_data_ops->copyData(d_Q_scratch_idx, d_Q_new_idx);
+            d_Q_bdry_bc_fill_op->fillData(new_time);
+        }
+        else
+        {
+            d_Q_fcn->setDataOnPatchHierarchy(d_Q_current_idx, d_Q_var, d_hierarchy, current_time);
+            d_Q_fcn->setDataOnPatchHierarchy(d_Q_new_idx, d_Q_var, d_hierarchy, new_time);
+            d_hier_cc_data_ops->linearSum(d_Q_scratch_idx, 0.5, d_Q_current_idx, 0.5, d_Q_new_idx);
+            d_Q_bdry_bc_fill_op->fillData(half_time);
+        }
 
         // Account for momentum loss at sources/sinks.
         if (d_use_div_sink_drag_term && !d_creeping_flow)
         {
-            d_hier_sc_data_ops->linearSum(d_U_scratch_idx, 0.5, d_U_current_idx, 0.5, d_U_new_idx);
+            if (is_bdf_time_stepping_type(d_viscous_time_stepping_type))
+            {
+                if (cycle_num == 0)
+                {
+                    const double omega = getTimeStepSizeRatio();
+                    d_hier_sc_data_ops->linearSum(
+                        d_U_scratch_idx, 1.0 + omega, d_U_current_idx, -omega, d_U_old_current_idx);
+                }
+                else
+                {
+                    d_hier_sc_data_ops->copyData(d_U_scratch_idx, d_U_new_idx);
+                }
+            }
+            else
+            {
+                d_hier_sc_data_ops->linearSum(d_U_scratch_idx, 0.5, d_U_current_idx, 0.5, d_U_new_idx);
+            }
             computeDivSourceTerm(d_F_div_idx, d_Q_scratch_idx, d_U_scratch_idx);
             d_hier_sc_data_ops->scale(d_F_div_idx, rho, d_F_div_idx);
         }
@@ -2287,27 +2384,43 @@ INSStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double cu
     const double rho = d_problem_coefs.getRho();
     const double mu = d_problem_coefs.getMu();
     const double lambda = d_problem_coefs.getLambda();
-    double K = 0.0;
+    double K1 = 1.0, K2 = 0.0;
+    const double omega = getTimeStepSizeRatio();
     switch (d_viscous_time_stepping_type)
     {
     case BACKWARD_EULER:
-        K = 1.0;
+        K1 = 1.0;
+        K2 = 1.0;
+        break;
+    case BDF2:
+        if (getIntegratorStep() == 0)
+        {
+            K1 = 1.0;
+            K2 = 1.0;
+        }
+        else
+        {
+            K1 = (1.0 + 2.0 * omega) / (1.0 + omega);
+            K2 = 1.0;
+        }
         break;
     case FORWARD_EULER:
-        K = 0.0;
+        K1 = 1.0;
+        K2 = 0.0;
         break;
     case TRAPEZOIDAL_RULE:
-        K = 0.5;
+        K1 = 1.0;
+        K2 = 0.5;
         break;
     default:
         TBOX_ERROR("this statment should not be reached");
     }
     PoissonSpecifications U_problem_coefs(d_object_name + "::U_problem_coefs");
-    U_problem_coefs.setCConstant((rho / dt) + K * lambda);
-    U_problem_coefs.setDConstant(-K * mu);
+    U_problem_coefs.setCConstant(K1 * rho / dt + K2 * lambda);
+    U_problem_coefs.setDConstant(-K2 * mu);
     PoissonSpecifications P_problem_coefs(d_object_name + "::P_problem_coefs");
     P_problem_coefs.setCZero();
-    P_problem_coefs.setDConstant(rho == 0.0 ? -1.0 : -1.0 / rho);
+    P_problem_coefs.setDConstant(rho == 0.0 ? -1.0 : -1.0 / (K1 * rho));
 
     // Ensure that solver components are appropriately reinitialized when the
     // time step size changes.
@@ -2773,6 +2886,19 @@ INSStaggeredHierarchyIntegrator::getConvectiveTimeSteppingType(const int cycle_n
     }
     return convective_time_stepping_type;
 } // getConvectiveTimeSteppingType
+
+double
+INSStaggeredHierarchyIntegrator::getTimeStepSizeRatio() const
+{
+    if (getIntegratorStep() == 0)
+    {
+        return 1.0;
+    }
+    else
+    {
+        return d_current_dt / d_dt_previous[0];
+    }
+}
 
 //////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Adding support for BDF2-like time stepping. The goal is to enable "consistent" time stepping for IIM.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [ ] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
