### PR TITLE
adds VelocityCartGridFunction to save and load velocity field for tra…

### DIFF
--- a/examples/adv_diff/CMakeLists.txt
+++ b/examples/adv_diff/CMakeLists.txt
@@ -11,6 +11,6 @@
 ##
 ## ---------------------------------------------------------------------
 
-FOREACH(_dir ex0 ex1 ex2 ex3 ex4 ex5 ex6 ex7 ex8)
+FOREACH(_dir ex0 ex1 ex2 ex3 ex4 ex5 ex6 ex7 ex8 ex9)
   ADD_SUBDIRECTORY(${_dir})
 ENDFOREACH()

--- a/examples/adv_diff/ex9/CMakeLists.txt
+++ b/examples/adv_diff/ex9/CMakeLists.txt
@@ -1,0 +1,46 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (c) 2020 - 2020 by the IBAMR developers
+## All rights reserved.
+##
+## This file is part of IBAMR.
+##
+## IBAMR is free software and is distributed under the 3-clause BSD
+## license. The full text of the license can be found in the file
+## COPYRIGHT at the top level directory of IBAMR.
+##
+## ---------------------------------------------------------------------
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "adv_diff-ex9-2d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/adv_diff/ex9"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-adv_diff
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    IBAMR2d
+  INPUT_FILES
+    input2d
+    )
+
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "adv_diff-ex9-3d"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/adv_diff/ex9"
+  OUTPUT_NAME
+    main3d
+  EXAMPLE_GROUP
+    examples-adv_diff
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    IBAMR3d
+  INPUT_FILES
+    input3d
+    )

--- a/examples/adv_diff/ex9/example.cpp
+++ b/examples/adv_diff/ex9/example.cpp
@@ -152,7 +152,7 @@ main(int argc, char* argv[])
 
         // Tim
         Pointer<VelocityCartGridFunction> velocity_function =
-            new VelocityCartGridFunction("velocity", grid_geometry, -1);
+            new VelocityCartGridFunction("velocity", grid_geometry, -1, "saveVelocityDB");
 
         Pointer<FaceVariable<NDIM, double>> u_adv_var = new FaceVariable<NDIM, double>("u_adv");
         time_integrator->registerAdvectionVelocity(u_adv_var);
@@ -197,14 +197,14 @@ main(int argc, char* argv[])
         double loop_time = time_integrator->getIntegratorTime();
         const double dt = time_integrator->getMaximumTimeStepSize(); // fix time step
         double loop_time_end = time_integrator->getEndTime();
+
         while (!IBTK::rel_equal_eps(loop_time, loop_time_end))
         {
             u_init->setDataOnPatchHierarchy(u_side_index, u_side_adv_var, patch_hierarchy, loop_time);
-            velocity_function->save_velocity_data(patch_hierarchy, save_dir, loop_time, iteration_num);
+            velocity_function->saveVelocity(patch_hierarchy, iteration_num, loop_time);
             loop_time += dt;
             iteration_num += 1;
         }
-
         // Deallocate initialization objects.
         app_initializer.setNull();
 
@@ -233,8 +233,8 @@ main(int argc, char* argv[])
             pout << "At beginning of timestep # " << iteration_num << "\n";
             pout << "Simulation time is " << loop_time << "\n";
 
-            auto vel_time = velocity_function->read_velocity_data(patch_hierarchy, save_dir, iteration_num);
-            TBOX_ASSERT(loop_time == vel_time);
+            auto vel_time_db = velocity_function->readVelocity(patch_hierarchy, iteration_num);
+            TBOX_ASSERT(loop_time == vel_time_db);
 
             time_integrator->advanceHierarchy(dt);
             loop_time += dt;

--- a/examples/adv_diff/ex9/example.cpp
+++ b/examples/adv_diff/ex9/example.cpp
@@ -1,0 +1,311 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2017 - 2026 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+// Config files
+#include <SAMRAI_config.h>
+
+// Headers for basic PETSc functions
+#include <petscsys.h>
+
+// Headers for basic SAMRAI objects
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <LoadBalancer.h>
+#include <StandardTagAndInitialize.h>
+
+// Headers for application-specific algorithm/data structure objects
+#include <ibamr/AdvDiffPredictorCorrectorHierarchyIntegrator.h>
+#include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
+#include <ibamr/VelocityCartGridFunction.h>
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/muParserCartGridFunction.h>
+#include <ibtk/muParserRobinBcCoefs.h>
+
+// Set up application namespace declarations
+#include <ibamr/app_namespaces.h>
+
+/*******************************************************************************
+ * For each run, the input filename and restart information (if needed) must   *
+ * be given on the command line.  For non-restarted case, command line is:     *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ * For restarted run, command line is:                                         *
+ *                                                                             *
+ *    executable <input file name> <restart directory> <restart number>        *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+
+    { // cleanup dynamically allocated objects prior to shutdown
+
+        // Parse command line options, set some standard options from the input
+        // file, initialize the restart database (if this is a restarted run),
+        // and enable file logging.
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "adv_diff.log");
+        Pointer<Database> input_db = app_initializer->getInputDatabase();
+
+        // Get various standard options set in the input file.
+        const bool dump_viz_data = app_initializer->dumpVizData();
+        const int viz_dump_interval = app_initializer->getVizDumpInterval();
+        const bool uses_visit = dump_viz_data && app_initializer->getVisItDataWriter();
+
+        const bool dump_restart_data = app_initializer->dumpRestartData();
+        const int restart_dump_interval = app_initializer->getRestartDumpInterval();
+        const string restart_dump_dirname = app_initializer->getRestartDumpDirectory();
+
+        const bool dump_timer_data = app_initializer->dumpTimerData();
+        const int timer_dump_interval = app_initializer->getTimerDumpInterval();
+
+        Pointer<Database> main_db = app_initializer->getComponentDatabase("Main");
+
+        // Create major algorithm and data objects that comprise the
+        // application.  These objects are configured from the input database
+        // and, if this is a restarted run, from the restart database.
+        Pointer<AdvDiffHierarchyIntegrator> time_integrator;
+        const string solver_type = main_db->getStringWithDefault("solver_type", "GODUNOV");
+        if (solver_type == "GODUNOV")
+        {
+            Pointer<AdvectorExplicitPredictorPatchOps> predictor = new AdvectorExplicitPredictorPatchOps(
+                "AdvectorExplicitPredictorPatchOps",
+                app_initializer->getComponentDatabase("AdvectorExplicitPredictorPatchOps"));
+            time_integrator = new AdvDiffPredictorCorrectorHierarchyIntegrator(
+                "AdvDiffPredictorCorrectorHierarchyIntegrator",
+                app_initializer->getComponentDatabase("AdvDiffPredictorCorrectorHierarchyIntegrator"),
+                predictor);
+        }
+        else if (solver_type == "SEMI_IMPLICIT")
+        {
+            time_integrator = new AdvDiffSemiImplicitHierarchyIntegrator(
+                "AdvDiffSemiImplicitHierarchyIntegrator",
+                app_initializer->getComponentDatabase("AdvDiffSemiImplicitHierarchyIntegrator"));
+        }
+        else
+        {
+            TBOX_ERROR("Unsupported solver type: " << solver_type << "\n"
+                                                   << "Valid options are: GODUNOV, SEMI_IMPLICIT");
+        }
+        Pointer<CartesianGridGeometry<NDIM>> grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<PatchHierarchy<NDIM>> patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<StandardTagAndInitialize<NDIM>> error_detector =
+            new StandardTagAndInitialize<NDIM>("StandardTagAndInitialize",
+                                               time_integrator,
+                                               app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<BergerRigoutsos<NDIM>> box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM>> load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM>> gridding_algorithm =
+            new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                        app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                        error_detector,
+                                        box_generator,
+                                        load_balancer);
+
+        // Create an initial condition specification object.
+        Pointer<CartGridFunction> u_init = new muParserCartGridFunction(
+            "u_init", app_initializer->getComponentDatabase("VelocityInitialConditions"), grid_geometry);
+
+        // Create boundary condition specification objects (when necessary).
+        const IntVector<NDIM>& periodic_shift = grid_geometry->getPeriodicShift();
+        vector<RobinBcCoefStrategy<NDIM>*> u_bc_coefs(NDIM);
+        if (periodic_shift.min() > 0)
+        {
+            for (unsigned int d = 0; d < NDIM; ++d)
+            {
+                u_bc_coefs[d] = nullptr;
+            }
+        }
+        else
+        {
+            for (unsigned int d = 0; d < NDIM; ++d)
+            {
+                const std::string bc_coefs_name = "u_bc_coefs_" + std::to_string(d);
+                const std::string bc_coefs_db_name = "VelocityBcCoefs_" + std::to_string(d);
+                u_bc_coefs[d] = new muParserRobinBcCoefs(
+                    bc_coefs_name, app_initializer->getComponentDatabase(bc_coefs_db_name), grid_geometry);
+            }
+        }
+
+        // Set up the advected and diffused quantity.
+        Pointer<CellVariable<NDIM, double>> U_var = new CellVariable<NDIM, double>("U", NDIM);
+        time_integrator->registerTransportedQuantity(U_var);
+        time_integrator->setDiffusionCoefficient(U_var, input_db->getDouble("MU") / input_db->getDouble("RHO"));
+        time_integrator->setInitialConditions(U_var, u_init);
+        time_integrator->setPhysicalBcCoefs(U_var, u_bc_coefs);
+
+        // Tim
+        Pointer<VelocityCartGridFunction> velocity_function =
+            new VelocityCartGridFunction("velocity", grid_geometry, -1);
+
+        Pointer<FaceVariable<NDIM, double>> u_adv_var = new FaceVariable<NDIM, double>("u_adv");
+        time_integrator->registerAdvectionVelocity(u_adv_var);
+        time_integrator->setAdvectionVelocityFunction(u_adv_var, velocity_function);
+        time_integrator->setAdvectionVelocity(U_var, u_adv_var);
+
+        if (input_db->keyExists("ForcingFunction"))
+        {
+            Pointer<CellVariable<NDIM, double>> F_var = new CellVariable<NDIM, double>("F", NDIM);
+            Pointer<CartGridFunction> F_fcn = new muParserCartGridFunction(
+                "F_fcn", app_initializer->getComponentDatabase("ForcingFunction"), grid_geometry);
+            time_integrator->registerSourceTerm(F_var);
+            time_integrator->setSourceTermFunction(F_var, F_fcn);
+            time_integrator->setSourceTerm(U_var, F_var);
+        }
+
+        // Set up visualization plot file writers.
+        Pointer<VisItDataWriter<NDIM>> visit_data_writer = app_initializer->getVisItDataWriter();
+        if (uses_visit)
+        {
+            time_integrator->registerVisItDataWriter(visit_data_writer);
+        }
+
+        // Initialize hierarchy configuration and data on all patches.
+        time_integrator->initializePatchHierarchy(patch_hierarchy, gridding_algorithm);
+
+        // Create side variable for proxy of N-S solve
+        VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
+        Pointer<SideVariable<NDIM, double>> u_side_adv_var = new SideVariable<NDIM, double>("u_side_adv", 1);
+        Pointer<VariableContext> ctx = var_db->getContext("u_side_ctx");
+        const int u_side_index = var_db->registerVariableAndContext(u_side_adv_var, ctx, IntVector<NDIM>(0));
+
+        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+            patch_hierarchy->getPatchLevel(ln)->allocatePatchData(u_side_index);
+
+        // Set the real index now that data is allocated
+        velocity_function->setVelocityIndex(u_side_index);
+
+        // Fill from the analytic initial condition and save/load
+        const std::string save_dir = "save_velocity";
+        int iteration_num = time_integrator->getIntegratorStep();
+        double loop_time = time_integrator->getIntegratorTime();
+        const double dt = time_integrator->getMaximumTimeStepSize(); // fix time step
+        double loop_time_end = time_integrator->getEndTime();
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end))
+        {
+            u_init->setDataOnPatchHierarchy(u_side_index, u_side_adv_var, patch_hierarchy, loop_time);
+            velocity_function->save_velocity_data(patch_hierarchy, save_dir, loop_time, iteration_num);
+            loop_time += dt;
+            iteration_num += 1;
+        }
+
+        // Deallocate initialization objects.
+        app_initializer.setNull();
+
+        // Print the input database contents to the log file.
+        plog << "Input database:\n";
+        input_db->printClassData(plog);
+
+        // Write out initial visualization data.
+        iteration_num = time_integrator->getIntegratorStep();
+        loop_time = time_integrator->getIntegratorTime();
+        if (dump_viz_data && uses_visit)
+        {
+            pout << "\n\nWriting visualization files...\n\n";
+            time_integrator->setupPlotData();
+            visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+        }
+
+        // Main time step loop.
+        while (!IBTK::rel_equal_eps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        {
+            iteration_num = time_integrator->getIntegratorStep();
+            loop_time = time_integrator->getIntegratorTime();
+
+            pout << "\n";
+            pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+            pout << "At beginning of timestep # " << iteration_num << "\n";
+            pout << "Simulation time is " << loop_time << "\n";
+
+            auto vel_time = velocity_function->read_velocity_data(patch_hierarchy, save_dir, iteration_num);
+            TBOX_ASSERT(loop_time == vel_time);
+
+            time_integrator->advanceHierarchy(dt);
+            loop_time += dt;
+
+            pout << "\n";
+            pout << "At end       of timestep # " << iteration_num << "\n";
+            pout << "Simulation time is " << loop_time << "\n";
+            pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+            pout << "\n";
+
+            // At specified intervals, write visualization and restart files,
+            // print out timer data, and store hierarchy data for post
+            // processing.
+            iteration_num += 1;
+            const bool last_step = !time_integrator->stepsRemaining();
+            if (dump_viz_data && uses_visit && (iteration_num % viz_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting visualization files...\n\n";
+                time_integrator->setupPlotData();
+                visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+            }
+            if (dump_restart_data && (iteration_num % restart_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting restart files...\n\n";
+                RestartManager::getManager()->writeRestartFile(restart_dump_dirname, iteration_num);
+            }
+            if (dump_timer_data && (iteration_num % timer_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting timer data...\n\n";
+                TimerManager::getManager()->print(plog);
+            }
+        }
+
+        // Determine the accuracy of the computed solution.
+        pout << "\n"
+             << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n"
+             << "Computing error norms.\n\n";
+
+        const Pointer<VariableContext> U_ctx = time_integrator->getCurrentContext();
+        const int U_idx = var_db->mapVariableAndContextToIndex(U_var, U_ctx);
+        const int U_cloned_idx = var_db->registerClonedPatchDataIndex(U_var, U_idx);
+
+        const int coarsest_ln = 0;
+        const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+        for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+        {
+            patch_hierarchy->getPatchLevel(ln)->allocatePatchData(U_cloned_idx, loop_time);
+        }
+
+        u_init->setDataOnPatchHierarchy(U_cloned_idx, U_var, patch_hierarchy, loop_time);
+
+        HierarchyMathOps hier_math_ops("HierarchyMathOps", patch_hierarchy);
+        hier_math_ops.setPatchHierarchy(patch_hierarchy);
+        hier_math_ops.resetLevels(coarsest_ln, finest_ln);
+        const int wgt_cc_idx = hier_math_ops.getCellWeightPatchDescriptorIndex();
+
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(patch_hierarchy, coarsest_ln, finest_ln);
+        hier_cc_data_ops.subtract(U_idx, U_idx, U_cloned_idx);
+        pout << "Error in U at time " << loop_time << ":\n"
+             << "  L1-norm:  " << std::setprecision(10) << hier_cc_data_ops.L1Norm(U_idx, wgt_cc_idx) << "\n"
+             << "  L2-norm:  " << hier_cc_data_ops.L2Norm(U_idx, wgt_cc_idx) << "\n"
+             << "  max-norm: " << hier_cc_data_ops.maxNorm(U_idx, wgt_cc_idx) << "\n";
+
+        if (dump_viz_data && uses_visit)
+        {
+            time_integrator->setupPlotData();
+            visit_data_writer->writePlotData(patch_hierarchy, iteration_num + 1, loop_time);
+        }
+
+        // Cleanup boundary condition specification objects (when necessary).
+        for (unsigned int d = 0; d < NDIM; ++d) delete u_bc_coefs[d];
+
+    } // cleanup dynamically allocated objects prior to shutdown
+} // main

--- a/examples/adv_diff/ex9/input2d
+++ b/examples/adv_diff/ex9/input2d
@@ -1,0 +1,199 @@
+// physical parameters
+MU  = 1.0e-2                              // fluid viscosity
+RHO = 1.0                                 // fluid density
+L   = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 64                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// solver parameters
+SOLVER_TYPE        = "SEMI_IMPLICIT"      // the fluid solver to use (GODUNOV or SEMI_IMPLICIT)
+START_TIME         = 0.0e0                // initial simulation time
+END_TIME           = 0.125                // final simulation time
+GROW_DT            = 1.0e0                // growth factor for timesteps
+NUM_CYCLES         = 1                    // number of cycles of fixed-point iteration
+CONVECTIVE_TS_TYPE = "ADAMS_BASHFORTH"    // convective time stepping type
+CONVECTIVE_OP_TYPE = "PPM"                // convective differencing discretization type
+CONVECTIVE_FORM    = "ADVECTIVE"          // how to compute the convective terms
+CFL_MAX            = 0.2                  // maximum CFL number
+DT_MAX             = 0.0625/NFINEST       // maximum timestep size
+TAG_BUFFER         = 1                    // sized of tag buffer used by grid generation algorithm
+REGRID_INTERVAL    = 10000000             // effectively disable regridding
+ENABLE_LOGGING     = TRUE
+
+// exact solution function expressions
+U = "1 - 2*(cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)"
+V = "1 + 2*(sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t)))*exp(-8*PI*PI*nu*t)"
+P = "-(cos(4*PI*(X_0-t)) + cos(4*PI*(X_1-t)))*exp(-16*PI*PI*nu*t)"
+mGP0 = "-4*PI*sin(4*PI*(X_0-t))*exp(-16*PI*PI*nu*t)"  // - d/dX_0 P
+mGP1 = "-4*PI*sin(4*PI*(X_1-t))*exp(-16*PI*PI*nu*t)"  // - d/dX_1 P
+
+VelocityInitialConditions {
+   nu = MU/RHO
+   function_0 = U
+   function_1 = V
+}
+
+ForcingFunction {
+   nu = MU/RHO
+   function_0 = mGP0
+   function_1 = mGP1
+}
+
+VelocityBcCoefs_0 {
+   nu = MU/RHO
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = U
+   gcoef_function_1 = U
+   gcoef_function_2 = U
+   gcoef_function_3 = U
+}
+
+VelocityBcCoefs_1 {
+   nu = MU/RHO
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = V
+   gcoef_function_1 = V
+   gcoef_function_2 = V
+   gcoef_function_3 = V
+}
+
+AdvectorExplicitPredictorPatchOps {
+// Available values for limiter_type:
+// "CTU_ONLY", "MINMOD_LIMITED", "MC_LIMITED",
+// "SUPERBEE_LIMITED", "MUSCL_LIMITED"
+// "SECOND_ORDER", "FOURTH_ORDER",
+// "PPM", "XSPPM7"
+   limiter_type = "XSPPM7"
+   using_full_ctu = TRUE
+}
+
+AdvDiffPredictorCorrectorHierarchyIntegrator {
+   start_time                 = START_TIME
+   end_time                   = END_TIME
+   grow_dt                    = GROW_DT
+   convective_difference_form = CONVECTIVE_FORM
+   cfl                        = CFL_MAX
+   dt_max                     = DT_MAX
+   tag_buffer                 = TAG_BUFFER
+   regrid_interval            = REGRID_INTERVAL
+   enable_logging             = ENABLE_LOGGING
+
+   AdvDiffPredictorCorrectorHyperbolicPatchOps {
+      compute_init_velocity  = TRUE
+      compute_half_velocity  = TRUE
+      compute_final_velocity = FALSE
+      extrap_type = "LINEAR"
+   }
+
+   HyperbolicLevelIntegrator {
+      cfl                      = CFL_MAX
+      cfl_init                 = CFL_MAX
+      lag_dt_computation       = TRUE
+      use_ghosts_to_compute_dt = FALSE
+   }
+}
+
+AdvDiffSemiImplicitHierarchyIntegrator {
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   num_cycles                    = NUM_CYCLES
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   cfl                           = CFL_MAX
+   dt_max                        = DT_MAX
+   tag_buffer                    = TAG_BUFFER
+   regrid_interval               = REGRID_INTERVAL
+   enable_logging                = ENABLE_LOGGING
+}
+
+Main {
+   solver_type = SOLVER_TYPE
+
+// log file parameters
+   log_file_name               = "adv_diff2d.log"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = NFINEST/8
+   viz_dump_dirname            = "viz_adv_diff2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_adv_diff2d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = L,L
+   periodic_dimension = 1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+//    level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+//    level_0 = [(0,0),(N/2 - 1,N/2 - 1)]
+      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/examples/adv_diff/ex9/input3d
+++ b/examples/adv_diff/ex9/input3d
@@ -1,0 +1,255 @@
+// physical parameters
+MU  = 1.0e-2                              // fluid viscosity
+RHO = 1.0                                 // fluid density
+L   = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 32                                    // actual    number of grid cells on coarsest grid level
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // effective number of grid cells on finest   grid level
+
+// solver parameters
+SOLVER_TYPE        = "SEMI_IMPLICIT"      // the fluid solver to use (GODUNOV or SEMI_IMPLICIT)
+START_TIME         = 0.0e0                // initial simulation time
+END_TIME           = 0.5                  // final simulation time
+GROW_DT            = 2.0e0                // growth factor for timesteps
+NUM_CYCLES         = 1                    // number of cycles of fixed-point iteration
+CONVECTIVE_TS_TYPE = "ADAMS_BASHFORTH"    // convective time stepping type
+CONVECTIVE_OP_TYPE = "PPM"                // convective differencing discretization type
+CONVECTIVE_FORM    = "ADVECTIVE"          // how to compute the convective terms
+CFL_MAX            = 0.2                  // maximum CFL number
+DT_MAX             = 0.0625/NFINEST       // maximum timestep size
+TAG_BUFFER         = 1                    // sized of tag buffer used by grid generation algorithm
+REGRID_INTERVAL    = 10000000             // effectively disable regridding
+ENABLE_LOGGING     = TRUE
+
+// exact solution function expressions
+U = "1.0 + exp(-4.0*PI*PI*nu*t)*(C*cos(2*PI*(X_1-t)) + A*sin(2*PI*(X_2-t)))"
+V = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*sin(2*PI*(X_0-t)) + A*cos(2*PI*(X_2-t)))"
+W = "1.0 + exp(-4.0*PI*PI*nu*t)*(B*cos(2*PI*(X_0-t)) + C*sin(2*PI*(X_1-t)))"
+P = "-exp(-8.0*PI*PI*nu*t)*(A*C*cos(2*PI*(X_1-t))*sin(2*PI*(X_2-t)) + A*B*sin(2*PI*(X_0-t))*cos(2*PI*(X_2-t)) + B*C*cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t)))"
+mGP0 = "exp(-8.0*PI^2*nu*t)*(2*A*B*cos(2*PI*(X_0-t))*PI*cos(2*PI*(X_2-t))-2*B*C*sin(2*PI*(X_0-t))*PI*sin(2*PI*(X_1-t)))"  // - d/dX_0 P
+mGP1 = "exp(-8.0*PI^2*nu*t)*(-2*A*C*sin(2*PI*(X_1-t))*PI*sin(2*PI*(X_2-t))+2*B*C*cos(2*PI*(X_0-t))*cos(2*PI*(X_1-t))*PI)" // - d/dX_1 P
+mGP2 = "exp(-8.0*PI^2*nu*t)*(2*A*C*cos(2*PI*(X_1-t))*cos(2*PI*(X_2-t))*PI-2*A*B*sin(2*PI*(X_0-t))*sin(2*PI*(X_2-t))*PI)"  // -d/dX_2 P
+
+VelocityInitialConditions {
+   nu = MU/RHO
+   A = 1.0
+   B = 1.0
+   C = 1.0
+   function_0 = U
+   function_1 = V
+   function_2 = W
+}
+
+VelocityBcCoefs_0 {
+   nu = MU/RHO
+   A = 1.0
+   B = 1.0
+   C = 1.0
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   acoef_function_4 = "1.0"
+   acoef_function_5 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+   bcoef_function_4 = "0.0"
+   bcoef_function_5 = "0.0"
+
+   gcoef_function_0 = U
+   gcoef_function_1 = U
+   gcoef_function_2 = U
+   gcoef_function_3 = U
+   gcoef_function_4 = U
+   gcoef_function_5 = U
+}
+
+VelocityBcCoefs_1 {
+   nu = MU/RHO
+   A = 1.0
+   B = 1.0
+   C = 1.0
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   acoef_function_4 = "1.0"
+   acoef_function_5 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+   bcoef_function_4 = "0.0"
+   bcoef_function_5 = "0.0"
+
+   gcoef_function_0 = V
+   gcoef_function_1 = V
+   gcoef_function_2 = V
+   gcoef_function_3 = V
+   gcoef_function_4 = V
+   gcoef_function_5 = V
+}
+
+VelocityBcCoefs_2 {
+   nu = MU/RHO
+   A = 1.0
+   B = 1.0
+   C = 1.0
+
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+   acoef_function_4 = "1.0"
+   acoef_function_5 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+   bcoef_function_4 = "0.0"
+   bcoef_function_5 = "0.0"
+
+   gcoef_function_0 = W
+   gcoef_function_1 = W
+   gcoef_function_2 = W
+   gcoef_function_3 = W
+   gcoef_function_4 = W
+   gcoef_function_5 = W
+}
+
+ForcingFunction {
+   nu = MU/RHO
+   A = 1.0
+   B = 1.0
+   C = 1.0
+   function_0 = mGP0
+   function_1 = mGP1
+   function_2 = mGP2
+}
+
+AdvectorExplicitPredictorPatchOps {
+// Available values for limiter_type:
+// "CTU_ONLY", "MINMOD_LIMITED", "MC_LIMITED",
+// "SUPERBEE_LIMITED", "MUSCL_LIMITED"
+// "SECOND_ORDER", "FOURTH_ORDER",
+// "PPM", "XSPPM7"
+   limiter_type = "XSPPM7"
+   using_full_ctu = TRUE
+}
+
+AdvDiffPredictorCorrectorHierarchyIntegrator {
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   convective_difference_form    = CONVECTIVE_FORM
+   cfl                           = CFL_MAX
+   dt_max                        = DT_MAX
+   tag_buffer                    = TAG_BUFFER
+   regrid_interval               = REGRID_INTERVAL
+   enable_logging                = ENABLE_LOGGING
+
+   AdvDiffPredictorCorrectorHyperbolicPatchOps {
+      compute_init_velocity  = TRUE
+      compute_half_velocity  = TRUE
+      compute_final_velocity = FALSE
+      extrap_type = "LINEAR"
+   }
+
+   HyperbolicLevelIntegrator {
+      cfl                      = CFL_MAX
+      cfl_init                 = CFL_MAX
+      lag_dt_computation       = TRUE
+      use_ghosts_to_compute_dt = FALSE
+   }
+}
+
+AdvDiffSemiImplicitHierarchyIntegrator {
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   num_cycles                    = NUM_CYCLES
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   convective_op_type            = CONVECTIVE_OP_TYPE
+   convective_difference_form    = CONVECTIVE_FORM
+   cfl                           = CFL_MAX
+   dt_max                        = DT_MAX
+   tag_buffer                    = TAG_BUFFER
+   regrid_interval               = REGRID_INTERVAL
+   enable_logging                = ENABLE_LOGGING
+}
+
+Main {
+   solver_type = SOLVER_TYPE
+
+// log file parameters
+   log_file_name               = "adv_diff3d.log"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = NFINEST/8
+   viz_dump_dirname            = "viz_adv_diff3d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_adv_diff3d"
+
+// timer dump parameters
+   timer_dump_interval         = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0,0),(N - 1,N - 1,N - 1) ]
+   x_lo = 0,0,0
+   x_up = L,L,L
+   periodic_dimension = 1,1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.85e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [((REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0,(REF_RATIO^0)*N/4 + 0),(3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1,3*(REF_RATIO^0)*N/4 - 1)]
+      level_1 = [((REF_RATIO^1)*N/4 + 1,(REF_RATIO^1)*N/4 + 1,(REF_RATIO^1)*N/4 + 1),(3*(REF_RATIO^1)*N/4 - 2,3*(REF_RATIO^1)*N/4 - 2,3*(REF_RATIO^1)*N/4 - 2)]
+      level_2 = [((REF_RATIO^2)*N/4 + 2,(REF_RATIO^2)*N/4 + 2,(REF_RATIO^2)*N/4 + 2),(3*(REF_RATIO^2)*N/4 - 3,3*(REF_RATIO^2)*N/4 - 3,3*(REF_RATIO^2)*N/4 - 3)]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total     = TRUE
+   print_threshold = 0.1
+   timer_list      = "IBAMR::*::*","IBTK::*::*","*::*::*"
+}

--- a/include/ibamr/VelocityCartGridFunction.h
+++ b/include/ibamr/VelocityCartGridFunction.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/CartGridFunction.h>
 
+#include <tbox/HDFDatabase.h>
+
 #include <CartesianGridGeometry.h>
 
 #include <string>
@@ -52,7 +54,8 @@ public:
      */
     VelocityCartGridFunction(const std::string& object_name,
                              SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM>> grid_geometry,
-                             const int velocity_index);
+                             const int velocity_index,
+                             const std::string& db_base_name);
 
     ~VelocityCartGridFunction() override = default;
 
@@ -78,20 +81,25 @@ public:
                         SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>> patch_level =
                             SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>>(nullptr)) override;
 
-    void save_velocity_data(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
-                            const std::string& base_folder,
-                            double data_time,
-                            int iteration);
+    void saveVelocity(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
+                      int iteration_num,
+                      double loop_time);
 
-    double read_velocity_data(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
-                              const std::string& base_folder,
-                              int iteration);
+    double readVelocity(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy, int iteration_num);
 
     void setVelocityIndex(const int velocity_index);
 
+private:
+    std::string getIterationDir(int iteration_num) const;
+    std::string getIterationFilename(int iteration_num) const;
+    static void ensureDirectoryExists(const std::string& dir_path);
+    static bool fileExists(const std::string& filename);
+
 protected:
+    std::string d_object_name;
     SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM>> d_grid_geometry;
     int d_velocity_index;
+    std::string d_db_base_name;
 };
 
 } // namespace IBAMR

--- a/include/ibamr/VelocityCartGridFunction.h
+++ b/include/ibamr/VelocityCartGridFunction.h
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2011 - 2026 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+/////////////////////////////// INCLUDE GUARD ////////////////////////////////
+
+#ifndef included_IBAMR_VelocityCartGridFunction
+#define included_IBAMR_VelocityCartGridFunction
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include <ibtk/CartGridFunction.h>
+
+#include <CartesianGridGeometry.h>
+
+#include <string>
+
+namespace SAMRAI
+{
+namespace hier
+{
+template <int DIM>
+class Patch;
+template <int DIM>
+class PatchHierarchy;
+template <int DIM>
+class Variable;
+} // namespace hier
+} // namespace SAMRAI
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+namespace IBAMR
+{
+/*!
+ * \brief Class VelocityCartGridFunction provides an method to save a veloicity from an IBAMR simulation and use that
+ * field for a transport solve.
+ */
+class VelocityCartGridFunction : public IBTK::CartGridFunction
+{
+public:
+    /*!
+     * \brief The default constructor sets the name of the strategy object.
+     */
+    VelocityCartGridFunction(const std::string& object_name,
+                             SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM>> grid_geometry,
+                             const int velocity_index);
+
+    ~VelocityCartGridFunction() override = default;
+
+    /*!
+     * \brief Indicates whether the concrete CartGridFunction object is
+     * time-dependent.
+     */
+    bool isTimeDependent() const override;
+
+    void setDataOnPatchHierarchy(int data_idx,
+                                 SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM>> var,
+                                 SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy,
+                                 double data_time,
+                                 bool initial_time = false,
+                                 int coarsest_ln = -1,
+                                 int finest_ln = -1) override;
+
+    void setDataOnPatch(int data_idx,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM>> var,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
+                        double data_time,
+                        bool initial_time = false,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>> patch_level =
+                            SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>>(nullptr)) override;
+
+    void save_velocity_data(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
+                            const std::string& base_folder,
+                            double data_time,
+                            int iteration);
+
+    double read_velocity_data(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
+                              const std::string& base_folder,
+                              int iteration);
+
+    void setVelocityIndex(const int velocity_index);
+
+protected:
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianGridGeometry<NDIM>> d_grid_geometry;
+    int d_velocity_index;
+};
+
+} // namespace IBAMR
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif // #ifndef included_IBAMR_VelocityCartGridFunction

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -227,6 +227,7 @@ SET(CXX_SRC
   utilities/STSMassFluxIntegrator.cpp
   utilities/ins_utilities.cpp
   utilities/vc_ins_utilities.cpp
+  utilities/VelocityCartGridFunction.cpp
   )
 
 IF(${IBAMR_HAVE_LIBMESH})

--- a/src/utilities/VelocityCartGridFunction.cpp
+++ b/src/utilities/VelocityCartGridFunction.cpp
@@ -125,9 +125,14 @@ namespace IBAMR
 
 VelocityCartGridFunction::VelocityCartGridFunction(const std::string& object_name,
                                                    Pointer<CartesianGridGeometry<NDIM>> grid_geometry,
-                                                   int velocity_index)
-    : CartGridFunction(object_name), d_grid_geometry(grid_geometry), d_velocity_index(velocity_index)
+                                                   int velocity_index,
+                                                   const std::string& db_base_name)
+    : CartGridFunction(object_name),
+      d_grid_geometry(grid_geometry),
+      d_velocity_index(velocity_index),
+      d_db_base_name(db_base_name)
 {
+    ensureDirectoryExists(d_db_base_name);
 }
 
 bool
@@ -159,33 +164,21 @@ VelocityCartGridFunction::setDataOnPatch(const int /*data_idx*/,
 }
 
 void
-VelocityCartGridFunction::save_velocity_data(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
-                                             const std::string& base_folder,
-                                             double data_time,
-                                             int iteration)
+VelocityCartGridFunction::saveVelocity(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
+                                       int iteration_num,
+                                       double loop_time)
 {
+    // create <base_name>/<iteration_num>/
+    ensureDirectoryExists(getIterationDir(iteration_num));
+
+    const std::string filename = getIterationFilename(iteration_num);
+
+    Pointer<HDFDatabase> hdf_db = new HDFDatabase(d_object_name + "::hdf_db");
+    hdf_db->create(filename);
+
+    hdf_db->putDouble("time", loop_time);
+
     const int finest_ln = patch_hierarchy->getFinestLevelNumber();
-
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
-    // create base folder and iteration subfolder on rank 0
-    const std::string iter_folder = base_folder + "/" + std::to_string(iteration);
-    if (rank == 0)
-    {
-        mkdir(base_folder.c_str(), 0755);
-        mkdir(iter_folder.c_str(), 0755);
-    }
-    MPI_Barrier(MPI_COMM_WORLD);
-
-    const std::string filename = iter_folder + "/proc." + std::to_string(rank);
-    std::ofstream ofs(filename, std::ios::binary);
-
-    const int ndim = NDIM;
-    ofs.write(reinterpret_cast<const char*>(&data_time), sizeof(double));
-    ofs.write(reinterpret_cast<const char*>(&ndim), sizeof(int));
-    ofs.write(reinterpret_cast<const char*>(&rank), sizeof(int));
-    ofs.write(reinterpret_cast<const char*>(&iteration), sizeof(int));
 
     for (int ln = 0; ln <= finest_ln; ++ln)
     {
@@ -193,53 +186,27 @@ VelocityCartGridFunction::save_velocity_data(SAMRAI::tbox::Pointer<SAMRAI::hier:
         for (PatchLevel<NDIM>::Iterator p(*level); p; p++)
         {
             Pointer<Patch<NDIM>> patch = level->getPatch(p());
-            Pointer<SideData<NDIM, double>> sd = patch->getPatchData(d_velocity_index);
 
-            auto box = patch->getBox();
-            auto lo = box.lower();
-            auto hi = box.upper();
-
-            for (int d = 0; d < NDIM; ++d)
-            {
-                const int lo_d = lo(d);
-                const int hi_d = hi(d);
-                ofs.write(reinterpret_cast<const char*>(&lo_d), sizeof(int));
-                ofs.write(reinterpret_cast<const char*>(&hi_d), sizeof(int));
-            }
-
-            for (int axis = 0; axis < NDIM; ++axis)
-            {
-                for (SideIterator<NDIM> s(box, axis); s; s++)
-                {
-                    double val = (*sd)(*s, 0);
-                    ofs.write(reinterpret_cast<const char*>(&val), sizeof(double));
-                }
-            }
+            const std::string key = "patch_data_" + std::to_string(ln) + "_" + std::to_string(p());
+            patch->getPatchData(d_velocity_index)->putToDatabase(hdf_db->putDatabase(key));
         }
     }
+
+    hdf_db->close();
 }
 
 double
-VelocityCartGridFunction::read_velocity_data(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
-                                             const std::string& base_folder,
-                                             int iteration)
+VelocityCartGridFunction::readVelocity(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
+                                       int iteration_num)
 {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    const std::string filename = getIterationFilename(iteration_num);
+    TBOX_ASSERT(fileExists(filename) &&
+                "VelocityCartGridFunction: cannot read, file does not exist for this iteration");
 
-    const std::string filename = base_folder + "/" + std::to_string(iteration) + "/proc." + std::to_string(rank);
-    std::ifstream ifs(filename, std::ios::binary);
-    if (!ifs.is_open())
-    {
-        TBOX_ERROR("read_side_data: cannot open file: " + filename);
-    }
+    Pointer<HDFDatabase> hdf_db = new HDFDatabase(d_object_name + "::hdf_db");
+    hdf_db->open(filename);
 
-    double data_time;
-    int ndim, file_rank, file_iter;
-    ifs.read(reinterpret_cast<char*>(&data_time), sizeof(double));
-    ifs.read(reinterpret_cast<char*>(&ndim), sizeof(int));
-    ifs.read(reinterpret_cast<char*>(&file_rank), sizeof(int));
-    ifs.read(reinterpret_cast<char*>(&file_iter), sizeof(int));
+    const double loop_time = hdf_db->getDouble("time");
 
     const int finest_ln = patch_hierarchy->getFinestLevelNumber();
     for (int ln = 0; ln <= finest_ln; ++ln)
@@ -248,37 +215,52 @@ VelocityCartGridFunction::read_velocity_data(SAMRAI::tbox::Pointer<SAMRAI::hier:
         for (PatchLevel<NDIM>::Iterator p(*level); p; p++)
         {
             Pointer<Patch<NDIM>> patch = level->getPatch(p());
-            Pointer<SideData<NDIM, double>> sd = patch->getPatchData(d_velocity_index);
-
-            auto box = patch->getBox();
-
-            // Read (and discard) the box bounds written by save_side_data.
-            int file_lo, file_hi;
-            for (int d = 0; d < NDIM; ++d)
-            {
-                ifs.read(reinterpret_cast<char*>(&file_lo), sizeof(int));
-                ifs.read(reinterpret_cast<char*>(&file_hi), sizeof(int));
-            }
-
-            for (int axis = 0; axis < NDIM; ++axis)
-            {
-                for (SideIterator<NDIM> s(box, axis); s; s++)
-                {
-                    double val;
-                    ifs.read(reinterpret_cast<char*>(&val), sizeof(double));
-                    (*sd)(*s, 0) = val;
-                }
-            }
+            const std::string key = "patch_data_" + std::to_string(ln) + "_" + std::to_string(p());
+            TBOX_ASSERT(hdf_db->keyExists(key));
+            patch->getPatchData(d_velocity_index)->getFromDatabase(hdf_db->getDatabase(key));
         }
     }
 
-    return data_time;
+    hdf_db->close();
+    return loop_time;
 }
 
 void
 VelocityCartGridFunction::setVelocityIndex(const int velocity_index)
 {
     d_velocity_index = velocity_index;
+}
+
+void
+VelocityCartGridFunction::ensureDirectoryExists(const std::string& dir_path)
+{
+    if (!fileExists(dir_path))
+    {
+        // mode 0755: rwxr-xr-x
+        int status = mkdir(dir_path.c_str(), 0755);
+        TBOX_ASSERT(status == 0 && "VelocityCartGridFunction: failed to create directory");
+    }
+}
+
+bool
+VelocityCartGridFunction::fileExists(const std::string& filename)
+{
+    struct stat buffer;
+    return (stat(filename.c_str(), &buffer) == 0);
+}
+
+std::string
+VelocityCartGridFunction::getIterationDir(int iteration_num) const
+{
+    std::ostringstream oss;
+    oss << d_db_base_name << "/velocity." << std::setfill('0') << std::setw(6) << iteration_num;
+    return oss.str();
+}
+
+std::string
+VelocityCartGridFunction::getIterationFilename(int iteration_num) const
+{
+    return getIterationDir(iteration_num) + "/velocity.hdf5";
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/utilities/VelocityCartGridFunction.cpp
+++ b/src/utilities/VelocityCartGridFunction.cpp
@@ -1,0 +1,288 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2014 - 2026 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibamr/VelocityCartGridFunction.h>
+#include <ibamr/ibamr_utilities.h>
+
+#include <CartesianGridGeometry.h>
+#include <FaceData.h>
+#include <PatchHierarchy.h>
+#include <PatchLevel.h>
+#include <SideData.h>
+
+#include <cmath>
+
+#include <ibamr/namespaces.h>
+
+// FORTRAN ROUTINES
+#if (NDIM == 2)
+#define NAVIER_STOKES_SIDE_TO_FACE_FC IBAMR_FC_FUNC_(navier_stokes_side_to_face2d, NAVIER_STOKES_SIDE_TO_FACE2D)
+#endif
+
+#if (NDIM == 3)
+#define NAVIER_STOKES_SIDE_TO_FACE_FC IBAMR_FC_FUNC_(navier_stokes_side_to_face3d, NAVIER_STOKES_SIDE_TO_FACE3D)
+#endif
+
+extern "C"
+{
+    void NAVIER_STOKES_SIDE_TO_FACE_FC(
+#if (NDIM == 2)
+        const int&,
+        const int&,
+        const int&,
+        const int&,
+        const double*,
+        const double*,
+        const int&,
+        double*,
+        double*,
+        const int&
+#endif
+#if (NDIM == 3)
+        const int&,
+        const int&,
+        const int&,
+        const int&,
+        const int&,
+        const int&,
+        const double*,
+        const double*,
+        const double*,
+        const int&,
+        double*,
+        double*,
+        double*,
+        const int&
+#endif
+    );
+}
+
+// Copy data from a side-centered variable to a face-centered variable.
+void
+copy_side_to_face(const int U_fc_idx, const int U_sc_idx, Pointer<PatchHierarchy<NDIM>> hierarchy)
+{
+    const int coarsest_ln = 0;
+    const int finest_ln = hierarchy->getFinestLevelNumber();
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            const hier::Index<NDIM>& ilower = patch->getBox().lower();
+            const hier::Index<NDIM>& iupper = patch->getBox().upper();
+            Pointer<SideData<NDIM, double>> U_sc_data = patch->getPatchData(U_sc_idx);
+            Pointer<FaceData<NDIM, double>> U_fc_data = patch->getPatchData(U_fc_idx);
+
+#if !defined(NDEBUG)
+            TBOX_ASSERT(U_sc_data->getGhostCellWidth().min() == U_sc_data->getGhostCellWidth().max());
+            TBOX_ASSERT(U_fc_data->getGhostCellWidth().min() == U_fc_data->getGhostCellWidth().max());
+#endif
+            const int U_sc_gcw = U_sc_data->getGhostCellWidth().max();
+            const int U_fc_gcw = U_fc_data->getGhostCellWidth().max();
+            NAVIER_STOKES_SIDE_TO_FACE_FC(ilower(0),
+                                          iupper(0),
+                                          ilower(1),
+                                          iupper(1),
+#if (NDIM == 3)
+                                          ilower(2),
+                                          iupper(2),
+#endif
+                                          U_sc_data->getPointer(0),
+                                          U_sc_data->getPointer(1),
+#if (NDIM == 3)
+                                          U_sc_data->getPointer(2),
+#endif
+                                          U_sc_gcw,
+                                          U_fc_data->getPointer(0),
+                                          U_fc_data->getPointer(1),
+#if (NDIM == 3)
+                                          U_fc_data->getPointer(2),
+#endif
+                                          U_fc_gcw);
+        }
+    }
+    return;
+} // copy_side_to_face
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace IBAMR
+{
+/////////////////////////////// STATIC ///////////////////////////////////////
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+
+VelocityCartGridFunction::VelocityCartGridFunction(const std::string& object_name,
+                                                   Pointer<CartesianGridGeometry<NDIM>> grid_geometry,
+                                                   int velocity_index)
+    : CartGridFunction(object_name), d_grid_geometry(grid_geometry), d_velocity_index(velocity_index)
+{
+}
+
+bool
+VelocityCartGridFunction::isTimeDependent() const
+{
+    return true;
+}
+
+void
+VelocityCartGridFunction::setDataOnPatchHierarchy(const int data_idx,
+                                                  Pointer<Variable<NDIM>> /*var*/,
+                                                  Pointer<PatchHierarchy<NDIM>> hierarchy,
+                                                  const double data_time,
+                                                  const bool /*initial_time*/,
+                                                  int coarsest_ln,
+                                                  int finest_ln)
+{
+    copy_side_to_face(data_idx, d_velocity_index, hierarchy);
+}
+
+void
+VelocityCartGridFunction::setDataOnPatch(const int /*data_idx*/,
+                                         Pointer<Variable<NDIM>> /*var*/,
+                                         Pointer<Patch<NDIM>> /*patch*/,
+                                         const double data_time,
+                                         const bool /*initial_time*/,
+                                         Pointer<PatchLevel<NDIM>> /*patch_level*/)
+{
+}
+
+void
+VelocityCartGridFunction::save_velocity_data(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
+                                             const std::string& base_folder,
+                                             double data_time,
+                                             int iteration)
+{
+    const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    // create base folder and iteration subfolder on rank 0
+    const std::string iter_folder = base_folder + "/" + std::to_string(iteration);
+    if (rank == 0)
+    {
+        mkdir(base_folder.c_str(), 0755);
+        mkdir(iter_folder.c_str(), 0755);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    const std::string filename = iter_folder + "/proc." + std::to_string(rank);
+    std::ofstream ofs(filename, std::ios::binary);
+
+    const int ndim = NDIM;
+    ofs.write(reinterpret_cast<const char*>(&data_time), sizeof(double));
+    ofs.write(reinterpret_cast<const char*>(&ndim), sizeof(int));
+    ofs.write(reinterpret_cast<const char*>(&rank), sizeof(int));
+    ofs.write(reinterpret_cast<const char*>(&iteration), sizeof(int));
+
+    for (int ln = 0; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(*level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            Pointer<SideData<NDIM, double>> sd = patch->getPatchData(d_velocity_index);
+
+            auto box = patch->getBox();
+            auto lo = box.lower();
+            auto hi = box.upper();
+
+            for (int d = 0; d < NDIM; ++d)
+            {
+                const int lo_d = lo(d);
+                const int hi_d = hi(d);
+                ofs.write(reinterpret_cast<const char*>(&lo_d), sizeof(int));
+                ofs.write(reinterpret_cast<const char*>(&hi_d), sizeof(int));
+            }
+
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                for (SideIterator<NDIM> s(box, axis); s; s++)
+                {
+                    double val = (*sd)(*s, 0);
+                    ofs.write(reinterpret_cast<const char*>(&val), sizeof(double));
+                }
+            }
+        }
+    }
+}
+
+double
+VelocityCartGridFunction::read_velocity_data(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> patch_hierarchy,
+                                             const std::string& base_folder,
+                                             int iteration)
+{
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    const std::string filename = base_folder + "/" + std::to_string(iteration) + "/proc." + std::to_string(rank);
+    std::ifstream ifs(filename, std::ios::binary);
+    if (!ifs.is_open())
+    {
+        TBOX_ERROR("read_side_data: cannot open file: " + filename);
+    }
+
+    double data_time;
+    int ndim, file_rank, file_iter;
+    ifs.read(reinterpret_cast<char*>(&data_time), sizeof(double));
+    ifs.read(reinterpret_cast<char*>(&ndim), sizeof(int));
+    ifs.read(reinterpret_cast<char*>(&file_rank), sizeof(int));
+    ifs.read(reinterpret_cast<char*>(&file_iter), sizeof(int));
+
+    const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+    for (int ln = 0; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(*level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            Pointer<SideData<NDIM, double>> sd = patch->getPatchData(d_velocity_index);
+
+            auto box = patch->getBox();
+
+            // Read (and discard) the box bounds written by save_side_data.
+            int file_lo, file_hi;
+            for (int d = 0; d < NDIM; ++d)
+            {
+                ifs.read(reinterpret_cast<char*>(&file_lo), sizeof(int));
+                ifs.read(reinterpret_cast<char*>(&file_hi), sizeof(int));
+            }
+
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                for (SideIterator<NDIM> s(box, axis); s; s++)
+                {
+                    double val;
+                    ifs.read(reinterpret_cast<char*>(&val), sizeof(double));
+                    (*sd)(*s, 0) = val;
+                }
+            }
+        }
+    }
+
+    return data_time;
+}
+
+void
+VelocityCartGridFunction::setVelocityIndex(const int velocity_index)
+{
+    d_velocity_index = velocity_index;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+} // namespace IBAMR
+
+//////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
@boyceg Here is some code to allow for saving a velocity field to a binary file from an IBAMR simulation and then loading the velocity field for a transport solve in a different simulation. There is a lot that should be added here including check to ensure the meshes are identical, support for interpolation between time-steps, etc. But this is just to get it started. 

I added adv_diff/ex9 (ased of of adv_diff/ex_2) just to ensure this works. I am only grabbing the velocity field at time=0 in my example. 

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [ ] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
