### PR TITLE
Update CI for 0.18.

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -71,7 +71,7 @@ jobs:
   # build IBAMR with CMake and update the cache
   build_ibamr_cmake_016:
     runs-on: ubuntu-latest
-    name: Build IBAMR (0.17 dependencies ${{ matrix.name }})
+    name: Build IBAMR (0.18 dependencies ${{ matrix.name }})
     strategy:
       matrix:
         include:
@@ -96,7 +96,7 @@ jobs:
             os: "ubuntu"
 
     container:
-      image: 'docker://wellsd2/ibamr:ibamr-0.17-dependencies-${{ matrix.os }}'
+      image: 'docker://wellsd2/ibamr:ibamr-0.18-dependencies-${{ matrix.os }}'
     env:
       CCACHE_MAXSIZE: 250M
       CCACHE_DIR: /compilationcache
@@ -149,11 +149,11 @@ jobs:
           ccache $(echo "${{ matrix.ccache_eviction_flags }}")
 
   # build IBAMR with autotools
-  build_ibamr_archlinux_016_autotools:
+  build_ibamr_archlinux_autotools:
     runs-on: ubuntu-latest
-    name: Build IBAMR and run tests (autotools, 0.17 dependencies, Arch Linux 2025)
+    name: Build IBAMR and run tests (autotools, 0.18 dependencies, Arch Linux 2025)
     container:
-      image: 'docker://wellsd2/ibamr:ibamr-0.17-dependencies-archlinux'
+      image: 'docker://wellsd2/ibamr:ibamr-0.18-dependencies-archlinux'
     env:
       CCACHE_MAXSIZE: 250M
       CCACHE_DIR: /compilationcache

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -26,7 +26,7 @@ jobs:
   # build IBAMR with CMake and run tests
   build_ibamr_cmake_016:
     runs-on: ubuntu-latest
-    name: Build IBAMR and run tests (0.17 dependencies ${{ matrix.name }})
+    name: Build IBAMR and run tests (0.18 dependencies ${{ matrix.name }})
     strategy:
       matrix:
         include:
@@ -47,7 +47,7 @@ jobs:
             os: "ubuntu"
 
     container:
-      image: 'docker://wellsd2/ibamr:ibamr-0.17-dependencies-${{ matrix.os }}'
+      image: 'docker://wellsd2/ibamr:ibamr-0.18-dependencies-${{ matrix.os }}'
     env:
       CCACHE_MAXSIZE: 250M
       CCACHE_DIR: /compilationcache
@@ -134,9 +134,9 @@ jobs:
   # build IBAMR with autotools
   build_ibamr_archlinux_016_autotools:
     runs-on: ubuntu-latest
-    name: Build IBAMR and run tests (autotools, 0.17 dependencies, Arch Linux 2025)
+    name: Build IBAMR and run tests (autotools, 0.18 dependencies, Arch Linux 2025)
     container:
-      image: 'docker://wellsd2/ibamr:ibamr-0.17-dependencies-archlinux'
+      image: 'docker://wellsd2/ibamr:ibamr-0.18-dependencies-archlinux'
     env:
       CCACHE_MAXSIZE: 250M
       CCACHE_DIR: /compilationcache
@@ -342,7 +342,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Basic header checks
     container:
-      image: 'docker://wellsd2/ibamr:ibamr-0.17-dependencies-archlinux'
+      image: 'docker://wellsd2/ibamr:ibamr-0.18-dependencies-archlinux'
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3


### PR DESCRIPTION
This is needed for #1838, #1839, and #1850. Once this is in we can update the minimum supported version to 2025.10.29 and move to tagging another release with all of these fixes.