### PR TITLE
Fix a level number check.

### DIFF
--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -1758,7 +1758,7 @@ INSVCStaggeredHierarchyIntegrator::applyGradientDetectorSpecialized(const Pointe
         d_hier_math_ops->curl(d_Omega_idx, d_Omega_var, d_U_scratch_idx, d_U_var, d_U_bdry_bc_fill_op, error_data_time);
         tagCellsByVorticityMagnitude(level_number, d_Omega_idx, tag_index);
 
-        for (int ln = 0; ln < d_hierarchy->getFinestLevelNumber(); ++ln)
+        for (int ln = 0; ln <= d_hierarchy->getFinestLevelNumber(); ++ln)
         {
             Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
             level->deallocatePatchData(d_U_scratch_idx);


### PR DESCRIPTION
The test added in #1717 aborts on `master` because of this typo from the vorticity patches. @Raamkrishnan thanks again for adding this test!

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?