### PR TITLE
Get rid of snprintf() et al 

### DIFF
--- a/examples/ConstraintIB/eel2d/example.cpp
+++ b/examples/ConstraintIB/eel2d/example.cpp
@@ -433,9 +433,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -457,8 +455,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/ConstraintIB/eel3d/example.cpp
+++ b/examples/ConstraintIB/eel3d/example.cpp
@@ -308,9 +308,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -332,8 +330,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/ConstraintIB/falling_sphere/example.cpp
+++ b/examples/ConstraintIB/falling_sphere/example.cpp
@@ -328,9 +328,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -352,8 +350,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/ConstraintIB/flow_past_cylinder/example.cpp
+++ b/examples/ConstraintIB/flow_past_cylinder/example.cpp
@@ -396,9 +396,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -420,8 +418,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/ConstraintIB/impulsively_started_cylinder/example.cpp
+++ b/examples/ConstraintIB/impulsively_started_cylinder/example.cpp
@@ -308,9 +308,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -332,8 +330,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/ConstraintIB/knifefish/example.cpp
+++ b/examples/ConstraintIB/knifefish/example.cpp
@@ -308,9 +308,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -332,8 +330,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/ConstraintIB/moving_plate/example.cpp
+++ b/examples/ConstraintIB/moving_plate/example.cpp
@@ -436,9 +436,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -460,8 +458,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/ConstraintIB/oscillating_rigid_cylinder/example.cpp
+++ b/examples/ConstraintIB/oscillating_rigid_cylinder/example.cpp
@@ -308,9 +308,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -332,8 +330,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/ConstraintIB/stokes_first_problem/example.cpp
+++ b/examples/ConstraintIB/stokes_first_problem/example.cpp
@@ -308,9 +308,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -332,8 +330,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/IB/explicit/ex0/example.cpp
+++ b/examples/IB/explicit/ex0/example.cpp
@@ -574,9 +574,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -598,8 +596,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/IB/explicit/ex1/example.cpp
+++ b/examples/IB/explicit/ex1/example.cpp
@@ -312,9 +312,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -336,8 +334,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/IB/explicit/ex3/example.cpp
+++ b/examples/IB/explicit/ex3/example.cpp
@@ -330,9 +330,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -354,8 +352,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/IB/explicit/ex4/example.cpp
+++ b/examples/IB/explicit/ex4/example.cpp
@@ -352,9 +352,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -376,8 +374,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/IB/explicit/ex5/example.cpp
+++ b/examples/IB/explicit/ex5/example.cpp
@@ -333,9 +333,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
         pout << "\nWriting output files at timestep # " << iteration_num << " t=" << loop_time << "\n";
     }
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
 
     // Write Cartesian data.
     if (output_level >= 3)
@@ -364,8 +362,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
         VecDuplicate(X_petsc_vec, &X_lag_vec);
         l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
         file_name = data_dump_dirname + "/" + "X.";
-        std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-        file_name += temp_buf;
+        file_name += generateIterationName(iteration_num);
         PetscViewer viewer;
         PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
         VecView(X_lag_vec, viewer);

--- a/examples/IB/explicit/ex6/example.cpp
+++ b/examples/IB/explicit/ex6/example.cpp
@@ -311,9 +311,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -335,8 +333,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/IBFE/explicit/ex0/example.cpp
+++ b/examples/IBFE/explicit/ex0/example.cpp
@@ -604,9 +604,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -622,13 +620,11 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;
 } // output_data

--- a/examples/IBFE/explicit/ex1/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex1/convergence_tester.cpp
@@ -161,15 +161,11 @@ main(int argc, char* argv[])
         for (; files_exist;
              coarse_iteration_num += coarse_hier_dump_interval, fine_iteration_num += fine_hier_dump_interval)
         {
-            char temp_buf[128];
-
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
             string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
-            coarse_file_name += temp_buf;
+            coarse_file_name += generateSAMRAIName(coarse_iteration_num);
 
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
             string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
-            fine_file_name += temp_buf;
+            fine_file_name += generateSAMRAIName(fine_iteration_num);
 
             for (int rank = 0; rank < IBTK_MPI::getNodes(); ++rank)
             {
@@ -383,30 +379,26 @@ main(int argc, char* argv[])
 
             Mesh mesh_coarse(init.comm(), NDIM);
             file_name = coarse_hier_dump_dirname + "/" + "fe_mesh.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(coarse_iteration_num);
             file_name += ".xda";
             mesh_coarse.read(file_name);
 
             Mesh mesh_fine(init.comm(), NDIM);
             file_name = fine_hier_dump_dirname + "/" + "fe_mesh.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(fine_iteration_num);
             file_name += ".xda";
             mesh_fine.read(file_name);
 
             EquationSystems equation_systems_coarse(mesh_coarse);
             file_name = coarse_hier_dump_dirname + "/" + "fe_equation_systems.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(coarse_iteration_num);
             equation_systems_coarse.read(
                 file_name,
                 (EquationSystems::READ_HEADER | EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA));
 
             EquationSystems equation_systems_fine(mesh_fine);
             file_name = fine_hier_dump_dirname + "/" + "fe_equation_systems.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(fine_iteration_num);
             equation_systems_fine.read(
                 file_name,
                 (EquationSystems::READ_HEADER | EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA));

--- a/examples/IBFE/explicit/ex1/example.cpp
+++ b/examples/IBFE/explicit/ex1/example.cpp
@@ -520,9 +520,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -538,13 +536,11 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;
 } // output_data

--- a/examples/IBFE/explicit/ex2/example.cpp
+++ b/examples/IBFE/explicit/ex2/example.cpp
@@ -469,9 +469,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -487,13 +485,11 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;
 } // output_data

--- a/examples/IBFE/explicit/ex3/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex3/convergence_tester.cpp
@@ -159,15 +159,11 @@ main(int argc, char* argv[])
         for (; files_exist;
              coarse_iteration_num += coarse_hier_dump_interval, fine_iteration_num += fine_hier_dump_interval)
         {
-            char temp_buf[128];
-
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
             string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
-            coarse_file_name += temp_buf;
+            coarse_file_name += generateSAMRAIName(coarse_iteration_num);
 
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
             string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
-            fine_file_name += temp_buf;
+            fine_file_name += generateSAMRAIName(fine_iteration_num);
 
             for (int rank = 0; rank < IBTK_MPI::getNodes(); ++rank)
             {
@@ -381,30 +377,26 @@ main(int argc, char* argv[])
 
             Mesh mesh_coarse(init.comm(), NDIM);
             file_name = coarse_hier_dump_dirname + "/" + "fe_mesh.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(coarse_iteration_num);
             file_name += ".xda";
             mesh_coarse.read(file_name);
 
             Mesh mesh_fine(init.comm(), NDIM);
             file_name = fine_hier_dump_dirname + "/" + "fe_mesh.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(fine_iteration_num);
             file_name += ".xda";
             mesh_fine.read(file_name);
 
             EquationSystems equation_systems_coarse(mesh_coarse);
             file_name = coarse_hier_dump_dirname + "/" + "fe_equation_systems.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(coarse_iteration_num);
             equation_systems_coarse.read(
                 file_name,
                 (EquationSystems::READ_HEADER | EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA));
 
             EquationSystems equation_systems_fine(mesh_fine);
             file_name = fine_hier_dump_dirname + "/" + "fe_equation_systems.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(fine_iteration_num);
             equation_systems_fine.read(
                 file_name,
                 (EquationSystems::READ_HEADER | EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA));

--- a/examples/IBFE/explicit/ex3/example.cpp
+++ b/examples/IBFE/explicit/ex3/example.cpp
@@ -469,9 +469,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -487,13 +485,11 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;
 } // output_data

--- a/examples/IBFE/explicit/ex4/convergence_tester.cpp
+++ b/examples/IBFE/explicit/ex4/convergence_tester.cpp
@@ -160,15 +160,11 @@ main(int argc, char* argv[])
         for (; files_exist;
              coarse_iteration_num += coarse_hier_dump_interval, fine_iteration_num += fine_hier_dump_interval)
         {
-            char temp_buf[128];
-
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
             string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
-            coarse_file_name += temp_buf;
+            coarse_file_name += generateSAMRAIName(coarse_iteration_num);
 
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
             string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
-            fine_file_name += temp_buf;
+            fine_file_name += generateSAMRAIName(fine_iteration_num);
 
             for (int rank = 0; rank < IBTK_MPI::getNodes(); ++rank)
             {
@@ -382,30 +378,26 @@ main(int argc, char* argv[])
 
             Mesh mesh_coarse(init.comm(), NDIM);
             file_name = coarse_hier_dump_dirname + "/" + "fe_mesh.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(coarse_iteration_num);
             file_name += ".xda";
             mesh_coarse.read(file_name);
 
             Mesh mesh_fine(init.comm(), NDIM);
             file_name = fine_hier_dump_dirname + "/" + "fe_mesh.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(fine_iteration_num);
             file_name += ".xda";
             mesh_fine.read(file_name);
 
             EquationSystems equation_systems_coarse(mesh_coarse);
             file_name = coarse_hier_dump_dirname + "/" + "fe_equation_systems.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", coarse_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(coarse_iteration_num);
             equation_systems_coarse.read(
                 file_name,
                 (EquationSystems::READ_HEADER | EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA));
 
             EquationSystems equation_systems_fine(mesh_fine);
             file_name = fine_hier_dump_dirname + "/" + "fe_equation_systems.";
-            std::snprintf(temp_buf, sizeof(temp_buf), "%05d", fine_iteration_num);
-            file_name += temp_buf;
+            file_name += generateIterationName(fine_iteration_num);
             equation_systems_fine.read(
                 file_name,
                 (EquationSystems::READ_HEADER | EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA));

--- a/examples/IBFE/explicit/ex4/example.cpp
+++ b/examples/IBFE/explicit/ex4/example.cpp
@@ -626,9 +626,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -644,13 +642,11 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;
 } // output_data

--- a/examples/IBFE/explicit/ex7/example.cpp
+++ b/examples/IBFE/explicit/ex7/example.cpp
@@ -474,9 +474,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -492,13 +490,11 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;
 } // output_data

--- a/examples/IIM/ex2/example.cpp
+++ b/examples/IIM/ex2/example.cpp
@@ -705,9 +705,10 @@ output_data(tbox::Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
-    file_name += temp_buf;
+    std::ostringstream oss;
+    oss << std::setw(5) << std::setfill('0') << iteration_num << ".samrai." << std::setw(5) << std::setfill('0')
+        << SAMRAI_MPI::getRank();
+    file_name += oss.str();
     tbox::Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/adv_diff/ex8/example.cpp
+++ b/examples/adv_diff/ex8/example.cpp
@@ -938,9 +938,9 @@ compute_T_profile(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     size_array = std::accumulate(&data_size[0], &data_size[0] + nprocs, size_array);
     // Write out the result in a file.
     string file_name = data_dump_dirname + "/" + "temperature_angle_";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%.8f", data_time);
-    file_name += temp_buf;
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(8) << data_time;
+    file_name += oss.str();
     MPI_Status status;
     MPI_Offset mpi_offset;
     MPI_File file;

--- a/examples/complex_fluids/ex0/example.cpp
+++ b/examples/complex_fluids/ex0/example.cpp
@@ -386,9 +386,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/complex_fluids/ex1/example.cpp
+++ b/examples/complex_fluids/ex1/example.cpp
@@ -278,9 +278,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/complex_fluids/ex2/convergence_tester.cpp
+++ b/examples/complex_fluids/ex2/convergence_tester.cpp
@@ -153,15 +153,11 @@ main(int argc, char* argv[])
     for (; files_exist;
          coarse_iteration_num += coarse_hier_dump_interval, fine_iteration_num += fine_hier_dump_interval)
     {
-        char temp_buf[128];
-
-        std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
         string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
-        coarse_file_name += temp_buf;
+        coarse_file_name += generateSAMRAIName(coarse_iteration_num);
 
-        std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
         string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
-        fine_file_name += temp_buf;
+        fine_file_name += generateSAMRAIName(fine_iteration_num);
 
         for (int rank = 0; rank < IBTK_MPI::getNodes(); ++rank)
         {

--- a/examples/complex_fluids/ex2/example.cpp
+++ b/examples/complex_fluids/ex2/example.cpp
@@ -517,9 +517,7 @@ postprocess_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     {
         // Output files
         string file_name = data_dump_dirname + "/hier_data.";
-        char temp_buf[128];
-        std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-        file_name += temp_buf;
+        file_name += generateSAMRAIName(iteration_num);
         Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
         hier_db->create(file_name);
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/complex_fluids/ex3/example.cpp
+++ b/examples/complex_fluids/ex3/example.cpp
@@ -268,9 +268,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/multiphase_flow/ex0/example.cpp
+++ b/examples/multiphase_flow/ex0/example.cpp
@@ -462,9 +462,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/multiphase_flow/ex1/example.cpp
+++ b/examples/multiphase_flow/ex1/example.cpp
@@ -581,9 +581,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -605,8 +603,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/multiphase_flow/ex10/example.cpp
+++ b/examples/multiphase_flow/ex10/example.cpp
@@ -614,9 +614,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -638,8 +636,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/multiphase_flow/ex11/example.cpp
+++ b/examples/multiphase_flow/ex11/example.cpp
@@ -594,9 +594,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -618,8 +616,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/multiphase_flow/ex12/example.cpp
+++ b/examples/multiphase_flow/ex12/example.cpp
@@ -585,9 +585,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -609,8 +607,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/multiphase_flow/ex13/example.cpp
+++ b/examples/multiphase_flow/ex13/example.cpp
@@ -686,9 +686,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -710,8 +708,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/multiphase_flow/ex3/example.cpp
+++ b/examples/multiphase_flow/ex3/example.cpp
@@ -424,9 +424,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/multiphase_flow/ex4/example.cpp
+++ b/examples/multiphase_flow/ex4/example.cpp
@@ -433,9 +433,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/multiphase_flow/ex5/example.cpp
+++ b/examples/multiphase_flow/ex5/example.cpp
@@ -491,9 +491,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/multiphase_flow/ex6/example.cpp
+++ b/examples/multiphase_flow/ex6/example.cpp
@@ -450,9 +450,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/multiphase_flow/ex7/example.cpp
+++ b/examples/multiphase_flow/ex7/example.cpp
@@ -586,9 +586,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -610,8 +608,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/multiphase_flow/ex8/example.cpp
+++ b/examples/multiphase_flow/ex8/example.cpp
@@ -586,9 +586,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -610,8 +608,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/multiphase_flow/ex9/example.cpp
+++ b/examples/multiphase_flow/ex9/example.cpp
@@ -624,9 +624,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -648,8 +646,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/examples/navier_stokes/ex0/example.cpp
+++ b/examples/navier_stokes/ex0/example.cpp
@@ -330,9 +330,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/navier_stokes/ex1/convergence_tester.cpp
+++ b/examples/navier_stokes/ex1/convergence_tester.cpp
@@ -120,15 +120,11 @@ main(int argc, char* argv[])
     for (; files_exist;
          coarse_iteration_num += coarse_hier_dump_interval, fine_iteration_num += fine_hier_dump_interval)
     {
-        char temp_buf[128];
-
-        std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", coarse_iteration_num, IBTK_MPI::getRank());
         string coarse_file_name = coarse_hier_dump_dirname + "/" + "hier_data.";
-        coarse_file_name += temp_buf;
+        coarse_file_name += generateSAMRAIName(coarse_iteration_num);
 
-        std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", fine_iteration_num, IBTK_MPI::getRank());
         string fine_file_name = fine_hier_dump_dirname + "/" + "hier_data.";
-        fine_file_name += temp_buf;
+        fine_file_name += generateSAMRAIName(fine_iteration_num);
 
         for (int rank = 0; rank < IBTK_MPI::getNodes(); ++rank)
         {

--- a/examples/navier_stokes/ex1/example.cpp
+++ b/examples/navier_stokes/ex1/example.cpp
@@ -257,9 +257,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/navier_stokes/ex2/example.cpp
+++ b/examples/navier_stokes/ex2/example.cpp
@@ -257,9 +257,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/navier_stokes/ex3/example.cpp
+++ b/examples/navier_stokes/ex3/example.cpp
@@ -258,9 +258,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/vc_navier_stokes/ex0/example.cpp
+++ b/examples/vc_navier_stokes/ex0/example.cpp
@@ -387,9 +387,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/vc_navier_stokes/ex1/example.cpp
+++ b/examples/vc_navier_stokes/ex1/example.cpp
@@ -448,9 +448,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/vc_navier_stokes/ex2/example.cpp
+++ b/examples/vc_navier_stokes/ex2/example.cpp
@@ -440,9 +440,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/wave_tank/ex0/example.cpp
+++ b/examples/wave_tank/ex0/example.cpp
@@ -645,9 +645,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/examples/wave_tank/ex1/example.cpp
+++ b/examples/wave_tank/ex1/example.cpp
@@ -693,9 +693,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -717,8 +715,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/ibtk/contrib/boost/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/ibtk/contrib/boost/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -32,6 +32,8 @@
 #include <string>
 #include <cstring>
 #include <cstdio>
+#include <iomanip>
+#include <algorithm>
 #include <boost/limits.hpp>
 #include <boost/type_traits/conditional.hpp>
 #include <boost/type_traits/is_pointer.hpp>
@@ -278,38 +280,68 @@ namespace boost {
             bool shl_real_type(float val, char* begin) {
                 using namespace std;
                 const double val_as_double = val;
-                finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
-                    sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin,
-#endif
-                    "%.*g", static_cast<int>(boost::detail::lcast_get_precision<float>()), val_as_double);
+                
+                ostringstream oss;
+                oss << setprecision(static_cast<int>(boost::detail::lcast_get_precision<float>()))
+                    << val_as_double;
+
+                if (oss.fail())
+                    return false;
+
+                string str = oss.str();
+
+                if (str.size() >= CharacterBufferSize)
+                    return false;
+
+                copy(str.begin(), str.end(), begin);
+                begin[str.size()] = '\0';
+
+                finish = start + str.size();
                 return finish > start;
             }
 
             bool shl_real_type(double val, char* begin) {
                 using namespace std;
-                finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
-                    sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin,
-#endif
-                    "%.*g", static_cast<int>(boost::detail::lcast_get_precision<double>()), val);
+
+                ostringstream oss;
+                oss << setprecision(static_cast<int>(boost::detail::lcast_get_precision<double>()))
+                    << val;
+
+                if (oss.fail())
+                    return false;
+
+                string str = oss.str();
+
+                if (str.size() >= CharacterBufferSize)
+                    return false;
+
+                copy(str.begin(), str.end(), begin);
+                begin[str.size()] = '\0';
+
+                finish = start + str.size();
                 return finish > start;
             }
 
 #ifndef __MINGW32__
             bool shl_real_type(long double val, char* begin) {
                 using namespace std;
-                finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
-                    sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin,
-#endif
-                    "%.*Lg", static_cast<int>(boost::detail::lcast_get_precision<long double>()), val );
+
+                ostringstream oss;
+                oss << setprecision(static_cast<int>(boost::detail::lcast_get_precision<long double>()))
+                    << val;
+
+                if (oss.fail())
+                    return false;
+
+                string str = oss.str();
+
+                if (str.size() >= CharacterBufferSize)
+                    return false;
+
+                copy(str.begin(), str.end(), begin);
+                begin[str.size()] = '\0';
+
+                finish = start + str.size();
                 return finish > start;
             }
 #endif

--- a/ibtk/contrib/muparser/src/muParserDLL.cpp
+++ b/ibtk/contrib/muparser/src/muParserDLL.cpp
@@ -208,7 +208,10 @@ API_EXPORT(const muChar_t*) mupGetVersion(muParserHandle_t a_hParser)
 		muParser_t* const p(AsParser(a_hParser));
 
 #ifndef _UNICODE
-		snprintf(s_tmpOutBuf, count_of(s_tmpOutBuf), "%s", p->GetVersion().c_str());
+		std::string version = p->GetVersion();
+		std::size_t versionSize = std::min(version.size(), count_of(s_tmpOutBuf) - 1);
+		std::copy_n(version.begin(), versionSize, s_tmpOutBuf);
+		s_tmpOutBuf[versionSize] = '\0';
 #else
 		swprintf(s_tmpOutBuf, count_of(s_tmpOutBuf), _T("%s"), p->GetVersion().c_str());
 #endif
@@ -875,7 +878,10 @@ API_EXPORT(const muChar_t*) mupGetExpr(muParserHandle_t a_hParser)
 		// C# explodes when pMsg is returned directly. For some reason it can't access
 		// the memory where the message lies directly.
 #ifndef _UNICODE
-		snprintf(s_tmpOutBuf, count_of(s_tmpOutBuf), "%s", p->GetExpr().c_str());
+		std::string expression = p->GetExpr();
+		std::size_t expressionSize = std::min(expression.size(), count_of(s_tmpOutBuf) - 1);
+		std::copy_n(expression.begin(), expressionSize, s_tmpOutBuf);
+		s_tmpOutBuf[expressionSize] = '\0';
 #else
 		swprintf(s_tmpOutBuf, count_of(s_tmpOutBuf), _T("%s"), p->GetExpr().c_str());
 #endif
@@ -1212,7 +1218,10 @@ API_EXPORT(const muChar_t*) mupGetErrorMsg(muParserHandle_t a_hParser)
 	// C# explodes when pMsg is returned directly. For some reason it can't access
 	// the memory where the message lies directly.
 #ifndef _UNICODE
-	snprintf(s_tmpOutBuf, count_of(s_tmpOutBuf), "%s", pMsg);
+	std::string_view message = pMsg;
+	std::size_t messageSize = std::min(message.size(), count_of(s_tmpOutBuf) - 1);
+	std::copy_n(message.begin(), messageSize, s_tmpOutBuf);
+	s_tmpOutBuf[messageSize] = '\0';
 #else
 	swprintf(s_tmpOutBuf, count_of(s_tmpOutBuf), _T("%s"), pMsg);
 #endif
@@ -1230,7 +1239,10 @@ API_EXPORT(const muChar_t*) mupGetErrorToken(muParserHandle_t a_hParser)
 	// C# explodes when pMsg is returned directly. For some reason it can't access
 	// the memory where the message lies directly.
 #ifndef _UNICODE
-	snprintf(s_tmpOutBuf, count_of(s_tmpOutBuf), "%s", pToken);
+	std::string_view token = pToken;
+	std::size_t tokenSize = std::min(token.size(), count_of(s_tmpOutBuf) - 1);
+	std::copy_n(token.begin(), tokenSize, s_tmpOutBuf);
+	s_tmpOutBuf[tokenSize] = '\0';
 #else
 	swprintf(s_tmpOutBuf, count_of(s_tmpOutBuf), _T("%s"), pToken);
 #endif

--- a/ibtk/include/ibtk/ibtk_utilities.h
+++ b/ibtk/include/ibtk/ibtk_utilities.h
@@ -20,6 +20,8 @@
 
 #include <ibtk/config.h>
 
+#include <ibtk/IBTK_MPI.h>
+
 #include <tbox/MathUtilities.h>
 #include <tbox/PIO.h>
 #include <tbox/Pointer.h>
@@ -35,6 +37,9 @@ IBTK_ENABLE_EXTRA_WARNINGS
 
 #include <algorithm>
 #include <array>
+#include <iomanip>
+#include <sstream>
+#include <string>
 #include <utility>
 
 /////////////////////////////// MACRO DEFINITIONS ////////////////////////////
@@ -406,6 +411,28 @@ checked_dereference(SAMRAI::tbox::Pointer<T>& p)
     TBOX_ASSERT(p);
 #endif
     return *p;
+}
+
+/*!
+ * Generate a name for SAMRAI data files.
+ */
+inline std::string
+generateSAMRAIName(const int iteration_num)
+{
+    std::ostringstream oss;
+    oss << std::setw(5) << std::setfill('0') << iteration_num << ".samrai." << std::setw(5) << IBTK_MPI::getRank();
+    return oss.str();
+}
+
+/*!
+ * Generate a name for iteration data files.
+ */
+inline std::string
+generateIterationName(const int iteration_num)
+{
+    std::ostringstream oss;
+    oss << std::setw(5) << std::setfill('0') << iteration_num;
+    return oss.str();
 }
 
 } // namespace IBTK

--- a/ibtk/src/lagrangian/LSiloDataWriter.cpp
+++ b/ibtk/src/lagrangian/LSiloDataWriter.cpp
@@ -1194,7 +1194,6 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
     }
 
     int ierr;
-    char temp_buf[SILO_NAME_BUFSIZE];
     std::string current_file_name;
     DBfile* dbfile;
     const int mpi_rank = IBTK_MPI::getRank();
@@ -1211,16 +1210,23 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
     }
 
     // Create the working directory.
-    std::snprintf(temp_buf, sizeof(temp_buf), "%06d", d_time_step_number);
-    std::string current_dump_directory_name = SILO_DUMP_DIR_PREFIX + temp_buf;
+    std::string current_dump_directory_name;
+    {
+        std::ostringstream oss;
+        oss << std::setw(6) << std::setfill('0') << d_time_step_number;
+        current_dump_directory_name = SILO_DUMP_DIR_PREFIX + oss.str();
+    }
     std::string dump_dirname = d_dump_directory_name + "/" + current_dump_directory_name;
 
     Utilities::recursiveMkdir(dump_dirname);
 
     // Create one local DBfile per MPI process.
-    std::snprintf(temp_buf, sizeof(temp_buf), "%04d", mpi_rank);
     current_file_name = dump_dirname + "/" + SILO_PROCESSOR_FILE_PREFIX;
-    current_file_name += temp_buf;
+    {
+        std::ostringstream oss;
+        oss << std::setw(4) << std::setfill('0') << mpi_rank;
+        current_file_name += oss.str();
+    }
     current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
     if (!(dbfile = DBCreate(current_file_name.c_str(), DB_CLOBBER, DB_LOCAL, nullptr, DB_PDB)))
@@ -1710,9 +1716,13 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
     {
         // Create and initialize the multimesh Silo database on the root MPI
         // process.
-        std::snprintf(temp_buf, sizeof(temp_buf), "%06d", d_time_step_number);
-        std::string summary_file_name =
-            dump_dirname + "/" + SILO_SUMMARY_FILE_PREFIX + temp_buf + SILO_SUMMARY_FILE_POSTFIX;
+        std::string summary_file_name;
+        {
+            std::ostringstream oss;
+            oss << std::setw(6) << std::setfill('0') << d_time_step_number;
+            summary_file_name = dump_dirname + "/" + SILO_SUMMARY_FILE_PREFIX + oss.str() + SILO_SUMMARY_FILE_POSTFIX;
+        }
+
         if (!(dbfile = DBCreate(summary_file_name.c_str(), DB_CLOBBER, DB_LOCAL, nullptr, DB_PDB)))
         {
             TBOX_ERROR(d_object_name << "::writePlotData()\n"
@@ -1731,13 +1741,15 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
 
         for (int proc = 0; proc < mpi_nodes; ++proc)
         {
+            std::ostringstream oss;
+            oss << std::setw(4) << std::setfill('0') << proc;
+            const std::string proc_str = oss.str();
             for (int ln = d_coarsest_ln; ln <= d_finest_ln; ++ln)
             {
                 for (int cloud = 0; cloud < nclouds_per_proc[ln][proc]; ++cloud)
                 {
-                    std::snprintf(temp_buf, sizeof(temp_buf), "%04d", proc);
                     current_file_name = SILO_PROCESSOR_FILE_PREFIX;
-                    current_file_name += temp_buf;
+                    current_file_name += proc_str;
                     current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
                     std::string meshname = current_file_name + ":level_" + std::to_string(ln) + "_cloud_" +
@@ -1758,9 +1770,8 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
 
                 for (int block = 0; block < nblocks_per_proc[ln][proc]; ++block)
                 {
-                    std::snprintf(temp_buf, sizeof(temp_buf), "%04d", proc);
                     current_file_name = SILO_PROCESSOR_FILE_PREFIX;
-                    current_file_name += temp_buf;
+                    current_file_name += proc_str;
                     current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
                     std::string meshname = current_file_name + ":level_" + std::to_string(ln) + "_block_" +
@@ -1781,9 +1792,8 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
 
                 for (int mb = 0; mb < nmbs_per_proc[ln][proc]; ++mb)
                 {
-                    std::snprintf(temp_buf, sizeof(temp_buf), "%04d", proc);
                     current_file_name = SILO_PROCESSOR_FILE_PREFIX;
-                    current_file_name += temp_buf;
+                    current_file_name += proc_str;
                     current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
                     const int nblocks = mb_nblocks_per_proc[ln][proc][mb];
@@ -1817,9 +1827,8 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
 
                 for (int mesh = 0; mesh < nucd_meshes_per_proc[ln][proc]; ++mesh)
                 {
-                    std::snprintf(temp_buf, sizeof(temp_buf), "%04d", proc);
                     current_file_name = SILO_PROCESSOR_FILE_PREFIX;
-                    current_file_name += temp_buf;
+                    current_file_name += proc_str;
                     current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
                     std::string meshname =
@@ -1842,9 +1851,8 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
                 {
                     for (int cloud = 0; cloud < nclouds_per_proc[ln][proc]; ++cloud)
                     {
-                        std::snprintf(temp_buf, sizeof(temp_buf), "%04d", proc);
                         current_file_name = SILO_PROCESSOR_FILE_PREFIX;
-                        current_file_name += temp_buf;
+                        current_file_name += proc_str;
                         current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
                         std::string varname = current_file_name + ":level_" + std::to_string(ln) + "_cloud_" +
@@ -1861,9 +1869,8 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
 
                     for (int block = 0; block < nblocks_per_proc[ln][proc]; ++block)
                     {
-                        std::snprintf(temp_buf, sizeof(temp_buf), "%04d", proc);
                         current_file_name = SILO_PROCESSOR_FILE_PREFIX;
-                        current_file_name += temp_buf;
+                        current_file_name += proc_str;
                         current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
                         std::string varname = current_file_name + ":level_" + std::to_string(ln) + "_block_" +
@@ -1880,9 +1887,8 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
 
                     for (int mb = 0; mb < nmbs_per_proc[ln][proc]; ++mb)
                     {
-                        std::snprintf(temp_buf, sizeof(temp_buf), "%04d", proc);
                         current_file_name = SILO_PROCESSOR_FILE_PREFIX;
-                        current_file_name += temp_buf;
+                        current_file_name += proc_str;
                         current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
                         const int nblocks = mb_nblocks_per_proc[ln][proc][mb];
@@ -1914,9 +1920,8 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
 
                     for (int mesh = 0; mesh < nucd_meshes_per_proc[ln][proc]; ++mesh)
                     {
-                        std::snprintf(temp_buf, sizeof(temp_buf), "%04d", proc);
                         current_file_name = SILO_PROCESSOR_FILE_PREFIX;
-                        current_file_name += temp_buf;
+                        current_file_name += proc_str;
                         current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
                         std::string varname = current_file_name + ":level_" + std::to_string(ln) + "_mesh_" +
@@ -1939,9 +1944,12 @@ LSiloDataWriter::writePlotData(const int time_step_number, const double simulati
 
         // Create or update the dumps file on the root MPI process.
         std::string path = d_dump_directory_name + "/" + VISIT_DUMPS_FILENAME;
-        std::snprintf(temp_buf, sizeof(temp_buf), "%06d", d_time_step_number);
-        std::string file =
-            current_dump_directory_name + "/" + SILO_SUMMARY_FILE_PREFIX + temp_buf + SILO_SUMMARY_FILE_POSTFIX;
+        std::string file;
+        {
+            std::ostringstream oss;
+            oss << std::setw(6) << std::setfill('0') << d_time_step_number;
+            file = current_dump_directory_name + "/" + SILO_SUMMARY_FILE_PREFIX + oss.str() + SILO_SUMMARY_FILE_POSTFIX;
+        }
         if (!d_summary_file_opened)
         {
             d_summary_file_opened = true;

--- a/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
+++ b/src/IB/IBHydrodynamicSurfaceForceEvaluator.cpp
@@ -224,6 +224,11 @@ IBHydrodynamicSurfaceForceEvaluator::computeHydrodynamicForceTorque(IBTK::Vector
                    << " Forces are evalauted at only current or new time. \n");
     }
 
+    // Get the side weight patch data index that contains the correct volume element for each side-centered degree of
+    // freedom. This is used to compute the area element for each side-centered DoF.
+    Pointer<HierarchyMathOps> hierarchy_math_ops = d_fluid_solver->getHierarchyMathOps();
+    const int wgt_sc_idx = hierarchy_math_ops->getSideWeightPatchDescriptorIndex();
+
     // Allocate required patch data
     Pointer<PatchHierarchy<NDIM>> patch_hierarchy = d_fluid_solver->getPatchHierarchy();
     const int coarsest_ln = 0;
@@ -263,13 +268,12 @@ IBHydrodynamicSurfaceForceEvaluator::computeHydrodynamicForceTorque(IBTK::Vector
             const Box<NDIM>& patch_box = patch->getBox();
             const Pointer<CartesianPatchGeometry<NDIM>> patch_geom = patch->getPatchGeometry();
             const double* const patch_dx = patch_geom->getDx();
-            double cell_vol = 1.0;
-            for (unsigned int d = 0; d < NDIM; ++d) cell_vol *= patch_dx[d];
 
             // Get the required patch data
             Pointer<CellData<NDIM, double>> ls_solid_data = patch->getPatchData(d_ls_solid_idx);
             Pointer<SideData<NDIM, double>> u_data = patch->getPatchData(d_u_idx);
             Pointer<CellData<NDIM, double>> p_data = patch->getPatchData(d_p_idx);
+            Pointer<SideData<NDIM, double>> wgt_sc_data = patch->getPatchData(wgt_sc_idx);
             Pointer<CellData<NDIM, double>> mu_data;
             if (!d_mu_is_const) mu_data = patch->getPatchData(d_mu_idx);
 
@@ -277,9 +281,6 @@ IBHydrodynamicSurfaceForceEvaluator::computeHydrodynamicForceTorque(IBTK::Vector
 
             for (unsigned int axis = 0; axis < NDIM; ++axis)
             {
-                // Compute the required area element
-                const double dS = cell_vol / patch_dx[axis];
-
                 for (Box<NDIM>::Iterator it(SideGeometry<NDIM>::toSideBox(patch_box, axis)); it; it++)
                 {
                     SideIndex<NDIM> s_i(it(), axis, SideIndex<NDIM>::Lower);
@@ -290,6 +291,9 @@ IBHydrodynamicSurfaceForceEvaluator::computeHydrodynamicForceTorque(IBTK::Vector
 
                     // If not within a band near the body, do not use this cell in the force calculation
                     if ((phi_lower - d_surface_contour_value) * (phi_upper - d_surface_contour_value) >= 0.0) continue;
+
+                    // Compute the required area element
+                    const double dS = (*wgt_sc_data)(s_i) / patch_dx[axis];
 
                     // Compute the required unit normal
                     IBTK::Vector3d n = IBTK::Vector3d::Zero();

--- a/src/IB/IBInstrumentPanel.cpp
+++ b/src/IB/IBInstrumentPanel.cpp
@@ -1203,23 +1203,25 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
                                  << "  dump directory name is empty" << std::endl);
     }
 
-    char temp_buf[SILO_NAME_BUFSIZE];
     std::string current_file_name;
     DBfile* dbfile;
     const int mpi_rank = IBTK_MPI::getRank();
     const int mpi_nodes = IBTK_MPI::getNodes();
 
     // Create the working directory.
-    snprintf(temp_buf, sizeof(temp_buf), "%06d", d_instrument_read_timestep_num);
-    std::string current_dump_directory_name = SILO_DUMP_DIR_PREFIX + temp_buf;
+    std::ostringstream oss;
+    oss << std::setw(6) << std::setfill('0') << d_instrument_read_timestep_num;
+    std::string current_dump_directory_name = SILO_DUMP_DIR_PREFIX + oss.str();
     std::string dump_dirname = d_plot_directory_name + "/" + current_dump_directory_name;
 
     Utilities::recursiveMkdir(dump_dirname);
 
     // Create one local DBfile per MPI process.
-    snprintf(temp_buf, sizeof(temp_buf), "%04d", mpi_rank);
+    oss.str("");
+    oss.clear();
+    oss << std::setw(4) << std::setfill('0') << mpi_rank;
     current_file_name = dump_dirname + "/" + SILO_PROCESSOR_FILE_PREFIX;
-    current_file_name += temp_buf;
+    current_file_name += oss.str();
     current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
     if (!(dbfile = DBCreate(current_file_name.c_str(), DB_CLOBBER, DB_LOCAL, nullptr, DB_PDB)))
@@ -1249,9 +1251,11 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
     {
         // Create and initialize the multimesh Silo database on the root MPI
         // process.
-        snprintf(temp_buf, sizeof(temp_buf), "%06d", d_instrument_read_timestep_num);
+        oss.str("");
+        oss.clear();
+        oss << std::setw(6) << std::setfill('0') << d_instrument_read_timestep_num;
         std::string summary_file_name =
-            dump_dirname + "/" + SILO_SUMMARY_FILE_PREFIX + temp_buf + SILO_SUMMARY_FILE_POSTFIX;
+            dump_dirname + "/" + SILO_SUMMARY_FILE_PREFIX + oss.str() + SILO_SUMMARY_FILE_POSTFIX;
         if (!(dbfile = DBCreate(summary_file_name.c_str(), DB_CLOBBER, DB_LOCAL, nullptr, DB_PDB)))
         {
             TBOX_ERROR(d_object_name + "::writePlotData():\n"
@@ -1271,9 +1275,11 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
         for (unsigned int meter = 0; meter < d_num_meters; ++meter)
         {
             const int proc = meter % mpi_nodes;
-            snprintf(temp_buf, sizeof(temp_buf), "%04d", proc);
+            oss.str("");
+            oss.clear();
+            oss << std::setw(4) << std::setfill('0') << proc;
             current_file_name = SILO_PROCESSOR_FILE_PREFIX;
-            current_file_name += temp_buf;
+            current_file_name += oss.str();
             current_file_name += SILO_PROCESSOR_FILE_POSTFIX;
 
             std::string meshname = current_file_name + ":" + d_instrument_names[meter] + "/mesh";
@@ -1304,9 +1310,11 @@ IBInstrumentPanel::writePlotData(const int timestep_num, const double simulation
         // Create or update the dumps file on the root MPI process.
         static bool summary_file_opened = false;
         std::string path = d_plot_directory_name + "/" + VISIT_DUMPS_FILENAME;
-        snprintf(temp_buf, sizeof(temp_buf), "%06d", d_instrument_read_timestep_num);
+        oss.str("");
+        oss.clear();
+        oss << std::setw(6) << std::setfill('0') << d_instrument_read_timestep_num;
         std::string file =
-            current_dump_directory_name + "/" + SILO_SUMMARY_FILE_PREFIX + temp_buf + SILO_SUMMARY_FILE_POSTFIX;
+            current_dump_directory_name + "/" + SILO_SUMMARY_FILE_PREFIX + oss.str() + SILO_SUMMARY_FILE_POSTFIX;
         if (!summary_file_opened)
         {
             summary_file_opened = true;

--- a/tests/ConstraintIB/oscillating_rigid_cylinder.cpp
+++ b/tests/ConstraintIB/oscillating_rigid_cylinder.cpp
@@ -377,9 +377,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -401,8 +399,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/tests/IB/explicit_ex1.cpp
+++ b/tests/IB/explicit_ex1.cpp
@@ -332,9 +332,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -356,8 +354,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/tests/IBFE/explicit_ex0.cpp
+++ b/tests/IBFE/explicit_ex0.cpp
@@ -606,9 +606,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -624,13 +622,11 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;
 } // output_data

--- a/tests/IBFE/explicit_ex1.cpp
+++ b/tests/IBFE/explicit_ex1.cpp
@@ -554,9 +554,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -572,13 +570,11 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;
 } // output_data

--- a/tests/IBFE/explicit_ex2.cpp
+++ b/tests/IBFE/explicit_ex2.cpp
@@ -492,9 +492,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -510,13 +508,11 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Lagrangian data.
     file_name = data_dump_dirname + "/" + "fe_mesh.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     file_name += ".xda";
     mesh.write(file_name);
     file_name = data_dump_dirname + "/" + "fe_equation_systems.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     equation_systems->write(file_name, (EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA));
     return;
 } // output_data

--- a/tests/IIM/hagen_poiseuille_flow.cpp
+++ b/tests/IIM/hagen_poiseuille_flow.cpp
@@ -728,9 +728,10 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, SAMRAI_MPI::getRank());
-    file_name += temp_buf;
+    std::ostringstream oss;
+    oss << std::setw(5) << std::setfill('0') << iteration_num << ".samrai." << std::setw(5) << std::setfill('0')
+        << SAMRAI_MPI::getRank();
+    file_name += oss.str();
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/tests/IIM/taylor_couette_2d.cpp
+++ b/tests/IIM/taylor_couette_2d.cpp
@@ -1080,9 +1080,9 @@ compute_velocity_profile(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write out the result in a file.
     string file_name = data_dump_dirname + "/" + "u_y_";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%.8f", data_time);
-    file_name += temp_buf;
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(8) << data_time;
+    file_name += oss.str();
 
     MPI_Status status;
     MPI_Offset mpi_offset;
@@ -1201,9 +1201,9 @@ compute_pressure_profile(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write out the result in a file.
     string file_name = data_dump_dirname + "/" + "p_";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%.8f", data_time);
-    file_name += temp_buf;
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(8) << data_time;
+    file_name += oss.str();
 
     MPI_Status status;
     MPI_Offset mpi_offset;

--- a/tests/multiphase_flow/check_hydro_force.amr.mpirun=2.input
+++ b/tests/multiphase_flow/check_hydro_force.amr.mpirun=2.input
@@ -1,0 +1,512 @@
+// physical parameters
+PI         = 3.1416
+MU_F       = 1.8e-5
+MU_G       = 1.8e-5
+RHO_F      = 1.0
+RHO_S      = 1.0
+RHO_G      = 1.0
+
+// Optional flag to set viscosity in the solid region
+SET_MU_S = TRUE
+MU_S     = MU_F
+
+// Ambient parameters that are used in constant case
+MU  = MU_G
+RHO = RHO_F
+
+// Solid and gas level set parameters
+R           = 0.1
+D           = 2.0*R
+HEIGHT      = 2.0
+LENGTH      = 0.5
+GAS_LS_INIT = 1.85
+XCOM        = LENGTH/2.0
+YCOM        = 1.0
+
+// grid spacing parameters
+MAX_LEVELS       = 2
+REF_RATIO        = 4
+REF_RATIO_FINEST = 4
+N                = 50
+NFINEST          = (REF_RATIO^(MAX_LEVELS - 1))*N
+H_COARSEST       = LENGTH/N
+H                = LENGTH/NFINEST
+Nx               = N
+Ny               = 4*N
+
+// Parameters for setting rho and mu
+NUM_SOLID_INTERFACE_CELLS = 2.0
+NUM_GAS_INTERFACE_CELLS   = 2.0
+
+
+// Level set option parameters
+LS_ORDER              = "THIRD_ORDER_ENO"
+LS_ABS_TOL            = 1.0e-8
+LS_REINIT_INTERVAL    = 1
+MAX_ITERATIONS        = 50
+LS_TAG_VALUE          = 0.0
+LS_TAG_ABS_THRESH     = 2*H_COARSEST
+APPLY_SIGN_FIX        = TRUE
+APPLY_SUBCELL_FIX     = TRUE
+APPLY_MASS_CONSTRAINT = FALSE
+
+
+VelocityInitialConditions {
+   function_0 = "0.0"
+   function_1 = "0.0"
+}
+
+PressureInitialConditions {
+    L        = LENGTH
+    function = "L - X1"
+}
+
+
+VelocityBcCoefs_0 {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+VelocityBcCoefs_1 {
+   acoef_function_0 = "1.0"
+   acoef_function_1 = "1.0"
+   acoef_function_2 = "1.0"
+   acoef_function_3 = "1.0"
+
+   bcoef_function_0 = "0.0"
+   bcoef_function_1 = "0.0"
+   bcoef_function_2 = "0.0"
+   bcoef_function_3 = "0.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+DensityBcCoefs {
+   acoef_function_0 = "0.0"
+   acoef_function_1 = "0.0"
+   acoef_function_2 = "0.0"
+   acoef_function_3 = "0.0"
+
+   bcoef_function_0 = "1.0"
+   bcoef_function_1 = "1.0"
+   bcoef_function_2 = "1.0"
+   bcoef_function_3 = "1.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+ViscosityBcCoefs {
+   acoef_function_0 = "0.0"
+   acoef_function_1 = "0.0"
+   acoef_function_2 = "0.0"
+   acoef_function_3 = "0.0"
+
+   bcoef_function_0 = "1.0"
+   bcoef_function_1 = "1.0"
+   bcoef_function_2 = "1.0"
+   bcoef_function_3 = "1.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+PhiBcCoefs {
+   acoef_function_0 = "0.0"
+   acoef_function_1 = "0.0"
+   acoef_function_2 = "0.0"
+   acoef_function_3 = "0.0"
+
+   bcoef_function_0 = "1.0"
+   bcoef_function_1 = "1.0"
+   bcoef_function_2 = "1.0"
+   bcoef_function_3 = "1.0"
+
+   gcoef_function_0 = "0.0"
+   gcoef_function_1 = "0.0"
+   gcoef_function_2 = "0.0"
+   gcoef_function_3 = "0.0"
+}
+
+
+// Simulation Parameters
+DELTA_FUNCTION       = "IB_4"
+SOLVER_TYPE          = "STAGGERED"
+DISCRETIZATION_FORM  = "CONSERVATIVE"
+START_TIME           =   0.0e0
+END_TIME             =   10.0e0
+GROW_DT              =   2.0e0
+MAX_INTEGRATOR_STEPS =   10000000
+CFL_MAX              =   0.5
+NUM_INS_CYCLES       =   2
+NON_CONSERVATIVE_CONVECTIVE_OP_TYPE = "CUI"
+CONVECTIVE_FORM      = "CONSERVATIVE"                // how to compute the convective terms
+INIT_CONVECTIVE_TS_TYPE = "MIDPOINT_RULE"
+CONVECTIVE_TS_TYPE = "MIDPOINT_RULE"    // convective time stepping type
+NORMALIZE_PRESSURE   = TRUE
+VORTICITY_TAGGING    = TRUE
+TAG_BUFFER           = 2
+REGRID_CFL_INTERVAL  = 0.2
+DT_MAX               = 1.0e-3
+OUTPUT_U             = TRUE
+OUTPUT_P             = TRUE
+OUTPUT_F             = TRUE
+OUTPUT_OMEGA         = TRUE
+OUTPUT_DIV_U         = TRUE
+OUTPUT_RHO           = TRUE
+OUTPUT_MU            = TRUE
+RHO_IS_CONST         = FALSE
+MU_IS_CONST          = FALSE
+ERROR_ON_DT_CHANGE   = FALSE
+
+// Application
+PRECOND_REINIT_INTERVAL      = 1
+VC_INTERPOLATION_TYPE        = "VC_HARMONIC_INTERP"
+DENSITY_CONVECTIVE_LIMITER   = "CUI"
+VELOCITY_CONVECTIVE_LIMITER  = "CUI"
+DENSITY_TS                   = "SSPRK3"
+OPERATOR_SCALE_FACTORS       =   1.0
+EXPLICITLY_REMOVE_NULLSPACE  = FALSE
+ENABLE_LOGGING               = TRUE
+
+// AdvDiff solver parameters
+ADV_DIFF_SOLVER_TYPE        = "SEMI_IMPLICIT"   // the advection-diffusion solver to use (PREDICTOR_CORRECTOR or SEMI_IMPLICIT)
+ADV_DIFF_NUM_CYCLES         = 2                 // number of cycles of fixed-point iteration
+ADV_DIFF_CONVECTIVE_TS_TYPE = "MIDPOINT_RULE" // convective time stepping type
+ADV_DIFF_CONVECTIVE_OP_TYPE = "PPM"             // convective differencing discretization type
+ADV_DIFF_CONVECTIVE_FORM    = "CONSERVATIVE"       // how to compute the convective terms
+
+
+INSVCStaggeredConservativeHierarchyIntegrator {
+   start_time                 = START_TIME
+   end_time                   = END_TIME
+   grow_dt                    = GROW_DT
+   convective_difference_form = CONVECTIVE_FORM
+   normalize_pressure         = NORMALIZE_PRESSURE
+   cfl                        = CFL_MAX
+   dt_max                     = DT_MAX
+   using_vorticity_tagging    = VORTICITY_TAGGING
+   vorticity_rel_thresh       = 0.25
+   tag_buffer                 = TAG_BUFFER
+   regrid_cfl_interval        = REGRID_CFL_INTERVAL
+   output_U                   = OUTPUT_U
+   output_P                   = OUTPUT_P
+   output_F                   = OUTPUT_F
+   output_Omega               = OUTPUT_OMEGA
+   output_Div_U               = OUTPUT_DIV_U
+   output_rho                 = OUTPUT_RHO
+   output_mu                  = OUTPUT_MU
+   rho_is_const               = RHO_IS_CONST
+   mu_is_const                = MU_IS_CONST
+   precond_reinit_interval    = PRECOND_REINIT_INTERVAL
+   operator_scale_factors     = OPERATOR_SCALE_FACTORS
+   vc_interpolation_type      = VC_INTERPOLATION_TYPE
+   enable_logging             = ENABLE_LOGGING
+   max_integrator_steps       = MAX_INTEGRATOR_STEPS
+   explicitly_remove_nullspace= EXPLICITLY_REMOVE_NULLSPACE
+   num_cycles                 = NUM_INS_CYCLES
+
+   // Solver parameters
+   velocity_solver_type = "VC_VELOCITY_PETSC_KRYLOV_SOLVER"
+   velocity_precond_type = "VC_VELOCITY_POINT_RELAXATION_FAC_PRECONDITIONER"
+   velocity_solver_db {
+      ksp_type = "richardson"
+      max_iterations = 5
+      rel_residual_tol = 1.0e-2
+   }
+   velocity_precond_db {
+      num_pre_sweeps = 0
+      num_post_sweeps = 3
+      prolongation_method = "CONSERVATIVE_LINEAR_REFINE"
+      restriction_method = "CONSERVATIVE_COARSEN"
+      coarse_solver_type = "VC_VELOCITY_PETSC_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 100
+      coarse_solver_db {
+         ksp_type = "gmres"
+         pc_type = "jacobi"
+      }
+   }
+    pressure_solver_type = "PETSC_KRYLOV_SOLVER"
+    pressure_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+    pressure_solver_db
+    {
+      ksp_type = "richardson"
+      max_iterations = 5
+      rel_residual_tol = 1.0e-2
+    }
+
+    pressure_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type = "PETSC_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 100
+      coarse_solver_db {
+         ksp_type = "gmres"
+         pc_type = "jacobi"
+      }
+    }
+    mass_momentum_integrator_db {
+      density_time_stepping_type = DENSITY_TS
+      velocity_convective_limiter = VELOCITY_CONVECTIVE_LIMITER
+      density_convective_limiter = DENSITY_CONVECTIVE_LIMITER
+    }
+
+}
+
+INSVCStaggeredNonConservativeHierarchyIntegrator {
+   start_time                 = START_TIME
+   end_time                   = END_TIME
+   grow_dt                    = GROW_DT
+   convective_op_type         = NON_CONSERVATIVE_CONVECTIVE_OP_TYPE
+   convective_difference_form = CONVECTIVE_FORM
+   normalize_pressure         = NORMALIZE_PRESSURE
+   init_convective_time_stepping_type = INIT_CONVECTIVE_TS_TYPE
+   convective_time_stepping_type = CONVECTIVE_TS_TYPE
+   cfl                        = CFL_MAX
+   dt_max                     = DT_MAX
+   using_vorticity_tagging    = VORTICITY_TAGGING
+   vorticity_rel_thresh       = 0.25
+   tag_buffer                 = TAG_BUFFER
+   regrid_cfl_interval        = REGRID_CFL_INTERVAL
+   output_U                   = OUTPUT_U
+   output_P                   = OUTPUT_P
+   output_F                   = OUTPUT_F
+   output_Omega               = OUTPUT_OMEGA
+   output_Div_U               = OUTPUT_DIV_U
+   output_rho                 = OUTPUT_RHO
+   output_mu                  = OUTPUT_MU
+   rho_is_const               = RHO_IS_CONST
+   mu_is_const                = MU_IS_CONST
+   precond_reinit_interval    = PRECOND_REINIT_INTERVAL
+   operator_scale_factors     = OPERATOR_SCALE_FACTORS
+   vc_interpolation_type      = VC_INTERPOLATION_TYPE
+   enable_logging             = ENABLE_LOGGING
+   max_integrator_steps       = MAX_INTEGRATOR_STEPS
+   explicitly_remove_nullspace= EXPLICITLY_REMOVE_NULLSPACE
+   num_cycles                 = NUM_INS_CYCLES
+
+   // Solver parameters
+   velocity_solver_type = "VC_VELOCITY_PETSC_KRYLOV_SOLVER"
+   velocity_precond_type = "VC_VELOCITY_POINT_RELAXATION_FAC_PRECONDITIONER"
+   velocity_solver_db {
+      ksp_type = "richardson"
+      max_iterations = 1
+      rel_residual_tol = 1.0e-1
+   }
+   velocity_precond_db {
+      num_pre_sweeps = 0
+      num_post_sweeps = 3
+      prolongation_method = "CONSERVATIVE_LINEAR_REFINE"
+      restriction_method = "CONSERVATIVE_COARSEN"
+      coarse_solver_type = "VC_VELOCITY_PETSC_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 100
+      coarse_solver_db {
+         ksp_type = "gmres"
+         pc_type = "jacobi"
+      }
+   }
+    pressure_solver_type = "PETSC_KRYLOV_SOLVER"
+    pressure_precond_type = "POINT_RELAXATION_FAC_PRECONDITIONER"
+    pressure_solver_db
+    {
+      ksp_type = "richardson"
+      max_iterations = 1
+      rel_residual_tol = 1.0e-1
+    }
+
+    pressure_precond_db {
+      num_pre_sweeps  = 0
+      num_post_sweeps = 3
+      prolongation_method = "LINEAR_REFINE"
+      restriction_method  = "CONSERVATIVE_COARSEN"
+      coarse_solver_type = "PETSC_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 100
+      coarse_solver_db {
+         ksp_type = "gmres"
+         pc_type = "jacobi"
+      }
+    }
+}
+
+AdvectorExplicitPredictorPatchOps {
+// Available values for limiter_type:
+// "CTU_ONLY", "MINMOD_LIMITED", "MC_LIMITED",
+// "SUPERBEE_LIMITED", "MUSCL_LIMITED"
+// "SECOND_ORDER", "FOURTH_ORDER",
+// "PPM", "XSPPM7"
+   limiter_type = "MC_LIMITED"
+}
+
+AdvDiffPredictorCorrectorHierarchyIntegrator {
+   start_time                 = START_TIME
+   end_time                   = END_TIME
+   grow_dt                    = GROW_DT
+   convective_difference_form = ADV_DIFF_CONVECTIVE_FORM
+   cfl                        = CFL_MAX
+   dt_max                     = DT_MAX
+   tag_buffer                 = TAG_BUFFER
+   enable_logging             = ENABLE_LOGGING
+
+   AdvDiffPredictorCorrectorHyperbolicPatchOps {
+      compute_init_velocity  = TRUE
+      compute_half_velocity  = TRUE
+      compute_final_velocity = FALSE
+      extrap_type = "LINEAR"
+   }
+
+   HyperbolicLevelIntegrator {
+      cfl                      = CFL_MAX
+      cfl_init                 = CFL_MAX
+      lag_dt_computation       = TRUE
+      use_ghosts_to_compute_dt = FALSE
+   }
+}
+
+AdvDiffSemiImplicitHierarchyIntegrator {
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   grow_dt                       = GROW_DT
+   num_cycles                    = ADV_DIFF_NUM_CYCLES
+   convective_time_stepping_type = ADV_DIFF_CONVECTIVE_TS_TYPE
+   convective_op_type            = ADV_DIFF_CONVECTIVE_OP_TYPE
+   convective_difference_form    = ADV_DIFF_CONVECTIVE_FORM
+   cfl                           = CFL_MAX
+   dt_max                        = DT_MAX
+   tag_buffer                    = TAG_BUFFER
+   enable_logging                = ENABLE_LOGGING
+}
+
+LevelSet_Gas {
+    order                 = LS_ORDER
+    abs_tol               = LS_ABS_TOL
+    max_iterations        = MAX_ITERATIONS
+    enable_logging        = TRUE
+    reinit_interval       = LS_REINIT_INTERVAL
+    apply_sign_fix        = APPLY_SIGN_FIX
+    apply_subcell_fix     = APPLY_SUBCELL_FIX
+    apply_mass_constraint = APPLY_MASS_CONSTRAINT
+}
+
+Main {
+   solver_type = SOLVER_TYPE
+   adv_diff_solver_type = ADV_DIFF_SOLVER_TYPE
+   discretization_form = DISCRETIZATION_FORM
+
+// log file parameters
+   log_file_name    = "hydro.out"
+   log_all_nodes    = FALSE
+
+// visualization dump parameters
+   viz_writer            = "VisIt"
+   viz_dump_interval     = 1
+   viz_dump_dirname      = "viz_cylinder2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_interval      = 0
+   restart_write_dirname = "restart_IB2d"
+
+// hierarchy data dump parameters
+   hier_dump_interval = 0
+   hier_dump_dirname  = "hier_data_IB2d"
+
+// timer dump parameters
+   timer_dump_interval   = 0
+
+// post processor parameters
+   postprocess_interval = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0) , (Nx - 1, Ny - 1) ]
+   x_lo         =   0.0,   0.0
+   x_up         =   LENGTH, HEIGHT
+   periodic_dimension = 0, 0
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS           // Maximum number of levels in hierarchy.
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO  // vector ratio to next coarser level
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+      level_4 = REF_RATIO,REF_RATIO
+      level_5 = REF_RATIO,REF_RATIO
+      level_6 = REF_RATIO,REF_RATIO
+      level_7 = REF_RATIO,REF_RATIO
+   }
+
+   largest_patch_size {
+      level_0 = 16, 16 // largest patch allowed in hierarchy
+                          // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 =  8, 8 // smallest patch allowed in hierarchy
+                            // all finer levels will use same values as level_0...
+   }
+
+   allow_patches_smaller_than_minimum_size_to_prevent_overlaps = TRUE
+   efficiency_tolerance   = 0.80e0    // min % of tag cells in new patch level
+   combine_efficiency     = 0.80e0    // chop box if sum of volumes of smaller
+                                      // boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   // tagging_method = "GRADIENT_DETECTOR"
+   RefineBoxes {
+      level_0 = [( Nx/4 , Ny/4 ),( 3*Nx/4 , 3*Ny/4 )]
+      level_1 = [( 0 , 0 ),( 2*Nx - 1 , 2*Ny - 1 )]
+      level_2 = [( 0 , 0 ),( 4*Nx - 1 , 4*Ny - 1 )]
+      level_3 = [( 0 , 0 ),( 8*Nx - 1 , 8*Ny - 1 )]
+      level_4 = [( 0 , 0 ),( 16*Nx - 1 , 16*Ny - 1 )]
+      level_5 = [( 0 , 0 ),( 32*Nx - 1 , 32*Ny - 1 )]
+      level_6 = [( 0 , 0 ),( 64*Nx - 1 , 64*Ny - 1 )]
+      level_7 = [( 0 , 0 ),( 128*Nx - 1 , 128*Ny - 1 )]
+      level_8 = [( 0 , 0 ),( 256*Nx - 1 , 256*Ny - 1 )]
+      level_9 = [( 0 , 0 ),( 512*Nx - 1 , 512*Ny - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total = TRUE
+   print_threshold = 0.1
+
+   timer_list = "IBAMR::*::*" , "IBTK::*::*" , "*::*::*"
+}

--- a/tests/multiphase_flow/check_hydro_force.amr.mpirun=2.output
+++ b/tests/multiphase_flow/check_hydro_force.amr.mpirun=2.output
@@ -1,0 +1,7 @@
+Vertical pressure force analytical = 0.0314159
+Vertical pressure force numerical  = 0.0314
+Horizontal pressure force analytical = 0
+Horizontal pressure force numerical  = 1.38778e-17
+Pressure torque (should be zero):            0
+           0
+-1.35525e-19

--- a/tests/multiphase_flow/water_entry_circular_cylinder.cpp
+++ b/tests/multiphase_flow/water_entry_circular_cylinder.cpp
@@ -607,9 +607,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -631,8 +629,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/tests/navier_stokes/navier_stokes_01.cpp
+++ b/tests/navier_stokes/navier_stokes_01.cpp
@@ -355,9 +355,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/tests/navier_stokes/poiseuille_flow_2d.cpp
+++ b/tests/navier_stokes/poiseuille_flow_2d.cpp
@@ -285,9 +285,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/tests/unfinished-tests/Stokes-IB/test1/main.cpp
+++ b/tests/unfinished-tests/Stokes-IB/test1/main.cpp
@@ -296,9 +296,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
@@ -320,8 +318,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     VecDuplicate(X_petsc_vec, &X_lag_vec);
     l_data_manager->scatterPETScToLagrangian(X_petsc_vec, X_lag_vec, finest_hier_level);
     file_name = data_dump_dirname + "/" + "X.";
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d", iteration_num);
-    file_name += temp_buf;
+    file_name += generateIterationName(iteration_num);
     PetscViewer viewer;
     PetscViewerASCIIOpen(PETSC_COMM_WORLD, file_name.c_str(), &viewer);
     VecView(X_lag_vec, viewer);

--- a/tests/unfinished-tests/Stokes/test0/main.cpp
+++ b/tests/unfinished-tests/Stokes/test0/main.cpp
@@ -316,9 +316,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/tests/vc_navier_stokes/vc_navier_stokes_01.cpp
+++ b/tests/vc_navier_stokes/vc_navier_stokes_01.cpp
@@ -382,9 +382,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
     plog << "writing hierarchy data at iteration " << iteration_num << " to disk" << endl;
     plog << "simulation time is " << loop_time << endl;
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();

--- a/tests/wave_tank/nwt.cpp
+++ b/tests/wave_tank/nwt.cpp
@@ -645,9 +645,7 @@ output_data(Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
 
     // Write Cartesian data.
     string file_name = data_dump_dirname + "/" + "hier_data.";
-    char temp_buf[128];
-    std::snprintf(temp_buf, sizeof(temp_buf), "%05d.samrai.%05d", iteration_num, IBTK_MPI::getRank());
-    file_name += temp_buf;
+    file_name += generateSAMRAIName(iteration_num);
     Pointer<HDFDatabase> hier_db = new HDFDatabase("hier_db");
     hier_db->create(file_name);
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();


### PR DESCRIPTION
Replaced all instances of snprintf() and sprintf() with modern C++ alternatives. As suggested in the issue, most replacements use std::ostringstream for string formatting and construction. Two utility functions were created that encode the standard file-naming scheme. Additionally, a test was created that makes sure the file names produced are correct.
Fixes #1602 

### IBAMR Pull Request Checklist
- [x] Does the test suite pass? 
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`. 
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?