### PR TITLE
Remove all uses of sprintf().

### DIFF
--- a/examples/ConstraintIB/eel2d/example.cpp
+++ b/examples/ConstraintIB/eel2d/example.cpp
@@ -434,7 +434,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -457,7 +457,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/ConstraintIB/eel3d/example.cpp
+++ b/examples/ConstraintIB/eel3d/example.cpp
@@ -309,7 +309,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -332,7 +332,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/ConstraintIB/falling_sphere/example.cpp
+++ b/examples/ConstraintIB/falling_sphere/example.cpp
@@ -329,7 +329,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -352,7 +352,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/ConstraintIB/flow_past_cylinder/example.cpp
+++ b/examples/ConstraintIB/flow_past_cylinder/example.cpp
@@ -397,7 +397,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -420,7 +420,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/ConstraintIB/impulsively_started_cylinder/example.cpp
+++ b/examples/ConstraintIB/impulsively_started_cylinder/example.cpp
@@ -309,7 +309,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -332,7 +332,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/ConstraintIB/knifefish/example.cpp
+++ b/examples/ConstraintIB/knifefish/example.cpp
@@ -309,7 +309,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -332,7 +332,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/ConstraintIB/moving_plate/example.cpp
+++ b/examples/ConstraintIB/moving_plate/example.cpp
@@ -437,7 +437,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -460,7 +460,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/ConstraintIB/oscillating_rigid_cylinder/example.cpp
+++ b/examples/ConstraintIB/oscillating_rigid_cylinder/example.cpp
@@ -309,7 +309,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -332,7 +332,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/ConstraintIB/stokes_first_problem/example.cpp
+++ b/examples/ConstraintIB/stokes_first_problem/example.cpp
@@ -309,7 +309,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -332,7 +332,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/IB/explicit/ex0/example.cpp
+++ b/examples/IB/explicit/ex0/example.cpp
@@ -575,7 +575,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -598,7 +598,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/IB/explicit/ex1/example.cpp
+++ b/examples/IB/explicit/ex1/example.cpp
@@ -313,7 +313,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -336,7 +336,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/IB/explicit/ex3/example.cpp
+++ b/examples/IB/explicit/ex3/example.cpp
@@ -331,7 +331,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -354,7 +354,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/IB/explicit/ex4/example.cpp
+++ b/examples/IB/explicit/ex4/example.cpp
@@ -353,7 +353,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -376,7 +376,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/IB/explicit/ex5/example.cpp
+++ b/examples/IB/explicit/ex5/example.cpp
@@ -334,7 +334,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     }
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
 
     // Write Cartesian data.
@@ -364,7 +364,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
         VecDuplicate(X_petsc_vec, &X_lag_vec);
         l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
         file_name = data_dump_dirname + "/" + "X.";
-        sprintf(temp_buf, "%05d", iteration_num);
+        std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
         file_name += temp_buf;
         PetscViewer viewer;
         PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/IB/explicit/ex6/example.cpp
+++ b/examples/IB/explicit/ex6/example.cpp
@@ -312,7 +312,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -335,7 +335,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/IBFE/explicit/ex0/example.cpp
+++ b/examples/IBFE/explicit/ex0/example.cpp
@@ -605,7 +605,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -622,12 +622,12 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;

--- a/examples/IBFE/explicit/ex1/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex1/convergence_tester.cpp
@@ -163,11 +163,11 @@ main(int argc, char* argv[])
         {
             char temp_buf[128];
 
-            sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
             string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
             coarse_file_name += temp_buf;
 
-            sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
             string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
             fine_file_name += temp_buf;
 
@@ -383,21 +383,21 @@ main(int argc, char* argv[])
 
             Mesh mesh_coarse(init.comm(), NDIM);
             file_name = coarse_hier_dump_dirname + "/" + "fe_mesh.";
-            sprintf(temp_buf, "%05d", coarse_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
             file_name += temp_buf;
             file_name += ".xda";
             mesh_coarse.read(file_name);
 
             Mesh mesh_fine(init.comm(), NDIM);
             file_name = fine_hier_dump_dirname + "/" + "fe_mesh.";
-            sprintf(temp_buf, "%05d", fine_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
             file_name += temp_buf;
             file_name += ".xda";
             mesh_fine.read(file_name);
 
             EquationSystems equation_systems_coarse(mesh_coarse);
             file_name = coarse_hier_dump_dirname + "/" + "fe_equation_systems.";
-            sprintf(temp_buf, "%05d", coarse_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
             file_name += temp_buf;
             equation_systems_coarse.read(
                 file_name,
@@ -405,7 +405,7 @@ main(int argc, char* argv[])
 
             EquationSystems equation_systems_fine(mesh_fine);
             file_name = fine_hier_dump_dirname + "/" + "fe_equation_systems.";
-            sprintf(temp_buf, "%05d", fine_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
             file_name += temp_buf;
             equation_systems_fine.read(
                 file_name,

--- a/examples/IBFE/explicit/ex1/example.cpp
+++ b/examples/IBFE/explicit/ex1/example.cpp
@@ -521,7 +521,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -538,12 +538,12 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;

--- a/examples/IBFE/explicit/ex2/example.cpp
+++ b/examples/IBFE/explicit/ex2/example.cpp
@@ -470,7 +470,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -487,12 +487,12 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;

--- a/examples/IBFE/explicit/ex3/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex3/convergence_tester.cpp
@@ -161,11 +161,11 @@ main(int argc, char* argv[])
         {
             char temp_buf[128];
 
-            sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
             string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
             coarse_file_name += temp_buf;
 
-            sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
             string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
             fine_file_name += temp_buf;
 
@@ -381,21 +381,21 @@ main(int argc, char* argv[])
 
             Mesh mesh_coarse(init.comm(), NDIM);
             file_name = coarse_hier_dump_dirname + "/" + "fe_mesh.";
-            sprintf(temp_buf, "%05d", coarse_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
             file_name += temp_buf;
             file_name += ".xda";
             mesh_coarse.read(file_name);
 
             Mesh mesh_fine(init.comm(), NDIM);
             file_name = fine_hier_dump_dirname + "/" + "fe_mesh.";
-            sprintf(temp_buf, "%05d", fine_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
             file_name += temp_buf;
             file_name += ".xda";
             mesh_fine.read(file_name);
 
             EquationSystems equation_systems_coarse(mesh_coarse);
             file_name = coarse_hier_dump_dirname + "/" + "fe_equation_systems.";
-            sprintf(temp_buf, "%05d", coarse_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
             file_name += temp_buf;
             equation_systems_coarse.read(
                 file_name,
@@ -403,7 +403,7 @@ main(int argc, char* argv[])
 
             EquationSystems equation_systems_fine(mesh_fine);
             file_name = fine_hier_dump_dirname + "/" + "fe_equation_systems.";
-            sprintf(temp_buf, "%05d", fine_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
             file_name += temp_buf;
             equation_systems_fine.read(
                 file_name,

--- a/examples/IBFE/explicit/ex3/example.cpp
+++ b/examples/IBFE/explicit/ex3/example.cpp
@@ -470,7 +470,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -487,12 +487,12 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;

--- a/examples/IBFE/explicit/ex4/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex4/convergence_tester.cpp
@@ -162,11 +162,11 @@ main(int argc, char* argv[])
         {
             char temp_buf[128];
 
-            sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
             string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
             coarse_file_name += temp_buf;
 
-            sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
             string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
             fine_file_name += temp_buf;
 
@@ -382,21 +382,21 @@ main(int argc, char* argv[])
 
             Mesh mesh_coarse(init.comm(), NDIM);
             file_name = coarse_hier_dump_dirname + "/" + "fe_mesh.";
-            sprintf(temp_buf, "%05d", coarse_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
             file_name += temp_buf;
             file_name += ".xda";
             mesh_coarse.read(file_name);
 
             Mesh mesh_fine(init.comm(), NDIM);
             file_name = fine_hier_dump_dirname + "/" + "fe_mesh.";
-            sprintf(temp_buf, "%05d", fine_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
             file_name += temp_buf;
             file_name += ".xda";
             mesh_fine.read(file_name);
 
             EquationSystems equation_systems_coarse(mesh_coarse);
             file_name = coarse_hier_dump_dirname + "/" + "fe_equation_systems.";
-            sprintf(temp_buf, "%05d", coarse_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
             file_name += temp_buf;
             equation_systems_coarse.read(
                 file_name,
@@ -404,7 +404,7 @@ main(int argc, char* argv[])
 
             EquationSystems equation_systems_fine(mesh_fine);
             file_name = fine_hier_dump_dirname + "/" + "fe_equation_systems.";
-            sprintf(temp_buf, "%05d", fine_iteration_num);
+            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
             file_name += temp_buf;
             equation_systems_fine.read(
                 file_name,

--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -627,7 +627,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -644,12 +644,12 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;

--- a/examples/IBFE/explicit/ex7/example.cpp
+++ b/examples/IBFE/explicit/ex7/example.cpp
@@ -475,7 +475,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -492,12 +492,12 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;

--- a/examples/IIM/ex2/example.cpp
+++ b/examples/IIM/ex2/example.cpp
@@ -693,7 +693,7 @@ output_data(tbox::Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
     file_name += temp_buf;
     tbox::Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/adv_diff/ex8/example.cpp
+++ b/examples/adv_diff/ex8/example.cpp
@@ -939,7 +939,7 @@ compute_T_profile(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write out the result in a file.
     string file_name = data_dump_dirname + "/" + "temperature_angle_";
     char temp_buf[128];
-    sprintf(temp_buf, "%.8f", data_time);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%.8f", data_time);
     file_name += temp_buf;
     MPI_Status status;
     MPI_Offset mpi_offset;

--- a/examples/complex_fluids/ex0/example.cpp
+++ b/examples/complex_fluids/ex0/example.cpp
@@ -387,7 +387,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/complex_fluids/ex1/example.cpp
+++ b/examples/complex_fluids/ex1/example.cpp
@@ -279,7 +279,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/complex_fluids/ex2/convergence_tester.cpp
+++ b/examples/complex_fluids/ex2/convergence_tester.cpp
@@ -155,11 +155,11 @@ main(int argc, char* argv[])
     {
         char temp_buf[128];
 
-        sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
+        std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
         string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
         coarse_file_name += temp_buf;
 
-        sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
+        std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
         string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
         fine_file_name += temp_buf;
 

--- a/examples/complex_fluids/ex2/example.cpp
+++ b/examples/complex_fluids/ex2/example.cpp
@@ -518,7 +518,7 @@ postprocess_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
         // Output files
         string file_name = data_dump_dirname + "/hier_data.";
         char temp_buf[128];
-        sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+        std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
         file_name += temp_buf;
         Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
         hier_db->create(file_name);

--- a/examples/complex_fluids/ex3/example.cpp
+++ b/examples/complex_fluids/ex3/example.cpp
@@ -269,7 +269,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex0/example.cpp
+++ b/examples/multiphase_flow/ex0/example.cpp
@@ -463,7 +463,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex1/example.cpp
+++ b/examples/multiphase_flow/ex1/example.cpp
@@ -582,7 +582,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -605,7 +605,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/multiphase_flow/ex10/example.cpp
+++ b/examples/multiphase_flow/ex10/example.cpp
@@ -615,7 +615,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -638,7 +638,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/multiphase_flow/ex11/example.cpp
+++ b/examples/multiphase_flow/ex11/example.cpp
@@ -595,7 +595,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -618,7 +618,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/multiphase_flow/ex12/example.cpp
+++ b/examples/multiphase_flow/ex12/example.cpp
@@ -586,7 +586,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -609,7 +609,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/multiphase_flow/ex13/example.cpp
+++ b/examples/multiphase_flow/ex13/example.cpp
@@ -687,7 +687,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -710,7 +710,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/multiphase_flow/ex3/example.cpp
+++ b/examples/multiphase_flow/ex3/example.cpp
@@ -425,7 +425,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex4/example.cpp
+++ b/examples/multiphase_flow/ex4/example.cpp
@@ -434,7 +434,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex5/example.cpp
+++ b/examples/multiphase_flow/ex5/example.cpp
@@ -492,7 +492,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex6/example.cpp
+++ b/examples/multiphase_flow/ex6/example.cpp
@@ -451,7 +451,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/multiphase_flow/ex7/example.cpp
+++ b/examples/multiphase_flow/ex7/example.cpp
@@ -587,7 +587,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -610,7 +610,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/multiphase_flow/ex8/example.cpp
+++ b/examples/multiphase_flow/ex8/example.cpp
@@ -587,7 +587,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -610,7 +610,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/multiphase_flow/ex9/example.cpp
+++ b/examples/multiphase_flow/ex9/example.cpp
@@ -625,7 +625,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -648,7 +648,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/examples/navier_stokes/ex0/example.cpp
+++ b/examples/navier_stokes/ex0/example.cpp
@@ -331,7 +331,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/navier_stokes/ex1/convergence_tester.cpp
+++ b/examples/navier_stokes/ex1/convergence_tester.cpp
@@ -122,11 +122,11 @@ main(int argc, char* argv[])
     {
         char temp_buf[128];
 
-        sprintf(temp_buf, "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
+        std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
         string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
         coarse_file_name += temp_buf;
 
-        sprintf(temp_buf, "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
+        std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
         string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
         fine_file_name += temp_buf;
 

--- a/examples/navier_stokes/ex1/example.cpp
+++ b/examples/navier_stokes/ex1/example.cpp
@@ -258,7 +258,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/navier_stokes/ex2/example.cpp
+++ b/examples/navier_stokes/ex2/example.cpp
@@ -258,7 +258,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/navier_stokes/ex3/example.cpp
+++ b/examples/navier_stokes/ex3/example.cpp
@@ -259,7 +259,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/vc_navier_stokes/ex0/example.cpp
+++ b/examples/vc_navier_stokes/ex0/example.cpp
@@ -388,7 +388,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/vc_navier_stokes/ex1/example.cpp
+++ b/examples/vc_navier_stokes/ex1/example.cpp
@@ -449,7 +449,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/vc_navier_stokes/ex2/example.cpp
+++ b/examples/vc_navier_stokes/ex2/example.cpp
@@ -441,7 +441,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/wave_tank/ex0/example.cpp
+++ b/examples/wave_tank/ex0/example.cpp
@@ -646,7 +646,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/examples/wave_tank/ex1/example.cpp
+++ b/examples/wave_tank/ex1/example.cpp
@@ -694,7 +694,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -717,7 +717,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/tests/ConstraintIB/oscillating_rigid_cylinder.cpp
+++ b/tests/ConstraintIB/oscillating_rigid_cylinder.cpp
@@ -380,7 +380,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -403,7 +403,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/tests/IB/explicit_ex1.cpp
+++ b/tests/IB/explicit_ex1.cpp
@@ -333,7 +333,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -356,7 +356,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/tests/IBFE/explicit_ex0.cpp
+++ b/tests/IBFE/explicit_ex0.cpp
@@ -607,7 +607,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -624,12 +624,12 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;

--- a/tests/IBFE/explicit_ex1.cpp
+++ b/tests/IBFE/explicit_ex1.cpp
@@ -555,7 +555,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -572,12 +572,12 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;

--- a/tests/IBFE/explicit_ex2.cpp
+++ b/tests/IBFE/explicit_ex2.cpp
@@ -493,7 +493,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -510,12 +510,12 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;

--- a/tests/IIM/hagen_poiseuille_flow.cpp
+++ b/tests/IIM/hagen_poiseuille_flow.cpp
@@ -719,7 +719,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/IIM/taylor_couette_2d.cpp
+++ b/tests/IIM/taylor_couette_2d.cpp
@@ -1081,7 +1081,7 @@ compute_velocity_profile(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write out the result in a file.
     string file_name = data_dump_dirname + "/" + "u_y_";
     char temp_buf[128];
-    sprintf(temp_buf, "%.8f", data_time);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%.8f", data_time);
     file_name += temp_buf;
 
     MPI_Status status;
@@ -1202,7 +1202,7 @@ compute_pressure_profile(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write out the result in a file.
     string file_name = data_dump_dirname + "/" + "p_";
     char temp_buf[128];
-    sprintf(temp_buf, "%.8f", data_time);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%.8f", data_time);
     file_name += temp_buf;
 
     MPI_Status status;

--- a/tests/multiphase_flow/water_entry_circular_cylinder.cpp
+++ b/tests/multiphase_flow/water_entry_circular_cylinder.cpp
@@ -608,7 +608,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -631,7 +631,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/tests/navier_stokes/navier_stokes_01.cpp
+++ b/tests/navier_stokes/navier_stokes_01.cpp
@@ -334,7 +334,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/navier_stokes/poiseuille_flow_2d.cpp
+++ b/tests/navier_stokes/poiseuille_flow_2d.cpp
@@ -286,7 +286,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/unfinished-tests/Stokes-IB/test1/main.cpp
+++ b/tests/unfinished-tests/Stokes-IB/test1/main.cpp
@@ -297,7 +297,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
@@ -320,7 +320,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    sprintf(temp_buf, "%05d", iteration_num);
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
     file_name += temp_buf;
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);

--- a/tests/unfinished-tests/Stokes/test0/main.cpp
+++ b/tests/unfinished-tests/Stokes/test0/main.cpp
@@ -317,7 +317,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/vc_navier_stokes/vc_navier_stokes_01.cpp
+++ b/tests/vc_navier_stokes/vc_navier_stokes_01.cpp
@@ -385,7 +385,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);

--- a/tests/wave_tank/nwt.cpp
+++ b/tests/wave_tank/nwt.cpp
@@ -648,7 +648,7 @@ output_data(Pointer<PatchHierarchy<NDIM> > patch_hierarchy,
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
     char temp_buf[128];
-    sprintf(temp_buf, "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
+    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
     file_name += temp_buf;
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);


### PR DESCRIPTION
Fixes #1618. Part of #1812. This function has been deprecated for a long time and macOS prints a lot of warnings about it.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?