### PR TITLE
Michaelli/ibfe/check mesh dim when constructing IBFEMethod or IBFESurfaceMethod objects

### DIFF
--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -375,7 +375,7 @@ IBFEMethod::IBFEMethod(const std::string& object_name,
     {
         unsigned int mesh_dim = mesh->mesh_dimension();
         unsigned int spatial_dim = mesh->spatial_dimension();
-        TBOX_ASSERT(mesh_dim == spatial_dim)
+        TBOX_ASSERT(mesh_dim == spatial_dim);
     }  
 
     commonConstructor(input_db, max_levels);
@@ -402,7 +402,7 @@ IBFEMethod::IBFEMethod(const std::string& object_name,
     {
         unsigned int mesh_dim = mesh->mesh_dimension();
         unsigned int spatial_dim = mesh->spatial_dimension();
-        TBOX_ASSERT(mesh_dim == spatial_dim)
+        TBOX_ASSERT(mesh_dim == spatial_dim);
     } 
        
     commonConstructor(input_db, max_levels);

--- a/src/IB/IBFEMethod.cpp
+++ b/src/IB/IBFEMethod.cpp
@@ -371,6 +371,13 @@ IBFEMethod::IBFEMethod(const std::string& object_name,
     : FEMechanicsBase(object_name, input_db, mesh, register_for_restart, restart_read_dirname, restart_restore_number),
       d_source_system_name(SOURCE_SYSTEM_NAME_VAL)
 {
+    // Check if the mesh dimention is compatable with the IBStategy
+    {
+        unsigned int mesh_dim = mesh->mesh_dimension();
+        unsigned int spatial_dim = mesh->spatial_dimension();
+        TBOX_ASSERT(mesh_dim == spatial_dim)
+    }  
+
     commonConstructor(input_db, max_levels);
     return;
 } // IBFEMethod
@@ -390,6 +397,14 @@ IBFEMethod::IBFEMethod(const std::string& object_name,
                       restart_restore_number),
       d_source_system_name(SOURCE_SYSTEM_NAME_VAL)
 {
+    // Check if the mesh dimention is compatable with the IBStategy
+    for (libMesh::MeshBase* mesh : meshes) 
+    {
+        unsigned int mesh_dim = mesh->mesh_dimension();
+        unsigned int spatial_dim = mesh->spatial_dimension();
+        TBOX_ASSERT(mesh_dim == spatial_dim)
+    } 
+       
     commonConstructor(input_db, max_levels);
     return;
 } // IBFEMethod

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -173,6 +173,13 @@ IBFESurfaceMethod::IBFESurfaceMethod(const std::string& object_name,
                                      const std::string& restart_read_dirname,
                                      unsigned int restart_restore_number)
 {
+    // Check if the mesh dimention is compatable with the IBStategy
+    {
+        unsigned int mesh_dim = mesh->mesh_dimension();
+        unsigned int spatial_dim = mesh->spatial_dimension();
+        TBOX_ASSERT(mesh_dim == spatial_dim - 1)
+    } 
+
     commonConstructor(object_name,
                       input_db,
                       std::vector<MeshBase*>(1, mesh),
@@ -192,6 +199,14 @@ IBFESurfaceMethod::IBFESurfaceMethod(const std::string& object_name,
                                      unsigned int restart_restore_number)
     : d_num_parts(static_cast<int>(meshes.size()))
 {
+    // Check if the mesh dimention is compatable with the IBStategy
+    for (libMesh::MeshBase* mesh : meshes) 
+    {
+        unsigned int mesh_dim = mesh->mesh_dimension();
+        unsigned int spatial_dim = mesh->spatial_dimension();
+        TBOX_ASSERT(mesh_dim == spatial_dim - 1)
+    } 
+
     commonConstructor(
         object_name, input_db, meshes, max_levels, register_for_restart, restart_read_dirname, restart_restore_number);
     return;

--- a/src/IB/IBFESurfaceMethod.cpp
+++ b/src/IB/IBFESurfaceMethod.cpp
@@ -177,7 +177,7 @@ IBFESurfaceMethod::IBFESurfaceMethod(const std::string& object_name,
     {
         unsigned int mesh_dim = mesh->mesh_dimension();
         unsigned int spatial_dim = mesh->spatial_dimension();
-        TBOX_ASSERT(mesh_dim == spatial_dim - 1)
+        TBOX_ASSERT(mesh_dim == spatial_dim - 1);
     } 
 
     commonConstructor(object_name,
@@ -204,7 +204,7 @@ IBFESurfaceMethod::IBFESurfaceMethod(const std::string& object_name,
     {
         unsigned int mesh_dim = mesh->mesh_dimension();
         unsigned int spatial_dim = mesh->spatial_dimension();
-        TBOX_ASSERT(mesh_dim == spatial_dim - 1)
+        TBOX_ASSERT(mesh_dim == spatial_dim - 1);
     } 
 
     commonConstructor(


### PR DESCRIPTION
**Issue:** When a surface mesh is provided to construct a FEMethod object, the simulation can run, but later, an error "_Assertion `length != static_cast<Real>(0.)' failed._" will encounter coming from trying to make a vector of zero length a unit vector.

**Fix:** Add mesh dimension check in the constructors of `FEMethod` and `FESurfaceMethod`.

For `FEMthod`, the mesh dimension must be the same as that of the physical dimension. 

For `FESurfaceMethod`, the mesh dimension must be 1 less than that of the physical dimension.


<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see  `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set up appropriately for restarts? If so, ensure that the restart version number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test or tests should be added. New tests should run quickly (less than a minute in release mode). If possible, an older test should gain a new option so that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on GitHub for the pull request?
