### PR TITLE
Optimize minmod and median.

### DIFF
--- a/doc/news/changes/minor/20260721Wells
+++ b/doc/news/changes/minor/20260721Wells
@@ -1,0 +1,7 @@
+Improved: The minmod() and median() functions were completely rewritten to both
+improve performance and enable inlining. These improvements make calling
+functions (e.g., slope limiters like
+IBAMR::INSStaggeredStabilizedPPMConvectiveOperator::applyConvectiveOperator())
+about 15\% faster.
+<br>
+(David Wells, 2026/06/21)

--- a/src/advect/fortran/advect_predictors2d.f.m4
+++ b/src/advect/fortran/advect_predictors2d.f.m4
@@ -25,8 +25,8 @@ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c
       REAL function minmod(a,b)
       implicit none
-      REAL a,b
-      minmod = 0.5d0*(sign(0.5d0,a)+sign(0.5d0,b))*(abs(a+b)-abs(a-b))
+      REAL, intent(in) :: a,b
+      minmod = max(0.0d0,min(a,b))+min(0.0d0,max(a,b))
       return
       end
 c
@@ -38,9 +38,11 @@ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c
       REAL function median(a,b,c)
       implicit none
-      REAL a,b,c
-      REAL minmod
-      median = a + minmod(b-a,c-a)
+      REAL, intent(in) :: a,b,c
+      REAL lo,hi
+      lo = merge(a,b,a<=b)
+      hi = merge(b,a,a<=b)
+      median = max(lo,min(hi,c))
       return
       end
 c

--- a/src/advect/fortran/advect_predictors3d.f.m4
+++ b/src/advect/fortran/advect_predictors3d.f.m4
@@ -25,8 +25,8 @@ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c
       REAL function minmod(a,b)
       implicit none
-      REAL a,b
-      minmod = 0.5d0*(sign(0.5d0,a)+sign(0.5d0,b))*(abs(a+b)-abs(a-b))
+      REAL, intent(in) :: a,b
+      minmod = max(0d0,min(a,b))+min(0d0,max(a,b))
       return
       end
 c
@@ -38,9 +38,11 @@ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c
       REAL function median(a,b,c)
       implicit none
-      REAL a,b,c
-      REAL minmod
-      median = a + minmod(b-a,c-a)
+      REAL, intent(in) :: a,b,c
+      REAL lo,hi
+      lo = merge(a,b,a<=b)
+      hi = merge(b,a,a<=b)
+      median = max(lo,min(hi,c))
       return
       end
 c


### PR DESCRIPTION
This makes
`IBAMR::INSStaggeredStabilizedPPMConvectiveOperator::applyConvectiveOperator()` about 15% faster by making `minmod()` both smaller and small enough to inline in `median()`.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?

The before-and-after assembly code of median is really interesting. Here's before:
```fortran
Dump of assembler code for function median:
42	      double precision function median(a,b,c)
   0x0000000000000bb0 <+0>:	push   %rbp
   0x0000000000000bb1 <+1>:	mov    %rsp,%rbp
   0x0000000000000bb4 <+4>:	sub    $0x20,%rsp

43	      implicit none
44	      double precision a,b,c
45	      double precision minmod
46	      median = a + minmod(b-a,c-a)
   0x0000000000000bb8 <+8>:	vmovsd (%rdi),%xmm1
   0x0000000000000bbc <+12>:	vmovsd (%rsi),%xmm0
   0x0000000000000bc0 <+16>:	lea    -0x10(%rbp),%rdi
   0x0000000000000bc4 <+20>:	lea    -0x8(%rbp),%rsi
   0x0000000000000bc8 <+24>:	vsubsd %xmm1,%xmm0,%xmm0
   0x0000000000000bcc <+28>:	vmovsd %xmm1,-0x18(%rbp)
   0x0000000000000bd1 <+33>:	vmovsd %xmm0,-0x10(%rbp)
   0x0000000000000bd6 <+38>:	vmovsd (%rdx),%xmm0
   0x0000000000000bda <+42>:	vsubsd %xmm1,%xmm0,%xmm0
   0x0000000000000bde <+46>:	vmovsd %xmm0,-0x8(%rbp)
   0x0000000000000be3 <+51>:	call   0xbe8 <median+56>
   0x0000000000000be8 <+56>:	vmovsd -0x18(%rbp),%xmm1
   0x0000000000000bee <+62>:	vaddsd %xmm0,%xmm1,%xmm0

47	      return
48	      end
   0x0000000000000bed <+61>:	leave  
   0x0000000000000bf2 <+66>:	ret    
   0x0000000000000bf3:	data16 cs nopw 0x0(%rax,%rax,1)
   0x0000000000000bfe:	xchg   %ax,%ax

End of assembler dump.
```
and after:
```fortran
Dump of assembler code for function median:
42	      double precision function median(a,b,c)

43	      implicit none
44	      double precision, INTENT(in) :: a,b,c
45	      double precision lo,hi
46	      lo = merge(a,b,a<=b)
   0x0000000000000040 <+0>:	vmovsd (%rdi),%xmm1
   0x0000000000000044 <+4>:	vmovsd (%rsi),%xmm0
   0x0000000000000048 <+8>:	vcomisd %xmm1,%xmm0
   0x000000000000004c <+12>:	jae    0x5c <median+28>
   0x000000000000004e <+14>:	vmovq  %xmm0,%rax
   0x0000000000000057 <+23>:	vmovq  %rax,%xmm1

47	      hi = merge(b,a,a<=b)
   0x0000000000000053 <+19>:	vmovsd %xmm1,%xmm1,%xmm0

48	      median = max(lo,min(hi,c))
   0x000000000000005c <+28>:	vminsd (%rdx),%xmm0,%xmm0
   0x0000000000000060 <+32>:	vmaxsd %xmm1,%xmm0,%xmm0

49	      return
50	      end
   0x0000000000000064 <+36>:	ret    
   0x0000000000000065:	data16 cs nopw 0x0(%rax,%rax,1)

End of assembler dump.
```
There are fewer instructions (11 vs 17) even though the former version also calls `minmod()`.

I used AI (qwen 3.8) to brainstorm these optimizations. I ignored its suggestions about upgrading to Fortran95 so we can use `pure elemental` functions: we don't need it since the optimizer is good enough at inlining (we already achieved very good code generation). I kept the `intent(in)` though I suspect it doesn't do anything (the compiler can see we don't actually write to those variables).