### PR TITLE
`IBHierarchyIntegrator` etc.: refactor sources derived from `IBStrategy`.

### DIFF
--- a/include/ibamr/IBHierarchyIntegrator.h
+++ b/include/ibamr/IBHierarchyIntegrator.h
@@ -232,6 +232,12 @@ public:
 
 protected:
     /*!
+     * Compute the values of the fluid sources which may be provided by
+     * d_ib_method_ops.
+     */
+    virtual void computeFluidSources(const int data_idx, const double data_time);
+
+    /*!
      * Perform necessary data movement, workload estimation, and logging prior
      * to regridding.
      */
@@ -511,7 +517,7 @@ protected:
         /*!
          * \brief Constructor.
          */
-        IBEulerianSourceFunction(const IBHierarchyIntegrator* ib_solver);
+        IBEulerianSourceFunction(IBHierarchyIntegrator* ib_solver);
 
         /*!
          * \brief Destructor.
@@ -529,7 +535,19 @@ protected:
         bool isTimeDependent() const override;
 
         /*!
-         * Set the data on the patch interior.
+         * \brief Set the data on the patch interiors on the specified levels of
+         * the patch hierarchy.
+         */
+        void setDataOnPatchHierarchy(const int data_idx,
+                                     SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM> > var,
+                                     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+                                     const double data_time,
+                                     const bool initial_time = false,
+                                     const int coarsest_ln = IBTK::invalid_level_number,
+                                     const int finest_ln = IBTK::invalid_level_number) override;
+
+        /*!
+         * Necessary override of setDataOnPatch - use setDataOnPatchHierarchy instead.
          */
         void setDataOnPatch(int data_idx,
                             SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM> > var,
@@ -569,7 +587,7 @@ protected:
          */
         IBEulerianSourceFunction& operator=(const IBEulerianSourceFunction& that) = delete;
 
-        const IBHierarchyIntegrator* const d_ib_solver;
+        IBHierarchyIntegrator* d_ib_solver;
     };
 
     friend class IBEulerianSourceFunction;

--- a/src/IB/IBEulerianSourceFunction.cpp
+++ b/src/IB/IBEulerianSourceFunction.cpp
@@ -46,7 +46,7 @@ namespace IBAMR
 
 ////////////////////////////// PUBLIC ///////////////////////////////////////
 
-IBHierarchyIntegrator::IBEulerianSourceFunction::IBEulerianSourceFunction(const IBHierarchyIntegrator* const ib_solver)
+IBHierarchyIntegrator::IBEulerianSourceFunction::IBEulerianSourceFunction(IBHierarchyIntegrator* ib_solver)
     : CartGridFunction(ib_solver->getName() + "::IBEulerianSourceFunction"), d_ib_solver(ib_solver)
 {
     // intentionally blank
@@ -60,6 +60,38 @@ IBHierarchyIntegrator::IBEulerianSourceFunction::isTimeDependent() const
 } // isTimeDependent
 
 void
+IBHierarchyIntegrator::IBEulerianSourceFunction::setDataOnPatchHierarchy(
+    const int data_idx,
+    SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM> > /*var*/,
+    SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM> > hierarchy,
+    const double data_time,
+    const bool initial_time,
+    const int coarsest_ln_in,
+    const int finest_ln_in)
+{
+    const int coarsest_ln = (coarsest_ln_in == IBTK::invalid_level_number ? 0 : coarsest_ln_in);
+    const int finest_ln =
+        (finest_ln_in == IBTK::invalid_level_number ? hierarchy->getFinestLevelNumber() : finest_ln_in);
+
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM> > level = hierarchy->getPatchLevel(ln);
+        TBOX_ASSERT(level->checkAllocated(data_idx));
+    }
+
+    HierarchyCellDataOpsReal<NDIM, double> hier_cc_ops(hierarchy, coarsest_ln, finest_ln);
+    hier_cc_ops.setToScalar(data_idx, 0.0, false);
+
+    // At the initial time the structures may not yet be set up, so we cannot
+    // call computeFluidSources()
+    if (initial_time) return;
+
+    d_ib_solver->computeFluidSources(data_idx, data_time);
+
+    return;
+}
+
+void
 IBHierarchyIntegrator::IBEulerianSourceFunction::setDataOnPatch(const int data_idx,
                                                                 Pointer<Variable<NDIM> > /*var*/,
                                                                 Pointer<Patch<NDIM> > patch,
@@ -67,16 +99,19 @@ IBHierarchyIntegrator::IBEulerianSourceFunction::setDataOnPatch(const int data_i
                                                                 const bool initial_time,
                                                                 Pointer<PatchLevel<NDIM> > /*level*/)
 {
-    Pointer<CellData<NDIM, double> > q_cc_data = patch->getPatchData(data_idx);
-#if !defined(NDEBUG)
-    TBOX_ASSERT(q_cc_data);
-#endif
-    q_cc_data->fillAll(0.0);
-    if (initial_time) return;
-    Pointer<CellData<NDIM, double> > q_ib_cc_data = patch->getPatchData(d_ib_solver->d_q_idx);
-    PatchCellDataBasicOps<NDIM, double> patch_ops;
-    patch_ops.add(q_cc_data, q_cc_data, q_ib_cc_data, patch->getBox());
-    return;
+    // This function is called during initialization, but at that point we are
+    // not guaranteed that Lagrangian data is set up in a way that we can
+    // actually compute fluid sources: in that case zero everything out.
+    if (initial_time)
+    {
+        Pointer<CellData<NDIM, double> > q_cc_data = patch->getPatchData(data_idx);
+        TBOX_ASSERT(q_cc_data);
+        q_cc_data->fillAll(0.0);
+    }
+    else
+    {
+        TBOX_ERROR("Use setDataOnPatchHierarchy() with this class instead.");
+    }
 } // setDataOnPatch
 
 /////////////////////////////// PROTECTED ////////////////////////////////////

--- a/src/IB/IBExplicitHierarchyIntegrator.cpp
+++ b/src/IB/IBExplicitHierarchyIntegrator.cpp
@@ -254,18 +254,7 @@ IBExplicitHierarchyIntegrator::integrateHierarchySpecialized(const double curren
     if (d_ib_method_ops->hasFluidSources())
     {
         const double data_time = is_bdf_time_stepping_type(d_time_stepping_type) ? new_time : half_time;
-        if (d_enable_logging)
-            plog << d_object_name << "::integrateHierarchy(): computing Lagrangian fluid source strength\n";
-        d_ib_method_ops->computeLagrangianFluidSource(data_time);
-        if (d_enable_logging)
-            plog << d_object_name
-                 << "::integrateHierarchy(): spreading Lagrangian fluid source "
-                    "strength to the Eulerian grid\n";
-        d_hier_pressure_data_ops->setToScalar(d_q_idx, 0.0);
-        // NOTE: This does not correctly treat the case in which the structure
-        // is close to the physical boundary.
-        d_ib_method_ops->spreadFluidSource(
-            d_q_idx, nullptr, getProlongRefineSchedules(d_object_name + "::q"), data_time);
+        computeFluidSources(d_q_idx, data_time);
     }
 
     // Solve the incompressible Navier-Stokes equations.

--- a/tests/IBFE/explicit_ex4_2d.source_test.output
+++ b/tests/IBFE/explicit_ex4_2d.source_test.output
@@ -28,16 +28,24 @@ IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian force to the E
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
 IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 IBHierarchyIntegrator::integrateHierarchy(): solving the incompressible Navier-Stokes equations
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 11
-INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 3.3730300296385233243e-15
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 3.3730300296377628623e-15
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 8
-INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 4.2690272033227826945e-15
+INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 4.2690272032459310763e-15
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
 IBHierarchyIntegrator::integrateHierarchy(): performing Lagrangian midpoint-rule step
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian fluid pressure to the Lagrangian mesh
 IBHierarchyIntegrator::postprocessIntegrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.0033334021315537332511
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.0033334021315537332511
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.0033334021315537323837
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.0033334021315537323837
 IBHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
 IBHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
 
@@ -58,14 +66,18 @@ IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian force to the E
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
 IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 IBHierarchyIntegrator::integrateHierarchy(): solving the incompressible Navier-Stokes equations
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 9
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000000000000
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
 IBHierarchyIntegrator::integrateHierarchy(): performing Lagrangian midpoint-rule step
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian fluid pressure to the Lagrangian mesh
 IBHierarchyIntegrator::postprocessIntegrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003332502493
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.006665904624
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003332089372
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.006665491504
 IBHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
 IBHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
 
@@ -73,7 +85,7 @@ At end       of timestep # 1
 Simulation time is 0.000976562
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-0.000976562500 0.125750010247
+0.000976562500 0.125750006981
 
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 At beginning of timestep # 2
@@ -86,14 +98,18 @@ IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian force to the E
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
 IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 IBHierarchyIntegrator::integrateHierarchy(): solving the incompressible Navier-Stokes equations
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 7
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000000000000
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
 IBHierarchyIntegrator::integrateHierarchy(): performing Lagrangian midpoint-rule step
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian fluid pressure to the Lagrangian mesh
 IBHierarchyIntegrator::postprocessIntegrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003331629317
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.009997533942
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003331215401
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.009996706905
 IBHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
 IBHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
 
@@ -101,7 +117,7 @@ At end       of timestep # 2
 Simulation time is 0.00146484
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-0.001464843750 0.125807644142
+0.001464843750 0.125807634353
 
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 At beginning of timestep # 3
@@ -114,14 +130,18 @@ IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian force to the E
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
 IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 IBHierarchyIntegrator::integrateHierarchy(): solving the incompressible Navier-Stokes equations
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 7
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000000000000
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
 IBHierarchyIntegrator::integrateHierarchy(): performing Lagrangian midpoint-rule step
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian fluid pressure to the Lagrangian mesh
 IBHierarchyIntegrator::postprocessIntegrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003330756466
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.013328290408
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003330341731
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.013327048636
 IBHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
 IBHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
 
@@ -129,7 +149,7 @@ At end       of timestep # 3
 Simulation time is 0.00195312
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-0.001953125000 0.125865278451
+0.001953125000 0.125865262143
 
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 At beginning of timestep # 4
@@ -142,14 +162,18 @@ IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian force to the E
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
 IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 IBHierarchyIntegrator::integrateHierarchy(): solving the incompressible Navier-Stokes equations
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 7
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000000000000
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
 IBHierarchyIntegrator::integrateHierarchy(): performing Lagrangian midpoint-rule step
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian fluid pressure to the Lagrangian mesh
 IBHierarchyIntegrator::postprocessIntegrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003329883821
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.016658174229
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003329468277
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.016656516913
 IBHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
 IBHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
 
@@ -157,7 +181,7 @@ At end       of timestep # 4
 Simulation time is 0.00244141
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-0.002441406250 0.125922913171
+0.002441406250 0.125922890348
 
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 At beginning of timestep # 5
@@ -170,14 +194,18 @@ IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian force to the E
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
 IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 IBHierarchyIntegrator::integrateHierarchy(): solving the incompressible Navier-Stokes equations
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 7
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000000000000
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
 IBHierarchyIntegrator::integrateHierarchy(): performing Lagrangian midpoint-rule step
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian fluid pressure to the Lagrangian mesh
 IBHierarchyIntegrator::postprocessIntegrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003329011200
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.019987185429
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003328594853
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.019985111765
 IBHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
 IBHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
 
@@ -185,7 +213,7 @@ At end       of timestep # 5
 Simulation time is 0.00292969
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-0.002929687500 0.125980548302
+0.002929687500 0.125980518966
 
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 At beginning of timestep # 6
@@ -198,14 +226,18 @@ IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian force to the E
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
 IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 IBHierarchyIntegrator::integrateHierarchy(): solving the incompressible Navier-Stokes equations
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 7
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000000000000
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
 IBHierarchyIntegrator::integrateHierarchy(): performing Lagrangian midpoint-rule step
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian fluid pressure to the Lagrangian mesh
 IBHierarchyIntegrator::postprocessIntegrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003328139090
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.023315324520
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003327721731
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.023312833496
 IBHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
 IBHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
 
@@ -213,7 +245,7 @@ At end       of timestep # 6
 Simulation time is 0.00341797
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-0.003417968750 0.126038183840
+0.003417968750 0.126038147995
 
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 At beginning of timestep # 7
@@ -226,14 +258,18 @@ IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian force to the E
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
 IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 IBHierarchyIntegrator::integrateHierarchy(): solving the incompressible Navier-Stokes equations
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 7
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000000000000
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
 IBHierarchyIntegrator::integrateHierarchy(): performing Lagrangian midpoint-rule step
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian fluid pressure to the Lagrangian mesh
 IBHierarchyIntegrator::postprocessIntegrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003327269153
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.026642593673
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003326851056
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.026639684552
 IBHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
 IBHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
 
@@ -241,7 +277,7 @@ At end       of timestep # 7
 Simulation time is 0.00390625
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-0.003906250000 0.126095819785
+0.003906250000 0.126095777434
 
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 At beginning of timestep # 8
@@ -254,14 +290,18 @@ IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian force to the E
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
 IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 IBHierarchyIntegrator::integrateHierarchy(): solving the incompressible Navier-Stokes equations
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 7
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000000000000
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
 IBHierarchyIntegrator::integrateHierarchy(): performing Lagrangian midpoint-rule step
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian fluid pressure to the Lagrangian mesh
 IBHierarchyIntegrator::postprocessIntegrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003326399323
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.029968992995
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003325980512
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.029965665063
 IBHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
 IBHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
 
@@ -269,7 +309,7 @@ At end       of timestep # 8
 Simulation time is 0.00439453
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-0.004394531250 0.126153456135
+0.004394531250 0.126153407281
 
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 At beginning of timestep # 9
@@ -282,14 +322,18 @@ IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian force to the E
 IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
 IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 IBHierarchyIntegrator::integrateHierarchy(): solving the incompressible Navier-Stokes equations
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
+IBHierarchyIntegrator::integrateHierarchy(): computing Lagrangian fluid source strength
+IBHierarchyIntegrator::integrateHierarchy(): spreading Lagrangian fluid source strength to the Eulerian grid
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve number of iterations = 7
 INSStaggeredHierarchyIntegrator::integrateHierarchy(): stokes solve residual norm        = 0.000000000000
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
 IBHierarchyIntegrator::integrateHierarchy(): performing Lagrangian midpoint-rule step
 IBHierarchyIntegrator::integrateHierarchy(): interpolating Eulerian fluid pressure to the Lagrangian mesh
 IBHierarchyIntegrator::postprocessIntegrateHierarchy(): interpolating Eulerian velocity to the Lagrangian mesh
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003325529503
-IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.033294522498
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): CFL number = 0.003325110005
+IBHierarchyIntegrator::postprocessIntegrateHierarchy(): Eulerian estimate of upper bound on IB point displacement since last regrid = 0.033290775068
 IBHierarchyIntegrator::advanceHierarchy(): synchronizing updated data
 IBHierarchyIntegrator::advanceHierarchy(): resetting time dependent data
 
@@ -297,4 +341,4 @@ At end       of timestep # 9
 Simulation time is 0.00488281
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-0.004882812500 0.126211092888
+0.004882812500 0.126211037535


### PR DESCRIPTION
This is the first of two PRs which will fix a bug where we didn't correctly update sources in calls to
`INSHierarchyIntegrator::regridProjection()`, which resulted in reading undefined data and therefore arbitrary velocity values. To begin, this commit makes it possible to compute sources outside of the normal timestepping loop and also modifies `IBEulerianSourceFunction` to work on the entire `PatchHierarchy` (instead of single patches) at once.

We don't use this implementation of sources in four-chambered-heart or Cardinal: those apps directly add it to the INS integrator. We do have a test for these sources in IBAMR and I checked that, in addition to passing, it has the same visual output as before.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?