### PR TITLE
Update clang-format scripts.

### DIFF
--- a/scripts/formatting/compile-clang-format
+++ b/scripts/formatting/compile-clang-format
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# based on the compile_clang_format deal.II script and licensed under the LGPL
+# based on the compile-clang-format deal.II script and licensed under the LGPL
 
 #
 # This script downloads, compiles and installs the clang-format binary. The
@@ -18,7 +18,7 @@ set -u
 PRG="$(cd "$(dirname "$0")" && pwd)/programs"
 
 VERSION="16"
-RELEASE_DATE="2023-06-01"
+RELEASE_DATE="2023-06-10"
 LLVM_COMMIT="7cbf1a2591520c2491aa35339f227775f4d3adf6"
 
 CLANG_PATH="${PRG}/clang-${VERSION}"

--- a/scripts/formatting/download-clang-format
+++ b/scripts/formatting/download-clang-format
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# based on deal.II's download_clang_format script and licensed under the LGPL
+# based on the compile-clang-format deal.II script and licensed under the LGPL
 
 #
 # This script downloads and installs the clang-format binary. The
@@ -62,11 +62,15 @@ mkdir -p "${tmpdir}"
 cd "${tmpdir}"
 if [ -x "$(command -v wget)" ]; then
   echo "Using wget to download..."
-  wget -q -L "${URL}/${FILENAME}" > /dev/null
+  # set progress option if available
+  wget --help | grep -q '\--show-progress' && \
+        _PROGRESS_OPT="--show-progress" || _PROGRESS_OPT=""
+
+  wget -q $_PROGRESS_OPT -L "${URL}/${FILENAME}" > /dev/null
 else
   if [ -x "$(command -v curl)" ]; then
     echo "Using curl to download..."
-    curl -L "${URL}/${FILENAME}" -O > /dev/null
+    curl --progress-bar -L "${URL}/${FILENAME}" -O > /dev/null
   else
     echo "Error: Neither wget nor curl is available..."
     exit 1


### PR DESCRIPTION
based on updates to the deal.II versions of these scripts.

This is just an infrastructure update so the normal list doesn't apply.