### PR TITLE
Increment the minimum PETSc version to 3.13.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -654,9 +654,9 @@ something is wrong with the PETSc installation.")
 
   SET(PETSC_VERSION
     "${PETSC_VERSION_MAJOR}.${PETSC_VERSION_MINOR}.${PETSC_VERSION_SUBMINOR}")
-  IF(${PETSC_VERSION} VERSION_LESS 3.7.0)
+  IF(${PETSC_VERSION} VERSION_LESS 3.13.0)
     MESSAGE(FATAL_ERROR
-      "IBAMR requires PETSc version 3.7.0 or newer but the version provided at
+      "IBAMR requires PETSc version 3.13.0 or newer but the version provided at
 ${PETSC_ROOT} is version ${PETSC_VERSION}")
   ENDIF()
 ENDIF()

--- a/doc/news/changes/incompatibilities/20260807DavidWells
+++ b/doc/news/changes/incompatibilities/20260807DavidWells
@@ -1,0 +1,3 @@
+Changed: The minimum supported version of PETSc is now 3.13.
+<br>
+(David Wells, 2026/08/07)

--- a/doc/release-tasks.md
+++ b/doc/release-tasks.md
@@ -31,8 +31,8 @@ GitHub.
 #endif
 ```
   around APIs to keep backwards compatibility with older versions of libMesh.
-- [ ] check the test suite with the oldest (3.7.0) and newest (latest release)
-  versions of PETSc. Also check with the oldest (1.1.0) and newest (latest
+- [ ] check the test suite with the oldest (3.13.0) and newest (latest release)
+  versions of PETSc. Also check with the oldest (1.7.0) and newest (latest
   release) versions of libMesh.
 - [ ] clear basic compilation warnings with GCC and clang on linux and macOS
 - [ ] run cppcheck via

--- a/ibtk/src/solvers/impls/PETScLevelSolver.cpp
+++ b/ibtk/src/solvers/impls/PETScLevelSolver.cpp
@@ -448,21 +448,12 @@ PETScLevelSolver::initializeSolverState(const SAMRAIVectorReal<NDIM, double>& x,
         }
 
         // Get the local submatrices.
-#if PETSC_VERSION_GE(3, 8, 0)
         ierr = MatCreateSubMatrices(d_petsc_mat,
                                     d_n_local_subdomains,
                                     d_overlap_is.data(),
                                     d_overlap_is.data(),
                                     MAT_INITIAL_MATRIX,
                                     &d_sub_mat);
-#else
-        ierr = MatGetSubMatrices(d_petsc_mat,
-                                 d_n_local_subdomains,
-                                 d_overlap_is.data(),
-                                 d_overlap_is.data(),
-                                 MAT_INITIAL_MATRIX,
-                                 &d_sub_mat);
-#endif
         IBTK_CHKERRQ(ierr);
 
         // Setup data for communicating values between local and global representations.
@@ -556,21 +547,12 @@ PETScLevelSolver::initializeSolverState(const SAMRAIVectorReal<NDIM, double>& x,
             ierr = ISCreateStride(PETSC_COMM_WORLD, n_hi - n_lo, n_lo, 1, &local_idx);
             IBTK_CHKERRQ(ierr);
             std::vector<IS> local_idxs(d_n_local_subdomains, local_idx);
-#if PETSC_VERSION_GE(3, 8, 0)
             ierr = MatCreateSubMatrices(d_petsc_mat,
                                         d_n_local_subdomains,
                                         get_data_or_null(d_overlap_is),
                                         get_data_or_null(local_idxs),
                                         MAT_INITIAL_MATRIX,
                                         &d_sub_bc_mat);
-#else
-            ierr = MatGetSubMatrices(d_petsc_mat,
-                                     d_n_local_subdomains,
-                                     get_data_or_null(d_overlap_is),
-                                     get_data_or_null(local_idxs),
-                                     MAT_INITIAL_MATRIX,
-                                     &d_sub_bc_mat);
-#endif
             IBTK_CHKERRQ(ierr);
             for (int i = 0; i < d_n_local_subdomains; ++i)
             {

--- a/ibtk/src/solvers/solver_utilities.cpp
+++ b/ibtk/src/solvers/solver_utilities.cpp
@@ -92,11 +92,6 @@ reportPETScSNESConvergedReason(const std::string& object_name, const SNESConverg
     case SNES_CONVERGED_ITS:
         os << object_name << ": converged: maximum number of iterations reached.\n";
         break;
-#if PETSC_VERSION_LT(3, 12, 0)
-    case SNES_CONVERGED_TR_DELTA:
-        os << object_name << ": converged: trust-region delta.\n";
-        break;
-#endif
     case SNES_DIVERGED_FUNCTION_DOMAIN:
         os << object_name << ": diverged: new x location passed to the function is not in the function domain.\n";
         break;
@@ -106,9 +101,15 @@ reportPETScSNESConvergedReason(const std::string& object_name, const SNESConverg
     case SNES_DIVERGED_LINEAR_SOLVE:
         os << object_name << ": diverged: the linear solve failed.\n";
         break;
+#if PETSC_VERSION_LT(3, 25, 0)
     case SNES_DIVERGED_FNORM_NAN:
         os << object_name << ": diverged: |F| is NaN.\n";
         break;
+#else
+    case SNES_DIVERGED_FUNCTION_NANORINF:
+        os << object_name << ": diverged: |F| is NaN or infinity.\n";
+        break;
+#endif
     case SNES_DIVERGED_MAX_IT:
         os << object_name << ": diverged: exceeded maximum number of iterations.\n";
         break;
@@ -121,11 +122,9 @@ reportPETScSNESConvergedReason(const std::string& object_name, const SNESConverg
     case SNES_DIVERGED_LOCAL_MIN:
         os << object_name << ": diverged: attained non-zero local minimum.\n";
         break;
-#if PETSC_VERSION_GE(3, 12, 0)
     case SNES_DIVERGED_TR_DELTA:
         os << object_name << ": diverged: trust-region delta.\n";
         break;
-#endif
     case SNES_CONVERGED_ITERATING:
         os << object_name << ": iterating.\n";
         break;


### PR DESCRIPTION
3.13 was released in early 2020.

While we're at it, address a deprecation warning for 3.25.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
