### PR TITLE
avoid vector copies in the FAC preconditioner

### DIFF
--- a/ibtk/src/solvers/impls/FACPreconditioner.cpp
+++ b/ibtk/src/solvers/impls/FACPreconditioner.cpp
@@ -105,21 +105,21 @@ FACPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, double>& x, SAMRAIVectorRe
     // Set the initial guess to equal zero.
     x.setToScalar(0.0, /*interior_only*/ false);
 
-    // Clone the right-hand-side vector to avoid modifying it during the
-    // preconditioning operation.
-    SAMRAIScopedVectorCopy<double> f(b);
-    SAMRAIScopedVectorDuplicate<double> r(b);
-
     // Apply a single FAC cycle.
     if (d_cycle_type == V_CYCLE && d_num_pre_sweeps == 0)
     {
         // V-cycle MG without presmoothing keeps the residual equal to the
         // initial right-hand-side vector f, so we can simply use that vector
         // for the residual in the FAC algorithm.
-        FACVCycleNoPreSmoothing(x, f, d_finest_ln);
+        FACVCycleNoPreSmoothing(x, b, d_finest_ln);
     }
     else
     {
+        // Clone the right-hand-side vector to avoid modifying it during the
+        // preconditioning operation.
+        SAMRAIScopedVectorCopy<double> f(b);
+        SAMRAIScopedVectorDuplicate<double> r(b);
+
         switch (d_cycle_type)
         {
         case F_CYCLE:


### PR DESCRIPTION
`FACPreconditioner` has a specialized code path that is used with V-cycles without presmoothing. We can avoid copying one `SAMRAIVectorReal` and duplicating another.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
