### PR TITLE
Deallocate and remove an unused data index.

### DIFF
--- a/ibtk/src/math/SAMRAIGhostDataAccumulator.cpp
+++ b/ibtk/src/math/SAMRAIGhostDataAccumulator.cpp
@@ -281,6 +281,14 @@ SAMRAIGhostDataAccumulator::SAMRAIGhostDataAccumulator(Pointer<BasePatchHierarch
             }
         }
     } // loop over levels
+
+    for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        level->deallocatePatchData(d_global_dof_idx);
+    }
+    var_db->removePatchDataIndex(d_global_dof_idx);
+    d_global_dof_idx = IBTK::invalid_index;
     IBTK_TIMER_STOP(t_constructor);
 }
 
@@ -352,14 +360,10 @@ SAMRAIGhostDataAccumulator::~SAMRAIGhostDataAccumulator()
     for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
     {
         Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
-        if (d_global_dof_idx != IBTK::invalid_index && level->checkAllocated(d_global_dof_idx))
-            level->deallocatePatchData(d_global_dof_idx);
-        if (d_local_dof_idx != IBTK::invalid_index && level->checkAllocated(d_local_dof_idx))
-            level->deallocatePatchData(d_local_dof_idx);
+        level->deallocatePatchData(d_local_dof_idx);
     }
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     var_db->removePatchDataIndex(d_local_dof_idx);
-    var_db->removePatchDataIndex(d_global_dof_idx);
 }
 /////////////////////////////// PRIVATE //////////////////////////////////////
 


### PR DESCRIPTION
I noticed this while profiling the heart model with massif - storing all these indexing arrays isn't negligible. We can get rid of the global indices after setting up the PETSc vector, which helps a little.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?