### PR TITLE
Don't save workload data in the restart database.

### DIFF
--- a/ibtk/src/utilities/HierarchyIntegrator.cpp
+++ b/ibtk/src/utilities/HierarchyIntegrator.cpp
@@ -83,7 +83,7 @@ namespace IBTK
 namespace
 {
 // Version of HierarchyIntegrator restart file data.
-static const int HIERARCHY_INTEGRATOR_VERSION = 1;
+static const int HIERARCHY_INTEGRATOR_VERSION = 2;
 // Timers.
 static Timer* t_regrid_hierarchy;
 static Timer* t_advance_hierarchy;
@@ -547,6 +547,10 @@ HierarchyIntegrator::updateWorkloadEstimates()
 {
     if (d_workload_idx != IBTK::invalid_index)
     {
+        // If we are starting from a restart file then we have to allocate this
+        // ourselves
+        allocatePatchData(d_workload_idx, d_integrator_time);
+
         HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(d_hierarchy);
         hier_cc_data_ops.setToScalar(d_workload_idx, 1.0, /*interior_only*/ false);
 
@@ -582,7 +586,7 @@ HierarchyIntegrator::registerLoadBalancer(Pointer<LoadBalancer<NDIM> > load_bala
     if (d_workload_idx == IBTK::invalid_index)
     {
         d_workload_var = new CellVariable<NDIM, double>(d_object_name + "::workload");
-        registerVariable(d_workload_idx, d_workload_var, 0, getCurrentContext());
+        registerVariable(d_workload_idx, d_workload_var, 0, getCurrentContext(), false);
     }
     d_load_balancer->setWorkloadPatchDataIndex(d_workload_idx);
     return;

--- a/include/ibamr/IBStrategy.h
+++ b/include/ibamr/IBStrategy.h
@@ -532,7 +532,8 @@ protected:
         const SAMRAI::hier::IntVector<NDIM>& scratch_ghosts = SAMRAI::hier::IntVector<NDIM>(0),
         const std::string& coarsen_name = "NO_COARSEN",
         const std::string& refine_name = "NO_REFINE",
-        SAMRAI::tbox::Pointer<IBTK::CartGridFunction> init_fcn = SAMRAI::tbox::Pointer<IBTK::CartGridFunction>(NULL));
+        SAMRAI::tbox::Pointer<IBTK::CartGridFunction> init_fcn = SAMRAI::tbox::Pointer<IBTK::CartGridFunction>(NULL),
+        const bool register_for_restart = true);
 
     /*!
      * Register a variable with the integrator that may not be maintained from
@@ -545,7 +546,8 @@ protected:
                           SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM> > variable,
                           const SAMRAI::hier::IntVector<NDIM>& ghosts = SAMRAI::hier::IntVector<NDIM>(0),
                           SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext> ctx =
-                              SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext>(NULL));
+                              SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext>(NULL),
+                          const bool register_for_restart = true);
 
     /*!
      * Register a ghost cell-filling refine algorithm.

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -171,7 +171,7 @@ static Timer* t_begin_data_redistribution;
 static Timer* t_end_data_redistribution;
 static Timer* t_apply_gradient_detector;
 // Version of IBFEMethod restart file data.
-const int IBFE_METHOD_VERSION = 6;
+const int IBFE_METHOD_VERSION = 7;
 
 inline boundary_id_type
 get_dirichlet_bdry_ids(const std::vector<boundary_id_type>& bdry_ids)
@@ -1288,7 +1288,9 @@ IBFEMethod::registerEulerianVariables()
                      d_lagrangian_workload_var,
                      ghosts,
                      d_lagrangian_workload_coarsen_type,
-                     d_lagrangian_workload_refine_type);
+                     d_lagrangian_workload_refine_type,
+                     nullptr,
+                     false);
     return;
 } // registerEulerianVariables
 

--- a/src/IB/IBStrategy.cpp
+++ b/src/IB/IBStrategy.cpp
@@ -373,13 +373,21 @@ IBStrategy::registerVariable(int& current_idx,
                              const IntVector<NDIM>& scratch_ghosts,
                              const std::string& coarsen_name,
                              const std::string& refine_name,
-                             Pointer<CartGridFunction> init_fcn)
+                             Pointer<CartGridFunction> init_fcn,
+                             const bool register_for_restart)
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(d_ib_solver);
 #endif
-    d_ib_solver->registerVariable(
-        current_idx, new_idx, scratch_idx, variable, scratch_ghosts, coarsen_name, refine_name, init_fcn);
+    d_ib_solver->registerVariable(current_idx,
+                                  new_idx,
+                                  scratch_idx,
+                                  variable,
+                                  scratch_ghosts,
+                                  coarsen_name,
+                                  refine_name,
+                                  init_fcn,
+                                  register_for_restart);
     return;
 } // registerVariable
 
@@ -387,12 +395,13 @@ void
 IBStrategy::registerVariable(int& idx,
                              Pointer<Variable<NDIM> > variable,
                              const IntVector<NDIM>& ghosts,
-                             Pointer<VariableContext> ctx)
+                             Pointer<VariableContext> ctx,
+                             const bool register_for_restart)
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(d_ib_solver);
 #endif
-    d_ib_solver->registerVariable(idx, variable, ghosts, ctx);
+    d_ib_solver->registerVariable(idx, variable, ghosts, ctx, register_for_restart);
     return;
 } // registerVariable
 


### PR DESCRIPTION
Last part of #1697.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
