### PR TITLE
Making the sign of gas level set consistent in wave_tank ex0 and ex1

### DIFF
--- a/examples/wave_tank/ex0/LSLocateColumnInterface.cpp
+++ b/examples/wave_tank/ex0/LSLocateColumnInterface.cpp
@@ -93,7 +93,7 @@ LSLocateColumnInterface::setLevelSetPatchData(int D_idx,
                 {
                     coord[d] = patch_X_lower[d] + patch_dx[d] * (static_cast<double>(ci(d) - patch_lower_idx(d)) + 0.5);
                 }
-                (*D_data)(ci) = coord[NDIM - 1] - depth;
+                (*D_data)(ci) = depth - coord[NDIM - 1];
             }
         }
     }

--- a/examples/wave_tank/ex0/example.cpp
+++ b/examples/wave_tank/ex0/example.cpp
@@ -316,6 +316,7 @@ main(int argc, char* argv[])
         wave_damper.d_x_zone_end = x_zone_end;
         wave_damper.d_depth = depth;
         wave_damper.d_alpha = alpha;
+        wave_damper.d_sign_gas_phase = -1;
         wave_damper.d_ins_hier_integrator = time_integrator;
         wave_damper.d_adv_diff_hier_integrator = adv_diff_integrator;
         wave_damper.d_phi_var = phi_var;
@@ -364,6 +365,7 @@ main(int argc, char* argv[])
             wave_generator->d_wave_gen_data.d_x_zone_start = inlet_zone_start;
             wave_generator->d_wave_gen_data.d_x_zone_end = inlet_zone_end;
             wave_generator->d_wave_gen_data.d_alpha = alpha;
+            wave_generator->d_wave_gen_data.d_sign_gas_phase = -1;
             wave_generator->d_wave_gen_data.d_ins_hier_integrator = time_integrator;
             wave_generator->d_wave_gen_data.d_adv_diff_hier_integrator = adv_diff_integrator;
             wave_generator->d_wave_gen_data.d_phi_var = phi_var;

--- a/examples/wave_tank/ex0/input2d
+++ b/examples/wave_tank/ex0/input2d
@@ -26,10 +26,10 @@ INLET_ZONE_END        = WAVELENGTH
 ALPHA                 = 3.5
 
 // material properties
-MU_I       = 1.137e-3
-MU_O       = 1.78e-5
-RHO_I      = 1.0e3
-RHO_O      = 1.226
+MU_I       = 1.78e-5
+MU_O       = 1.137e-3
+RHO_I      = 1.226
+RHO_O      = 1.0e3
 
 NUM_INTERFACE_CELLS = 1.0
 
@@ -59,7 +59,7 @@ VORTICITY_REL_THRESH = 0.5
 // Level set initial conditions
 LevelSetInitialConditions {
   depth = DEPTH
-  function = "X_1 - depth" 
+  function = "depth - X_1" 
 }
 
 

--- a/examples/wave_tank/ex0/input2d_5thOrderStokes
+++ b/examples/wave_tank/ex0/input2d_5thOrderStokes
@@ -26,10 +26,10 @@ X_ZONE_END = L
 ALPHA = 3.5
 
 // material properties
-MU_I       = 1.137e-3
-MU_O       = 1.78e-5
-RHO_I      = 1.0e3
-RHO_O      = 1.226
+MU_I       = 1.78e-5
+MU_O       = 1.137e-3
+RHO_I      = 1.226
+RHO_O      = 1.0e3
 
 NUM_INTERFACE_CELLS = 1.0
 
@@ -61,7 +61,7 @@ VORTICITY_REL_THRESH = 0.5
 // Level set initial conditions
 LevelSetInitialConditions {
   depth = DEPTH
-  function = "X_1 - depth" 
+  function = "depth - X_1" 
 }
 
 

--- a/examples/wave_tank/ex0/input2d_CaseA
+++ b/examples/wave_tank/ex0/input2d_CaseA
@@ -25,10 +25,10 @@ X_ZONE_END = L
 ALPHA = 3.5
 
 // material properties
-MU_I       = 1.137e-3
-MU_O       = 1.78e-5
-RHO_I      = 1.0e3
-RHO_O      = 1.226
+MU_I       = 1.78e-5
+MU_O       = 1.137e-3
+RHO_I      = 1.226
+RHO_O      = 1.0e3
 
 NUM_INTERFACE_CELLS = 1.0
 
@@ -60,7 +60,7 @@ VORTICITY_REL_THRESH = 0.5
 // Level set initial conditions
 LevelSetInitialConditions {
   depth = DEPTH
-  function = "X_1 - depth" 
+  function = "depth - X_1" 
 }
 
 

--- a/examples/wave_tank/ex0/input2d_CaseA_IrregularWave
+++ b/examples/wave_tank/ex0/input2d_CaseA_IrregularWave
@@ -29,10 +29,10 @@ INLET_ZONE_END      = WAVELENGTH
 ALPHA               = 3.5
 
 // material properties
-MU_I  = 1.137e-3
-MU_O  = 1.78e-5
-RHO_I = 1.0e3
-RHO_O = 1.226
+MU_I  = 1.78e-5
+MU_O  = 1.137e-3
+RHO_I = 1.226
+RHO_O = 1.0e3
 
 NUM_INTERFACE_CELLS = 1.0
 
@@ -64,7 +64,7 @@ VORTICITY_REL_THRESH = 0.5
 // Level set initial conditions
 LevelSetInitialConditions {
   depth = DEPTH
-  function = "X_1 - depth" 
+  function = "depth - X_1" 
 }
 
 

--- a/examples/wave_tank/ex0/input2d_CaseB
+++ b/examples/wave_tank/ex0/input2d_CaseB
@@ -25,10 +25,10 @@ X_ZONE_END = L
 ALPHA = 3.5
 
 // material properties
-MU_I       = 1.137e-3
-MU_O       = 1.78e-5
-RHO_I      = 1.0e3
-RHO_O      = 1.226
+MU_I       = 1.78e-5
+MU_O       = 1.137e-3
+RHO_I      = 1.226
+RHO_O      = 1.0e3
 
 NUM_INTERFACE_CELLS = 1.0
 
@@ -60,7 +60,7 @@ VORTICITY_REL_THRESH = 0.5
 // Level set initial conditions
 LevelSetInitialConditions {
   depth = DEPTH
-  function = "X_1 - depth" 
+  function = "depth - X_1" 
 }
 
 

--- a/examples/wave_tank/ex0/input2d_CaseC
+++ b/examples/wave_tank/ex0/input2d_CaseC
@@ -25,10 +25,10 @@ X_ZONE_END = L
 ALPHA = 3.5
 
 // material properties
-MU_I       = 1.137e-3
-MU_O       = 1.78e-5
-RHO_I      = 1.0e3
-RHO_O      = 1.226
+MU_I       = 1.78e-5
+MU_O       = 1.137e-3
+RHO_I      = 1.226
+RHO_O      = 1.0e3
 
 NUM_INTERFACE_CELLS = 1.0
 
@@ -60,7 +60,7 @@ VORTICITY_REL_THRESH = 0.5
 // Level set initial conditions
 LevelSetInitialConditions {
   depth = DEPTH
-  function = "X_1 - depth" 
+  function = "depth - X_1" 
 }
 
 

--- a/examples/wave_tank/ex0/input3d
+++ b/examples/wave_tank/ex0/input3d
@@ -24,10 +24,10 @@ X_ZONE_END = Lx
 ALPHA = 2.0
 
 // material properties
-MU_I       = 1.137e-3
-MU_O       = 1.78e-5
-RHO_I      = 1.0e3
-RHO_O      = 1.226
+MU_I       = 1.78e-5
+MU_O       = 1.137e-3
+RHO_I      = 1.226
+RHO_O      = 1.0e3
 
 NUM_INTERFACE_CELLS = 1.0
 
@@ -60,7 +60,7 @@ VORTICITY_REL_THRESH = 0.5
 // Level set initial conditions
 LevelSetInitialConditions {
   depth = DEPTH
-  function = "X_2 - depth" 
+  function = "depth - X_2" 
 }
 
 

--- a/examples/wave_tank/ex1/example.cpp
+++ b/examples/wave_tank/ex1/example.cpp
@@ -390,6 +390,7 @@ main(int argc, char* argv[])
         wave_damper.d_x_zone_end = x_zone_end;
         wave_damper.d_depth = depth;
         wave_damper.d_alpha = alpha;
+        wave_damper.d_sign_gas_phase = -1;
         wave_damper.d_ins_hier_integrator = navier_stokes_integrator;
         wave_damper.d_adv_diff_hier_integrator = adv_diff_integrator;
         wave_damper.d_phi_var = phi_var_gas;


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [ ] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
