### PR TITLE
CMake: support Eigen versions newer than 3.4.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,11 +337,14 @@ IF (${IBAMR_FORCE_BUNDLED_EIGEN3})
 ELSE()
   # set up the root with the proper package name too
   SET(Eigen3_ROOT ${EIGEN3_ROOT})
-  FIND_PACKAGE(Eigen3 3.4 QUIET)
+  FIND_PACKAGE(Eigen3 QUIET)
+  SET(IBAMR_USE_BUNDLED_EIGEN3 TRUE)
+  # we can't combine these if statements since Eigen3_VERSION won't be defined
+  # if Eigen is not found
   IF(${Eigen3_FOUND})
-    SET(IBAMR_USE_BUNDLED_EIGEN3 FALSE)
-  ELSE()
-    SET(IBAMR_USE_BUNDLED_EIGEN3 TRUE)
+    IF((${Eigen3_VERSION} VERSION_GREATER_EQUAL 3.4))
+      SET(IBAMR_USE_BUNDLED_EIGEN3 FALSE)
+    ENDIF()
   ENDIF()
 ENDIF()
 IF(NOT ${IBAMR_USE_BUNDLED_EIGEN3})

--- a/cmake/IBAMRConfig.cmake.in
+++ b/cmake/IBAMRConfig.cmake.in
@@ -96,7 +96,7 @@ ENDIF()
 
 IF(NOT @IBAMR_USE_BUNDLED_EIGEN3@)
   SET(Eigen3_ROOT "@EIGEN3_ROOT@")
-  FIND_PACKAGE(Eigen3 3.2.5 REQUIRED)
+  FIND_PACKAGE(Eigen3 REQUIRED)
 ENDIF()
 
 # non-bundled muParser is not handled as a package so we don't set it up again


### PR DESCRIPTION
We are also compatible with newer versions.