### PR TITLE
CI: update to macOS 26.

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -198,8 +198,8 @@ jobs:
 
   # build on macOS
   macos:
-    runs-on: macos-15
-    name: Build IBAMR (macOS 15)
+    runs-on: macos-26
+    name: Build IBAMR (macOS)
     env:
       CCACHE_MAXSIZE: 250M
       CCACHE_DIR: /tmp/ibamr-ccache


### PR DESCRIPTION
I suspect this is now better-supported than macOS 15, so this may fix the new CI failure.