### PR TITLE
LEInteractor: use stack allocation for small arrays and `tbox::Array` for larger ones.

### DIFF
--- a/doc/news/changes/major/20251027DavidWells
+++ b/doc/news/changes/major/20251027DavidWells
@@ -1,0 +1,3 @@
+Improved: LEInteractor now allocates significantly fewer temporary arrays.
+<br>
+(David Wells, 2025/10/27)


### PR DESCRIPTION
in Cardinal we typically do interpolation or spreading on small ranges of elements with consecutive DoFs instead of all elements which intersect a patch. For instance, one such set of ranges has sizes

3, 3, 3, 6, 6, 6, 12, 12, 12, 30, 33, 33, 52, 78, 81, 81, 84, 282, 708

so, by using `std::array<int, 64>`, we can avoid allocating memory in most of the cases. We can further lower memory pressure by using `tbox::Array` for everything else, since that now has its own memory pool.

Here's a flamegraph (of running the heart model for 100 timesteps) of allocations before:
<img width="1882" height="766" alt="image" src="https://github.com/user-attachments/assets/0044828d-d3e3-4598-b160-9eb718843acc" />
and after:
<img width="1882" height="766" alt="image" src="https://github.com/user-attachments/assets/d10e6de3-7d59-4274-b8c7-0b3ab049c592" />
so this reduces total allocations by 50%. We can also get rid of some temporary buffers in the same way, but lets fix one thing at a time. These experiments also include the recent SAMRAI patches which vastly reduce our total allocations in other places as well.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
