### PR TITLE
Fixing boundary box width for codim 1 boxes with ghost cell width > 1

### DIFF
--- a/ibtk/src/boundary/physical_boundary/CartExtrapPhysBdryOp.cpp
+++ b/ibtk/src/boundary/physical_boundary/CartExtrapPhysBdryOp.cpp
@@ -245,8 +245,17 @@ CartExtrapPhysBdryOp::setPhysicalBoundaryConditions(Patch<NDIM>& patch,
     for (int n = 0; n < n_physical_codim1_boxes; ++n)
     {
         const BoundaryBox<NDIM>& bdry_box = physical_codim1_boxes[n];
-        const Box<NDIM> bdry_fill_box = pgeom->getBoundaryFillBox(bdry_box, patch_box, ghost_width_to_fill);
         const unsigned int location_index = bdry_box.getLocationIndex();
+        const int bdry_normal_axis = location_index / 2;
+        Box<NDIM> extended_box = bdry_box.getBox();
+        for (int axis = 0; axis < NDIM; ++axis)
+        {
+            if (axis == bdry_normal_axis) continue;
+            extended_box.lower(axis) = patch_box.lower(axis) - ghost_width_to_fill(axis);
+            extended_box.upper(axis) = patch_box.upper(axis) + ghost_width_to_fill(axis);
+        }
+        const BoundaryBox<NDIM> extended_bdry_box(extended_box, bdry_box.getBoundaryType(), location_index);
+        const Box<NDIM> bdry_fill_box = pgeom->getBoundaryFillBox(extended_bdry_box, patch_box, ghost_width_to_fill);
         const int codim = 1;
         bdry_fill_boxes.push_back(std::make_pair(bdry_fill_box, std::make_pair(location_index, codim)));
     }


### PR DESCRIPTION
<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [ ] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
