### PR TITLE
libMesh: remove old workarounds.

### DIFF
--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -23,24 +23,20 @@
 #ifdef IBTK_HAVE_LIBMESH
 
 #include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/ibtk_utilities.h"
 
 #include "tbox/Utilities.h"
 
 IBTK_DISABLE_EXTRA_WARNINGS
-#include "libmesh/libmesh_config.h"
-#include "libmesh/libmesh_version.h"
-
-#if LIBMESH_VERSION_LESS_THAN(1, 2, 0)
-#include "libmesh/mesh_tools.h"
-#else
 #include "libmesh/bounding_box.h"
-#endif
 #include "libmesh/dof_map.h"
 #include "libmesh/dof_object.h"
 #include "libmesh/edge.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/face.h"
 #include "libmesh/fe.h"
+#include "libmesh/libmesh_config.h"
+#include "libmesh/libmesh_version.h"
 #include "libmesh/petsc_vector.h"
 #include "libmesh/point.h"
 #include "libmesh/quadrature_gauss.h"
@@ -65,12 +61,10 @@ namespace libMeshWrappers
 {
 /**
  * Compatibility type alias for supporting older versions of libMesh.
+ *
+ * @deprecated Use libMesh::BoundingBox instead.
  */
-#if LIBMESH_VERSION_LESS_THAN(1, 2, 0)
-using BoundingBox = libMesh::MeshTools::BoundingBox;
-#else
-using BoundingBox = libMesh::BoundingBox;
-#endif
+using BoundingBox IBTK_DEPRECATED("Use libMesh::BoundingBox instead.") = libMesh::BoundingBox;
 } // namespace libMeshWrappers
 
 /**
@@ -1553,14 +1547,14 @@ void write_node_partitioning(const std::string& file_name, const libMesh::System
  * range of finite double precision values. They are still included in the
  * output vector so that that vector can be indexed by element ids.
  */
-std::vector<libMeshWrappers::BoundingBox> get_local_element_bounding_boxes(const libMesh::MeshBase& mesh,
-                                                                           const libMesh::System& X_system,
-                                                                           libMesh::QuadratureType quad_type,
-                                                                           libMesh::Order quad_order,
-                                                                           bool use_adaptive_quadrature,
-                                                                           double point_density,
-                                                                           bool allow_rules_with_negative_weights,
-                                                                           double patch_dx_min);
+std::vector<libMesh::BoundingBox> get_local_element_bounding_boxes(const libMesh::MeshBase& mesh,
+                                                                   const libMesh::System& X_system,
+                                                                   libMesh::QuadratureType quad_type,
+                                                                   libMesh::Order quad_order,
+                                                                   bool use_adaptive_quadrature,
+                                                                   double point_density,
+                                                                   bool allow_rules_with_negative_weights,
+                                                                   double patch_dx_min);
 
 /**
  * Compute bounding boxes for each local (i.e., owned by the current
@@ -1571,8 +1565,8 @@ std::vector<libMeshWrappers::BoundingBox> get_local_element_bounding_boxes(const
  * range of finite double precision values. They are still included in the
  * output vector so that that vector can be indexed by element ids.
  */
-std::vector<libMeshWrappers::BoundingBox> get_local_element_bounding_boxes(const libMesh::MeshBase& mesh,
-                                                                           const libMesh::System& X_system);
+std::vector<libMesh::BoundingBox> get_local_element_bounding_boxes(const libMesh::MeshBase& mesh,
+                                                                   const libMesh::System& X_system);
 
 /**
  * Get the global list of bounding boxes from the local list.
@@ -1582,9 +1576,8 @@ std::vector<libMeshWrappers::BoundingBox> get_local_element_bounding_boxes(const
  * range of finite double precision values. They are still included in the
  * output vector so that that vector can be indexed by element ids.
  */
-std::vector<libMeshWrappers::BoundingBox>
-get_global_element_bounding_boxes(const libMesh::MeshBase& mesh,
-                                  const std::vector<libMeshWrappers::BoundingBox>& local_bboxes);
+std::vector<libMesh::BoundingBox>
+get_global_element_bounding_boxes(const libMesh::MeshBase& mesh, const std::vector<libMesh::BoundingBox>& local_bboxes);
 
 /**
  * Compute bounding boxes for all elements in @p mesh with coordinates given
@@ -1595,8 +1588,8 @@ get_global_element_bounding_boxes(const libMesh::MeshBase& mesh,
  * range of finite double precision values. They are still included in the
  * output vector so that that vector can be indexed by element ids.
  */
-std::vector<libMeshWrappers::BoundingBox> get_global_element_bounding_boxes(const libMesh::MeshBase& mesh,
-                                                                            const libMesh::System& X_system);
+std::vector<libMesh::BoundingBox> get_global_element_bounding_boxes(const libMesh::MeshBase& mesh,
+                                                                    const libMesh::System& X_system);
 } // namespace IBTK
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ibtk/include/ibtk/libmesh_utilities.h
+++ b/ibtk/include/ibtk/libmesh_utilities.h
@@ -1346,42 +1346,17 @@ struct DofObjectComp
  * the DoFs corresponding to basis functions with node value functionals. This
  * compatibility function either calls that function directly or uses our own
  * implementation if the present libMesh is too old.
+ *
+ * @deprecated Use DofMap::dof_indices() instead.
  */
+IBTK_DEPRECATED("Use DofMap::dof_indices() instead.")
 inline void
 get_nodal_dof_indices(const libMesh::DofMap& dof_map,
                       const libMesh::Node* const node,
                       const unsigned int variable_n,
                       std::vector<libMesh::dof_id_type>& nodal_indices)
 {
-#if LIBMESH_VERSION_LESS_THAN(1, 2, 0)
-    // See dof_map.C, circa line 2208
-
-    // We only call this function with variable numbers 0, 1, or 2, so skip
-    // implementing some stuff
-    TBOX_ASSERT(variable_n != libMesh::invalid_uint);
-
-    nodal_indices.clear();
-    const unsigned int system_n = dof_map.sys_number();
-
-    // Get the dof numbers
-    const libMesh::Variable& var = dof_map.variable(variable_n);
-    if (var.type().family == libMesh::SCALAR)
-    {
-        dof_map.SCALAR_dof_indices(nodal_indices, variable_n);
-    }
-    else
-    {
-        const int n_components = node->n_comp(system_n, variable_n);
-        for (int component_n = 0; component_n != n_components; ++component_n)
-        {
-            libmesh_assert_not_equal_to(node->dof_number(system_n, variable_n, component_n),
-                                        libMesh::DofObject::invalid_id);
-            nodal_indices.push_back(node->dof_number(system_n, variable_n, component_n));
-        }
-    }
-#else
     dof_map.dof_indices(node, nodal_indices, variable_n);
-#endif
 }
 
 /**

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -659,7 +659,7 @@ FEDataManager::reinitElementMappings()
                     bool inside_patch = true;
                     for (unsigned int d = 0; d < NDIM; ++d)
                     {
-                        IBTK::get_nodal_dof_indices(X_dof_map, n, d, X_idxs);
+                        X_dof_map.dof_indices(n, X_idxs, d);
                         X[d] = X_local_soln[X_petsc_vec->map_global_to_local_index(X_idxs[0])];
                         // Due to how SAMRAI computes patch boundaries, even if the
                         // patch's domain is [0, 1]^2 the patches on the boundary
@@ -1086,7 +1086,7 @@ FEDataManager::spread(const int f_data_idx,
                     bool inside_patch = true;
                     for (unsigned int d = 0; d < NDIM; ++d)
                     {
-                        IBTK::get_nodal_dof_indices(X_dof_map, n, d, X_idxs);
+                        X_dof_map.dof_indices(n, X_idxs, d);
                         X[d] = X_local_soln[X_petsc_vec->map_global_to_local_index(X_idxs[0])];
                         inside_patch =
                             inside_patch && (X[d] >= patch_x_lower[d]) &&
@@ -1096,7 +1096,7 @@ FEDataManager::spread(const int f_data_idx,
                     {
                         for (unsigned int i = 0; i < n_vars; ++i)
                         {
-                            IBTK::get_nodal_dof_indices(F_dof_map, n, i, F_idxs);
+                            F_dof_map.dof_indices(n, F_idxs, i);
                             for (const auto& F_idx : F_idxs)
                             {
                                 F_x_dX_node.push_back(
@@ -1861,7 +1861,7 @@ FEDataManager::interpWeighted(const int f_data_idx,
                     bool inside_patch = true;
                     for (unsigned int d = 0; d < NDIM; ++d)
                     {
-                        IBTK::get_nodal_dof_indices(X_dof_map, n, d, X_idxs);
+                        X_dof_map.dof_indices(n, X_idxs, d);
                         X[d] = X_local_soln[X_petsc_vec->map_global_to_local_index(X_idxs[0])];
                         inside_patch =
                             inside_patch && (X[d] >= patch_x_lower[d]) &&
@@ -1873,7 +1873,7 @@ FEDataManager::interpWeighted(const int f_data_idx,
                         X_node.insert(X_node.end(), &X[0], &X[0] + NDIM);
                         for (unsigned int i = 0; i < n_vars; ++i)
                         {
-                            IBTK::get_nodal_dof_indices(F_dof_map, n, i, F_idxs);
+                            F_dof_map.dof_indices(n, F_idxs, i);
                             F_node_idxs.insert(F_node_idxs.end(), F_idxs.begin(), F_idxs.end());
                         }
                     }
@@ -3007,7 +3007,7 @@ FEDataManager::updateQuadPointCountData(const int coarsest_ln, const int finest_
                     const Node* const n = patch_nodes[k];
                     for (unsigned int d = 0; d < NDIM; ++d)
                     {
-                        IBTK::get_nodal_dof_indices(X_dof_map, n, d, X_idxs);
+                        X_dof_map.dof_indices(n, X_idxs, d);
                         X_qp[d] = X_local_soln[X_petsc_vec->map_global_to_local_index(X_idxs[0])];
                     }
                     const hier::Index<NDIM> i = IndexUtilities::getCellIndex(X_qp, grid_geom, ratio);

--- a/ibtk/src/lagrangian/FEDataManager.cpp
+++ b/ibtk/src/lagrangian/FEDataManager.cpp
@@ -229,48 +229,6 @@ get_JxW(quadrature_key_type key,
     }
 }
 IBTK_ENABLE_EXTRA_WARNINGS
-
-#if LIBMESH_VERSION_LESS_THAN(1, 6, 0)
-// libMesh's box intersection code is slow and not in a header (i.e., cannot be
-// inlined). This is problematic for us since we presently call this function
-// for every element on every patch: i.e., for N patches on the current
-// processor and K *total* (i.e., on all processors) elements we call this
-// function K*N times, which takes up a lot of time in regrids. For example:
-// switching to this function lowers the time required to get to the end of the
-// first time step in the TAVR model by 20%.
-inline bool
-bbox_intersects(const libMeshWrappers::BoundingBox& a, const libMeshWrappers::BoundingBox& b)
-{
-    const libMesh::Point& a_lower = a.first;
-    const libMesh::Point& a_upper = a.second;
-
-    const libMesh::Point& b_lower = b.first;
-    const libMesh::Point& b_upper = b.second;
-
-    // Since boxes are tensor products of line intervals it suffices to check
-    // that the line segments for each coordinate axis overlap.
-    for (unsigned int d = 0; d < NDIM; ++d)
-    {
-        // Line segments can intersect in two ways:
-        // 1. They can overlap.
-        // 2. One can be inside the other.
-        //
-        // In the first case we want to see if either end point of the second
-        // line segment lies within the first. In the second case we can simply
-        // check that one end point of the first line segment lies in the second
-        // line segment. Note that we don't need, in the second case, to do two
-        // checks since that case is already covered by the first.
-        if (!((a_lower(d) <= b_lower(d) && b_lower(d) <= a_upper(d)) ||
-              (a_lower(d) <= b_upper(d) && b_upper(d) <= a_upper(d))) &&
-            !((b_lower(d) <= a_lower(d) && a_lower(d) <= b_upper(d))))
-        {
-            return false;
-        }
-    }
-
-    return true;
-}
-#endif
 } // namespace
 
 FEData::FEData(std::string object_name, EquationSystems& equation_systems, const bool register_for_restart)
@@ -2752,7 +2710,7 @@ FEDataManager::zeroExteriorValues(const CartesianPatchGeometry<NDIM>& patch_geom
     std::size_t n_qp = X_qp.size() / NDIM;
     TBOX_ASSERT(n_qp * NDIM == X_qp.size());
     TBOX_ASSERT(F_qp.size() == n_vars * n_qp);
-    libMeshWrappers::BoundingBox patch_box;
+    libMesh::BoundingBox patch_box;
 
     for (unsigned int d = 0; d < NDIM; ++d)
     {
@@ -3137,9 +3095,8 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
     // be a bit paranoid by computing bounding boxes for elements as the union
     // of the bounding box of the nodes and the bounding box of the quadrature
     // points:
-    const std::vector<libMeshWrappers::BoundingBox> local_nodal_bboxes =
-        get_local_element_bounding_boxes(mesh, X_system);
-    const std::vector<libMeshWrappers::BoundingBox> local_qp_bboxes =
+    const std::vector<libMesh::BoundingBox> local_nodal_bboxes = get_local_element_bounding_boxes(mesh, X_system);
+    const std::vector<libMesh::BoundingBox> local_qp_bboxes =
         get_local_element_bounding_boxes(mesh,
                                          X_system,
                                          d_default_interp_spec.quad_type,
@@ -3149,25 +3106,13 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
                                          d_default_interp_spec.allow_rules_with_negative_weights,
                                          dx_0);
     TBOX_ASSERT(local_nodal_bboxes.size() == local_qp_bboxes.size());
-    std::vector<libMeshWrappers::BoundingBox> local_bboxes;
+    std::vector<libMesh::BoundingBox> local_bboxes;
     for (std::size_t box_n = 0; box_n < local_nodal_bboxes.size(); ++box_n)
     {
         local_bboxes.emplace_back(local_nodal_bboxes[box_n]);
-#if LIBMESH_VERSION_LESS_THAN(1, 2, 0)
-        // no BoundingBox::union_with in libMesh 1.1
-        auto& box = local_bboxes.back();
-        auto& other_box = local_qp_bboxes[box_n];
-        for (unsigned int d = 0; d < LIBMESH_DIM; ++d)
-        {
-            box.first(d) = std::min(box.first(d), other_box.first(d));
-            box.second(d) = std::max(box.second(d), other_box.second(d));
-        }
-#else
         local_bboxes.back().union_with(local_qp_bboxes[box_n]);
-#endif
     }
-    const std::vector<libMeshWrappers::BoundingBox> global_bboxes =
-        get_global_element_bounding_boxes(mesh, local_bboxes);
+    const std::vector<libMesh::BoundingBox> global_bboxes = get_global_element_bounding_boxes(mesh, local_bboxes);
 
     int local_patch_num = 0;
     for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++local_patch_num)
@@ -3177,7 +3122,7 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
         const Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
         const double* const dx = pgeom->getDx();
         // TODO: reimplement this with an rtree description of SAMRAI's patches
-        libMeshWrappers::BoundingBox patch_bbox;
+        libMesh::BoundingBox patch_bbox;
         for (unsigned int d = 0; d < NDIM; ++d)
         {
             patch_bbox.first(d) = pgeom->getXLower()[d] - dx[d] * d_associated_elem_ghost_width(d);
@@ -3190,20 +3135,14 @@ FEDataManager::collectActivePatchElements(std::vector<std::vector<Elem*> >& acti
         }
 
         auto el_it = mesh.elements_begin();
-        for (const libMeshWrappers::BoundingBox& bbox : global_bboxes)
+        for (const libMesh::BoundingBox& bbox : global_bboxes)
         {
             if ((*el_it)->active())
             {
                 const int elem_ln = getPatchLevel(*el_it);
                 if (coarsest_elem_ln <= elem_ln && elem_ln <= finest_elem_ln)
                 {
-#if LIBMESH_VERSION_LESS_THAN(1, 6, 0)
-                    if (bbox_intersects(bbox, patch_bbox)) elems.insert(*el_it);
-#else
-                    // New versions of libMesh have this function's performance
-                    // problems fixed
                     if (bbox.intersects(patch_bbox)) elems.insert(*el_it);
-#endif
                 }
             }
             ++el_it;

--- a/ibtk/src/lagrangian/FEMapping.cpp
+++ b/ibtk/src/lagrangian/FEMapping.cpp
@@ -288,11 +288,7 @@ FELagrangeMapping<dim, spacedim, n_nodes>::FELagrangeMapping(
       d_n_nodes(n_nodes == -1 ? static_cast<int>(get_n_nodes(std::get<0>(quad_key))) : n_nodes)
 {
     if (n_nodes != -1) TBOX_ASSERT(d_n_nodes == n_nodes);
-#if LIBMESH_VERSION_LESS_THAN(1, 4, 0)
-    TBOX_ASSERT(d_n_nodes <= 27);
-#else
     TBOX_ASSERT(d_n_nodes <= static_cast<int>(libMesh::Elem::max_n_nodes));
-#endif
     typename decltype(d_dphi)::extent_gen extents;
     d_dphi.resize(extents[d_n_nodes][this->d_quadrature_data.size()]);
 
@@ -318,13 +314,7 @@ FELagrangeMapping<dim, spacedim, n_nodes>::fillTransforms(const libMesh::Elem* e
     TBOX_ASSERT(this->d_update_flags & FEUpdateFlags::update_contravariants);
     TBOX_ASSERT(d_n_nodes <= static_cast<int>(elem->n_nodes()));
 
-    // max_n_nodes is a constant defined by libMesh - currently 27
-#if LIBMESH_VERSION_LESS_THAN(1, 4, 0)
-    double xs[27][spacedim];
-#else
     double xs[libMesh::Elem::max_n_nodes][spacedim];
-#endif
-
     const int n_nodes_ = n_nodes == -1 ? d_n_nodes : n_nodes;
     for (int i = 0; i < n_nodes_; ++i)
     {

--- a/ibtk/src/lagrangian/StableCentroidPartitioner.cpp
+++ b/ibtk/src/lagrangian/StableCentroidPartitioner.cpp
@@ -61,11 +61,7 @@ StableCentroidPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
     auto el_end = mesh.elements_end();
     for (auto it = mesh.elements_begin(); it != el_end; ++it)
     {
-#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
-        const libMesh::Point centroid = (*it)->centroid();
-#else
         const libMesh::Point centroid = (*it)->vertex_average();
-#endif
 
         std::array<float, LIBMESH_DIM> rounded_centroid = { 0.0f };
         for (unsigned int d = 0; d < LIBMESH_DIM; ++d)

--- a/ibtk/src/lagrangian/StableCentroidPartitioner.cpp
+++ b/ibtk/src/lagrangian/StableCentroidPartitioner.cpp
@@ -49,11 +49,7 @@ StableCentroidPartitioner::clone() const
 void
 StableCentroidPartitioner::_do_partition(MeshBase& mesh, const unsigned int n)
 {
-    // We assume every cell is on every processor: this function is only in
-    // libMesh 1.2.0 and newer
-#if !LIBMESH_VERSION_LESS_THAN(1, 2, 0)
     TBOX_ASSERT(mesh.is_replicated());
-#endif
     // only implemented when we use SAMRAI's partitioning
     TBOX_ASSERT(n == static_cast<unsigned int>(IBTK_MPI::getNodes()));
 

--- a/ibtk/src/utilities/libmesh_utilities.cpp
+++ b/ibtk/src/utilities/libmesh_utilities.cpp
@@ -19,11 +19,7 @@
 
 #include "tbox/Utilities.h"
 
-#if LIBMESH_VERSION_LESS_THAN(1, 2, 0)
-#include "libmesh/mesh_tools.h"
-#else
 #include "libmesh/bounding_box.h"
-#endif
 #include "libmesh/dof_map.h"
 #include "libmesh/elem.h"
 #include "libmesh/enum_elem_type.h"
@@ -356,7 +352,7 @@ write_node_partitioning(const std::string& file_name, const libMesh::System& pos
     }
 }
 
-std::vector<libMeshWrappers::BoundingBox>
+std::vector<libMesh::BoundingBox>
 get_local_element_bounding_boxes(const libMesh::MeshBase& mesh,
                                  const libMesh::System& X_system,
                                  const libMesh::QuadratureType quad_type,
@@ -374,7 +370,7 @@ get_local_element_bounding_boxes(const libMesh::MeshBase& mesh,
     auto& X_ghost_vec = dynamic_cast<libMesh::PetscVector<double>&>(*X_ghost_vec_ptr);
     X_ghost_vec = *X_system.solution;
 
-    std::vector<libMeshWrappers::BoundingBox> bboxes;
+    std::vector<libMesh::BoundingBox> bboxes;
 
     std::vector<std::vector<libMesh::dof_id_type> > dof_indices(NDIM);
     boost::multi_array<double, 2> X_node;
@@ -457,7 +453,7 @@ get_local_element_bounding_boxes(const libMesh::MeshBase& mesh,
     return bboxes;
 } // get_local_element_bounding_boxes
 
-std::vector<libMeshWrappers::BoundingBox>
+std::vector<libMesh::BoundingBox>
 get_local_element_bounding_boxes(const libMesh::MeshBase& mesh, const libMesh::System& X_system)
 {
     const unsigned int spacedim = mesh.spatial_dimension();
@@ -467,7 +463,7 @@ get_local_element_bounding_boxes(const libMesh::MeshBase& mesh, const libMesh::S
     auto& X_ghost_vec = dynamic_cast<libMesh::PetscVector<double>&>(*X_ghost_vec_ptr);
     X_ghost_vec = *X_system.solution;
 
-    std::vector<libMeshWrappers::BoundingBox> bboxes;
+    std::vector<libMesh::BoundingBox> bboxes;
     bboxes.reserve(mesh.n_local_elem());
 
     std::vector<libMesh::dof_id_type> dof_indices;
@@ -526,9 +522,8 @@ get_local_element_bounding_boxes(const libMesh::MeshBase& mesh, const libMesh::S
     return bboxes;
 } // get_local_element_bounding_boxes
 
-std::vector<libMeshWrappers::BoundingBox>
-get_global_element_bounding_boxes(const libMesh::MeshBase& mesh,
-                                  const std::vector<libMeshWrappers::BoundingBox>& local_bboxes)
+std::vector<libMesh::BoundingBox>
+get_global_element_bounding_boxes(const libMesh::MeshBase& mesh, const std::vector<libMesh::BoundingBox>& local_bboxes)
 {
     const std::size_t n_elem = mesh.n_elem();
     std::vector<double> flattened_bboxes(2 * LIBMESH_DIM * n_elem);
@@ -550,7 +545,7 @@ get_global_element_bounding_boxes(const libMesh::MeshBase& mesh,
         MPI_IN_PLACE, flattened_bboxes.data(), flattened_bboxes.size(), MPI_DOUBLE, MPI_SUM, mesh.comm().get());
     TBOX_ASSERT(ierr == 0);
 
-    std::vector<libMeshWrappers::BoundingBox> global_bboxes(n_elem);
+    std::vector<libMesh::BoundingBox> global_bboxes(n_elem);
     for (unsigned int e = 0; e < n_elem; ++e)
     {
         for (unsigned int d = 0; d < LIBMESH_DIM; ++d)
@@ -562,7 +557,7 @@ get_global_element_bounding_boxes(const libMesh::MeshBase& mesh,
     return global_bboxes;
 } // get_local_element_bounding_boxes
 
-std::vector<libMeshWrappers::BoundingBox>
+std::vector<libMesh::BoundingBox>
 get_global_element_bounding_boxes(const libMesh::MeshBase& mesh, const libMesh::System& X_system)
 {
     static_assert(NDIM <= LIBMESH_DIM,

--- a/src/IB/IBFEInstrumentPanel.cpp
+++ b/src/IB/IBFEInstrumentPanel.cpp
@@ -83,17 +83,12 @@ IBFEInstrumentPanel::initializeHierarchyIndependentData(IBFEMethod* const ib_met
     // Get boundary information.
     std::vector<dof_id_type> nodes;
     std::vector<boundary_id_type> bcs;
-    // new API in 1.4.0
-#if LIBMESH_VERSION_LESS_THAN(1, 4, 0)
-    boundary_info.build_node_list(nodes, bcs);
-#else
     const std::vector<std::tuple<dof_id_type, boundary_id_type> > node_list = boundary_info.build_node_list();
     for (const std::tuple<dof_id_type, boundary_id_type>& pair : node_list)
     {
         nodes.push_back(std::get<0>(pair));
         bcs.push_back(std::get<1>(pair));
     }
-#endif
 
     // Check to make sure there are node sets to work with.
     if (nodes.size() == 0 || bcs.size() == 0 || (nodes.size() != bcs.size()))

--- a/src/level_set/FESurfaceDistanceEvaluator.cpp
+++ b/src/level_set/FESurfaceDistanceEvaluator.cpp
@@ -1392,11 +1392,7 @@ FESurfaceDistanceEvaluator::collectNeighboringPatchElements(int level_number)
             }
 
             // First check the centroids.
-#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
-            const libMesh::Point c = elem->centroid();
-#else
             const libMesh::Point c = elem->vertex_average();
-#endif
 
             bool centroid_in_patch = true;
             for (unsigned int d = 0; d < NDIM; ++d)

--- a/tests/IBFE/explicit_ex4.cpp
+++ b/tests/IBFE/explicit_ex4.cpp
@@ -229,11 +229,7 @@ main(int argc, char** argv)
             const MeshBase::element_iterator el_end = mesh.active_elements_end();
             for (MeshBase::element_iterator el = mesh.active_elements_begin(); el != el_end; ++el)
             {
-#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
-                const libMesh::Point centroid = (*el)->centroid();
-#else
                 const libMesh::Point centroid = (*el)->vertex_average();
-#endif
                 if (centroid.norm() > 0.75 * R)
                 {
                     (*el)->subdomain_id() = outer_id;
@@ -252,11 +248,7 @@ main(int argc, char** argv)
             for (MeshBase::element_iterator el = mesh.elements_begin(); el != el_end; ++el)
             {
                 Elem* elem = *el;
-#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
-                const libMesh::Point centroid = elem->centroid();
-#else
                 const libMesh::Point centroid = elem->vertex_average();
-#endif
 
                 if (centroid(1) > 0.0) elem->set_refinement_flag(Elem::REFINE);
             }

--- a/tests/IBFE/instrument_panel_01.cpp
+++ b/tests/IBFE/instrument_panel_01.cpp
@@ -514,11 +514,7 @@ main(int argc, char** argv)
                     // at data_time = t the bottom face is at z = t and the top face is at z = 1 + t
                     std::unique_ptr<Elem> side_ptr = elem.side_ptr(side_n);
 
-#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
-                    const double z = side_ptr->centroid()(2);
-#else
                     const double z = side_ptr->vertex_average()(2);
-#endif
                     // include a simple correction velocity for the 4th test only (note that it needs to be a linear
                     // field)
                     double u_corr = (data_time == 3 ? 1.0 : 0.0);

--- a/tests/IBFE/interpolate_velocity_01.cpp
+++ b/tests/IBFE/interpolate_velocity_01.cpp
@@ -183,11 +183,7 @@ main(int argc, char** argv)
             for (auto elem_iter = mesh.active_elements_begin(); elem_iter != mesh.active_elements_end(); ++elem_iter)
             {
                 Elem* elem = *elem_iter;
-#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
-                const libMesh::Point centroid = elem->centroid();
-#else
                 const libMesh::Point centroid = elem->vertex_average();
-#endif
 #if NDIM == 2
                 if (centroid(1) > 0.0)
                     elem->subdomain_id() = 1;

--- a/tests/IBTK/bounding_boxes_01.cpp
+++ b/tests/IBTK/bounding_boxes_01.cpp
@@ -144,26 +144,21 @@ test(LibMeshInit& init,
         else
         {
             // the non-nodal box should be a subset of the nodal one
-#if !LIBMESH_VERSION_LESS_THAN(1, 2, 0)
             libMeshWrappers::BoundingBox box_union(box_2);
             box_union.union_with(box_1);
             TBOX_ASSERT(box_union.min() == box_2.min());
             TBOX_ASSERT(box_union.max() == box_2.max());
-#endif
 
             // box 2 should be a superset of box 1: i.e., the corners of box 1
             // should be in box 2
-#if !LIBMESH_VERSION_LESS_THAN(1, 4, 0)
             TBOX_ASSERT(box_2.signed_distance(box_1.min()) <= 0.0);
             TBOX_ASSERT(box_2.signed_distance(box_1.max()) <= 0.0);
-#endif
         }
         out << box_2.first << ", " << box_2.second << std::endl;
 
         // Since X is just the initial coordinates of the mesh, we should
         // match the bounding box which is computed directly from the
         // element too.
-#if !LIBMESH_VERSION_LESS_THAN(1, 2, 0)
         libMeshWrappers::BoundingBox box_3 = (*el_it)->loose_bounding_box();
         if (order == FIRST)
         {
@@ -177,14 +172,11 @@ test(LibMeshInit& init,
         box_union.union_with(box_2);
         TBOX_ASSERT((box_union.min() - box_3.min()).norm() < std::max(1.0, box_union.min().norm()) * 1e-16);
         TBOX_ASSERT((box_union.max() - box_3.max()).norm() < std::max(1.0, box_union.max().norm()) * 1e-16);
-#endif
 
         // box 3 should be a superset of box 2: i.e., the corners of box 2
         // should be in box 3
-#if !LIBMESH_VERSION_LESS_THAN(1, 4, 0)
         TBOX_ASSERT(box_2.signed_distance(box_1.min()) <= 0.0);
         TBOX_ASSERT(box_2.signed_distance(box_1.max()) <= 0.0);
-#endif
     }
 }
 

--- a/tests/IBTK/mapping_01.cpp
+++ b/tests/IBTK/mapping_01.cpp
@@ -63,9 +63,7 @@ test(LibMeshInit& init)
     std::vector<libMesh::QuadratureType> quad_types;
     quad_types.push_back(QGAUSS);
     quad_types.push_back(QGRID);
-#if !LIBMESH_VERSION_LESS_THAN(1, 5, 0)
     quad_types.push_back(QNODAL);
-#endif
 
     for (const libMesh::QuadratureType quad_type : quad_types)
     {

--- a/tests/IBTK/multilevel_fe_01.cpp
+++ b/tests/IBTK/multilevel_fe_01.cpp
@@ -98,11 +98,7 @@ public:
         for (MeshBase::element_iterator el = d_mesh.elements_begin(); el != el_end; ++el)
         {
             Elem* elem = *el;
-#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
-            const libMesh::Point centroid = elem->centroid();
-#else
             const libMesh::Point centroid = elem->vertex_average();
-#endif
 #if NDIM == 2
             if (centroid(1) > 0.0)
                 elem->subdomain_id() = 1;

--- a/tests/spread/spread_02.cpp
+++ b/tests/spread/spread_02.cpp
@@ -129,11 +129,7 @@ main(int argc, char** argv)
             MeshBase::element_iterator el_end = mesh.active_elements_end();
             for (MeshBase::element_iterator el = mesh.active_elements_begin(); el != el_end; ++el)
             {
-#if LIBMESH_VERSION_LESS_THAN(1, 7, 0)
-                const libMesh::Point centroid = (*el)->centroid();
-#else
                 const libMesh::Point centroid = (*el)->vertex_average();
-#endif
                 if (centroid(0) < 0.5)
                 {
                     (*el)->subdomain_id() = 2;


### PR DESCRIPTION
Similar to the other PR - this one removes all the old workarounds which aren't necessary now that 1.7 is the oldest supported version.

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?