### PR TITLE
Fix IB Redistribution

### DIFF
--- a/doc/news/changes/minor/20260616Barrett
+++ b/doc/news/changes/minor/20260616Barrett
@@ -1,0 +1,3 @@
+Fixed: Update LNode ghost data prior to redistribution in IBMethod.
+<br>
+(Aaron Barrett, 2026/06/16)

--- a/ibtk/include/ibtk/LDataManager.h
+++ b/ibtk/include/ibtk/LDataManager.h
@@ -850,6 +850,16 @@ public:
     void scatterToZero(Vec& parallel_vec, Vec& sequential_vec) const;
 
     /*!
+     * \brief Synchronize node-attached payloads for the ghost nodes that are
+     * already present in the current Lagrangian mesh.
+     *
+     * This routine updates the node data stored on existing ghost LNodes
+     * without changing ghost topology or PETSc indexing.
+     */
+    void synchronizeExistingGhostNodes(int coarsest_ln = invalid_level_number,
+                                       int finest_ln = invalid_level_number);
+
+    /*!
      * \brief Start the process of redistributing the Lagrangian data.
      *
      * This method uses the present location of each Lagrangian mesh node to

--- a/ibtk/include/ibtk/LDataManager.h
+++ b/ibtk/include/ibtk/LDataManager.h
@@ -856,8 +856,7 @@ public:
      * This routine updates the node data stored on existing ghost LNodes
      * without changing ghost topology or PETSc indexing.
      */
-    void synchronizeExistingGhostNodes(int coarsest_ln = invalid_level_number,
-                                       int finest_ln = invalid_level_number);
+    void synchronizeGhostLNodes(int coarsest_ln = invalid_level_number, int finest_ln = invalid_level_number);
 
     /*!
      * \brief Start the process of redistributing the Lagrangian data.

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -1346,6 +1346,81 @@ LDataManager::scatterToZero(Vec& parallel_vec, Vec& sequential_vec) const
 } // scatterToZero
 
 void
+LDataManager::synchronizeExistingGhostNodes(const int coarsest_ln_in, const int finest_ln_in)
+{
+    const int coarsest_ln = (coarsest_ln_in == invalid_level_number) ? d_coarsest_ln : coarsest_ln_in;
+    const int finest_ln = (finest_ln_in == invalid_level_number) ? d_finest_ln : finest_ln_in;
+
+#if !defined(NDEBUG)
+    TBOX_ASSERT(coarsest_ln >= d_coarsest_ln && coarsest_ln <= d_finest_ln);
+    TBOX_ASSERT(finest_ln >= d_coarsest_ln && finest_ln <= d_finest_ln);
+#endif
+
+    const int num_procs = IBTK_MPI::getNodes();
+    for (int level_number = coarsest_ln; level_number <= finest_ln; ++level_number)
+    {
+        if (!d_level_contains_lag_data[level_number]) continue;
+
+        const Pointer<LMesh> mesh = getLMesh(level_number);
+        if (!mesh) continue;
+
+        using LNodeTransactionComponent = LNodeTransaction::LTransactionComponent;
+        const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
+        const std::vector<LNode*>& ghost_nodes = mesh->getGhostNodes();
+
+        std::map<int, std::vector<LNode*>> ghost_node_map;
+        for (LNode* ghost_node : ghost_nodes)
+        {
+            ghost_node_map[ghost_node->getLagrangianIndex()].push_back(ghost_node);
+        }
+
+        std::vector<LNodeTransactionComponent> local_node_data;
+        local_node_data.reserve(local_nodes.size());
+        for (LNode* local_node : local_nodes)
+        {
+            local_node_data.emplace_back(Pointer<LNode>(local_node, false), Point::Zero());
+        }
+
+        Schedule lnode_data_mover;
+        std::vector<std::vector<Pointer<Transaction>>> transactions(num_procs,
+                                                                    std::vector<Pointer<Transaction>>(num_procs));
+        for (int src_proc = 0; src_proc < num_procs; ++src_proc)
+        {
+            for (int dst_proc = 0; dst_proc < num_procs; ++dst_proc)
+            {
+                if (src_proc == IBTK_MPI::getRank())
+                {
+                    transactions[src_proc][dst_proc] = new LNodeTransaction(src_proc, dst_proc, local_node_data);
+                }
+                else
+                {
+                    transactions[src_proc][dst_proc] = new LNodeTransaction(src_proc, dst_proc);
+                }
+                lnode_data_mover.appendTransaction(transactions[src_proc][dst_proc]);
+            }
+        }
+        lnode_data_mover.communicate();
+
+        for (int src_proc = 0; src_proc < num_procs; ++src_proc)
+        {
+            Pointer<LNodeTransaction> transaction = transactions[src_proc][IBTK_MPI::getRank()];
+            const std::vector<LNodeTransactionComponent>& received_node_data = transaction->getDestinationData();
+            for (const auto& transaction_comp : received_node_data)
+            {
+                const int lag_idx = transaction_comp.item->getLagrangianIndex();
+                auto ghost_it = ghost_node_map.find(lag_idx);
+                if (ghost_it == ghost_node_map.end()) continue;
+                for (LNode* ghost_node : ghost_it->second)
+                {
+                    ghost_node->setNodeData(transaction_comp.item->getNodeData());
+                }
+            }
+        }
+    }
+    return;
+} // synchronizeExistingGhostNodes
+
+void
 LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int finest_ln_in)
 {
     IBTK_TIMER_START(t_begin_data_redistribution);
@@ -1369,6 +1444,10 @@ LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int finest
                          << "\tLagrangian node position data is probably invalid!\n");
         }
     }
+
+    // Refresh payloads on the currently known ghost nodes before ownership is
+    // rebuilt from ghost-region LNode copies.
+    synchronizeExistingGhostNodes(coarsest_ln, finest_ln);
 
     // Ensure that no IB points manage to escape the computational domain.
     const double* const domain_x_lower = d_grid_geom->getXLower();
@@ -1658,6 +1737,23 @@ LDataManager::endDataRedistribution(const int coarsest_ln_in, const int finest_l
         d_displaced_strct_bounding_boxes[level_number].clear();
         d_displaced_strct_lnode_idxs[level_number].clear();
         d_displaced_strct_lnode_posns[level_number].clear();
+    }
+
+    // Fill the ghost cells of each level.
+    for (int level_number = coarsest_ln; level_number <= finest_ln; ++level_number)
+    {
+        if (!d_level_contains_lag_data[level_number]) continue;
+
+        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(level_number);
+        level->allocatePatchData(d_scratch_data);
+
+        const double current_time = 0.0;
+        level->setTime(current_time, d_current_data);
+        level->setTime(current_time, d_scratch_data);
+
+        d_lag_node_index_bdry_fill_scheds[level_number]->fillData(current_time);
+
+        level->deallocatePatchData(d_scratch_data);
     }
 
     // Define the PETSc data needed to communicate the LData from its

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -1346,7 +1346,7 @@ LDataManager::scatterToZero(Vec& parallel_vec, Vec& sequential_vec) const
 } // scatterToZero
 
 void
-LDataManager::synchronizeExistingGhostNodes(const int coarsest_ln_in, const int finest_ln_in)
+LDataManager::synchronizeGhostLNodes(const int coarsest_ln_in, const int finest_ln_in)
 {
     const int coarsest_ln = (coarsest_ln_in == invalid_level_number) ? d_coarsest_ln : coarsest_ln_in;
     const int finest_ln = (finest_ln_in == invalid_level_number) ? d_finest_ln : finest_ln_in;
@@ -1368,10 +1368,16 @@ LDataManager::synchronizeExistingGhostNodes(const int coarsest_ln_in, const int 
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
         const std::vector<LNode*>& ghost_nodes = mesh->getGhostNodes();
 
-        std::vector<int> num_local_nodes_proc(num_procs, 0);
-        IBTK_MPI::allGather(static_cast<int>(local_nodes.size()), &num_local_nodes_proc[0]);
-        std::vector<int> node_offsets(num_procs + 1, 0);
-        std::partial_sum(num_local_nodes_proc.begin(), num_local_nodes_proc.end(), node_offsets.begin() + 1);
+        const Vec position_vec = d_lag_mesh_data[level_number][POSN_DATA_NAME]->getVec();
+        const PetscInt* ownership_ranges = nullptr;
+        int ierr = VecGetOwnershipRanges(position_vec, &ownership_ranges);
+        IBTK_CHKERRQ(ierr);
+        // Position vector has NIMD * (num_lag_points) entries. Convert position ranges to LNode index ranges.
+        std::vector<PetscInt> node_ownership_ranges(num_procs + 1, 0);
+        for (int rank = 0; rank <= num_procs; ++rank)
+        {
+            node_ownership_ranges[rank] = ownership_ranges[rank] / NDIM;
+        }
 
         std::map<int, std::vector<LNode*>> ghost_node_map;
         std::map<int, std::set<int>> requested_lag_indices;
@@ -1380,46 +1386,61 @@ LDataManager::synchronizeExistingGhostNodes(const int coarsest_ln_in, const int 
             const int lag_idx = ghost_node->getLagrangianIndex();
             ghost_node_map[lag_idx].push_back(ghost_node);
 
-            // The current PETSc ownership range identifies the rank that own the authoritative local copy of this ghost
-            // node.
+            // The current node-wise PETSc ownership range identifies the rank
+            // that owns the authoritative local copy of this ghost node.
             const int global_petsc_idx = ghost_node->getGlobalPETScIndex();
-            const int owner_rank =
-                static_cast<int>(std::upper_bound(node_offsets.begin(), node_offsets.end(), global_petsc_idx) -
-                                 node_offsets.begin()) -
-                1;
+            const int owner_rank = static_cast<int>(std::upper_bound(node_ownership_ranges.begin(),
+                                                                     node_ownership_ranges.end(),
+                                                                     static_cast<PetscInt>(global_petsc_idx)) -
+                                                    node_ownership_ranges.begin()) -
+                                   1;
             requested_lag_indices[owner_rank].insert(lag_idx);
         }
 
-        std::vector<int> request_data;
+        std::vector<std::pair<int, int>> owned_requests;
+        std::vector<int> send_counts(num_procs, 0), recv_counts(num_procs, 0);
+        for (const auto& owner_requests : requested_lag_indices)
+        {
+            send_counts[owner_requests.first] = static_cast<int>(owner_requests.second.size());
+        }
+
+        // Exchange request counts to preallocate send and receive buffers.
+        ierr =
+            MPI_Alltoall(send_counts.data(), 1, MPI_INT, recv_counts.data(), 1, MPI_INT, IBTK_MPI::getCommunicator());
+        TBOX_ASSERT(ierr == MPI_SUCCESS);
+
+        std::vector<int> send_displs(num_procs + 1, 0), recv_displs(num_procs + 1, 0);
+        std::partial_sum(send_counts.begin(), send_counts.end(), send_displs.begin() + 1);
+        std::partial_sum(recv_counts.begin(), recv_counts.end(), recv_displs.begin() + 1);
+
+        std::vector<int> send_lag_indices(send_displs.back()), recv_lag_indices(recv_displs.back());
         for (const auto& owner_requests : requested_lag_indices)
         {
             const int owner_rank = owner_requests.first;
-            for (const int lag_idx : owner_requests.second)
-            {
-                request_data.push_back(owner_rank);
-                request_data.push_back(IBTK_MPI::getRank());
-                request_data.push_back(lag_idx);
-            }
+            std::copy(owner_requests.second.begin(),
+                      owner_requests.second.end(),
+                      send_lag_indices.begin() + send_displs[owner_rank]);
         }
 
-        const int request_data_size = static_cast<int>(request_data.size());
-        const int all_request_data_size = IBTK_MPI::sumReduction(request_data_size);
-        std::vector<int> all_request_data(all_request_data_size);
-        // Share only request data globally; LNode payloads are sent later only by the ranks that own the requested
-        // ghost nodes.
-        IBTK_MPI::allGather(request_data_size > 0 ? &request_data[0] : nullptr,
-                            request_data_size,
-                            all_request_data_size > 0 ? &all_request_data[0] : nullptr,
-                            all_request_data_size);
+        // Ship only the requested lag indices to each owner rank; payloads are
+        // still sent later through the existing LNodeTransaction path.
+        ierr = MPI_Alltoallv(send_lag_indices.empty() ? nullptr : send_lag_indices.data(),
+                             send_counts.data(),
+                             send_displs.data(),
+                             MPI_INT,
+                             recv_lag_indices.empty() ? nullptr : recv_lag_indices.data(),
+                             recv_counts.data(),
+                             recv_displs.data(),
+                             MPI_INT,
+                             IBTK_MPI::getCommunicator());
+        TBOX_ASSERT(ierr == MPI_SUCCESS);
 
-        std::vector<std::pair<int, int>> owned_requests;
-        for (int k = 0; k < all_request_data_size; k += 3)
+        for (int requester_rank = 0; requester_rank < num_procs; ++requester_rank)
         {
-            const int owner_rank = all_request_data[k + 0];
-            const int dst_rank = all_request_data[k + 1];
-            const int lag_idx = all_request_data[k + 2];
-            if (owner_rank != IBTK_MPI::getRank()) continue;
-            owned_requests.emplace_back(dst_rank, lag_idx);
+            for (int k = recv_displs[requester_rank]; k < recv_displs[requester_rank + 1]; ++k)
+            {
+                owned_requests.emplace_back(requester_rank, recv_lag_indices[k]);
+            }
         }
 
         std::vector<int> owned_request_petsc_indices(owned_requests.size());
@@ -1429,9 +1450,11 @@ LDataManager::synchronizeExistingGhostNodes(const int coarsest_ln_in, const int 
         }
         if (!owned_request_petsc_indices.empty())
         {
-            int ierr = AOApplicationToPetsc(d_ao[level_number],
-                                            static_cast<int>(owned_request_petsc_indices.size()),
-                                            &owned_request_petsc_indices[0]);
+            // Convert all requested Lagrangian indices for this owner rank to
+            // PETSc indices in one AO lookup before indexing local_nodes.
+            ierr = AOApplicationToPetsc(d_ao[level_number],
+                                        static_cast<int>(owned_request_petsc_indices.size()),
+                                        &owned_request_petsc_indices[0]);
             IBTK_CHKERRQ(ierr);
         }
 
@@ -1485,7 +1508,7 @@ LDataManager::synchronizeExistingGhostNodes(const int coarsest_ln_in, const int 
         }
     }
     return;
-} // synchronizeExistingGhostNodes
+} // synchronizeGhostLNodes
 
 void
 LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int finest_ln_in)
@@ -1515,7 +1538,7 @@ LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int finest
     // Refresh payloads on the currently known ghost nodes before ownership is
     // rebuilt from ghost-region LNode copies. This updates attached Streamable
     // data without changing the current ghost-node topology.
-    synchronizeExistingGhostNodes(coarsest_ln, finest_ln);
+    synchronizeGhostLNodes(coarsest_ln, finest_ln);
 
     // Ensure that no IB points manage to escape the computational domain.
     const double* const domain_x_lower = d_grid_geom->getXLower();

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -1471,29 +1471,38 @@ LDataManager::synchronizeGhostLNodes(const int coarsest_ln_in, const int finest_
         }
 
         Schedule lnode_data_mover;
-        std::vector<std::vector<Pointer<Transaction>>> transactions(num_procs,
-                                                                    std::vector<Pointer<Transaction>>(num_procs));
+        const int rank = IBTK_MPI::getRank();
+        std::vector<Pointer<LNodeTransaction>> receive_transactions(num_procs);
+
+        // Each entry in recv_counts represents a request received from that
+        // rank, and hence a payload that this rank must send.  Conversely,
+        // each entry in send_counts represents a request issued by this rank,
+        // and hence a payload that this rank must receive.  Only create
+        // transactions for these active communication links.
+        for (int dst_proc = 0; dst_proc < num_procs; ++dst_proc)
+        {
+            if (recv_counts[dst_proc] > 0)
+            {
+                Pointer<LNodeTransaction> transaction =
+                    new LNodeTransaction(rank, dst_proc, requested_node_data[dst_proc]);
+                lnode_data_mover.appendTransaction(transaction);
+                if (dst_proc == rank) receive_transactions[rank] = transaction;
+            }
+        }
         for (int src_proc = 0; src_proc < num_procs; ++src_proc)
         {
-            for (int dst_proc = 0; dst_proc < num_procs; ++dst_proc)
+            if (send_counts[src_proc] > 0 && src_proc != rank)
             {
-                if (src_proc == IBTK_MPI::getRank())
-                {
-                    transactions[src_proc][dst_proc] =
-                        new LNodeTransaction(src_proc, dst_proc, requested_node_data[dst_proc]);
-                }
-                else
-                {
-                    transactions[src_proc][dst_proc] = new LNodeTransaction(src_proc, dst_proc);
-                }
-                lnode_data_mover.appendTransaction(transactions[src_proc][dst_proc]);
+                receive_transactions[src_proc] = new LNodeTransaction(src_proc, rank);
+                lnode_data_mover.appendTransaction(receive_transactions[src_proc]);
             }
         }
         lnode_data_mover.communicate();
 
         for (int src_proc = 0; src_proc < num_procs; ++src_proc)
         {
-            Pointer<LNodeTransaction> transaction = transactions[src_proc][IBTK_MPI::getRank()];
+            Pointer<LNodeTransaction> transaction = receive_transactions[src_proc];
+            if (!transaction) continue;
             const std::vector<LNodeTransactionComponent>& received_node_data = transaction->getDestinationData();
             for (const auto& transaction_comp : received_node_data)
             {

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -1348,6 +1348,10 @@ LDataManager::scatterToZero(Vec& parallel_vec, Vec& sequential_vec) const
 void
 LDataManager::synchronizeGhostLNodes(const int coarsest_ln_in, const int finest_ln_in)
 {
+    // All requests complete before another such exchange or a Schedule
+    // communication is initiated.
+    static const int ghost_request_tag = 0;
+
     const int coarsest_ln = (coarsest_ln_in == invalid_level_number) ? d_coarsest_ln : coarsest_ln_in;
     const int finest_ln = (finest_ln_in == invalid_level_number) ? d_finest_ln : finest_ln_in;
 
@@ -1372,7 +1376,7 @@ LDataManager::synchronizeGhostLNodes(const int coarsest_ln_in, const int finest_
         const PetscInt* ownership_ranges = nullptr;
         int ierr = VecGetOwnershipRanges(position_vec, &ownership_ranges);
         IBTK_CHKERRQ(ierr);
-        // Position vector has NIMD * (num_lag_points) entries. Convert position ranges to LNode index ranges.
+        // Position vector has NDIM * (num_lag_points) entries. Convert position ranges to LNode index ranges.
         std::vector<PetscInt> node_ownership_ranges(num_procs + 1, 0);
         for (int rank = 0; rank <= num_procs; ++rank)
         {
@@ -1380,6 +1384,7 @@ LDataManager::synchronizeGhostLNodes(const int coarsest_ln_in, const int finest_
         }
 
         std::map<int, std::vector<LNode*>> ghost_node_map;
+        // Maps each owner rank to the distinct ghost-node indices requested from that owner.
         std::map<int, std::set<int>> requested_lag_indices;
         for (LNode* ghost_node : ghost_nodes)
         {
@@ -1397,7 +1402,7 @@ LDataManager::synchronizeGhostLNodes(const int coarsest_ln_in, const int finest_
             requested_lag_indices[owner_rank].insert(lag_idx);
         }
 
-        std::vector<std::pair<int, int>> owned_requests;
+        // send_counts records requests sent to other ranks; recv_counts records requests received from each requester.
         std::vector<int> send_counts(num_procs, 0), recv_counts(num_procs, 0);
         for (const auto& owner_requests : requested_lag_indices)
         {
@@ -1409,10 +1414,12 @@ LDataManager::synchronizeGhostLNodes(const int coarsest_ln_in, const int finest_
             MPI_Alltoall(send_counts.data(), 1, MPI_INT, recv_counts.data(), 1, MPI_INT, IBTK_MPI::getCommunicator());
         TBOX_ASSERT(ierr == MPI_SUCCESS);
 
+        // Per-rank offsets into the packed outbound and inbound request-index buffers.
         std::vector<int> send_displs(num_procs + 1, 0), recv_displs(num_procs + 1, 0);
         std::partial_sum(send_counts.begin(), send_counts.end(), send_displs.begin() + 1);
         std::partial_sum(recv_counts.begin(), recv_counts.end(), recv_displs.begin() + 1);
 
+        // Request indices sent to owners and received from requesters, respectively.
         std::vector<int> send_lag_indices(send_displs.back()), recv_lag_indices(recv_displs.back());
         for (const auto& owner_requests : requested_lag_indices)
         {
@@ -1422,56 +1429,81 @@ LDataManager::synchronizeGhostLNodes(const int coarsest_ln_in, const int finest_
                       send_lag_indices.begin() + send_displs[owner_rank]);
         }
 
-        // Ship only the requested lag indices to each owner rank; payloads are
-        // still sent later through the existing LNodeTransaction path.
-        ierr = MPI_Alltoallv(send_lag_indices.empty() ? nullptr : send_lag_indices.data(),
-                             send_counts.data(),
-                             send_displs.data(),
-                             MPI_INT,
-                             recv_lag_indices.empty() ? nullptr : recv_lag_indices.data(),
-                             recv_counts.data(),
-                             recv_displs.data(),
-                             MPI_INT,
-                             IBTK_MPI::getCommunicator());
-        TBOX_ASSERT(ierr == MPI_SUCCESS);
-
-        for (int requester_rank = 0; requester_rank < num_procs; ++requester_rank)
+        // Send requested indices only along active rank-pairings. The preceding count exchange identifies every
+        // positive-count send and receive. Note the use of non-blocking calls is not strictly necessary, but greatly
+        // simplifies the communication strategy.
+        const int rank = IBTK_MPI::getRank();
+        std::vector<MPI_Request> request_exchange_requests;
+        request_exchange_requests.reserve(2 * num_procs);
+        for (int src_proc = 0; src_proc < num_procs; ++src_proc)
         {
-            for (int k = recv_displs[requester_rank]; k < recv_displs[requester_rank + 1]; ++k)
+            if (recv_counts[src_proc] == 0) continue;
+            if (src_proc == rank)
             {
-                owned_requests.emplace_back(requester_rank, recv_lag_indices[k]);
+                std::copy(send_lag_indices.begin() + send_displs[rank],
+                          send_lag_indices.begin() + send_displs[rank + 1],
+                          recv_lag_indices.begin() + recv_displs[rank]);
+                continue;
             }
+            request_exchange_requests.emplace_back();
+            ierr = MPI_Irecv(recv_lag_indices.data() + recv_displs[src_proc],
+                             recv_counts[src_proc],
+                             MPI_INT,
+                             src_proc,
+                             ghost_request_tag,
+                             IBTK_MPI::getCommunicator(),
+                             &request_exchange_requests.back());
+            TBOX_ASSERT(ierr == MPI_SUCCESS);
+        }
+        for (int dst_proc = 0; dst_proc < num_procs; ++dst_proc)
+        {
+            if (send_counts[dst_proc] == 0 || dst_proc == rank) continue;
+            request_exchange_requests.emplace_back();
+            ierr = MPI_Isend(send_lag_indices.data() + send_displs[dst_proc],
+                             send_counts[dst_proc],
+                             MPI_INT,
+                             dst_proc,
+                             ghost_request_tag,
+                             IBTK_MPI::getCommunicator(),
+                             &request_exchange_requests.back());
+            TBOX_ASSERT(ierr == MPI_SUCCESS);
+        }
+        // Need to wait for sends and recv calls to finish before proceeding.
+        if (!request_exchange_requests.empty())
+        {
+            ierr = MPI_Waitall(static_cast<int>(request_exchange_requests.size()),
+                               request_exchange_requests.data(),
+                               MPI_STATUSES_IGNORE);
+            TBOX_ASSERT(ierr == MPI_SUCCESS);
         }
 
-        std::vector<int> owned_request_petsc_indices(owned_requests.size());
-        for (std::size_t k = 0; k < owned_requests.size(); ++k)
+        if (!recv_lag_indices.empty())
         {
-            owned_request_petsc_indices[k] = owned_requests[k].second;
-        }
-        if (!owned_request_petsc_indices.empty())
-        {
-            // Convert all requested Lagrangian indices for this owner rank to
-            // PETSc indices in one AO lookup before indexing local_nodes.
-            ierr = AOApplicationToPetsc(d_ao[level_number],
-                                        static_cast<int>(owned_request_petsc_indices.size()),
-                                        &owned_request_petsc_indices[0]);
+            // Convert the packed received Lagrangian indices to PETSc indices
+            // in one AO lookup before indexing local_nodes.
+            ierr = AOApplicationToPetsc(
+                d_ao[level_number], static_cast<int>(recv_lag_indices.size()), recv_lag_indices.data());
             IBTK_CHKERRQ(ierr);
         }
 
         std::vector<std::vector<LNodeTransactionComponent>> requested_node_data(num_procs);
-        for (std::size_t k = 0; k < owned_requests.size(); ++k)
+        for (int requester_rank = 0; requester_rank < num_procs; ++requester_rank)
         {
-            const int dst_rank = owned_requests[k].first;
-            const int local_idx = owned_request_petsc_indices[k] - static_cast<int>(d_node_offset[level_number]);
-            if (local_idx < 0 || local_idx >= static_cast<int>(local_nodes.size())) continue;
+            for (int k = recv_displs[requester_rank]; k < recv_displs[requester_rank + 1]; ++k)
+            {
+                // Note rcv_lag_indices now contains the PETSc index.
+                const int local_idx = recv_lag_indices[k] - static_cast<int>(d_node_offset[level_number]);
+                if (local_idx < 0 || local_idx >= static_cast<int>(local_nodes.size())) continue;
 
-            // Reuse the existing transaction path, but only populate it with payloads that were actually requested by
-            // ghost-node holders.
-            requested_node_data[dst_rank].emplace_back(Pointer<LNode>(local_nodes[local_idx], false), Point::Zero());
+                // Reuse the existing transaction path, but only populate it with payloads that were actually requested
+                // by ghost-node holders.
+                requested_node_data[requester_rank].emplace_back(Pointer<LNode>(local_nodes[local_idx], false),
+                                                                 Point::Zero());
+            }
         }
 
         Schedule lnode_data_mover;
-        const int rank = IBTK_MPI::getRank();
+        // Incoming payload transactions, indexed by the owner rank.
         std::vector<Pointer<LNodeTransaction>> receive_transactions(num_procs);
 
         // Each entry in recv_counts represents a request received from that
@@ -1508,7 +1540,13 @@ LDataManager::synchronizeGhostLNodes(const int coarsest_ln_in, const int finest_
             {
                 const int lag_idx = transaction_comp.item->getLagrangianIndex();
                 auto ghost_it = ghost_node_map.find(lag_idx);
-                if (ghost_it == ghost_node_map.end()) continue;
+                if (ghost_it == ghost_node_map.end())
+                {
+                    TBOX_ERROR("LDataManager::synchronizeGhostLNodes():\n"
+                               << "\tReceived an unexpected ghost-node payload.\n"
+                               << "\tLagrangian index = " << lag_idx << "\n"
+                               << "\tsource rank = " << src_proc << "\n");
+                }
                 for (LNode* ghost_node : ghost_it->second)
                 {
                     ghost_node->setNodeData(transaction_comp.item->getNodeData());

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -1660,23 +1660,6 @@ LDataManager::endDataRedistribution(const int coarsest_ln_in, const int finest_l
         d_displaced_strct_lnode_posns[level_number].clear();
     }
 
-    // Fill the ghost cells of each level.
-    for (int level_number = coarsest_ln; level_number <= finest_ln; ++level_number)
-    {
-        if (!d_level_contains_lag_data[level_number]) continue;
-
-        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(level_number);
-        level->allocatePatchData(d_scratch_data);
-
-        const double current_time = 0.0;
-        level->setTime(current_time, d_current_data);
-        level->setTime(current_time, d_scratch_data);
-
-        d_lag_node_index_bdry_fill_scheds[level_number]->fillData(current_time);
-
-        level->deallocatePatchData(d_scratch_data);
-    }
-
     // Define the PETSc data needed to communicate the LData from its
     // old configuration to its new configuration.
     int ierr;

--- a/ibtk/src/lagrangian/LDataManager.cpp
+++ b/ibtk/src/lagrangian/LDataManager.cpp
@@ -1368,17 +1368,83 @@ LDataManager::synchronizeExistingGhostNodes(const int coarsest_ln_in, const int 
         const std::vector<LNode*>& local_nodes = mesh->getLocalNodes();
         const std::vector<LNode*>& ghost_nodes = mesh->getGhostNodes();
 
+        std::vector<int> num_local_nodes_proc(num_procs, 0);
+        IBTK_MPI::allGather(static_cast<int>(local_nodes.size()), &num_local_nodes_proc[0]);
+        std::vector<int> node_offsets(num_procs + 1, 0);
+        std::partial_sum(num_local_nodes_proc.begin(), num_local_nodes_proc.end(), node_offsets.begin() + 1);
+
         std::map<int, std::vector<LNode*>> ghost_node_map;
+        std::map<int, std::set<int>> requested_lag_indices;
         for (LNode* ghost_node : ghost_nodes)
         {
-            ghost_node_map[ghost_node->getLagrangianIndex()].push_back(ghost_node);
+            const int lag_idx = ghost_node->getLagrangianIndex();
+            ghost_node_map[lag_idx].push_back(ghost_node);
+
+            // The current PETSc ownership range identifies the rank that own the authoritative local copy of this ghost
+            // node.
+            const int global_petsc_idx = ghost_node->getGlobalPETScIndex();
+            const int owner_rank =
+                static_cast<int>(std::upper_bound(node_offsets.begin(), node_offsets.end(), global_petsc_idx) -
+                                 node_offsets.begin()) -
+                1;
+            requested_lag_indices[owner_rank].insert(lag_idx);
         }
 
-        std::vector<LNodeTransactionComponent> local_node_data;
-        local_node_data.reserve(local_nodes.size());
-        for (LNode* local_node : local_nodes)
+        std::vector<int> request_data;
+        for (const auto& owner_requests : requested_lag_indices)
         {
-            local_node_data.emplace_back(Pointer<LNode>(local_node, false), Point::Zero());
+            const int owner_rank = owner_requests.first;
+            for (const int lag_idx : owner_requests.second)
+            {
+                request_data.push_back(owner_rank);
+                request_data.push_back(IBTK_MPI::getRank());
+                request_data.push_back(lag_idx);
+            }
+        }
+
+        const int request_data_size = static_cast<int>(request_data.size());
+        const int all_request_data_size = IBTK_MPI::sumReduction(request_data_size);
+        std::vector<int> all_request_data(all_request_data_size);
+        // Share only request data globally; LNode payloads are sent later only by the ranks that own the requested
+        // ghost nodes.
+        IBTK_MPI::allGather(request_data_size > 0 ? &request_data[0] : nullptr,
+                            request_data_size,
+                            all_request_data_size > 0 ? &all_request_data[0] : nullptr,
+                            all_request_data_size);
+
+        std::vector<std::pair<int, int>> owned_requests;
+        for (int k = 0; k < all_request_data_size; k += 3)
+        {
+            const int owner_rank = all_request_data[k + 0];
+            const int dst_rank = all_request_data[k + 1];
+            const int lag_idx = all_request_data[k + 2];
+            if (owner_rank != IBTK_MPI::getRank()) continue;
+            owned_requests.emplace_back(dst_rank, lag_idx);
+        }
+
+        std::vector<int> owned_request_petsc_indices(owned_requests.size());
+        for (std::size_t k = 0; k < owned_requests.size(); ++k)
+        {
+            owned_request_petsc_indices[k] = owned_requests[k].second;
+        }
+        if (!owned_request_petsc_indices.empty())
+        {
+            int ierr = AOApplicationToPetsc(d_ao[level_number],
+                                            static_cast<int>(owned_request_petsc_indices.size()),
+                                            &owned_request_petsc_indices[0]);
+            IBTK_CHKERRQ(ierr);
+        }
+
+        std::vector<std::vector<LNodeTransactionComponent>> requested_node_data(num_procs);
+        for (std::size_t k = 0; k < owned_requests.size(); ++k)
+        {
+            const int dst_rank = owned_requests[k].first;
+            const int local_idx = owned_request_petsc_indices[k] - static_cast<int>(d_node_offset[level_number]);
+            if (local_idx < 0 || local_idx >= static_cast<int>(local_nodes.size())) continue;
+
+            // Reuse the existing transaction path, but only populate it with payloads that were actually requested by
+            // ghost-node holders.
+            requested_node_data[dst_rank].emplace_back(Pointer<LNode>(local_nodes[local_idx], false), Point::Zero());
         }
 
         Schedule lnode_data_mover;
@@ -1390,7 +1456,8 @@ LDataManager::synchronizeExistingGhostNodes(const int coarsest_ln_in, const int 
             {
                 if (src_proc == IBTK_MPI::getRank())
                 {
-                    transactions[src_proc][dst_proc] = new LNodeTransaction(src_proc, dst_proc, local_node_data);
+                    transactions[src_proc][dst_proc] =
+                        new LNodeTransaction(src_proc, dst_proc, requested_node_data[dst_proc]);
                 }
                 else
                 {
@@ -1446,7 +1513,8 @@ LDataManager::beginDataRedistribution(const int coarsest_ln_in, const int finest
     }
 
     // Refresh payloads on the currently known ghost nodes before ownership is
-    // rebuilt from ghost-region LNode copies.
+    // rebuilt from ghost-region LNode copies. This updates attached Streamable
+    // data without changing the current ghost-node topology.
     synchronizeExistingGhostNodes(coarsest_ln, finest_ln);
 
     // Ensure that no IB points manage to escape the computational domain.

--- a/ibtk/src/lagrangian/LTransaction.cpp
+++ b/ibtk/src/lagrangian/LTransaction.cpp
@@ -116,6 +116,7 @@ LTransaction<T>::unpackStream(AbstractStream& stream)
     d_dst_item_set.resize(num_items);
     for (auto it = d_dst_item_set.begin(); it != d_dst_item_set.end(); ++it)
     {
+        it->item = new T();
         it->item->unpackStream(stream, periodic_offset);
         Point& posn = it->posn;
         stream.unpack(posn.data(), NDIM);

--- a/ibtk/src/lagrangian/LTransaction.cpp
+++ b/ibtk/src/lagrangian/LTransaction.cpp
@@ -116,6 +116,7 @@ LTransaction<T>::unpackStream(AbstractStream& stream)
     d_dst_item_set.resize(num_items);
     for (auto it = d_dst_item_set.begin(); it != d_dst_item_set.end(); ++it)
     {
+        // Allocate the destination object before unpacking into it.
         it->item = new T();
         it->item->unpackStream(stream, periodic_offset);
         Point& posn = it->posn;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -294,6 +294,7 @@ SETUP_2D(IBTK helmholtz.cpp)
 SETUP_2D(IBTK index_utilities.cpp)
 SETUP_2D(IBTK marker_points_01.cpp)
 SETUP_2D(IBTK marker_points_02.cpp)
+SETUP_2D(IBTK l_data_manager_redistribution_01.cpp)
 SETUP_2D(IBTK cf_interface.cpp)
 
 IF(${IBAMR_HAVE_LIBMESH})

--- a/tests/IBTK/l_data_manager_redistribution_01.cpp
+++ b/tests/IBTK/l_data_manager_redistribution_01.cpp
@@ -1,0 +1,353 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2026 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#include <ibamr/IBTargetPointForceSpec.h>
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
+#include <ibtk/IndexUtilities.h>
+#include <ibtk/LData.h>
+#include <ibtk/LDataManager.h>
+#include <ibtk/LInitStrategy.h>
+#include <ibtk/LMesh.h>
+#include <ibtk/LNode.h>
+#include <ibtk/LNodeSetData.h>
+
+#include <tbox/Pointer.h>
+
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <CartesianPatchGeometry.h>
+#include <GriddingAlgorithm.h>
+#include <LoadBalancer.h>
+#include <PatchHierarchy.h>
+#include <PatchLevel.h>
+#include <StandardTagAndInitialize.h>
+
+#include <array>
+#include <sstream>
+#include <vector>
+
+#include "../tests.h"
+
+#include <ibtk/app_namespaces.h>
+
+namespace
+{
+constexpr int N_MARKERS = 4;
+
+std::array<std::array<IBTK::Vector, N_MARKERS>, 4>
+get_step_translations()
+{
+    const IBTK::Vector dx_pp(0.005, 0.005);
+    const IBTK::Vector dx_mp(-0.005, 0.005);
+    const IBTK::Vector dx_pm(0.005, -0.005);
+    const IBTK::Vector dx_mm(-0.005, -0.005);
+    return { std::array<IBTK::Vector, N_MARKERS>{ dx_pp, dx_mp, dx_pm, dx_mm },
+             std::array<IBTK::Vector, N_MARKERS>{ dx_pp, dx_mp, dx_pm, dx_mm },
+             std::array<IBTK::Vector, N_MARKERS>{ dx_pp, dx_mp, dx_pm, dx_mm },
+             std::array<IBTK::Vector, N_MARKERS>{ dx_pp, dx_mp, dx_pm, dx_mm } };
+}
+
+std::array<IBTK::Point, N_MARKERS>
+get_initial_positions()
+{
+    return { IBTK::Point(0.49, 0.49), IBTK::Point(0.51, 0.49), IBTK::Point(0.49, 0.51), IBTK::Point(0.51, 0.51) };
+}
+
+std::array<IBTK::Point, N_MARKERS>
+get_exact_positions(const int step_number)
+{
+    auto positions = get_initial_positions();
+    const auto step_translations = get_step_translations();
+    for (int step = 0; step < step_number; ++step)
+    {
+        for (int k = 0; k < N_MARKERS; ++k)
+        {
+            positions[k] += step_translations[step][k];
+        }
+    }
+    return positions;
+}
+
+class FourPointInitializer : public IBTK::LInitStrategy
+{
+public:
+    FourPointInitializer()
+    {
+        IBAMR::IBTargetPointForceSpec::registerWithStreamableManager();
+        d_X = get_initial_positions();
+        d_U = get_step_translations()[0];
+    }
+
+    bool getLevelHasLagrangianData(int level_number, bool /*can_be_refined*/) const override
+    {
+        return level_number == 0;
+    }
+
+    bool getIsAllLagrangianDataInDomain(Pointer<PatchHierarchy<NDIM>> /*hierarchy*/) const override
+    {
+        return true;
+    }
+
+    unsigned int computeGlobalNodeCountOnPatchLevel(Pointer<PatchHierarchy<NDIM>> /*hierarchy*/,
+                                                    int level_number,
+                                                    double /*init_data_time*/,
+                                                    bool /*can_be_refined*/,
+                                                    bool /*initial_time*/) override
+    {
+        return level_number == 0 ? N_MARKERS : 0;
+    }
+
+    unsigned int computeLocalNodeCountOnPatchLevel(Pointer<PatchHierarchy<NDIM>> hierarchy,
+                                                   int level_number,
+                                                   double /*init_data_time*/,
+                                                   bool /*can_be_refined*/,
+                                                   bool /*initial_time*/) override
+    {
+        if (level_number != 0) return 0;
+
+        unsigned int count = 0;
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(level_number);
+        const IntVector<NDIM>& ratio = level->getRatio();
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            const Box<NDIM>& patch_box = patch->getBox();
+            for (int k = 0; k < N_MARKERS; ++k)
+            {
+                const CellIndex<NDIM> cell_idx =
+                    IndexUtilities::getAssignedCellIndex(d_X[k], hierarchy->getGridGeometry(), ratio);
+                if (patch_box.contains(cell_idx)) ++count;
+            }
+        }
+        return count;
+    }
+
+    void initializeStructureIndexingOnPatchLevel(std::map<int, std::string>& strct_id_to_strct_name_map,
+                                                 std::map<int, std::pair<int, int>>& strct_id_to_lag_idx_range_map,
+                                                 int level_number,
+                                                 double /*init_data_time*/,
+                                                 bool /*can_be_refined*/,
+                                                 bool /*initial_time*/,
+                                                 IBTK::LDataManager* /*l_data_manager*/) override
+    {
+        if (level_number != 0) return;
+        for (int k = 0; k < N_MARKERS; ++k)
+        {
+            strct_id_to_strct_name_map[k] = "marker_" + std::to_string(k);
+            strct_id_to_lag_idx_range_map[k] = std::make_pair(k, k + 1);
+        }
+    }
+
+    unsigned int initializeDataOnPatchLevel(int lag_node_index_idx,
+                                            unsigned int global_index_offset,
+                                            unsigned int local_index_offset,
+                                            Pointer<IBTK::LData> X_data,
+                                            Pointer<IBTK::LData> U_data,
+                                            Pointer<PatchHierarchy<NDIM>> hierarchy,
+                                            int level_number,
+                                            double /*init_data_time*/,
+                                            bool /*can_be_refined*/,
+                                            bool /*initial_time*/,
+                                            IBTK::LDataManager* /*l_data_manager*/) override
+    {
+        if (level_number != 0) return 0;
+
+        boost::multi_array_ref<double, 2>& X_array = *X_data->getLocalFormVecArray();
+        boost::multi_array_ref<double, 2>& U_array = *U_data->getLocalFormVecArray();
+        int local_idx = -1;
+        unsigned int local_node_count = 0;
+
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(level_number);
+        const IntVector<NDIM>& ratio = level->getRatio();
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            Pointer<IBTK::LNodeSetData> index_data = patch->getPatchData(lag_node_index_idx);
+            const Box<NDIM>& patch_box = patch->getBox();
+            for (int k = 0; k < N_MARKERS; ++k)
+            {
+                const CellIndex<NDIM> cell_idx =
+                    IndexUtilities::getAssignedCellIndex(d_X[k], hierarchy->getGridGeometry(), ratio);
+                if (!patch_box.contains(cell_idx)) continue;
+
+                const int local_petsc_idx = ++local_idx + static_cast<int>(local_index_offset);
+                const int global_petsc_idx = ++local_node_count - 1 + static_cast<int>(global_index_offset);
+
+                for (int d = 0; d < NDIM; ++d)
+                {
+                    X_array[local_petsc_idx][d] = d_X[k][d];
+                    U_array[local_petsc_idx][d] = d_U[k][d];
+                }
+
+                if (!index_data->isElement(cell_idx))
+                {
+                    index_data->appendItemPointer(cell_idx, new IBTK::LNodeSet());
+                }
+                IBTK::LNodeSet* const node_set = index_data->getItem(cell_idx);
+                std::vector<Pointer<IBTK::Streamable>> node_data;
+                node_data.push_back(new IBAMR::IBTargetPointForceSpec(k, 1.0, 0.0, d_X[k]));
+                node_set->push_back(new IBTK::LNode(k,
+                                                    global_petsc_idx,
+                                                    local_petsc_idx,
+                                                    IntVector<NDIM>(0),
+                                                    IntVector<NDIM>(0),
+                                                    IBTK::Vector::Zero(),
+                                                    IBTK::Vector::Zero(),
+                                                    node_data));
+            }
+        }
+
+        local_node_count = static_cast<unsigned int>(local_idx + 1);
+
+        X_data->restoreArrays();
+        U_data->restoreArrays();
+        return local_node_count;
+    }
+
+private:
+    std::array<IBTK::Point, N_MARKERS> d_X;
+    std::array<IBTK::Vector, N_MARKERS> d_U;
+};
+
+void
+print_patch_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
+                 IBTK::LDataManager* l_data_manager,
+                 Pointer<IBTK::LData> X_data,
+                 Pointer<IBTK::LData> U_data,
+                 const std::string& label,
+                 const int step_number)
+{
+    const int rank = IBTK_MPI::getRank();
+    if (rank != 0) return;
+
+    std::ostringstream out;
+    const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+    Pointer<IBTK::LMesh> mesh = l_data_manager->getLMesh(finest_ln);
+    const std::vector<IBTK::LNode*>& local_nodes = mesh->getLocalNodes();
+    boost::multi_array_ref<double, 2>& X_array = *X_data->getGhostedLocalFormVecArray();
+    boost::multi_array_ref<double, 2>& U_array = *U_data->getGhostedLocalFormVecArray();
+    const auto exact_positions = get_exact_positions(step_number);
+
+    out << label << " rank = 0 local_nodes = " << local_nodes.size() << '\n';
+    Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(finest_ln);
+    const IntVector<NDIM>& ratio = level->getRatio();
+    for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+    {
+        Pointer<Patch<NDIM>> patch = level->getPatch(p());
+        out << "patch = " << patch->getBox() << '\n';
+        int patch_count = 0;
+        for (IBTK::LNode* node : local_nodes)
+        {
+            const int local_idx = node->getLocalPETScIndex();
+            IBTK::Point X;
+            for (int d = 0; d < NDIM; ++d) X[d] = X_array[local_idx][d];
+            const CellIndex<NDIM> cell_idx =
+                IndexUtilities::getAssignedCellIndex(X, patch_hierarchy->getGridGeometry(), ratio);
+            if (!patch->getBox().contains(cell_idx)) continue;
+            const auto* target_spec = node->getNodeDataItem<IBAMR::IBTargetPointForceSpec>();
+            TBOX_ASSERT(target_spec);
+            const IBTK::Point& X_target = target_spec->getTargetPointPosition();
+            const IBTK::Point& X_target_exact = exact_positions[node->getLagrangianIndex()];
+
+            out << "  index = " << node->getLagrangianIndex() << " X = " << X[0] << ", " << X[1]
+                << " U = " << U_array[local_idx][0] << ", " << U_array[local_idx][1] << " X_target = " << X_target[0]
+                << ", " << X_target[1] << " X_target_exact = " << X_target_exact[0] << ", " << X_target_exact[1]
+                << '\n';
+            ++patch_count;
+        }
+        out << "  count = " << patch_count << '\n';
+    }
+
+    X_data->restoreArrays();
+    U_data->restoreArrays();
+    plog << out.str();
+}
+} // namespace
+
+int
+main(int argc, char** argv)
+{
+    IBTK::IBTKInit ibtk_init(argc, argv);
+    Logger::getInstance()->setWarning(false);
+    Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv);
+
+    if (IBTK_MPI::getNodes() != 4)
+    {
+        TBOX_ERROR("This test must be run with exactly 4 MPI processes.\n");
+    }
+
+    Pointer<CartesianGridGeometry<NDIM>> grid_geometry = new CartesianGridGeometry<NDIM>(
+        "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+    Pointer<PatchHierarchy<NDIM>> patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+    Pointer<StandardTagAndInitialize<NDIM>> error_detector =
+        new StandardTagAndInitialize<NDIM>("StandardTagAndInitialize", nullptr, Pointer<Database>(nullptr));
+    Pointer<BergerRigoutsos<NDIM>> box_generator = new BergerRigoutsos<NDIM>();
+    Pointer<LoadBalancer<NDIM>> load_balancer =
+        new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+    Pointer<GriddingAlgorithm<NDIM>> gridding_algorithm =
+        new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                    app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                    error_detector,
+                                    box_generator,
+                                    load_balancer);
+
+    gridding_algorithm->makeCoarsestLevel(patch_hierarchy, 0.0);
+
+    IBTK::LDataManager* const l_data_manager =
+        IBTK::LDataManager::getManager("LDataManagerRedistribution01", "IB_4", "IB_4");
+    l_data_manager->registerLInitStrategy(new FourPointInitializer());
+    l_data_manager->setPatchHierarchy(patch_hierarchy);
+    l_data_manager->setPatchLevels(0, 0);
+    l_data_manager->initializeLevelData(patch_hierarchy, 0, 0.0, false, true);
+    l_data_manager->resetHierarchyConfiguration(patch_hierarchy, 0, 0);
+
+    Pointer<IBTK::LData> X_data = l_data_manager->getLData(IBTK::LDataManager::POSN_DATA_NAME, 0);
+    Pointer<IBTK::LData> U_data = l_data_manager->getLData(IBTK::LDataManager::VEL_DATA_NAME, 0);
+    print_patch_data(patch_hierarchy, l_data_manager, X_data, U_data, "before redistribution", 0);
+    const auto step_translations = get_step_translations();
+    for (std::size_t step = 0; step < step_translations.size(); ++step)
+    {
+        Pointer<IBTK::LMesh> mesh = l_data_manager->getLMesh(0);
+        const std::vector<IBTK::LNode*>& local_nodes = mesh->getLocalNodes();
+        boost::multi_array_ref<double, 2>& X_array = *X_data->getLocalFormVecArray();
+        boost::multi_array_ref<double, 2>& U_array = *U_data->getLocalFormVecArray();
+        for (IBTK::LNode* node : local_nodes)
+        {
+            const int lag_idx = node->getLagrangianIndex();
+            const int local_idx = node->getLocalPETScIndex();
+            for (int d = 0; d < NDIM; ++d)
+            {
+                const double dX = step_translations[step][lag_idx][d];
+                U_array[local_idx][d] = dX;
+                X_array[local_idx][d] += dX;
+            }
+            auto* target_spec = node->getNodeDataItem<IBAMR::IBTargetPointForceSpec>();
+            TBOX_ASSERT(target_spec);
+            IBTK::Point& X_target = target_spec->getTargetPointPosition();
+            for (int d = 0; d < NDIM; ++d) X_target[d] = X_array[local_idx][d];
+        }
+        X_data->restoreArrays();
+        U_data->restoreArrays();
+
+        if (IBTK_MPI::getRank() == 0) plog << "step " << step + 1 << ": begin redistribution\n";
+        l_data_manager->beginDataRedistribution(0, 0);
+        l_data_manager->endDataRedistribution(0, 0);
+        if (IBTK_MPI::getRank() == 0) plog << "step " << step + 1 << ": end redistribution\n";
+
+        print_patch_data(
+            patch_hierarchy, l_data_manager, X_data, U_data, "after step " + std::to_string(step + 1), step + 1);
+    }
+}

--- a/tests/IBTK/l_data_manager_redistribution_01_2d.mpirun=4.input
+++ b/tests/IBTK/l_data_manager_redistribution_01_2d.mpirun=4.input
@@ -1,0 +1,37 @@
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}
+
+N = 32
+
+CartesianGeometry {
+   domain_boxes = [(0,0),(N/2 - 1,N/2 - 1)], [(N/2,0),(N - 1,N/2 - 1)], [(0,N/2),(N/2 - 1,N - 1)], [(N/2,N/2),(N - 1,N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = 1
+
+   ratio_to_coarser {
+      level_1 = 2, 2
+   }
+
+   largest_patch_size {
+      level_0 = 16, 16
+   }
+
+   smallest_patch_size {
+      level_0 = 16, 16
+   }
+
+   efficiency_tolerance = 0.70e0
+   combine_efficiency = 0.85e0
+}
+
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/IBTK/l_data_manager_redistribution_01_2d.mpirun=4.output
+++ b/tests/IBTK/l_data_manager_redistribution_01_2d.mpirun=4.output
@@ -1,0 +1,27 @@
+before redistribution rank = 0 local_nodes = 1
+patch = [(0,0),(15,15)]
+  index = 0 X = 0.49, 0.49 U = 0.005, 0.005 X_target = 0.49, 0.49 X_target_exact = 0.49, 0.49
+  count = 1
+step 1: begin redistribution
+step 1: end redistribution
+after step 1 rank = 0 local_nodes = 1
+patch = [(0,0),(15,15)]
+  index = 0 X = 0.495, 0.495 U = 0.005, 0.005 X_target = 0.495, 0.495 X_target_exact = 0.495, 0.495
+  count = 1
+step 2: begin redistribution
+step 2: end redistribution
+after step 2 rank = 0 local_nodes = 0
+patch = [(0,0),(15,15)]
+  count = 0
+step 3: begin redistribution
+step 3: end redistribution
+after step 3 rank = 0 local_nodes = 1
+patch = [(0,0),(15,15)]
+  index = 3 X = 0.495, 0.495 U = -0.005, -0.005 X_target = 0.5, 0.5 X_target_exact = 0.495, 0.495
+  count = 1
+step 4: begin redistribution
+step 4: end redistribution
+after step 4 rank = 0 local_nodes = 1
+patch = [(0,0),(15,15)]
+  index = 3 X = 0.49, 0.49 U = -0.005, -0.005 X_target = 0.49, 0.49 X_target_exact = 0.49, 0.49
+  count = 1

--- a/tests/IBTK/l_data_manager_redistribution_01_2d.mpirun=4.output
+++ b/tests/IBTK/l_data_manager_redistribution_01_2d.mpirun=4.output
@@ -17,7 +17,7 @@ step 3: begin redistribution
 step 3: end redistribution
 after step 3 rank = 0 local_nodes = 1
 patch = [(0,0),(15,15)]
-  index = 3 X = 0.495, 0.495 U = -0.005, -0.005 X_target = 0.5, 0.5 X_target_exact = 0.495, 0.495
+  index = 3 X = 0.495, 0.495 U = -0.005, -0.005 X_target = 0.495, 0.495 X_target_exact = 0.495, 0.495
   count = 1
 step 4: begin redistribution
 step 4: end redistribution


### PR DESCRIPTION
This fixes a bug that can occur during redistributions using `IBMethod`. If local `LNode` data is changed prior to regridding, stale ghost `LNode` data can potentially become local. This updates ghost `LNode` data prior to redistributing Lagrangian data.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
