### PR TITLE
autotools: fix the bootstrap script.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -94,7 +94,7 @@ then
                     : # don't do anything if we match
                     ;;
                 *)
-                    echo "Libtool version $libtool_version doesn't match, building a new one..."
+                    echo "Libtool version $detected_libtool_version doesn't match, building a new one..."
                     build_autotools=1
             esac
         else


### PR DESCRIPTION
This is clearly a typo, and the script works just fine with the fix. I have libtool 2.6 on my desktop and it correctly detects and does not use it.

Fixes #1846.