### PR TITLE
Allow for multiple stress tensors in CFINSForcing.

### DIFF
--- a/doc/news/changes/minor/20260303Barrett
+++ b/doc/news/changes/minor/20260303Barrett
@@ -1,0 +1,4 @@
+Fixed: Updated CFINSForcing to allow for mutiple stress tensors to be evolved.
+Updated the logging to prefix the object name to all logged messages.
+<br>
+(Aaron Barrett, 2026/03/03)

--- a/src/complex_fluids/CFINSForcing.cpp
+++ b/src/complex_fluids/CFINSForcing.cpp
@@ -211,14 +211,14 @@ CFINSForcing::commonConstructor(const Pointer<Database> input_db,
     {
         d_conform_var_draw = new CellVariable<NDIM, double>(d_object_name + "::conform_draw", NDIM * NDIM);
         d_conform_idx_draw = var_db->registerVariableAndContext(d_conform_var_draw, d_context, IntVector<NDIM>(0));
-        visit_data_writer->registerPlotQuantity("Conformation_Tensor", "TENSOR", d_conform_idx_draw);
+        visit_data_writer->registerPlotQuantity(d_object_name + "_Conformation_Tensor", "TENSOR", d_conform_idx_draw);
     }
     d_stress_draw = input_db->getBoolWithDefault("output_stress_tensor", d_stress_draw);
     if (d_stress_draw)
     {
         d_stress_var_draw = new CellVariable<NDIM, double>(d_object_name + "::stress_draw", NDIM * NDIM);
         d_stress_idx_draw = var_db->registerVariableAndContext(d_stress_var_draw, d_context, IntVector<NDIM>(0));
-        visit_data_writer->registerPlotQuantity("Stress_Tensor", "TENSOR", d_stress_idx_draw);
+        visit_data_writer->registerPlotQuantity(d_object_name + "_Stress_Tensor", "TENSOR", d_stress_idx_draw);
     }
 
     // Set up AMR tagging if necessary
@@ -229,7 +229,8 @@ CFINSForcing::commonConstructor(const Pointer<Database> input_db,
     {
         d_div_sig_var_draw = new CellVariable<NDIM, double>(d_object_name + "::divW_draw", NDIM);
         d_div_sig_idx_draw = var_db->registerVariableAndContext(d_div_sig_var_draw, d_context, IntVector<NDIM>(0));
-        if (d_div_sig_draw) visit_data_writer->registerPlotQuantity("Stress_Divergence", "VECTOR", d_div_sig_idx_draw);
+        if (d_div_sig_draw)
+            visit_data_writer->registerPlotQuantity(d_object_name + "_Stress_Divergence", "VECTOR", d_div_sig_idx_draw);
     }
     if (d_div_sig_rel_tag) d_div_sig_rel_thresh = input_db->getDoubleArray("divergence_rel_thresh");
     if (d_div_sig_abs_tag) d_div_sig_abs_thresh = input_db->getDoubleArray("divergence_abs_thresh");
@@ -258,7 +259,7 @@ CFINSForcing::commonConstructor(const Pointer<Database> input_db,
     std::string convec_oper_type = input_db->getStringWithDefault("convective_operator_type", "CENTERED");
     auto difference_form =
         string_to_enum<ConvectiveDifferencingType>(input_db->getStringWithDefault("difference_form", "ADVECTIVE"));
-    d_convec_oper = new CFUpperConvectiveOperator("ComplexFluidConvectiveOperator",
+    d_convec_oper = new CFUpperConvectiveOperator(d_object_name + "::ComplexFluidConvectiveOperator",
                                                   d_C_cc_var,
                                                   input_db,
                                                   convec_oper_type,
@@ -403,7 +404,7 @@ CFINSForcing::setDataOnPatchHierarchy(const int data_idx,
     checkPositiveDefinite(d_C_scratch_idx, d_C_cc_var, data_time, initial_time);
     int temp = d_positive_def ? 1 : 0;
     d_positive_def = IBTK_MPI::maxReduction(temp) == 1 ? true : false;
-    plog << "Conformation tensor is " << (d_positive_def ? "SPD" : "NOT SPD") << "\n";
+    plog << d_object_name << ": Conformation tensor is " << (d_positive_def ? "SPD" : "NOT SPD") << "\n";
     if (d_error_on_spd && !d_positive_def)
     {
         TBOX_ERROR("ERROR: \n "
@@ -418,8 +419,8 @@ CFINSForcing::setDataOnPatchHierarchy(const int data_idx,
         findDeterminant(d_C_scratch_idx, d_C_cc_var, data_time, initial_time);
         d_max_det = IBTK_MPI::maxReduction(d_max_det);
         d_min_det = IBTK_MPI::minReduction(d_min_det);
-        plog << "Largest det:  " << d_max_det << "\n";
-        plog << "Smallest det: " << d_min_det << "\n";
+        plog << d_object_name << ": Largest det:  " << d_max_det << "\n";
+        plog << d_object_name << ": Smallest det: " << d_min_det << "\n";
     }
 
     // If necessary, output the conformation tensor.
@@ -440,8 +441,8 @@ CFINSForcing::setDataOnPatchHierarchy(const int data_idx,
     {
         IBTK_MPI::maxReduction(d_max_norm);
         IBTK_MPI::minReduction(d_min_norm);
-        plog << "Largest max norm of Div W:  " << d_max_norm << "\n";
-        plog << "Smallest max norm of Div W: " << d_min_norm << "\n";
+        plog << d_object_name << ": Largest max norm of Div W:  " << d_max_norm << "\n";
+        plog << d_object_name << ": Smallest max norm of Div W: " << d_min_norm << "\n";
     }
 
     // Deallocate data as needed.

--- a/src/complex_fluids/CFUpperConvectiveOperator.cpp
+++ b/src/complex_fluids/CFUpperConvectiveOperator.cpp
@@ -184,7 +184,7 @@ CFUpperConvectiveOperator::CFUpperConvectiveOperator(const std::string& object_n
                                                      const std::vector<RobinBcCoefStrategy<NDIM>*>& u_bc_coefs)
     : ConvectiveOperator(object_name, difference_form),
       d_Q_var(Q_var),
-      d_u_adv_var(new SideVariable<NDIM, double>("Complex U var")),
+      d_u_adv_var(new SideVariable<NDIM, double>(d_object_name + "::Complex U var")),
       d_Q_bc_coefs(Q_bc_coefs),
       d_u_bc_coefs(u_bc_coefs)
 {
@@ -203,7 +203,7 @@ CFUpperConvectiveOperator::CFUpperConvectiveOperator(const std::string& object_n
                                                      const std::vector<RobinBcCoefStrategy<NDIM>*>& u_bc_coefs)
     : ConvectiveOperator(object_name, difference_form),
       d_Q_var(Q_var),
-      d_u_adv_var(new SideVariable<NDIM, double>("Complex U var")),
+      d_u_adv_var(new SideVariable<NDIM, double>(d_object_name + "::Complex U var")),
       d_convec_oper(convective_op),
       d_Q_bc_coefs(Q_bc_coefs),
       d_u_bc_coefs(u_bc_coefs)

--- a/tests/complex_fluids/cf_forcing_op_01_2d.cell.logarithm.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.cell.logarithm.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.97983536
   L2-norm:  1.0673658

--- a/tests/complex_fluids/cf_forcing_op_01_2d.cell.square_root.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.cell.square_root.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.30806833
   L2-norm:  0.3156627

--- a/tests/complex_fluids/cf_forcing_op_01_2d.cell.standard.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.cell.standard.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.060524546
   L2-norm:  0.055059717

--- a/tests/complex_fluids/cf_forcing_op_01_2d.draw.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.draw.output
@@ -1,2 +1,2 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD

--- a/tests/complex_fluids/cf_forcing_op_01_2d.side.logarithm.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.side.logarithm.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.3969317
   L2-norm:  1.1131887

--- a/tests/complex_fluids/cf_forcing_op_01_2d.side.square_root.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.side.square_root.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.12170821
   L2-norm:  0.33180885

--- a/tests/complex_fluids/cf_forcing_op_01_2d.side.standard.output
+++ b/tests/complex_fluids/cf_forcing_op_01_2d.side.standard.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.022434108
   L2-norm:  0.055404802

--- a/tests/complex_fluids/cf_forcing_op_01_3d.cell.logarithm.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.cell.logarithm.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  1.3924034
   L2-norm:  1.2122335

--- a/tests/complex_fluids/cf_forcing_op_01_3d.cell.square_root.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.cell.square_root.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.43615221
   L2-norm:  0.35422102

--- a/tests/complex_fluids/cf_forcing_op_01_3d.cell.standard.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.cell.standard.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.086218396
   L2-norm:  0.061995291

--- a/tests/complex_fluids/cf_forcing_op_01_3d.draw.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.draw.output
@@ -1,2 +1,2 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD

--- a/tests/complex_fluids/cf_forcing_op_01_3d.side.logarithm.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.side.logarithm.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.49867983
   L2-norm:  1.1225451

--- a/tests/complex_fluids/cf_forcing_op_01_3d.side.square_root.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.side.square_root.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.15367068
   L2-norm:  0.33425013

--- a/tests/complex_fluids/cf_forcing_op_01_3d.side.standard.output
+++ b/tests/complex_fluids/cf_forcing_op_01_3d.side.standard.output
@@ -1,5 +1,5 @@
 AdvDiffHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
-Conformation tensor is SPD
+ComplexFluid: Conformation tensor is SPD
 Error norms:
   L1-norm:  0.028835889
   L2-norm:  0.055862145

--- a/tests/complex_fluids/cf_four_roll_mill.cpp
+++ b/tests/complex_fluids/cf_four_roll_mill.cpp
@@ -106,7 +106,7 @@ main(int argc, char* argv[])
         }
         // Create body force function specification objects (when necessary).
         Pointer<CartGridFunctionSet> external_functions = new CartGridFunctionSet("ExternalFunctions");
-        Pointer<CFINSForcing> polymericStressForcing;
+        Pointer<CFINSForcing> polymericStressForcing, polymericStressForcing2;
         Pointer<CartGridFunction> f_fcn;
         if (input_db->keyExists("ForcingFunction"))
         {
@@ -124,6 +124,16 @@ main(int argc, char* argv[])
                                                       visit_data_writer);
 
             external_functions->addFunction(polymericStressForcing);
+        }
+        if (input_db->getBoolWithDefault("USE_2_CF", false))
+        {
+            polymericStressForcing2 = new CFINSForcing("PolymericStressForcing2",
+                                                       app_initializer->getComponentDatabase("ComplexFluid"),
+                                                       time_integrator,
+                                                       grid_geometry,
+                                                       adv_diff_integrator,
+                                                       visit_data_writer);
+            external_functions->addFunction(polymericStressForcing2);
         }
         time_integrator->registerBodyForceFunction(external_functions);
         // Initialize hierarchy configuration and data on all patches.

--- a/tests/complex_fluids/cf_four_roll_mill.logarithm.output
+++ b/tests/complex_fluids/cf_four_roll_mill.logarithm.output
@@ -1,309 +1,309 @@
 INSStaggeredHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.005
-Smallest det: 1.00001
-Conformation tensor is SPD
-Largest det:  1.01003
-Smallest det: 1.00002
-Conformation tensor is SPD
-Largest det:  1.03008
-Smallest det: 1.00007
-Conformation tensor is SPD
-Largest det:  1.05019
-Smallest det: 1.00012
-Conformation tensor is SPD
-Largest det:  1.07034
-Smallest det: 1.00016
-Conformation tensor is SPD
-Largest det:  1.09052
-Smallest det: 1.00021
-Conformation tensor is SPD
-Largest det:  1.11074
-Smallest det: 1.00025
-Conformation tensor is SPD
-Largest det:  1.13098
-Smallest det: 1.00029
-Conformation tensor is SPD
-Largest det:  1.15126
-Smallest det: 1.00034
-Conformation tensor is SPD
-Largest det:  1.17155
-Smallest det: 1.00038
-Conformation tensor is SPD
-Largest det:  1.19187
-Smallest det: 1.00042
-Conformation tensor is SPD
-Largest det:  1.21221
-Smallest det: 1.00046
-Conformation tensor is SPD
-Largest det:  1.23256
-Smallest det: 1.0005
-Conformation tensor is SPD
-Largest det:  1.25293
-Smallest det: 1.00053
-Conformation tensor is SPD
-Largest det:  1.27331
-Smallest det: 1.00057
-Conformation tensor is SPD
-Largest det:  1.29369
-Smallest det: 1.00061
-Conformation tensor is SPD
-Largest det:  1.31409
-Smallest det: 1.00064
-Conformation tensor is SPD
-Largest det:  1.33449
-Smallest det: 1.00068
-Conformation tensor is SPD
-Largest det:  1.35489
-Smallest det: 1.00071
-Conformation tensor is SPD
-Largest det:  1.37529
-Smallest det: 1.00074
-Conformation tensor is SPD
-Largest det:  1.39568
-Smallest det: 1.00077
-Conformation tensor is SPD
-Largest det:  1.41607
-Smallest det: 1.0008
-Conformation tensor is SPD
-Largest det:  1.43645
-Smallest det: 1.00083
-Conformation tensor is SPD
-Largest det:  1.45683
-Smallest det: 1.00086
-Conformation tensor is SPD
-Largest det:  1.47719
-Smallest det: 1.00089
-Conformation tensor is SPD
-Largest det:  1.49753
-Smallest det: 1.00092
-Conformation tensor is SPD
-Largest det:  1.51786
-Smallest det: 1.00095
-Conformation tensor is SPD
-Largest det:  1.53817
-Smallest det: 1.00098
-Conformation tensor is SPD
-Largest det:  1.55846
-Smallest det: 1.001
-Conformation tensor is SPD
-Largest det:  1.57872
-Smallest det: 1.00103
-Conformation tensor is SPD
-Largest det:  1.59896
-Smallest det: 1.00105
-Conformation tensor is SPD
-Largest det:  1.61917
-Smallest det: 1.00108
-Conformation tensor is SPD
-Largest det:  1.63935
-Smallest det: 1.0011
-Conformation tensor is SPD
-Largest det:  1.6595
-Smallest det: 1.00112
-Conformation tensor is SPD
-Largest det:  1.67962
-Smallest det: 1.00115
-Conformation tensor is SPD
-Largest det:  1.6997
-Smallest det: 1.00117
-Conformation tensor is SPD
-Largest det:  1.71974
-Smallest det: 1.00119
-Conformation tensor is SPD
-Largest det:  1.73975
-Smallest det: 1.00121
-Conformation tensor is SPD
-Largest det:  1.75971
-Smallest det: 1.00123
-Conformation tensor is SPD
-Largest det:  1.77963
-Smallest det: 1.00125
-Conformation tensor is SPD
-Largest det:  1.79951
-Smallest det: 1.00127
-Conformation tensor is SPD
-Largest det:  1.81934
-Smallest det: 1.00129
-Conformation tensor is SPD
-Largest det:  1.83912
-Smallest det: 1.00131
-Conformation tensor is SPD
-Largest det:  1.85885
-Smallest det: 1.00132
-Conformation tensor is SPD
-Largest det:  1.87853
-Smallest det: 1.00134
-Conformation tensor is SPD
-Largest det:  1.89816
-Smallest det: 1.00136
-Conformation tensor is SPD
-Largest det:  1.91774
-Smallest det: 1.00138
-Conformation tensor is SPD
-Largest det:  1.93725
-Smallest det: 1.00139
-Conformation tensor is SPD
-Largest det:  1.95671
-Smallest det: 1.00141
-Conformation tensor is SPD
-Largest det:  1.97612
-Smallest det: 1.00142
-Conformation tensor is SPD
-Largest det:  1.99546
-Smallest det: 1.00144
-Conformation tensor is SPD
-Largest det:  2.01474
-Smallest det: 1.00145
-Conformation tensor is SPD
-Largest det:  2.03396
-Smallest det: 1.00147
-Conformation tensor is SPD
-Largest det:  2.05311
-Smallest det: 1.00148
-Conformation tensor is SPD
-Largest det:  2.0722
-Smallest det: 1.00149
-Conformation tensor is SPD
-Largest det:  2.09122
-Smallest det: 1.00151
-Conformation tensor is SPD
-Largest det:  2.11018
-Smallest det: 1.00152
-Conformation tensor is SPD
-Largest det:  2.12907
-Smallest det: 1.00153
-Conformation tensor is SPD
-Largest det:  2.14788
-Smallest det: 1.00155
-Conformation tensor is SPD
-Largest det:  2.16663
-Smallest det: 1.00156
-Conformation tensor is SPD
-Largest det:  2.1853
-Smallest det: 1.00157
-Conformation tensor is SPD
-Largest det:  2.20391
-Smallest det: 1.00158
-Conformation tensor is SPD
-Largest det:  2.22243
-Smallest det: 1.00159
-Conformation tensor is SPD
-Largest det:  2.24089
-Smallest det: 1.00161
-Conformation tensor is SPD
-Largest det:  2.25927
-Smallest det: 1.00162
-Conformation tensor is SPD
-Largest det:  2.27757
-Smallest det: 1.00163
-Conformation tensor is SPD
-Largest det:  2.2958
-Smallest det: 1.00164
-Conformation tensor is SPD
-Largest det:  2.31395
-Smallest det: 1.00165
-Conformation tensor is SPD
-Largest det:  2.33202
-Smallest det: 1.00166
-Conformation tensor is SPD
-Largest det:  2.35001
-Smallest det: 1.00167
-Conformation tensor is SPD
-Largest det:  2.36792
-Smallest det: 1.00168
-Conformation tensor is SPD
-Largest det:  2.38575
-Smallest det: 1.00169
-Conformation tensor is SPD
-Largest det:  2.4035
-Smallest det: 1.0017
-Conformation tensor is SPD
-Largest det:  2.42117
-Smallest det: 1.00171
-Conformation tensor is SPD
-Largest det:  2.43875
-Smallest det: 1.00172
-Conformation tensor is SPD
-Largest det:  2.45626
-Smallest det: 1.00173
-Conformation tensor is SPD
-Largest det:  2.47368
-Smallest det: 1.00174
-Conformation tensor is SPD
-Largest det:  2.49102
-Smallest det: 1.00175
-Conformation tensor is SPD
-Largest det:  2.50827
-Smallest det: 1.00176
-Conformation tensor is SPD
-Largest det:  2.52544
-Smallest det: 1.00177
-Conformation tensor is SPD
-Largest det:  2.54252
-Smallest det: 1.00177
-Conformation tensor is SPD
-Largest det:  2.55952
-Smallest det: 1.00178
-Conformation tensor is SPD
-Largest det:  2.57644
-Smallest det: 1.00179
-Conformation tensor is SPD
-Largest det:  2.59327
-Smallest det: 1.0018
-Conformation tensor is SPD
-Largest det:  2.61001
-Smallest det: 1.00181
-Conformation tensor is SPD
-Largest det:  2.62667
-Smallest det: 1.00182
-Conformation tensor is SPD
-Largest det:  2.64324
-Smallest det: 1.00182
-Conformation tensor is SPD
-Largest det:  2.65973
-Smallest det: 1.00183
-Conformation tensor is SPD
-Largest det:  2.67612
-Smallest det: 1.00184
-Conformation tensor is SPD
-Largest det:  2.69243
-Smallest det: 1.00185
-Conformation tensor is SPD
-Largest det:  2.70866
-Smallest det: 1.00186
-Conformation tensor is SPD
-Largest det:  2.7248
-Smallest det: 1.00186
-Conformation tensor is SPD
-Largest det:  2.74085
-Smallest det: 1.00187
-Conformation tensor is SPD
-Largest det:  2.75681
-Smallest det: 1.00188
-Conformation tensor is SPD
-Largest det:  2.77269
-Smallest det: 1.00189
-Conformation tensor is SPD
-Largest det:  2.78848
-Smallest det: 1.00189
-Conformation tensor is SPD
-Largest det:  2.80418
-Smallest det: 1.0019
-Conformation tensor is SPD
-Largest det:  2.81979
-Smallest det: 1.00191
-Conformation tensor is SPD
-Largest det:  2.83532
-Smallest det: 1.00192
-Conformation tensor is SPD
-Largest det:  2.85076
-Smallest det: 1.00192
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.005
+PolymericStressForcing: Smallest det: 1.00001
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01003
+PolymericStressForcing: Smallest det: 1.00002
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.03008
+PolymericStressForcing: Smallest det: 1.00007
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.05019
+PolymericStressForcing: Smallest det: 1.00012
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.07034
+PolymericStressForcing: Smallest det: 1.00016
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.09052
+PolymericStressForcing: Smallest det: 1.00021
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.11074
+PolymericStressForcing: Smallest det: 1.00025
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.13098
+PolymericStressForcing: Smallest det: 1.00029
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.15126
+PolymericStressForcing: Smallest det: 1.00034
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.17155
+PolymericStressForcing: Smallest det: 1.00038
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.19187
+PolymericStressForcing: Smallest det: 1.00042
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.21221
+PolymericStressForcing: Smallest det: 1.00046
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.23256
+PolymericStressForcing: Smallest det: 1.0005
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.25293
+PolymericStressForcing: Smallest det: 1.00053
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.27331
+PolymericStressForcing: Smallest det: 1.00057
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.29369
+PolymericStressForcing: Smallest det: 1.00061
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.31409
+PolymericStressForcing: Smallest det: 1.00064
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.33449
+PolymericStressForcing: Smallest det: 1.00068
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.35489
+PolymericStressForcing: Smallest det: 1.00071
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.37529
+PolymericStressForcing: Smallest det: 1.00074
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.39568
+PolymericStressForcing: Smallest det: 1.00077
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.41607
+PolymericStressForcing: Smallest det: 1.0008
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.43645
+PolymericStressForcing: Smallest det: 1.00083
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.45683
+PolymericStressForcing: Smallest det: 1.00086
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.47719
+PolymericStressForcing: Smallest det: 1.00089
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.49753
+PolymericStressForcing: Smallest det: 1.00092
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.51786
+PolymericStressForcing: Smallest det: 1.00095
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.53817
+PolymericStressForcing: Smallest det: 1.00098
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.55846
+PolymericStressForcing: Smallest det: 1.001
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.57872
+PolymericStressForcing: Smallest det: 1.00103
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.59896
+PolymericStressForcing: Smallest det: 1.00105
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.61917
+PolymericStressForcing: Smallest det: 1.00108
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.63935
+PolymericStressForcing: Smallest det: 1.0011
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.6595
+PolymericStressForcing: Smallest det: 1.00112
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.67962
+PolymericStressForcing: Smallest det: 1.00115
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.6997
+PolymericStressForcing: Smallest det: 1.00117
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.71974
+PolymericStressForcing: Smallest det: 1.00119
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.73975
+PolymericStressForcing: Smallest det: 1.00121
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.75971
+PolymericStressForcing: Smallest det: 1.00123
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.77963
+PolymericStressForcing: Smallest det: 1.00125
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.79951
+PolymericStressForcing: Smallest det: 1.00127
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.81934
+PolymericStressForcing: Smallest det: 1.00129
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.83912
+PolymericStressForcing: Smallest det: 1.00131
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.85885
+PolymericStressForcing: Smallest det: 1.00132
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.87853
+PolymericStressForcing: Smallest det: 1.00134
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.89816
+PolymericStressForcing: Smallest det: 1.00136
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.91774
+PolymericStressForcing: Smallest det: 1.00138
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.93725
+PolymericStressForcing: Smallest det: 1.00139
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.95671
+PolymericStressForcing: Smallest det: 1.00141
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.97612
+PolymericStressForcing: Smallest det: 1.00142
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.99546
+PolymericStressForcing: Smallest det: 1.00144
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.01474
+PolymericStressForcing: Smallest det: 1.00145
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.03396
+PolymericStressForcing: Smallest det: 1.00147
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.05311
+PolymericStressForcing: Smallest det: 1.00148
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.0722
+PolymericStressForcing: Smallest det: 1.00149
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.09122
+PolymericStressForcing: Smallest det: 1.00151
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.11018
+PolymericStressForcing: Smallest det: 1.00152
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.12907
+PolymericStressForcing: Smallest det: 1.00153
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.14788
+PolymericStressForcing: Smallest det: 1.00155
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.16663
+PolymericStressForcing: Smallest det: 1.00156
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.1853
+PolymericStressForcing: Smallest det: 1.00157
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.20391
+PolymericStressForcing: Smallest det: 1.00158
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.22243
+PolymericStressForcing: Smallest det: 1.00159
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.24089
+PolymericStressForcing: Smallest det: 1.00161
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.25927
+PolymericStressForcing: Smallest det: 1.00162
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.27757
+PolymericStressForcing: Smallest det: 1.00163
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.2958
+PolymericStressForcing: Smallest det: 1.00164
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.31395
+PolymericStressForcing: Smallest det: 1.00165
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.33202
+PolymericStressForcing: Smallest det: 1.00166
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.35001
+PolymericStressForcing: Smallest det: 1.00167
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.36792
+PolymericStressForcing: Smallest det: 1.00168
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.38575
+PolymericStressForcing: Smallest det: 1.00169
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.4035
+PolymericStressForcing: Smallest det: 1.0017
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.42117
+PolymericStressForcing: Smallest det: 1.00171
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.43875
+PolymericStressForcing: Smallest det: 1.00172
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.45626
+PolymericStressForcing: Smallest det: 1.00173
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.47368
+PolymericStressForcing: Smallest det: 1.00174
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.49102
+PolymericStressForcing: Smallest det: 1.00175
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.50827
+PolymericStressForcing: Smallest det: 1.00176
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.52544
+PolymericStressForcing: Smallest det: 1.00177
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.54252
+PolymericStressForcing: Smallest det: 1.00177
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.55952
+PolymericStressForcing: Smallest det: 1.00178
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.57644
+PolymericStressForcing: Smallest det: 1.00179
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.59327
+PolymericStressForcing: Smallest det: 1.0018
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.61001
+PolymericStressForcing: Smallest det: 1.00181
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.62667
+PolymericStressForcing: Smallest det: 1.00182
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.64324
+PolymericStressForcing: Smallest det: 1.00182
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.65973
+PolymericStressForcing: Smallest det: 1.00183
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.67612
+PolymericStressForcing: Smallest det: 1.00184
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.69243
+PolymericStressForcing: Smallest det: 1.00185
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.70866
+PolymericStressForcing: Smallest det: 1.00186
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.7248
+PolymericStressForcing: Smallest det: 1.00186
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.74085
+PolymericStressForcing: Smallest det: 1.00187
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.75681
+PolymericStressForcing: Smallest det: 1.00188
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.77269
+PolymericStressForcing: Smallest det: 1.00189
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.78848
+PolymericStressForcing: Smallest det: 1.00189
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.80418
+PolymericStressForcing: Smallest det: 1.0019
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.81979
+PolymericStressForcing: Smallest det: 1.00191
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.83532
+PolymericStressForcing: Smallest det: 1.00192
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  2.85076
+PolymericStressForcing: Smallest det: 1.00192
 Soln norms in sxx at time 1:
   L1-norm:  7.826606441
   L2-norm:  2.193154019

--- a/tests/complex_fluids/cf_four_roll_mill.multiple_stresses.input
+++ b/tests/complex_fluids/cf_four_roll_mill.multiple_stresses.input
@@ -1,0 +1,282 @@
+PI = 3.14159265358979
+// physical parameters
+MU  = 1.0                              // fluid viscosity
+RHO = 0.0                                 // fluid density
+L   = 2*PI
+
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 64                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+End_L = L
+Start_L = 0.0
+
+// Complex Fluid parameters
+FLUID_MODEL = "OLDROYDB"
+EVOLVE_TYPE = "STANDARD"
+LOG_DETERMINANT     = TRUE
+CONVECTIVE_OPERATOR_TYPE     = "WAVE_PROP"
+OUTPUT_CONFORMATION_TENSOR = TRUE
+OUTPUT_STRESS_TENSOR = FALSE
+RELAXATION_TIME = 0.7
+VISCOSITY = 0.5
+USE_2_CF = TRUE
+
+// solver parameters
+NORMALIZE_VELOCITY = TRUE
+VISCOUS_TS_TYPE = "BACKWARD_EULER"
+START_TIME         = 0.0e0                // initial simulation time
+END_TIME           = 0.1                  // final simulation time
+GROW_DT            = 2.0e0                // growth factor for timesteps
+NUM_CYCLES         = 1                    // number of cycles of fixed-point iteration
+CONVECTIVE_TS_TYPE = "ADAMS_BASHFORTH"    // convective time stepping type
+CONVECTIVE_OP_TYPE = "PPM"                // convective differencing discretization type
+CONVECTIVE_FORM    = "ADVECTIVE"          // how to compute the convective terms
+NORMALIZE_PRESSURE = TRUE                 // whether to explicitly force the pressure to have mean zero
+CFL_MAX            = 0.3                  // maximum CFL number
+//DT_MAX             = 0.0625/NFINEST       // maximum timestep size
+DT_MAX = 0.01
+VORTICITY_TAGGING  = FALSE                // whether to tag cells for refinement based on vorticity thresholds
+TAG_BUFFER         = 1                    // sized of tag buffer used by grid generation algorithm
+REGRID_INTERVAL    = 10000000             // effectively disable regridding
+OUTPUT_U           = TRUE
+OUTPUT_P           = TRUE
+OUTPUT_F           = TRUE
+OUTPUT_OMEGA       = TRUE
+OUTPUT_DIV_U       = TRUE
+ENABLE_LOGGING     = FALSE
+//Advection Diffusion solver parameters
+ADV_DIFF_SOLVER_TYPE = "SEMI_IMPLICIT"
+ADV_DIFF_NUM_CYCLES = 2
+ADV_DIFF_CONVECTIVE_OP_TYPE = "PPM"
+ADV_DIFF_CONVECTIVE_TS_TYPE = "TRAPEZOIDAL_RULE"
+ADV_DIFF_CONVECTIVE_FORM = "ADVECTIVE"
+
+// collocated solver parameters
+PROJECTION_METHOD_TYPE = "PRESSURE_UPDATE"
+SECOND_ORDER_PRESSURE_UPDATE = TRUE
+P = "1.0"
+
+// Initial Conditions for Stress
+C_XX = "1.0"
+C_YY = "1.0"
+C_XY = "0"
+// Velocity Initial Conditions
+U = "0.0"
+V = "0.0"
+
+N_values {
+ Wi = "0.5"
+ N = "064"
+}
+ForcingFunction {
+function_0 = "2*sin(X_0)*cos(X_1)"
+function_1 = "-2*cos(X_0)*sin(X_1)"
+}
+
+ComplexFluid {
+InitialConditions{
+ function_0 = C_XX
+ function_1 = C_YY
+ function_2 = C_XY
+}
+relaxation_time = RELAXATION_TIME
+viscosity = VISCOSITY
+fluid_model         = FLUID_MODEL
+log_determinant     = LOG_DETERMINANT
+convective_operator_type     = CONVECTIVE_OPERATOR_TYPE
+evolution_type = EVOLVE_TYPE
+output_stress_tensor = OUTPUT_STRESS_TENSOR
+output_conformation_tensor = OUTPUT_CONFORMATION_TENSOR
+}
+
+VelocityInitialConditions {
+   mu = MU
+   function_0 = U
+   function_1 = V
+}
+
+PressureInitialConditions {
+   nu = MU/RHO
+   function = "0"
+}
+
+INSStaggeredHierarchyIntegrator {
+   mu                            = MU
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   viscous_time_stepping_type    = VISCOUS_TS_TYPE
+   num_cycles                    = NUM_CYCLES
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   normalize_velocity            = NORMALIZE_VELOCITY
+   normalize_pressure            = NORMALIZE_PRESSURE
+   cfl                           = CFL_MAX
+   dt_max                        = DT_MAX
+   using_vorticity_tagging       = VORTICITY_TAGGING
+   vorticity_rel_thresh          = 0.25,0.125
+   tag_buffer                    = TAG_BUFFER
+   regrid_interval               = REGRID_INTERVAL
+   output_U                      = OUTPUT_U
+   output_P                      = OUTPUT_P
+   output_F                      = OUTPUT_F
+   output_Omega                  = OUTPUT_OMEGA
+   output_Div_U                  = OUTPUT_DIV_U
+   enable_logging                = ENABLE_LOGGING
+   enable_logging_solver_iterations = FALSE
+
+   stokes_solver_type = "PETSC_KRYLOV_SOLVER"
+   stokes_precond_type = "PROJECTION_PRECONDITIONER"
+   stokes_solver_db {
+      ksp_type = "fgmres"
+   }
+
+   velocity_solver_type = "PETSC_KRYLOV_SOLVER"
+   velocity_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   velocity_solver_db {
+      ksp_type = "richardson"
+      max_iterations = 1
+   }
+   velocity_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "CONSTANT_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "Split"
+         split_solver_type    = "PFMG"
+         enable_logging       = FALSE
+      }
+   }
+
+   pressure_solver_type = "PETSC_KRYLOV_SOLVER"
+   pressure_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   pressure_solver_db {
+      ksp_type = "richardson"
+      max_iterations = 1
+   }
+   pressure_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+
+   regrid_projection_solver_type = "PETSC_KRYLOV_SOLVER"
+   regrid_projection_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+   regrid_projection_solver_db {
+      ksp_type = "fgmres"
+   }
+   regrid_projection_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type  = "HYPRE_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         solver_type          = "PFMG"
+         num_pre_relax_steps  = 0
+         num_post_relax_steps = 3
+         enable_logging       = FALSE
+      }
+   }
+}
+
+Main {
+
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "visit"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_INS2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = Start_L, Start_L
+   x_up = End_L,End_L
+   periodic_dimension = 1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+//    level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+//    level_0 = [(0,0),(N/2 - 1,N/2 - 1)]
+      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}
+AdvDiffSemiImplicitHierarchyIntegrator {
+ start_time = START_TIME
+ end_time = END_TIME
+ grow_dt = GROW_DT
+ num_cycles = ADV_DIFF_NUM_CYCLES
+ convective_time_stepping_type = ADV_DIFF_CONVECTIVE_TS_TYPE
+ convective_op_type = ADV_DIFF_CONVECTIVE_OP_TYPE
+ convective_difference_form = ADV_DIFF_CONVECTIVE_FORM
+ cfl = CFL_MAX
+ dt_max = DT_MAX
+ tag_buffer = TAG_BUFFER
+ enable_logging = ENABLE_LOGGING
+}

--- a/tests/complex_fluids/cf_four_roll_mill.multiple_stresses.output
+++ b/tests/complex_fluids/cf_four_roll_mill.multiple_stresses.output
@@ -1,0 +1,81 @@
+INSStaggeredHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
+  projecting the interpolated velocity field
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1
+PolymericStressForcing2: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999975
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1
+PolymericStressForcing2: Smallest det: 0.999975
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.9999
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1
+PolymericStressForcing2: Smallest det: 0.9999
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999912
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1
+PolymericStressForcing2: Smallest det: 0.999912
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999939
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1
+PolymericStressForcing2: Smallest det: 0.999939
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999991
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1
+PolymericStressForcing2: Smallest det: 0.999991
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00008
+PolymericStressForcing: Smallest det: 0.999999
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1.00008
+PolymericStressForcing2: Smallest det: 0.999999
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00021
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1.00021
+PolymericStressForcing2: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00038
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1.00038
+PolymericStressForcing2: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00061
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1.00061
+PolymericStressForcing2: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00091
+PolymericStressForcing: Smallest det: 0.999999
+PolymericStressForcing2: Conformation tensor is SPD
+PolymericStressForcing2: Largest det:  1.00091
+PolymericStressForcing2: Smallest det: 0.999999
+Soln norms in sxx at time 0.1:
+  L1-norm:  39.62475934
+  L2-norm:  6.328791816
+  max-norm: 1.183676754
+Soln norms in syy at time 0.1:
+  L1-norm:  39.62475934
+  L2-norm:  6.328791816
+  max-norm: 1.183676754
+Soln norms in sxy at time 0.1:
+  L1-norm:  0.05912931115
+  L2-norm:  0.01160585691
+  max-norm: 0.003688475664

--- a/tests/complex_fluids/cf_four_roll_mill.square_root.output
+++ b/tests/complex_fluids/cf_four_roll_mill.square_root.output
@@ -1,309 +1,309 @@
 INSStaggeredHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 0.999988
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 0.99995
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 0.999959
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 0.999985
-Conformation tensor is SPD
-Largest det:  1.00004
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00012
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00025
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00043
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00067
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00097
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00135
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00179
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00232
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00294
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00364
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00443
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00531
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.0063
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00738
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00857
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00985
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01124
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01274
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01434
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01605
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01787
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01979
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.02182
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.02396
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.02621
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.02856
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.03102
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.03358
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.03625
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.03902
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.04189
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.04486
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.04793
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.0511
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.05437
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.05773
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.06119
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.06474
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.06838
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.07211
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.07592
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.07982
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.08381
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.08788
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.09202
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.09625
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.10055
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.10493
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.10938
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.11391
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.1185
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.12316
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.12788
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.13267
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.13752
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.14243
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.1474
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.15242
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.15751
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.16264
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.16782
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.17306
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.17834
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.18367
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.18904
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.19445
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.19991
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.20541
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.21094
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.21651
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.22212
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.22775
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.23343
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.23913
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.24485
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.25061
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.25639
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.2622
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.26803
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.27389
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.27976
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.28565
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.29156
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.29749
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.30344
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.30939
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.31537
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.32135
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.32735
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.33335
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.33937
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.34539
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.35142
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.35745
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.36349
-Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999988
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.99995
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999959
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999985
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00004
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00012
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00025
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00043
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00067
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00097
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00135
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00179
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00232
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00294
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00364
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00443
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00531
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.0063
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00738
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00857
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00985
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01124
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01274
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01434
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01605
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01787
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01979
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.02182
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.02396
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.02621
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.02856
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.03102
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.03358
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.03625
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.03902
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.04189
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.04486
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.04793
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.0511
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.05437
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.05773
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.06119
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.06474
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.06838
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.07211
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.07592
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.07982
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.08381
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.08788
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.09202
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.09625
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.10055
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.10493
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.10938
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.11391
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.1185
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.12316
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.12788
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.13267
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.13752
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.14243
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.1474
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.15242
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.15751
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.16264
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.16782
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.17306
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.17834
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.18367
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.18904
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.19445
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.19991
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.20541
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.21094
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.21651
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.22212
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.22775
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.23343
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.23913
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.24485
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.25061
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.25639
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.2622
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.26803
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.27389
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.27976
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.28565
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.29156
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.29749
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.30344
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.30939
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.31537
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.32135
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.32735
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.33335
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.33937
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.34539
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.35142
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.35745
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.36349
+PolymericStressForcing: Smallest det: 1
 Soln norms in sxx at time 1:
   L1-norm:  41.08564205
   L2-norm:  6.676467325

--- a/tests/complex_fluids/cf_four_roll_mill.standard.output
+++ b/tests/complex_fluids/cf_four_roll_mill.standard.output
@@ -1,318 +1,318 @@
 INSStaggeredHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
 INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
   projecting the interpolated velocity field
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 0.999975
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 0.9999
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 0.999912
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 0.999939
-Conformation tensor is SPD
-Largest det:  1
-Smallest det: 0.999991
-Conformation tensor is SPD
-Largest det:  1.00008
-Smallest det: 0.999999
-Conformation tensor is SPD
-Largest det:  1.00021
-Smallest det: 0.999999
-Conformation tensor is SPD
-Largest det:  1.00039
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00063
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00094
-Smallest det: 0.999999
-Conformation tensor is SPD
-Largest det:  1.00131
-Smallest det: 0.999999
-Conformation tensor is SPD
-Largest det:  1.00176
-Smallest det: 0.999999
-Conformation tensor is SPD
-Largest det:  1.00229
-Smallest det: 0.999999
-Conformation tensor is SPD
-Largest det:  1.00291
-Smallest det: 0.999999
-Conformation tensor is SPD
-Largest det:  1.00361
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.0044
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00529
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00627
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00736
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00854
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.00983
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01122
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01272
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01432
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01603
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01785
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.01977
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.02181
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.02394
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.02619
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.02854
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.031
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.03356
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.03623
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.039
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.04187
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.04484
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.04792
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.05109
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.05435
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.05772
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.06117
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.06472
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.06836
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.07209
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.07591
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.07981
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.0838
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.08786
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.09201
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.09624
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.10054
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.10492
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.10937
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.11389
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.11848
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.12314
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.12787
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.13266
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.13751
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.14242
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.14739
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.15241
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.15749
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.16263
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.16781
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.17304
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.17833
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.18365
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.18903
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.19444
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.1999
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.20539
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.21093
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.2165
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.2221
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.22774
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.23341
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.23911
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.24484
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.2506
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.25638
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.26219
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.26802
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.27387
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.27975
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.28564
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.29155
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.29748
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.30342
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.30938
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.31535
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.32134
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.32733
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.33334
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.33935
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.34537
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.3514
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.35744
-Smallest det: 1
-Conformation tensor is SPD
-Largest det:  1.36348
-Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999975
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.9999
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999912
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999939
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1
+PolymericStressForcing: Smallest det: 0.999991
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00008
+PolymericStressForcing: Smallest det: 0.999999
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00021
+PolymericStressForcing: Smallest det: 0.999999
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00039
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00063
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00094
+PolymericStressForcing: Smallest det: 0.999999
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00131
+PolymericStressForcing: Smallest det: 0.999999
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00176
+PolymericStressForcing: Smallest det: 0.999999
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00229
+PolymericStressForcing: Smallest det: 0.999999
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00291
+PolymericStressForcing: Smallest det: 0.999999
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00361
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.0044
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00529
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00627
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00736
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00854
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.00983
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01122
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01272
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01432
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01603
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01785
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.01977
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.02181
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.02394
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.02619
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.02854
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.031
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.03356
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.03623
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.039
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.04187
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.04484
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.04792
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.05109
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.05435
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.05772
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.06117
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.06472
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.06836
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.07209
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.07591
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.07981
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.0838
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.08786
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.09201
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.09624
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.10054
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.10492
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.10937
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.11389
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.11848
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.12314
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.12787
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.13266
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.13751
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.14242
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.14739
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.15241
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.15749
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.16263
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.16781
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.17304
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.17833
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.18365
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.18903
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.19444
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.1999
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.20539
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.21093
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.2165
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.2221
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.22774
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.23341
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.23911
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.24484
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.2506
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.25638
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.26219
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.26802
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.27387
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.27975
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.28564
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.29155
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.29748
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.30342
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.30938
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.31535
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.32134
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.32733
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.33334
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.33935
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.34537
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.3514
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.35744
+PolymericStressForcing: Smallest det: 1
+PolymericStressForcing: Conformation tensor is SPD
+PolymericStressForcing: Largest det:  1.36348
+PolymericStressForcing: Smallest det: 1
 Soln norms in sxx at time 1:
   L1-norm:  44.60778085
   L2-norm:  7.728263339
-  max-norm: 2.64690267
+  max-norm: 2.646902669
 Soln norms in syy at time 1:
   L1-norm:  44.60778085
   L2-norm:  7.728263339
-  max-norm: 2.64690267
+  max-norm: 2.646902669
 Soln norms in sxy at time 1:
   L1-norm:  1.915578886
   L2-norm:  0.3759901117
-  max-norm: 0.1200481671
+  max-norm: 0.1200481614


### PR DESCRIPTION
This adds support for multiple `CFINSForcing` and `CFUpperConvectiveOperator` objects by prefixing the object name to all variables created by the classes.

This also appends the object name to any logging done by the class, which changes the preexisting tests.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
