### PR TITLE
Fix some out-of-bounds refinement errors.

### DIFF
--- a/doc/news/changes/minor/20260603DavidWells
+++ b/doc/news/changes/minor/20260603DavidWells
@@ -1,0 +1,4 @@
+Fixed: Side-centered refinement operators will no longer read out-of-bounds
+data.
+<br>
+(David Wells, 2026/06/03)

--- a/ibtk/src/refine_ops/fortran/cart_side_refine2d.f.m4
+++ b/ibtk/src/refine_ops/fortran/cart_side_refine2d.f.m4
@@ -108,7 +108,7 @@ c
          enddo
       enddo
 
-      do i1=ilower1,iupper1+1
+      do i1=ilower1,iupper1
          coarsen_index(i1,i_c1,i_f1,ratio(1))
          do i0=ilower0,iupper0
             coarsen_index(i0,i_c0,i_f0,ratio(0))
@@ -188,7 +188,7 @@ c
 
       do i1=ilower1,iupper1
          coarsen_index(i1,i_c1,i_f1,ratio(1))
-         do i0=ilower0,iupper0+1
+         do i0=ilower0,iupper0
             coarsen_index(i0,i_c0,i_f0,ratio(0))
             i_f0 = i_c0*ratio(0)
 
@@ -205,7 +205,7 @@ c
          enddo
       enddo
 
-      do i1=ilower1,iupper1+1
+      do i1=ilower1,iupper1
          coarsen_index(i1,i_c1,i_f1,ratio(1))
          do i0=ilower0,iupper0
             coarsen_index(i0,i_c0,i_f0,ratio(0))

--- a/ibtk/src/refine_ops/fortran/cart_side_refine3d.f.m4
+++ b/ibtk/src/refine_ops/fortran/cart_side_refine3d.f.m4
@@ -112,7 +112,7 @@ c
          coarsen_index(i2,i_c2,i_f2,ratio(2))
          do i1=ilower1,iupper1
             coarsen_index(i1,i_c1,i_f1,ratio(1))
-            do i0=ilower0,iupper0+1
+            do i0=ilower0,iupper0
                coarsen_index(i0,i_c0,i_f0,ratio(0))
                if ( i0 .eq. i_f0 ) then
                   u0_f(i0,i1,i2) = u0_c(i_c0,i_c1,i_c2)
@@ -129,7 +129,7 @@ c
 
       do i2=ilower2,iupper2
          coarsen_index(i2,i_c2,i_f2,ratio(2))
-         do i1=ilower1,iupper1+1
+         do i1=ilower1,iupper1
             coarsen_index(i1,i_c1,i_f1,ratio(1))
             do i0=ilower0,iupper0
                coarsen_index(i0,i_c0,i_f0,ratio(0))
@@ -146,7 +146,7 @@ c
          enddo
       enddo
 
-      do i2=ilower2,iupper2+1
+      do i2=ilower2,iupper2
          coarsen_index(i2,i_c2,i_f2,ratio(2))
          do i1=ilower1,iupper1
             coarsen_index(i1,i_c1,i_f1,ratio(1))
@@ -240,7 +240,7 @@ c
          coarsen_index(i2,i_c2,i_f2,ratio(2))
          do i1=ilower1,iupper1
             coarsen_index(i1,i_c1,i_f1,ratio(1))
-            do i0=ilower0,iupper0+1
+            do i0=ilower0,iupper0
                coarsen_index(i0,i_c0,i_f0,ratio(0))
 
                w0 = 1.d0-dble(i0-i_f0)/dx0
@@ -266,7 +266,7 @@ c
          coarsen_index(i2,i_c2,i_f2,ratio(2))
          do i1=ilower1,iupper1
             coarsen_index(i1,i_c1,i_f1,ratio(1))
-            do i0=ilower0,iupper0+1
+            do i0=ilower0,iupper0
                coarsen_index(i0,i_c0,i_f0,ratio(0))
 
                i_f0 = i_c0*ratio(0)
@@ -296,7 +296,7 @@ c
          coarsen_index(i2,i_c2,i_f2,ratio(2))
          do i1=ilower1,iupper1
             coarsen_index(i1,i_c1,i_f1,ratio(1))
-            do i0=ilower0,iupper0+1
+            do i0=ilower0,iupper0
                coarsen_index(i0,i_c0,i_f0,ratio(0))
 
                i_f0 = i_c0*ratio(0)

--- a/tests/refine/rt0_refine_01_2d.2.4.output
+++ b/tests/refine/rt0_refine_01_2d.2.4.output
@@ -18,10 +18,10 @@ max norm of u_sc: 1.93848
 max norm of exact - refined: 0.0910645
 test results for non_rt
 max norm of u_sc: 1.93848
-max norm of exact - refined: 0.0461426
+max norm of exact - refined: 0.0461273
 test results for non_rt
 max norm of u_sc: 1.93848
-max norm of exact - refined: 0.0232544
+max norm of exact - refined: 0.0232496
 test results for non_rt
 max norm of u_sc: 1.93848
-max norm of exact - refined: 0.011673
+max norm of exact - refined: 0.0116722

--- a/tests/refine/rt0_refine_01_3d.2.4.output
+++ b/tests/refine/rt0_refine_01_3d.2.4.output
@@ -14,7 +14,7 @@ test results for both_linear
 max norm of u_sc: 5
 max norm of exact - refined: 0
 test results for non_rt
-max norm of u_sc: 1.8125
+max norm of u_sc: 2.57422
 max norm of exact - refined: 1.15234
 test results for non_rt
 max norm of u_sc: 2.85547

--- a/tests/refine/rt0_refine_01_3d.2.output
+++ b/tests/refine/rt0_refine_01_3d.2.output
@@ -14,7 +14,7 @@ test results for both_linear
 max norm of u_sc: 5
 max norm of exact - refined: 0
 test results for non_rt
-max norm of u_sc: 2.48438
+max norm of u_sc: 2.57422
 max norm of exact - refined: 0.410156
 test results for non_rt
 max norm of u_sc: 2.85547

--- a/tests/refine/rt0_refine_01_3d.4.output
+++ b/tests/refine/rt0_refine_01_3d.4.output
@@ -14,7 +14,7 @@ test results for both_linear
 max norm of u_sc: 5
 max norm of exact - refined: 0
 test results for non_rt
-max norm of u_sc: 1.8125
+max norm of u_sc: 2.57422
 max norm of exact - refined: 1.16016
 test results for non_rt
 max norm of u_sc: 2.85547


### PR DESCRIPTION
Nowadays gfortran has options like

    -fcheck=bits,bounds,do

which verifies that we do not mess up bitwise operations, exceed loop bounds, or modify do-loop iteration counters. The second one is most relevant to us: we pass around a lot of arrays and array sizes in independent structures.

Since we should convert to a side box before ever calling these functions, and these functions don't take into account the axis, I can't figure out why we ever wanted the upper bound incremented by 1 in these places. The only assertion error I got was in 3d (i.e., the 3d navier stokes test fails) but we have the same logic error in 2d. Interestingly no IB tests caught this assertion.

I updated some test output but this is a pretty sophisticated bug and I think we should dig through the Fortran during review to make sure this makes sense (and the refining functions do what we want).

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?