### PR TITLE
Refine include-style integration in formatting scripts

### DIFF
--- a/scripts/formatting/indent
+++ b/scripts/formatting/indent
@@ -31,7 +31,10 @@ checks
 # Process all source and header files:
 #
 
-rewrite_include_style_changed
+if should_rewrite_include_style; then
+  process_changed "include src ibtk/include ibtk/src examples ibtk/examples tests" \
+    ".*\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inl|tcc)" rewrite_include_style_file
+fi
 
 process_changed "include src ibtk/include ibtk/src examples ibtk/examples tests" \
   ".*\.(cpp|h)" format_file

--- a/scripts/formatting/indent-all
+++ b/scripts/formatting/indent-all
@@ -31,7 +31,10 @@ checks
 # Process all source and header files:
 #
 
-rewrite_include_style_all
+if should_rewrite_include_style; then
+  process "include src ibtk/include ibtk/src examples ibtk/examples tests" \
+    ".*\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inl|tcc)" rewrite_include_style_file
+fi
 
 process "include src ibtk/include ibtk/src examples ibtk/examples tests" \
   ".*\.(cpp|h)" format_file

--- a/scripts/formatting/indent_common.sh
+++ b/scripts/formatting/indent_common.sh
@@ -33,14 +33,6 @@ checks() {
     exit 1
   fi
 
-  if ! [ -x "$(command -v "python3")" ]; then
-    echo "***   Warning: no python3 program found."
-    echo "***   Include-style rewrite will be skipped for this indent run."
-    export IBAMR_SKIP_INCLUDE_STYLE_REWRITE=true
-  else
-    export IBAMR_SKIP_INCLUDE_STYLE_REWRITE=false
-  fi
-
   # Make sure to have the right version.
   CLANG_FORMAT_VERSION="$(clang-format --version)"
   CLANG_FORMAT_MAJOR_VERSION=$(echo "${CLANG_FORMAT_VERSION}" | sed 's/^[^0-9]*\([0-9]*\).*$/\1/g')
@@ -54,6 +46,14 @@ checks() {
     echo "***   script, or the 'scripts/formatting/compile-clang-format' script "
     echo "***   to install a compatible binary into 'scripts/formatting/programs'."
     exit 1
+  fi
+
+  if ! [ -x "$(command -v "python3")" ]; then
+    echo "***   Warning: no python3 program found."
+    echo "***   Include-style rewrite will be skipped for this indent run."
+    export IBAMR_SKIP_INCLUDE_STYLE_REWRITE=true
+  else
+    export IBAMR_SKIP_INCLUDE_STYLE_REWRITE=false
   fi
 }
 
@@ -291,22 +291,8 @@ rewrite_include_style_file()
 }
 export -f rewrite_include_style_file
 
-rewrite_include_style_changed()
+should_rewrite_include_style()
 {
-  if [ "${IBAMR_SKIP_INCLUDE_STYLE_REWRITE:-false}" = "true" ]; then
-    return
-  fi
-  process_changed "include src ibtk/include ibtk/src examples ibtk/examples tests" \
-    ".*\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inl|tcc)" rewrite_include_style_file
+  [ "${IBAMR_SKIP_INCLUDE_STYLE_REWRITE:-false}" != "true" ]
 }
-export -f rewrite_include_style_changed
-
-rewrite_include_style_all()
-{
-  if [ "${IBAMR_SKIP_INCLUDE_STYLE_REWRITE:-false}" = "true" ]; then
-    return
-  fi
-  process "include src ibtk/include ibtk/src examples ibtk/examples tests" \
-    ".*\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inl|tcc)" rewrite_include_style_file
-}
-export -f rewrite_include_style_all
+export -f should_rewrite_include_style


### PR DESCRIPTION
- Move include file-selection logic into indent and indent-all.
- Keep indent_common focused on shared helper functions.
- Place python3 availability check at end of checks() and preserve warning-based skip behavior.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [ ] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
