### PR TITLE
CI: enable SILO for Arch Linux.

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          FLAGS="${{ matrix.cmake_flags }} -DHYPRE_ROOT=/petsc/ -DPETSC_ROOT=/petsc/ -DSAMRAI_ROOT=/samrai"
+          FLAGS="${{ matrix.cmake_flags }} -DHYPRE_ROOT=/petsc -DPETSC_ROOT=/petsc -DSAMRAI_ROOT=/samrai"
           # add a subshell to ensure flags are passed as separate arguments
           cmake $(echo "$FLAGS") -DNUMDIFF_ROOT=/numdiff/ \
                 -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER="$(which ccache)" \


### PR DESCRIPTION
We compiled and installed SILO

https://github.com/IBAMR/docker-files/blob/30e47f39719af9c1c7aa909c9bbb4139e52e1588/dependencies/Dockerfile.archlinux#L51

but didn't turn it on.