### PR TITLE
Remove redundant component output.

### DIFF
--- a/src/IB/CIBMethod.cpp
+++ b/src/IB/CIBMethod.cpp
@@ -570,12 +570,6 @@ CIBMethod::initializePatchHierarchy(Pointer<PatchHierarchy<NDIM> > hierarchy,
     if (d_output_eul_lambda && d_visit_writer)
     {
         d_visit_writer->registerPlotQuantity("S_lambda", "VECTOR", d_eul_lambda_idx, 0);
-        for (unsigned int d = 0; d < NDIM; ++d)
-        {
-            if (d == 0) d_visit_writer->registerPlotQuantity("S_lambda_x", "SCALAR", d_eul_lambda_idx, d);
-            if (d == 1) d_visit_writer->registerPlotQuantity("S_lambda_y", "SCALAR", d_eul_lambda_idx, d);
-            if (d == 2) d_visit_writer->registerPlotQuantity("S_lambda_z", "SCALAR", d_eul_lambda_idx, d);
-        }
     }
 
     // Initialize mobility regularization data.

--- a/src/advect/AdvectorPredictorCorrectorHyperbolicPatchOps.cpp
+++ b/src/advect/AdvectorPredictorCorrectorHyperbolicPatchOps.cpp
@@ -488,12 +488,12 @@ AdvectorPredictorCorrectorHyperbolicPatchOps::registerModelVariables(HyperbolicL
             {
                 d_visit_writer->registerPlotQuantity(Q_var->getName(), "SCALAR", Q_idx);
             }
+            else if (depth == NDIM)
+            {
+                d_visit_writer->registerPlotQuantity(Q_var->getName(), "VECTOR", Q_idx);
+            }
             else
             {
-                if (depth == NDIM)
-                {
-                    d_visit_writer->registerPlotQuantity(Q_var->getName(), "VECTOR", Q_idx);
-                }
                 for (int d = 0; d < depth; ++d)
                 {
                     d_visit_writer->registerPlotQuantity(

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -764,12 +764,6 @@ INSCollocatedHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHie
         if (d_output_U)
         {
             d_visit_writer->registerPlotQuantity("U", "VECTOR", d_U_current_idx, 0, d_U_scale);
-            for (unsigned int d = 0; d < NDIM; ++d)
-            {
-                if (d == 0) d_visit_writer->registerPlotQuantity("U_x", "SCALAR", d_U_current_idx, d, d_U_scale);
-                if (d == 1) d_visit_writer->registerPlotQuantity("U_y", "SCALAR", d_U_current_idx, d, d_U_scale);
-                if (d == 2) d_visit_writer->registerPlotQuantity("U_z", "SCALAR", d_U_current_idx, d, d_U_scale);
-            }
         }
 
         if (d_output_P)
@@ -780,12 +774,6 @@ INSCollocatedHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHie
         if (d_F_fcn && d_output_F)
         {
             d_visit_writer->registerPlotQuantity("F", "VECTOR", d_F_current_idx, 0, d_F_scale);
-            for (unsigned int d = 0; d < NDIM; ++d)
-            {
-                if (d == 0) d_visit_writer->registerPlotQuantity("F_x", "SCALAR", d_F_current_idx, d, d_F_scale);
-                if (d == 1) d_visit_writer->registerPlotQuantity("F_y", "SCALAR", d_F_current_idx, d, d_F_scale);
-                if (d == 2) d_visit_writer->registerPlotQuantity("F_z", "SCALAR", d_F_current_idx, d, d_F_scale);
-            }
         }
 
         if (d_Q_fcn && d_output_Q)
@@ -795,18 +783,8 @@ INSCollocatedHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHie
 
         if (d_output_Omega)
         {
-#if (NDIM == 2)
-            d_visit_writer->registerPlotQuantity("Omega", "SCALAR", d_Omega_idx, 0, d_Omega_scale);
-#endif
-#if (NDIM == 3)
-            d_visit_writer->registerPlotQuantity("Omega", "VECTOR", d_Omega_idx, 0, d_Omega_scale);
-            for (unsigned int d = 0; d < NDIM; ++d)
-            {
-                if (d == 0) d_visit_writer->registerPlotQuantity("Omega_x", "SCALAR", d_Omega_idx, d, d_Omega_scale);
-                if (d == 1) d_visit_writer->registerPlotQuantity("Omega_y", "SCALAR", d_Omega_idx, d, d_Omega_scale);
-                if (d == 2) d_visit_writer->registerPlotQuantity("Omega_z", "SCALAR", d_Omega_idx, d, d_Omega_scale);
-            }
-#endif
+            d_visit_writer->registerPlotQuantity(
+                "Omega", ((NDIM == 2) ? "SCALAR" : "VECTOR"), d_Omega_idx, 0, d_Omega_scale);
         }
 
         if (d_output_Div_U)

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -964,11 +964,6 @@ INSStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHier
         if (d_output_U)
         {
             d_visit_writer->registerPlotQuantity("U", "VECTOR", d_U_nc_idx, 0, d_U_scale);
-            for (unsigned int i = 0; i < NDIM; ++i)
-            {
-                const std::string suffix = (i == 0 ? "x" : i == 1 ? "y" : "z");
-                d_visit_writer->registerPlotQuantity("U_" + suffix, "SCALAR", d_U_nc_idx, i, d_U_scale);
-            }
         }
 
         if (d_output_P)
@@ -979,11 +974,6 @@ INSStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHier
         if (d_F_fcn && d_output_F)
         {
             d_visit_writer->registerPlotQuantity("F", "VECTOR", d_F_cc_idx, 0, d_F_scale);
-            for (unsigned int i = 0; i < NDIM; ++i)
-            {
-                const std::string suffix = (i == 0 ? "x" : i == 1 ? "y" : "z");
-                d_visit_writer->registerPlotQuantity("F_" + suffix, "SCALAR", d_F_cc_idx, i, d_F_scale);
-            }
         }
 
         if (d_Q_fcn && d_output_Q)
@@ -995,14 +985,6 @@ INSStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHier
         {
             d_visit_writer->registerPlotQuantity(
                 "Omega", ((NDIM == 2) ? "SCALAR" : "VECTOR"), d_Omega_nc_idx, 0, d_Omega_scale);
-            if (NDIM == 3)
-            {
-                for (unsigned int i = 0; i < NDIM; ++i)
-                {
-                    const std::string suffix = (i == 0 ? "x" : i == 1 ? "y" : "z");
-                    d_visit_writer->registerPlotQuantity("Omega_" + suffix, "SCALAR", d_Omega_nc_idx, i, d_Omega_scale);
-                }
-            }
         }
 
         if (d_output_Div_U)

--- a/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredConservativeHierarchyIntegrator.cpp
@@ -198,15 +198,6 @@ INSVCStaggeredConservativeHierarchyIntegrator::initializeHierarchyIntegrator(
         if (d_output_rho)
         {
             d_visit_writer->registerPlotQuantity("rho_ins_cc", "VECTOR", d_rho_interp_cc_idx, 0, d_rho_scale);
-            for (unsigned int d = 0; d < NDIM; ++d)
-            {
-                if (d == 0)
-                    d_visit_writer->registerPlotQuantity("rho_x", "SCALAR", d_rho_interp_cc_idx, d, d_rho_scale);
-                if (d == 1)
-                    d_visit_writer->registerPlotQuantity("rho_y", "SCALAR", d_rho_interp_cc_idx, d, d_rho_scale);
-                if (d == 2)
-                    d_visit_writer->registerPlotQuantity("rho_z", "SCALAR", d_rho_interp_cc_idx, d, d_rho_scale);
-            }
         }
     }
 

--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -941,12 +941,6 @@ INSVCStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHi
         if (d_output_U)
         {
             d_visit_writer->registerPlotQuantity("U", "VECTOR", d_U_cc_idx, 0, d_U_scale);
-            for (unsigned int d = 0; d < NDIM; ++d)
-            {
-                if (d == 0) d_visit_writer->registerPlotQuantity("U_x", "SCALAR", d_U_cc_idx, d, d_U_scale);
-                if (d == 1) d_visit_writer->registerPlotQuantity("U_y", "SCALAR", d_U_cc_idx, d, d_U_scale);
-                if (d == 2) d_visit_writer->registerPlotQuantity("U_z", "SCALAR", d_U_cc_idx, d, d_U_scale);
-            }
         }
 
         if (d_output_P)
@@ -962,12 +956,6 @@ INSVCStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHi
         if (d_F_fcn && d_output_F)
         {
             d_visit_writer->registerPlotQuantity("F", "VECTOR", d_F_cc_idx, 0, d_F_scale);
-            for (unsigned int d = 0; d < NDIM; ++d)
-            {
-                if (d == 0) d_visit_writer->registerPlotQuantity("F_x", "SCALAR", d_F_cc_idx, d, d_F_scale);
-                if (d == 1) d_visit_writer->registerPlotQuantity("F_y", "SCALAR", d_F_cc_idx, d, d_F_scale);
-                if (d == 2) d_visit_writer->registerPlotQuantity("F_z", "SCALAR", d_F_cc_idx, d, d_F_scale);
-            }
         }
 
         if (d_Q_fcn && d_output_Q)
@@ -977,18 +965,8 @@ INSVCStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHi
 
         if (d_output_Omega)
         {
-#if (NDIM == 2)
-            d_visit_writer->registerPlotQuantity("Omega", "SCALAR", d_Omega_idx, 0, d_Omega_scale);
-#endif
-#if (NDIM == 3)
-            d_visit_writer->registerPlotQuantity("Omega", "VECTOR", d_Omega_idx, 0, d_Omega_scale);
-            for (unsigned int d = 0; d < NDIM; ++d)
-            {
-                if (d == 0) d_visit_writer->registerPlotQuantity("Omega_x", "SCALAR", d_Omega_idx, d, d_Omega_scale);
-                if (d == 1) d_visit_writer->registerPlotQuantity("Omega_y", "SCALAR", d_Omega_idx, d, d_Omega_scale);
-                if (d == 2) d_visit_writer->registerPlotQuantity("Omega_z", "SCALAR", d_Omega_idx, d, d_Omega_scale);
-            }
-#endif
+            d_visit_writer->registerPlotQuantity(
+                "Omega", ((NDIM == 2) ? "SCALAR" : "VECTOR"), d_Omega_idx, 0, d_Omega_scale);
         }
 
         if (d_output_Div_U)

--- a/src/phase_change/PhaseChangeHierarchyIntegrator.cpp
+++ b/src/phase_change/PhaseChangeHierarchyIntegrator.cpp
@@ -441,12 +441,6 @@ PhaseChangeHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHiera
     if (d_visit_writer && d_output_temp_k)
     {
         d_visit_writer->registerPlotQuantity("temperature_kappa", "VECTOR", d_D_cc_current_idx, 0);
-        for (unsigned int d = 0; d < NDIM; ++d)
-        {
-            if (d == 0) d_visit_writer->registerPlotQuantity("temp_kappa_x", "SCALAR", d_D_cc_current_idx, d);
-            if (d == 1) d_visit_writer->registerPlotQuantity("temp_kappa_y", "SCALAR", d_D_cc_current_idx, d);
-            if (d == 2) d_visit_writer->registerPlotQuantity("temp_kappa_z", "SCALAR", d_D_cc_current_idx, d);
-        }
     }
 
     d_U_old_var = new FaceVariable<NDIM, double>(d_object_name + "::U_old");


### PR DESCRIPTION
We already store the data once as a vector field and both ParaView and VisIt make it easy to extract components.

We have an ongoing problem where we generate huge amounts of data which needs to be stored, moved around, etc: we can make that process a lot easier by just not storing two copies of most variables.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
