### PR TITLE
add an option to skip the velocity solve in the projection preconditioner

### DIFF
--- a/doc/news/changes/minor/20240907BoyceGriffith
+++ b/doc/news/changes/minor/20240907BoyceGriffith
@@ -1,0 +1,3 @@
+New: added an option to skip the velocity solve in the projection preconditioner.
+<br>
+(Boyce Griffith, 2024/09/07)

--- a/include/ibamr/StaggeredStokesProjectionPreconditioner.h
+++ b/include/ibamr/StaggeredStokesProjectionPreconditioner.h
@@ -50,6 +50,13 @@ namespace IBAMR
  * that implements a staggered grid (MAC) projection solver for the
  * incompressible Stokes operator.
  *
+ * Sample parameters for initialization from database (and their default
+ * values): \verbatim
+
+ skip_velocity_solve = FALSE  // set whether to skip the velocity solve; this is equivalent
+                              // to treating viscosity explicitly in the preconditioner
+ \endverbatim
+ *
  * \see INSStaggeredHierarchyIntegrator
  */
 class StaggeredStokesProjectionPreconditioner : public StaggeredStokesBlockPreconditioner

--- a/src/navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
+++ b/src/navier_stokes/StaggeredStokesProjectionPreconditioner.cpp
@@ -83,10 +83,13 @@ static Timer* t_deallocate_solver_state;
 
 StaggeredStokesProjectionPreconditioner::StaggeredStokesProjectionPreconditioner(
     const std::string& object_name,
-    Pointer<Database> /*input_db*/,
+    Pointer<Database> input_db,
     const std::string& /*default_options_prefix*/)
-    : StaggeredStokesBlockPreconditioner(/*needs_velocity_solver*/ true,
-                                         /*needs_pressure_solver*/ true)
+    : StaggeredStokesBlockPreconditioner(
+          /*needs_velocity_solver*/ input_db ?
+              (input_db->keyExists("skip_velocity_solve") ? !input_db->getBool("skip_velocity_solve") : true) :
+              true,
+          /*needs_pressure_solver*/ true)
 {
     GeneralSolver::init(object_name, /*homogeneous_bc*/ true);
 
@@ -215,10 +218,20 @@ StaggeredStokesProjectionPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, doub
     // U^* := inv(rho/dt - K*mu*L) F_U
     //
     // An approximate Helmholtz solver is used.
-    d_velocity_solver->setHomogeneousBc(true);
-    auto p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
-    if (p_velocity_solver) p_velocity_solver->setInitialGuessNonzero(false);
-    d_velocity_solver->solveSystem(*U_vec, *F_U_vec);
+    if (d_needs_velocity_solver)
+    {
+        d_velocity_solver->setHomogeneousBc(true);
+        auto p_velocity_solver = dynamic_cast<LinearSolver*>(d_velocity_solver.getPointer());
+        if (p_velocity_solver) p_velocity_solver->setInitialGuessNonzero(false);
+        d_velocity_solver->solveSystem(*U_vec, *F_U_vec);
+    }
+    else
+    {
+        TBOX_ASSERT(!d_U_problem_coefs.cIsZero());
+        d_velocity_data_ops->scale(U_vec->getComponentDescriptorIndex(0),
+                                   1.0 / d_U_problem_coefs.getCConstant(),
+                                   F_U_vec->getComponentDescriptorIndex(0));
+    }
 
     // (2) Solve the pressure sub-problem.
     //

--- a/tests/navier_stokes/navier_stokes_01_2d.projection_preconditioner_skip_velocity_solve.input
+++ b/tests/navier_stokes/navier_stokes_01_2d.projection_preconditioner_skip_velocity_solve.input
@@ -1,0 +1,357 @@
+// physical parameters
+MU  = 1.0e-2                              // fluid viscosity
+RHO = 1.0                                 // fluid density
+L   = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 16                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// solver parameters
+SOLVER_TYPE        = "STAGGERED"          // the fluid solver to use (STAGGERED or COLLOCATED)
+CFL_MAX            = 0.3                  // maximum CFL number
+DT_MAX             = 0.0625/NFINEST       // maximum timestep size
+START_TIME         = 0.0e0                // initial simulation time
+END_TIME           = 10*DT_MAX            // final simulation time
+GROW_DT            = 2.0e0                // growth factor for timesteps
+NUM_CYCLES         = 1                    // number of cycles of fixed-point iteration
+CONVECTIVE_TS_TYPE = "ADAMS_BASHFORTH"    // convective time stepping type
+CONVECTIVE_OP_TYPE = "PPM"                // convective differencing discretization type
+CONVECTIVE_FORM    = "ADVECTIVE"          // how to compute the convective terms
+NORMALIZE_PRESSURE = TRUE                 // whether to explicitly force the pressure to have mean zero
+VORTICITY_TAGGING  = FALSE                // whether to tag cells for refinement based on vorticity thresholds
+TAG_BUFFER         = 1                    // sized of tag buffer used by grid generation algorithm
+REGRID_INTERVAL    = 10000000             // effectively disable regridding
+OUTPUT_U           = TRUE
+OUTPUT_P           = TRUE
+OUTPUT_F           = FALSE
+OUTPUT_OMEGA       = TRUE
+OUTPUT_DIV_U       = TRUE
+ENABLE_LOGGING     = TRUE
+
+// collocated solver parameters
+PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
+SECOND_ORDER_PRESSURE_UPDATE = TRUE
+
+// exact solution function expressions
+U = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)"
+V = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)"
+P = "-(cos(4*PI*(X_0-t)) + cos(4*PI*(X_1-t)))*exp(-16*PI*PI*nu*t)"
+
+// normal tractions
+T_n_X_0 = "(cos(4*PI*(X_0-t))+cos(4*PI*(X_1-t)))*exp(-16*PI^2*nu*t)+8*nu*sin(2*PI*(X_0-t))*PI*sin(2*PI*(X_1-t))*exp(-8*PI^2*nu*t)"
+T_n_X_1 = "(cos(4*PI*(X_0-t))+cos(4*PI*(X_1-t)))*exp(-16*PI^2*nu*t)-8*nu*sin(2*PI*(X_0-t))*PI*sin(2*PI*(X_1-t))*exp(-8*PI^2*nu*t)"
+
+// tangential tractions
+T_t = "0.0"
+
+VelocityInitialConditions {
+   nu = MU/RHO
+   function_0 = U
+   function_1 = V
+}
+
+VelocityBcCoefs_0 {
+   nu = MU/RHO
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = U
+   gcoef_function_1 = U
+   gcoef_function_2 = U
+   gcoef_function_3 = U
+}
+
+VelocityBcCoefs_1 {
+   nu = MU/RHO
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = V
+   gcoef_function_1 = V
+   gcoef_function_2 = V
+   gcoef_function_3 = V
+}
+
+PressureInitialConditions {
+   nu = MU/RHO
+   function = P
+}
+
+INSCollocatedHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   num_cycles                    = NUM_CYCLES
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT_MAX
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_rel_thresh          = 0.25,0.125
+   tag_buffer                    = TAG_BUFFER
+   regrid_interval               = REGRID_INTERVAL
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+   projection_method_type        = PROJECTION_METHOD_TYPE
+   use_2nd_order_pressure_update = SECOND_ORDER_PRESSURE_UPDATE
+
+   velocity_solver_type = "PETSC_KRYLOV_SOLVER"
+   velocity_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   velocity_solver_db {
+      ksp_type = "fgmres"
+   }
+   velocity_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+
+   pressure_solver_type = "PETSC_KRYLOV_SOLVER"
+   pressure_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   pressure_solver_db {
+      ksp_type = "fgmres"
+   }
+   pressure_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+
+   regrid_projection_solver_type = "PETSC_KRYLOV_SOLVER"
+   regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   regrid_projection_solver_db {
+      ksp_type = "fgmres"
+   }
+   regrid_projection_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+}
+
+INSStaggeredHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   num_cycles                    = NUM_CYCLES
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT_MAX
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_rel_thresh          = 0.25,0.125
+   tag_buffer                    = TAG_BUFFER
+   regrid_interval               = REGRID_INTERVAL
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+
+   stokes_solver_type = "PETSC_KRYLOV_SOLVER"
+   stokes_precond_type = "PROJECTION_PRECONDITIONER"
+   stokes_solver_db {
+      ksp_type = "fgmres"
+   }
+   stokes_precond_db {
+      skip_velocity_solve = TRUE
+   }
+
+   velocity_solver_type = "PETSC_KRYLOV_SOLVER"
+   velocity_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   velocity_solver_db {
+      ksp_type = "richardson"
+      max_iterations = 1
+   }
+   velocity_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "CONSTANT_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "Split"
+         split_solver_type    = "PFMG"
+         enable_logging       = FALSE
+      }
+   }
+
+   pressure_solver_type = "PETSC_KRYLOV_SOLVER"
+   pressure_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   pressure_solver_db {
+      ksp_type = "richardson"
+      max_iterations = 1
+   }
+   pressure_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+
+   regrid_projection_solver_type = "PETSC_KRYLOV_SOLVER"
+   regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   regrid_projection_solver_db {
+      ksp_type = "fgmres"
+   }
+   regrid_projection_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+}
+
+Main {
+   solver_type = SOLVER_TYPE
+
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = int(END_TIME/(3*DT_MAX))
+   viz_dump_dirname            = "viz_INS2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 0,0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+//    level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+//    level_0 = [(0,0),(N/2 - 1,N/2 - 1)]
+      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/navier_stokes/navier_stokes_01_2d.projection_preconditioner_skip_velocity_solve.output
+++ b/tests/navier_stokes/navier_stokes_01_2d.projection_preconditioner_skip_velocity_solve.output
@@ -1,0 +1,525 @@
+INSStaggeredHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1
+INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
+  projecting the interpolated velocity field
+INSStaggeredHierarchyIntegrator::regridProjection(): regrid projection solve number of iterations = 8
+INSStaggeredHierarchyIntegrator::regridProjection(): regrid projection solve residual norm        = 1.19714e-19
+Input database:
+input_db {
+   MU                           = 0.01                      // input used
+   RHO                          = 1                         // input used
+   L                            = 1                         // input used
+   MAX_LEVELS                   = 2                         // input used
+   REF_RATIO                    = 4                         // input used
+   N                            = 16                        // input used
+   NFINEST                      = 64                        // input used
+   SOLVER_TYPE                  = "STAGGERED"               // input used
+   CFL_MAX                      = 0.3                       // input used
+   DT_MAX                       = 0.000976562               // input used
+   START_TIME                   = 0                         // input used
+   END_TIME                     = 0.00976562                // input used
+   GROW_DT                      = 2                         // input used
+   NUM_CYCLES                   = 1                         // input used
+   CONVECTIVE_TS_TYPE           = "ADAMS_BASHFORTH"         // input used
+   CONVECTIVE_OP_TYPE           = "PPM"                     // input used
+   CONVECTIVE_FORM              = "ADVECTIVE"               // input used
+   NORMALIZE_PRESSURE           = TRUE                      // input used
+   VORTICITY_TAGGING            = FALSE                     // input used
+   TAG_BUFFER                   = 1                         // input used
+   REGRID_INTERVAL              = 10000000                  // input used
+   OUTPUT_U                     = TRUE                      // input used
+   OUTPUT_P                     = TRUE                      // input used
+   OUTPUT_F                     = FALSE                     // input used
+   OUTPUT_OMEGA                 = TRUE                      // input used
+   OUTPUT_DIV_U                 = TRUE                      // input used
+   ENABLE_LOGGING               = TRUE                      // input used
+   PROJECTION_METHOD_TYPE       = "PRESSURE_UPDATE"         // input used
+   SECOND_ORDER_PRESSURE_UPDATE = TRUE                      // input used
+   U                            = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+   V                            = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+   P                            = "-(cos(4*PI*(X_0-t)) + cos(4*PI*(X_1-t)))*exp(-16*PI*PI*nu*t)" // input used
+   T_n_X_0                      = "(cos(4*PI*(X_0-t))+cos(4*PI*(X_1-t)))*exp(-16*PI^2*nu*t)+8*nu*sin(2*PI*(X_0-t))*PI*sin(2*PI*(X_1-t))*exp(-8*PI^2*nu*t)" // input not used
+   T_n_X_1                      = "(cos(4*PI*(X_0-t))+cos(4*PI*(X_1-t)))*exp(-16*PI^2*nu*t)-8*nu*sin(2*PI*(X_0-t))*PI*sin(2*PI*(X_1-t))*exp(-8*PI^2*nu*t)" // input not used
+   T_t                          = "0.0"                     // input not used
+   VelocityInitialConditions {
+      nu         = 0.01                                     // input used
+      function_0 = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      function_1 = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+   }
+   VelocityBcCoefs_0 {
+      nu               = 0.01                               // input used
+      acoef_function_0 = "1.0"                              // input used
+      acoef_function_1 = "1.0"                              // input used
+      acoef_function_2 = "1.0"                              // input used
+      acoef_function_3 = "1.0"                              // input used
+      bcoef_function_0 = "0.0"                              // input used
+      bcoef_function_1 = "0.0"                              // input used
+      bcoef_function_2 = "0.0"                              // input used
+      bcoef_function_3 = "0.0"                              // input used
+      gcoef_function_0 = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_1 = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_2 = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_3 = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+   }
+   VelocityBcCoefs_1 {
+      nu               = 0.01                               // input used
+      acoef_function_0 = "1.0"                              // input used
+      acoef_function_1 = "1.0"                              // input used
+      acoef_function_2 = "1.0"                              // input used
+      acoef_function_3 = "1.0"                              // input used
+      bcoef_function_0 = "0.0"                              // input used
+      bcoef_function_1 = "0.0"                              // input used
+      bcoef_function_2 = "0.0"                              // input used
+      bcoef_function_3 = "0.0"                              // input used
+      gcoef_function_0 = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_1 = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_2 = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+      gcoef_function_3 = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)" // input used
+   }
+   PressureInitialConditions {
+      nu       = 0.01                                       // input used
+      function = "-(cos(4*PI*(X_0-t)) + cos(4*PI*(X_1-t)))*exp(-16*PI*PI*nu*t)" // input used
+   }
+   INSCollocatedHierarchyIntegrator {
+      mu                             = 0.01                 // input not used
+      rho                            = 1                    // input not used
+      start_time                     = 0                    // input not used
+      end_time                       = 0.00976562           // input not used
+      grow_dt                        = 2                    // input not used
+      num_cycles                     = 1                    // input not used
+      convective_time_stepping_type  = "ADAMS_BASHFORTH"    // input not used
+      convective_op_type             = "PPM"                // input not used
+      convective_difference_form     = "ADVECTIVE"          // input not used
+      normalize_pressure             = TRUE                 // input not used
+      cfl                            = 0.3                  // input not used
+      dt_max                         = 0.000976562          // input not used
+      using_vorticity_tagging        = FALSE                // input not used
+      vorticity_rel_thresh           = 0.25, 0.125          // input not used
+      tag_buffer                     = 1                    // input not used
+      regrid_interval                = 10000000             // input not used
+      output_U                       = TRUE                 // input not used
+      output_P                       = TRUE                 // input not used
+      output_F                       = FALSE                // input not used
+      output_Omega                   = TRUE                 // input not used
+      output_Div_U                   = TRUE                 // input not used
+      enable_logging                 = TRUE                 // input not used
+      projection_method_type         = "PRESSURE_UPDATE"    // input not used
+      use_2nd_order_pressure_update  = TRUE                 // input not used
+      velocity_solver_type           = "PETSC_KRYLOV_SOLVER" // input not used
+      velocity_precond_type          = "POINT_RELAXATION_FAC_PRECONDITIONER" // input not used
+      pressure_solver_type           = "PETSC_KRYLOV_SOLVER" // input not used
+      pressure_precond_type          = "POINT_RELAXATION_FAC_PRECONDITIONER" // input not used
+      regrid_projection_solver_type  = "PETSC_KRYLOV_SOLVER" // input not used
+      regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER" // input not used
+      velocity_solver_db {
+         ksp_type = "fgmres"                                // input not used
+      }
+      velocity_precond_db {
+         num_pre_sweeps                 = 0                 // input not used
+         num_post_sweeps                = 3                 // input not used
+         prolongation_method            = "LINEAR_REFINE"   // input not used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input not used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input not used
+         coarse_solver_rel_residual_tol = 1e-12             // input not used
+         coarse_solver_abs_residual_tol = 1e-50             // input not used
+         coarse_solver_max_iterations   = 1                 // input not used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input not used
+            num_pre_relax_steps  = 0                        // input not used
+            num_post_relax_steps = 3                        // input not used
+            enable_logging       = FALSE                    // input not used
+         }
+      }
+      pressure_solver_db {
+         ksp_type = "fgmres"                                // input not used
+      }
+      pressure_precond_db {
+         num_pre_sweeps                 = 0                 // input not used
+         num_post_sweeps                = 3                 // input not used
+         prolongation_method            = "LINEAR_REFINE"   // input not used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input not used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input not used
+         coarse_solver_rel_residual_tol = 1e-12             // input not used
+         coarse_solver_abs_residual_tol = 1e-50             // input not used
+         coarse_solver_max_iterations   = 1                 // input not used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input not used
+            num_pre_relax_steps  = 0                        // input not used
+            num_post_relax_steps = 3                        // input not used
+            enable_logging       = FALSE                    // input not used
+         }
+      }
+      regrid_projection_solver_db {
+         ksp_type = "fgmres"                                // input not used
+      }
+      regrid_projection_precond_db {
+         num_pre_sweeps                 = 0                 // input not used
+         num_post_sweeps                = 3                 // input not used
+         prolongation_method            = "LINEAR_REFINE"   // input not used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input not used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input not used
+         coarse_solver_rel_residual_tol = 1e-12             // input not used
+         coarse_solver_abs_residual_tol = 1e-50             // input not used
+         coarse_solver_max_iterations   = 1                 // input not used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input not used
+            num_pre_relax_steps  = 0                        // input not used
+            num_post_relax_steps = 3                        // input not used
+            enable_logging       = FALSE                    // input not used
+         }
+      }
+   }
+   INSStaggeredHierarchyIntegrator {
+      mu                             = 0.01                 // input used
+      rho                            = 1                    // input used
+      start_time                     = 0                    // input used
+      end_time                       = 0.00976562           // input used
+      grow_dt                        = 2                    // input used
+      num_cycles                     = 1                    // input used
+      convective_time_stepping_type  = "ADAMS_BASHFORTH"    // input used
+      convective_op_type             = "PPM"                // input used
+      convective_difference_form     = "ADVECTIVE"          // input used
+      normalize_pressure             = TRUE                 // input used
+      cfl                            = 0.3                  // input used
+      dt_max                         = 0.000976562          // input used
+      using_vorticity_tagging        = FALSE                // input used
+      vorticity_rel_thresh           = 0.25, 0.125          // input used
+      tag_buffer                     = 1                    // input used
+      regrid_interval                = 10000000             // input used
+      output_U                       = TRUE                 // input used
+      output_P                       = TRUE                 // input used
+      output_F                       = FALSE                // input used
+      output_Omega                   = TRUE                 // input used
+      output_Div_U                   = TRUE                 // input used
+      enable_logging                 = TRUE                 // input used
+      stokes_solver_type             = "PETSC_KRYLOV_SOLVER" // input used
+      stokes_precond_type            = "PROJECTION_PRECONDITIONER" // input used
+      velocity_solver_type           = "PETSC_KRYLOV_SOLVER" // input used
+      velocity_precond_type          = "POINT_RELAXATION_FAC_PRECONDITIONER" // input used
+      pressure_solver_type           = "PETSC_KRYLOV_SOLVER" // input used
+      pressure_precond_type          = "POINT_RELAXATION_FAC_PRECONDITIONER" // input used
+      regrid_projection_solver_type  = "PETSC_KRYLOV_SOLVER" // input used
+      regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER" // input used
+      U_P_bdry_interp_type           = "LINEAR"             // from default
+      stokes_solver_db {
+         ksp_type               = "fgmres"                  // input used
+         refine_type            = "NONE"                    // from default
+         coarsen_type           = "CUBIC_COARSEN"           // from default
+         bdry_extrap_type       = "LINEAR"                  // from default
+         bdry_interp_type       = "LINEAR"                  // from default
+         use_cf_interpolation   = TRUE                      // from default
+         consistent_type_2_bdry = FALSE                     // from default
+      }
+      stokes_precond_db {
+         skip_velocity_solve = TRUE                         // input used
+      }
+      velocity_solver_db {
+         ksp_type       = "richardson"                      // input not used
+         max_iterations = 1                                 // input not used
+      }
+      velocity_precond_db {
+         num_pre_sweeps                 = 0                 // input not used
+         num_post_sweeps                = 3                 // input not used
+         prolongation_method            = "CONSTANT_REFINE" // input not used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input not used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input not used
+         coarse_solver_rel_residual_tol = 1e-12             // input not used
+         coarse_solver_abs_residual_tol = 1e-50             // input not used
+         coarse_solver_max_iterations   = 1                 // input not used
+         coarse_solver_db {
+            solver_type       = "Split"                     // input not used
+            split_solver_type = "PFMG"                      // input not used
+            enable_logging    = FALSE                       // input not used
+         }
+      }
+      pressure_solver_db {
+         ksp_type       = "richardson"                      // input used
+         max_iterations = 1                                 // input used
+      }
+      pressure_precond_db {
+         num_pre_sweeps                 = 0                 // input used
+         num_post_sweeps                = 3                 // input used
+         prolongation_method            = "LINEAR_REFINE"   // input used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input used
+         coarse_solver_rel_residual_tol = 1e-12             // input used
+         coarse_solver_abs_residual_tol = 1e-50             // input used
+         coarse_solver_max_iterations   = 1                 // input used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input used
+            num_pre_relax_steps  = 0                        // input used
+            num_post_relax_steps = 3                        // input used
+            enable_logging       = FALSE                    // input used
+         }
+      }
+      regrid_projection_solver_db {
+         ksp_type = "fgmres"                                // input used
+      }
+      regrid_projection_precond_db {
+         num_pre_sweeps                 = 0                 // input used
+         num_post_sweeps                = 3                 // input used
+         prolongation_method            = "LINEAR_REFINE"   // input used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input used
+         coarse_solver_rel_residual_tol = 1e-12             // input used
+         coarse_solver_abs_residual_tol = 1e-50             // input used
+         coarse_solver_max_iterations   = 1                 // input used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input used
+            num_pre_relax_steps  = 0                        // input used
+            num_post_relax_steps = 3                        // input used
+            enable_logging       = FALSE                    // input used
+         }
+      }
+   }
+   Main {
+      solver_type                 = "STAGGERED"             // input used
+      log_file_name               = "output"                // input used
+      log_all_nodes               = FALSE                   // input used
+      viz_writer                  = "VisIt"                 // input used
+      viz_dump_interval           = 3                       // input used
+      viz_dump_dirname            = "viz_INS2d"             // input used
+      visit_number_procs_per_file = 1                       // input used
+      restart_dump_interval       = 0                       // input used
+      restart_dump_dirname        = "restart_INS2d"         // input used
+      timer_dump_interval         = 0                       // input used
+   }
+   CartesianGeometry {
+      domain_boxes       = [(0,0),(15,15)]                  // input used
+      x_lo               = 0, 0                             // input used
+      x_up               = 1, 1                             // input used
+      periodic_dimension = 0, 0                             // input used
+   }
+   GriddingAlgorithm {
+      max_levels                = 2                         // input used
+      efficiency_tolerance      = 0.85                      // input used
+      combine_efficiency        = 0.85                      // input used
+      check_nonrefined_tags     = 'w'                       // from default
+      check_overlapping_patches = 'i'                       // from default
+      extend_tags_to_bdry       = FALSE                     // from default
+      ratio_to_coarser {
+         level_1 = 4, 4                                     // input used
+         level_2 = 4, 4                                     // input not used
+         level_3 = 4, 4                                     // input not used
+      }
+      largest_patch_size {
+         level_0 = 512, 512                                 // input used
+      }
+      smallest_patch_size {
+         level_0 = 4, 4                                     // input used
+      }
+   }
+   StandardTagAndInitialize {
+      tagging_method = "REFINE_BOXES"                       // input used
+      RefineBoxes {
+         level_0 = [(4,4),(11,7)], [(4,8),(7,11)]           // input used
+      }
+   }
+   LoadBalancer {
+      bin_pack_method                      = "SPATIAL"      // input used
+      max_workload_factor                  = 1              // input used
+      ignore_level_box_union_is_single_box = FALSE          // from default
+   }
+   TimerManager {
+      print_exclusive = FALSE                               // input not used
+      print_total     = TRUE                                // input not used
+      print_threshold = 0.1                                 // input not used
+      timer_list      = "IBAMR::*::*", "IBTK::*::*", "*::*::*" // input not used
+   }
+}
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 0
+Simulation time is 0
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0,0.000976562], dt = 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): regridding prior to timestep 0
+INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
+INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver
+INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing incompressible Stokes solver
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): executing cycle 1 of 2
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 2
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00427797
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): executing cycle 2 of 2
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00374896
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187619
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 0
+Simulation time is 0.000976562
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 1
+Simulation time is 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.000976562,0.00195312], dt = 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 2
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00133703
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187721
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 1
+Simulation time is 0.00195312
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 2
+Simulation time is 0.00195312
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00195312,0.00292969], dt = 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 2
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000822346
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187826
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 2
+Simulation time is 0.00292969
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 3
+Simulation time is 0.00292969
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00292969,0.00390625], dt = 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 2
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000685433
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.187922
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 3
+Simulation time is 0.00390625
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 4
+Simulation time is 0.00390625
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00390625,0.00488281], dt = 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.0179495
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.188006
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 4
+Simulation time is 0.00488281
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 5
+Simulation time is 0.00488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00488281,0.00585938], dt = 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.0165497
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.188119
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 5
+Simulation time is 0.00585938
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 6
+Simulation time is 0.00585938
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00585938,0.00683594], dt = 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.0155054
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.188177
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 6
+Simulation time is 0.00683594
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 7
+Simulation time is 0.00683594
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00683594,0.0078125], dt = 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.0146374
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.188205
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 7
+Simulation time is 0.0078125
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 8
+Simulation time is 0.0078125
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.0078125,0.00878906], dt = 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.0139827
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.188206
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 8
+Simulation time is 0.00878906
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 9
+Simulation time is 0.00878906
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00878906,0.00976562], dt = 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.0135586
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.188182
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 9
+Simulation time is 0.00976562
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+Computing error norms.
+
+Error in u at time 0.00976562:
+  L1-norm:  0.003588513016
+  L2-norm:  0.004420511743
+  max-norm: 0.04208048315
+Error in p at time 0.00927734375:
+  L1-norm:  0.02181661755
+  L2-norm:  0.02939656769
+  max-norm: 0.2193477306
++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/tests/navier_stokes/navier_stokes_01_3d.projection_preconditioner_skip_velocity_solve.input
+++ b/tests/navier_stokes/navier_stokes_01_3d.projection_preconditioner_skip_velocity_solve.input
@@ -1,0 +1,395 @@
+// physical parameters
+MU  = 1.0e-2                              // fluid viscosity
+RHO = 1.0                                 // fluid density
+L   = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// solver parameters
+SOLVER_TYPE        = "STAGGERED"          // the fluid solver to use (STAGGERED or COLLOCATED)
+CFL_MAX            = 0.3                  // maximum CFL number
+DT_MAX             = 0.0625/NFINEST       // maximum timestep size
+START_TIME         = 0.0e0                // initial simulation time
+END_TIME           = 10*DT_MAX                  // final simulation time
+GROW_DT            = 2.0e0                // growth factor for timesteps
+NUM_CYCLES         = 1                    // number of cycles of fixed-point iteration
+CONVECTIVE_TS_TYPE = "ADAMS_BASHFORTH"    // convective time stepping type
+CONVECTIVE_OP_TYPE = "PPM"                // convective differencing discretization type
+CONVECTIVE_FORM    = "ADVECTIVE"          // how to compute the convective terms
+NORMALIZE_PRESSURE = TRUE                 // whether to explicitly force the pressure to have mean zero
+VORTICITY_TAGGING  = TRUE                 // whether to tag cells for refinement based on vorticity thresholds
+TAG_BUFFER         = 1                    // sized of tag buffer used by grid generation algorithm
+REGRID_INTERVAL    = 10000000             // effectively disable regridding
+OUTPUT_U           = TRUE
+OUTPUT_P           = TRUE
+OUTPUT_F           = FALSE
+OUTPUT_OMEGA       = TRUE
+OUTPUT_DIV_U       = TRUE
+ENABLE_LOGGING     = TRUE
+
+// collocated solver parameters
+PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
+SECOND_ORDER_PRESSURE_UPDATE = TRUE
+
+// exact solution function expressions
+U = "1.0 + exp(-4.0*PI*PI*nu*t)*(C*cos(2*PI*(X_1-t)) + A*sin(2*PI*(X_2-t)))"
+V = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*sin(2*PI*(X_0-t)) + A*cos(2*PI*(X_2-t)))"
+W = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*cos(2*PI*(X_0-t)) + C*sin(2*PI*(X_1-t)))"
+P = "-exp(-8.0*PI*PI*nu*t)*(A*C*cos(2*PI*(X_1-t))*sin(2*PI*(X_2-t)) + A*B*sin(2*PI*(X_0-t))*cos(2*PI*(X_2-t)) + B*C*cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))"
+
+VelocityInitialConditions {
+   nu = MU/RHO
+   A = 1.0
+   B = 1.0
+   C = 1.0
+   function_0 = U
+   function_1 = V
+   function_2 = W
+}
+
+VelocityBcCoefs_0 {
+   nu = MU/RHO
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   acoef_function_4 = "1.0"
+   acoef_function_5 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+   bcoef_function_4 = "0.0"
+   bcoef_function_5 = "0.0"
+
+   gcoef_function_0 = U
+   gcoef_function_1 = U
+   gcoef_function_2 = U
+   gcoef_function_3 = U
+   gcoef_function_4 = U
+   gcoef_function_5 = U
+}
+
+VelocityBcCoefs_1 {
+   nu = MU/RHO
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   acoef_function_4 = "1.0"
+   acoef_function_5 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+   bcoef_function_4 = "0.0"
+   bcoef_function_5 = "0.0"
+
+   gcoef_function_0 = V
+   gcoef_function_1 = V
+   gcoef_function_2 = V
+   gcoef_function_3 = V
+   gcoef_function_4 = V
+   gcoef_function_5 = V
+}
+
+VelocityBcCoefs_2 {
+   nu = MU/RHO
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   acoef_function_4 = "1.0"
+   acoef_function_5 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+   bcoef_function_4 = "0.0"
+   bcoef_function_5 = "0.0"
+
+   gcoef_function_0 = W
+   gcoef_function_1 = W
+   gcoef_function_2 = W
+   gcoef_function_3 = W
+   gcoef_function_4 = W
+   gcoef_function_5 = W
+}
+
+PressureInitialConditions {
+   nu = MU/RHO
+   A = 1.0
+   B = 1.0
+   C = 1.0
+   function = P
+}
+
+INSCollocatedHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   num_cycles                    = NUM_CYCLES
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT_MAX
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_rel_thresh          = 0.25,0.125
+   tag_buffer                    = TAG_BUFFER
+   regrid_interval               = REGRID_INTERVAL
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+   projection_method_type        = PROJECTION_METHOD_TYPE
+   use_2nd_order_pressure_update = SECOND_ORDER_PRESSURE_UPDATE
+
+   velocity_solver_type = "PETSC_KRYLOV_SOLVER"
+   velocity_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   velocity_solver_db {
+      ksp_type = "fgmres"
+   }
+   velocity_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+
+   pressure_solver_type = "PETSC_KRYLOV_SOLVER"
+   pressure_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   pressure_solver_db {
+      ksp_type = "fgmres"
+   }
+   pressure_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+
+   regrid_projection_solver_type = "PETSC_KRYLOV_SOLVER"
+   regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   regrid_projection_solver_db {
+      ksp_type = "fgmres"
+   }
+   regrid_projection_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+}
+
+INSStaggeredHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   num_cycles                    = NUM_CYCLES
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT_MAX
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_rel_thresh          = 0.25,0.125
+   tag_buffer                    = TAG_BUFFER
+   regrid_interval               = REGRID_INTERVAL
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+
+   stokes_solver_type = "PETSC_KRYLOV_SOLVER"
+   stokes_precond_type = "PROJECTION_PRECONDITIONER"
+   stokes_solver_db {
+      ksp_type = "fgmres"
+   }
+   stokes_precond_db {
+      skip_velocity_solve = TRUE
+   }
+
+   velocity_solver_type = "PETSC_KRYLOV_SOLVER"
+   velocity_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   velocity_solver_db {
+      ksp_type = "richardson"
+      max_iterations = 1
+   }
+   velocity_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "CONSTANT_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "Split"
+         split_solver_type    = "PFMG"
+         enable_logging       = FALSE
+      }
+   }
+
+   pressure_solver_type = "PETSC_KRYLOV_SOLVER"
+   pressure_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   pressure_solver_db {
+      ksp_type = "richardson"
+      max_iterations = 1
+   }
+   pressure_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+
+   regrid_projection_solver_type = "PETSC_KRYLOV_SOLVER"
+   regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   regrid_projection_solver_db {
+      ksp_type = "fgmres"
+   }
+   regrid_projection_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+}
+
+Main {
+   solver_type = SOLVER_TYPE
+
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = int(END_TIME/(3*DT_MAX))
+   viz_dump_dirname            = "viz_INS3d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS3d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0,0,0
+   x_up = L,L,L
+   periodic_dimension = 1,1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+      level_1 = [((REF_RATIO^1)*N/4 + 1,(REF_RATIO^1)*N/4 + 1,(REF_RATIO^1)*N/4 + 1),(3*(REF_RATIO^1)*N/4 - 2,3*(REF_RATIO^1)*N/4 - 2,3*(REF_RATIO^1)*N/4 - 2)]
+      level_2 = [((REF_RATIO^2)*N/4 + 2,(REF_RATIO^2)*N/4 + 2,(REF_RATIO^2)*N/4 + 2),(3*(REF_RATIO^2)*N/4 - 3,3*(REF_RATIO^2)*N/4 - 3,3*(REF_RATIO^2)*N/4 - 3)]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/tests/navier_stokes/navier_stokes_01_3d.projection_preconditioner_skip_velocity_solve.output
+++ b/tests/navier_stokes/navier_stokes_01_3d.projection_preconditioner_skip_velocity_solve.output
@@ -1,0 +1,565 @@
+INSStaggeredHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 1
+INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
+  projecting the interpolated velocity field
+INSStaggeredHierarchyIntegrator::regridProjection(): regrid projection solve number of iterations = 0
+INSStaggeredHierarchyIntegrator::regridProjection(): regrid projection solve residual norm        = 0
+Input database:
+input_db {
+   MU                           = 0.01                      // input used
+   RHO                          = 1                         // input used
+   L                            = 1                         // input used
+   MAX_LEVELS                   = 2                         // input used
+   REF_RATIO                    = 4                         // input used
+   N                            = 32                        // input used
+   NFINEST                      = 128                       // input used
+   SOLVER_TYPE                  = "STAGGERED"               // input used
+   CFL_MAX                      = 0.3                       // input used
+   DT_MAX                       = 0.000488281               // input used
+   START_TIME                   = 0                         // input used
+   END_TIME                     = 0.00488281                // input used
+   GROW_DT                      = 2                         // input used
+   NUM_CYCLES                   = 1                         // input used
+   CONVECTIVE_TS_TYPE           = "ADAMS_BASHFORTH"         // input used
+   CONVECTIVE_OP_TYPE           = "PPM"                     // input used
+   CONVECTIVE_FORM              = "ADVECTIVE"               // input used
+   NORMALIZE_PRESSURE           = TRUE                      // input used
+   VORTICITY_TAGGING            = TRUE                      // input used
+   TAG_BUFFER                   = 1                         // input used
+   REGRID_INTERVAL              = 10000000                  // input used
+   OUTPUT_U                     = TRUE                      // input used
+   OUTPUT_P                     = TRUE                      // input used
+   OUTPUT_F                     = FALSE                     // input used
+   OUTPUT_OMEGA                 = TRUE                      // input used
+   OUTPUT_DIV_U                 = TRUE                      // input used
+   ENABLE_LOGGING               = TRUE                      // input used
+   PROJECTION_METHOD_TYPE       = "PRESSURE_UPDATE"         // input used
+   SECOND_ORDER_PRESSURE_UPDATE = TRUE                      // input used
+   U                            = "1.0 + exp(-4.0*PI*PI*nu*t)*(C*cos(2*PI*(X_1-t)) + A*sin(2*PI*(X_2-t)))" // input used
+   V                            = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*sin(2*PI*(X_0-t)) + A*cos(2*PI*(X_2-t)))" // input used
+   W                            = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*cos(2*PI*(X_0-t)) + C*sin(2*PI*(X_1-t)))" // input used
+   P                            = "-exp(-8.0*PI*PI*nu*t)*(A*C*cos(2*PI*(X_1-t))*sin(2*PI*(X_2-t)) + A*B*sin(2*PI*(X_0-t))*cos(2*PI*(X_2-t)) + B*C*cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))" // input used
+   VelocityInitialConditions {
+      nu         = 0.01                                     // input used
+      A          = 1                                        // input used
+      B          = 1                                        // input used
+      C          = 1                                        // input used
+      function_0 = "1.0 + exp(-4.0*PI*PI*nu*t)*(C*cos(2*PI*(X_1-t)) + A*sin(2*PI*(X_2-t)))" // input used
+      function_1 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*sin(2*PI*(X_0-t)) + A*cos(2*PI*(X_2-t)))" // input used
+      function_2 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*cos(2*PI*(X_0-t)) + C*sin(2*PI*(X_1-t)))" // input used
+   }
+   VelocityBcCoefs_0 {
+      nu               = 0.01                               // input not used
+      acoef_function_0 = "1.0"                              // input not used
+      acoef_function_1 = "1.0"                              // input not used
+      acoef_function_2 = "1.0"                              // input not used
+      acoef_function_3 = "1.0"                              // input not used
+      acoef_function_4 = "1.0"                              // input not used
+      acoef_function_5 = "1.0"                              // input not used
+      bcoef_function_0 = "0.0"                              // input not used
+      bcoef_function_1 = "0.0"                              // input not used
+      bcoef_function_2 = "0.0"                              // input not used
+      bcoef_function_3 = "0.0"                              // input not used
+      bcoef_function_4 = "0.0"                              // input not used
+      bcoef_function_5 = "0.0"                              // input not used
+      gcoef_function_0 = "1.0 + exp(-4.0*PI*PI*nu*t)*(C*cos(2*PI*(X_1-t)) + A*sin(2*PI*(X_2-t)))" // input not used
+      gcoef_function_1 = "1.0 + exp(-4.0*PI*PI*nu*t)*(C*cos(2*PI*(X_1-t)) + A*sin(2*PI*(X_2-t)))" // input not used
+      gcoef_function_2 = "1.0 + exp(-4.0*PI*PI*nu*t)*(C*cos(2*PI*(X_1-t)) + A*sin(2*PI*(X_2-t)))" // input not used
+      gcoef_function_3 = "1.0 + exp(-4.0*PI*PI*nu*t)*(C*cos(2*PI*(X_1-t)) + A*sin(2*PI*(X_2-t)))" // input not used
+      gcoef_function_4 = "1.0 + exp(-4.0*PI*PI*nu*t)*(C*cos(2*PI*(X_1-t)) + A*sin(2*PI*(X_2-t)))" // input not used
+      gcoef_function_5 = "1.0 + exp(-4.0*PI*PI*nu*t)*(C*cos(2*PI*(X_1-t)) + A*sin(2*PI*(X_2-t)))" // input not used
+   }
+   VelocityBcCoefs_1 {
+      nu               = 0.01                               // input not used
+      acoef_function_0 = "1.0"                              // input not used
+      acoef_function_1 = "1.0"                              // input not used
+      acoef_function_2 = "1.0"                              // input not used
+      acoef_function_3 = "1.0"                              // input not used
+      acoef_function_4 = "1.0"                              // input not used
+      acoef_function_5 = "1.0"                              // input not used
+      bcoef_function_0 = "0.0"                              // input not used
+      bcoef_function_1 = "0.0"                              // input not used
+      bcoef_function_2 = "0.0"                              // input not used
+      bcoef_function_3 = "0.0"                              // input not used
+      bcoef_function_4 = "0.0"                              // input not used
+      bcoef_function_5 = "0.0"                              // input not used
+      gcoef_function_0 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*sin(2*PI*(X_0-t)) + A*cos(2*PI*(X_2-t)))" // input not used
+      gcoef_function_1 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*sin(2*PI*(X_0-t)) + A*cos(2*PI*(X_2-t)))" // input not used
+      gcoef_function_2 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*sin(2*PI*(X_0-t)) + A*cos(2*PI*(X_2-t)))" // input not used
+      gcoef_function_3 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*sin(2*PI*(X_0-t)) + A*cos(2*PI*(X_2-t)))" // input not used
+      gcoef_function_4 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*sin(2*PI*(X_0-t)) + A*cos(2*PI*(X_2-t)))" // input not used
+      gcoef_function_5 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*sin(2*PI*(X_0-t)) + A*cos(2*PI*(X_2-t)))" // input not used
+   }
+   VelocityBcCoefs_2 {
+      nu               = 0.01                               // input not used
+      acoef_function_0 = "1.0"                              // input not used
+      acoef_function_1 = "1.0"                              // input not used
+      acoef_function_2 = "1.0"                              // input not used
+      acoef_function_3 = "1.0"                              // input not used
+      acoef_function_4 = "1.0"                              // input not used
+      acoef_function_5 = "1.0"                              // input not used
+      bcoef_function_0 = "0.0"                              // input not used
+      bcoef_function_1 = "0.0"                              // input not used
+      bcoef_function_2 = "0.0"                              // input not used
+      bcoef_function_3 = "0.0"                              // input not used
+      bcoef_function_4 = "0.0"                              // input not used
+      bcoef_function_5 = "0.0"                              // input not used
+      gcoef_function_0 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*cos(2*PI*(X_0-t)) + C*sin(2*PI*(X_1-t)))" // input not used
+      gcoef_function_1 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*cos(2*PI*(X_0-t)) + C*sin(2*PI*(X_1-t)))" // input not used
+      gcoef_function_2 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*cos(2*PI*(X_0-t)) + C*sin(2*PI*(X_1-t)))" // input not used
+      gcoef_function_3 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*cos(2*PI*(X_0-t)) + C*sin(2*PI*(X_1-t)))" // input not used
+      gcoef_function_4 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*cos(2*PI*(X_0-t)) + C*sin(2*PI*(X_1-t)))" // input not used
+      gcoef_function_5 = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*cos(2*PI*(X_0-t)) + C*sin(2*PI*(X_1-t)))" // input not used
+   }
+   PressureInitialConditions {
+      nu       = 0.01                                       // input used
+      A        = 1                                          // input used
+      B        = 1                                          // input used
+      C        = 1                                          // input used
+      function = "-exp(-8.0*PI*PI*nu*t)*(A*C*cos(2*PI*(X_1-t))*sin(2*PI*(X_2-t)) + A*B*sin(2*PI*(X_0-t))*cos(2*PI*(X_2-t)) + B*C*cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))" // input used
+   }
+   INSCollocatedHierarchyIntegrator {
+      mu                             = 0.01                 // input not used
+      rho                            = 1                    // input not used
+      start_time                     = 0                    // input not used
+      end_time                       = 0.00488281           // input not used
+      grow_dt                        = 2                    // input not used
+      num_cycles                     = 1                    // input not used
+      convective_time_stepping_type  = "ADAMS_BASHFORTH"    // input not used
+      convective_op_type             = "PPM"                // input not used
+      convective_difference_form     = "ADVECTIVE"          // input not used
+      normalize_pressure             = TRUE                 // input not used
+      cfl                            = 0.3                  // input not used
+      dt_max                         = 0.000488281          // input not used
+      using_vorticity_tagging        = TRUE                 // input not used
+      vorticity_rel_thresh           = 0.25, 0.125          // input not used
+      tag_buffer                     = 1                    // input not used
+      regrid_interval                = 10000000             // input not used
+      output_U                       = TRUE                 // input not used
+      output_P                       = TRUE                 // input not used
+      output_F                       = FALSE                // input not used
+      output_Omega                   = TRUE                 // input not used
+      output_Div_U                   = TRUE                 // input not used
+      enable_logging                 = TRUE                 // input not used
+      projection_method_type         = "PRESSURE_UPDATE"    // input not used
+      use_2nd_order_pressure_update  = TRUE                 // input not used
+      velocity_solver_type           = "PETSC_KRYLOV_SOLVER" // input not used
+      velocity_precond_type          = "POINT_RELAXATION_FAC_PRECONDITIONER" // input not used
+      pressure_solver_type           = "PETSC_KRYLOV_SOLVER" // input not used
+      pressure_precond_type          = "POINT_RELAXATION_FAC_PRECONDITIONER" // input not used
+      regrid_projection_solver_type  = "PETSC_KRYLOV_SOLVER" // input not used
+      regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER" // input not used
+      velocity_solver_db {
+         ksp_type = "fgmres"                                // input not used
+      }
+      velocity_precond_db {
+         num_pre_sweeps                 = 0                 // input not used
+         num_post_sweeps                = 3                 // input not used
+         prolongation_method            = "LINEAR_REFINE"   // input not used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input not used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input not used
+         coarse_solver_rel_residual_tol = 1e-12             // input not used
+         coarse_solver_abs_residual_tol = 1e-50             // input not used
+         coarse_solver_max_iterations   = 1                 // input not used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input not used
+            num_pre_relax_steps  = 0                        // input not used
+            num_post_relax_steps = 3                        // input not used
+            enable_logging       = FALSE                    // input not used
+         }
+      }
+      pressure_solver_db {
+         ksp_type = "fgmres"                                // input not used
+      }
+      pressure_precond_db {
+         num_pre_sweeps                 = 0                 // input not used
+         num_post_sweeps                = 3                 // input not used
+         prolongation_method            = "LINEAR_REFINE"   // input not used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input not used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input not used
+         coarse_solver_rel_residual_tol = 1e-12             // input not used
+         coarse_solver_abs_residual_tol = 1e-50             // input not used
+         coarse_solver_max_iterations   = 1                 // input not used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input not used
+            num_pre_relax_steps  = 0                        // input not used
+            num_post_relax_steps = 3                        // input not used
+            enable_logging       = FALSE                    // input not used
+         }
+      }
+      regrid_projection_solver_db {
+         ksp_type = "fgmres"                                // input not used
+      }
+      regrid_projection_precond_db {
+         num_pre_sweeps                 = 0                 // input not used
+         num_post_sweeps                = 3                 // input not used
+         prolongation_method            = "LINEAR_REFINE"   // input not used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input not used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input not used
+         coarse_solver_rel_residual_tol = 1e-12             // input not used
+         coarse_solver_abs_residual_tol = 1e-50             // input not used
+         coarse_solver_max_iterations   = 1                 // input not used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input not used
+            num_pre_relax_steps  = 0                        // input not used
+            num_post_relax_steps = 3                        // input not used
+            enable_logging       = FALSE                    // input not used
+         }
+      }
+   }
+   INSStaggeredHierarchyIntegrator {
+      mu                             = 0.01                 // input used
+      rho                            = 1                    // input used
+      start_time                     = 0                    // input used
+      end_time                       = 0.00488281           // input used
+      grow_dt                        = 2                    // input used
+      num_cycles                     = 1                    // input used
+      convective_time_stepping_type  = "ADAMS_BASHFORTH"    // input used
+      convective_op_type             = "PPM"                // input used
+      convective_difference_form     = "ADVECTIVE"          // input used
+      normalize_pressure             = TRUE                 // input used
+      cfl                            = 0.3                  // input used
+      dt_max                         = 0.000488281          // input used
+      using_vorticity_tagging        = TRUE                 // input used
+      vorticity_rel_thresh           = 0.25, 0.125          // input used
+      tag_buffer                     = 1                    // input used
+      regrid_interval                = 10000000             // input used
+      output_U                       = TRUE                 // input used
+      output_P                       = TRUE                 // input used
+      output_F                       = FALSE                // input used
+      output_Omega                   = TRUE                 // input used
+      output_Div_U                   = TRUE                 // input used
+      enable_logging                 = TRUE                 // input used
+      stokes_solver_type             = "PETSC_KRYLOV_SOLVER" // input used
+      stokes_precond_type            = "PROJECTION_PRECONDITIONER" // input used
+      velocity_solver_type           = "PETSC_KRYLOV_SOLVER" // input used
+      velocity_precond_type          = "POINT_RELAXATION_FAC_PRECONDITIONER" // input used
+      pressure_solver_type           = "PETSC_KRYLOV_SOLVER" // input used
+      pressure_precond_type          = "POINT_RELAXATION_FAC_PRECONDITIONER" // input used
+      regrid_projection_solver_type  = "PETSC_KRYLOV_SOLVER" // input used
+      regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER" // input used
+      U_P_bdry_interp_type           = "LINEAR"             // from default
+      stokes_solver_db {
+         ksp_type               = "fgmres"                  // input used
+         refine_type            = "NONE"                    // from default
+         coarsen_type           = "CUBIC_COARSEN"           // from default
+         bdry_extrap_type       = "LINEAR"                  // from default
+         bdry_interp_type       = "LINEAR"                  // from default
+         use_cf_interpolation   = TRUE                      // from default
+         consistent_type_2_bdry = FALSE                     // from default
+      }
+      stokes_precond_db {
+         skip_velocity_solve = TRUE                         // input used
+      }
+      velocity_solver_db {
+         ksp_type       = "richardson"                      // input not used
+         max_iterations = 1                                 // input not used
+      }
+      velocity_precond_db {
+         num_pre_sweeps                 = 0                 // input not used
+         num_post_sweeps                = 3                 // input not used
+         prolongation_method            = "CONSTANT_REFINE" // input not used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input not used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input not used
+         coarse_solver_rel_residual_tol = 1e-12             // input not used
+         coarse_solver_abs_residual_tol = 1e-50             // input not used
+         coarse_solver_max_iterations   = 1                 // input not used
+         coarse_solver_db {
+            solver_type       = "Split"                     // input not used
+            split_solver_type = "PFMG"                      // input not used
+            enable_logging    = FALSE                       // input not used
+         }
+      }
+      pressure_solver_db {
+         ksp_type       = "richardson"                      // input used
+         max_iterations = 1                                 // input used
+      }
+      pressure_precond_db {
+         num_pre_sweeps                 = 0                 // input used
+         num_post_sweeps                = 3                 // input used
+         prolongation_method            = "LINEAR_REFINE"   // input used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input used
+         coarse_solver_rel_residual_tol = 1e-12             // input used
+         coarse_solver_abs_residual_tol = 1e-50             // input used
+         coarse_solver_max_iterations   = 1                 // input used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input used
+            num_pre_relax_steps  = 0                        // input used
+            num_post_relax_steps = 3                        // input used
+            enable_logging       = FALSE                    // input used
+         }
+      }
+      regrid_projection_solver_db {
+         ksp_type = "fgmres"                                // input used
+      }
+      regrid_projection_precond_db {
+         num_pre_sweeps                 = 0                 // input used
+         num_post_sweeps                = 3                 // input used
+         prolongation_method            = "LINEAR_REFINE"   // input used
+         restriction_method             = "CONSERVATIVE_COARSEN" // input used
+         coarse_solver_type             = "HYPRE_LEVEL_SOLVER" // input used
+         coarse_solver_rel_residual_tol = 1e-12             // input used
+         coarse_solver_abs_residual_tol = 1e-50             // input used
+         coarse_solver_max_iterations   = 1                 // input used
+         coarse_solver_db {
+            solver_type          = "PFMG"                   // input used
+            num_pre_relax_steps  = 0                        // input used
+            num_post_relax_steps = 3                        // input used
+            enable_logging       = FALSE                    // input used
+         }
+      }
+   }
+   Main {
+      solver_type                 = "STAGGERED"             // input used
+      log_file_name               = "output"                // input used
+      log_all_nodes               = FALSE                   // input used
+      viz_writer                  = "VisIt"                 // input used
+      viz_dump_interval           = 3                       // input used
+      viz_dump_dirname            = "viz_INS3d"             // input used
+      visit_number_procs_per_file = 1                       // input used
+      restart_dump_interval       = 0                       // input used
+      restart_dump_dirname        = "restart_INS3d"         // input used
+      timer_dump_interval         = 0                       // input used
+   }
+   CartesianGeometry {
+      domain_boxes       = [(0,0,0),(31,31,31)]             // input used
+      x_lo               = 0, 0, 0                          // input used
+      x_up               = 1, 1, 1                          // input used
+      periodic_dimension = 1, 1, 1                          // input used
+   }
+   GriddingAlgorithm {
+      max_levels                = 2                         // input used
+      efficiency_tolerance      = 0.85                      // input used
+      combine_efficiency        = 0.85                      // input used
+      check_nonrefined_tags     = 'w'                       // from default
+      check_overlapping_patches = 'i'                       // from default
+      extend_tags_to_bdry       = FALSE                     // from default
+      ratio_to_coarser {
+         level_1 = 4, 4, 4                                  // input used
+         level_2 = 4, 4, 4                                  // input not used
+         level_3 = 4, 4, 4                                  // input not used
+      }
+      largest_patch_size {
+         level_0 = 512, 512, 512                            // input used
+      }
+      smallest_patch_size {
+         level_0 = 4, 4, 4                                  // input used
+      }
+   }
+   StandardTagAndInitialize {
+      tagging_method = "REFINE_BOXES"                       // input used
+      RefineBoxes {
+         level_0 = [(8,8,8),(23,23,23)]                     // input used
+         level_1 = [(33,33,33),(94,94,94)]                  // input used
+         level_2 = [(130,130,130),(381,381,381)]            // input used
+      }
+   }
+   LoadBalancer {
+      bin_pack_method                      = "SPATIAL"      // input used
+      max_workload_factor                  = 1              // input used
+      ignore_level_box_union_is_single_box = FALSE          // from default
+   }
+   TimerManager {
+      print_exclusive = FALSE                               // input not used
+      print_total     = TRUE                                // input not used
+      print_threshold = 0.1                                 // input not used
+      timer_list      = "IBAMR::*::*", "IBTK::*::*", "*::*::*" // input not used
+   }
+}
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 0
+Simulation time is 0
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0,0.000488281], dt = 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): regridding prior to timestep 0
+INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing convective operator
+INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing pressure subdomain solver
+INSStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(): initializing incompressible Stokes solver
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): executing cycle 1 of 2
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00636568
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): executing cycle 2 of 2
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 0
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.0267517
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.123618
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 0
+Simulation time is 0.000488281
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 1
+Simulation time is 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.000488281,0.000976562], dt = 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00460116
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.123785
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 1
+Simulation time is 0.000976562
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 2
+Simulation time is 0.000976562
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.000976562,0.00146484], dt = 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00306219
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.123951
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 2
+Simulation time is 0.00146484
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 3
+Simulation time is 0.00146484
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00146484,0.00195312], dt = 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00215168
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.124119
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 3
+Simulation time is 0.00195312
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 4
+Simulation time is 0.00195312
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00195312,0.00244141], dt = 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00168469
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.124289
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 4
+Simulation time is 0.00244141
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 5
+Simulation time is 0.00244141
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00244141,0.00292969], dt = 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00141836
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.124461
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 5
+Simulation time is 0.00292969
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 6
+Simulation time is 0.00292969
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00292969,0.00341797], dt = 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00127498
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.12464
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 6
+Simulation time is 0.00341797
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 7
+Simulation time is 0.00341797
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00341797,0.00390625], dt = 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00115686
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.124824
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 7
+Simulation time is 0.00390625
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 8
+Simulation time is 0.00390625
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00390625,0.00439453], dt = 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00105081
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.125008
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 8
+Simulation time is 0.00439453
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 9
+Simulation time is 0.00439453
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): time interval = [0.00439453,0.00488281], dt = 0.000488281
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): integrating hierarchy
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 1
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.00103974
+INSStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.125193
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
+INSStaggeredHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 9
+Simulation time is 0.00488281
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+Computing error norms.
+
+Error in u at time 0.00488281:
+  L1-norm:  0.0005104334089
+  L2-norm:  0.0004784614538
+  max-norm: 0.005540990599
+Error in p at time 0.004638671875:
+  L1-norm:  0.002154780963
+  L2-norm:  0.002497159941
+  max-norm: 0.00839288749
++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
If viscosity or time step size is very small, then we can skip solving the velocity block in the projection preconditioner without needing to take many more overall Stokes solver iterations.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
