### PR TITLE
Save the compilers we use.

### DIFF
--- a/cmake/IBAMRConfig.cmake.in
+++ b/cmake/IBAMRConfig.cmake.in
@@ -49,6 +49,15 @@ ELSE()
   SET(IBAMR_Fortran_FLAGS "@CMAKE_Fortran_FLAGS@")
 ENDIF()
 
+# Similarly, export the compilers so that downstream projects can choose to
+# automatically use the same ones. This is particularly helpful with the MPI
+# wrappers since, when cmake detects we are using those, it does not redundantly
+# set compiler flags (e.g., include directories, since the compiler wrapper sets
+# those).
+SET(IBAMR_C_COMPILER "@CMAKE_C_COMPILER@")
+SET(IBAMR_CXX_COMPILER "@CMAKE_CXX_COMPILER@")
+SET(IBAMR_Fortran_COMPILER "@CMAKE_Fortran_COMPILER@")
+
 IF(NOT "@MPI_ROOT@" STREQUAL "")
   # CMake wants to detect MPI with MPI_HOME, not MPI_ROOT (which we set up)
   SET(MPI_HOME "@MPI_ROOT@")


### PR DESCRIPTION
*Edit* The original version of this didn't work for several reasons, but we can solve the underlying problem in a different way.

Downstream projects will now be able to write something like

```cmake
SET(CMAKE_CXX_COMPILER "${IBAMR_CXX_COMPILER}")
```

etc. This works around a problem where autoibamr will use MPI compiler
wrappers but a user might not set those again when compiling a dependent
project, leading to compilation errors.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?