### PR TITLE
Fix unused compiler warnings in Release builds

### DIFF
--- a/ibtk/src/lagrangian/LEInteractor.cpp
+++ b/ibtk/src/lagrangian/LEInteractor.cpp
@@ -2821,6 +2821,7 @@ LEInteractor::interpolate(double* const Q_data,
     TBOX_ASSERT(Q_size / Q_depth == X_size / X_depth);
 #else
     NULL_USE(Q_size);
+    NULL_USE(X_depth);
 #endif
     // Determine the patch geometry.
     const Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
@@ -2884,6 +2885,7 @@ LEInteractor::interpolate(double* const Q_data,
     TBOX_ASSERT(mask_data->getDepth() == 1);
 #else
     NULL_USE(Q_size);
+    NULL_USE(X_depth);
 #endif
     // Determine the patch geometry.
     const Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
@@ -2993,6 +2995,7 @@ LEInteractor::interpolate(double* const Q_data,
     TBOX_ASSERT(Q_size / Q_depth == X_size / X_depth);
 #else
     NULL_USE(Q_size);
+    NULL_USE(X_depth);
 #endif
     // Determine the patch geometry.
     const Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
@@ -3062,6 +3065,7 @@ LEInteractor::interpolate(double* const Q_data,
     TBOX_ASSERT(q_data->getDepth() == 1);
 #else
     NULL_USE(Q_size);
+    NULL_USE(X_depth);
 #endif
     if (Q_depth != NDIM || q_data->getDepth() != 1)
     {
@@ -3150,6 +3154,7 @@ LEInteractor::interpolate(double* const Q_data,
     TBOX_ASSERT(mask_data->getDepth() == 1);
 #else
     NULL_USE(Q_size);
+    NULL_USE(X_depth);
 #endif
     // Determine the patch geometry.
     const Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
@@ -3271,6 +3276,7 @@ LEInteractor::interpolate(double* const Q_data,
     TBOX_ASSERT(q_data->getDepth() == 1);
 #else
     NULL_USE(Q_size);
+    NULL_USE(X_depth);
 #endif
     if (Q_depth != NDIM || q_data->getDepth() != 1)
     {
@@ -3967,6 +3973,7 @@ LEInteractor::spread(Pointer<CellData<NDIM, double>> q_data,
     TBOX_ASSERT(Q_size / Q_depth == X_size / X_depth);
 #else
     NULL_USE(Q_size);
+    NULL_USE(X_depth);
 #endif
     // Determine the patch geometry.
     const Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
@@ -4030,6 +4037,7 @@ LEInteractor::spread(Pointer<CellData<NDIM, double>> mask_data,
     TBOX_ASSERT(mask_data->getDepth() == 1);
 #else
     NULL_USE(Q_size);
+    NULL_USE(X_depth);
 #endif
     // Determine the patch geometry.
     const Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
@@ -4138,6 +4146,7 @@ LEInteractor::spread(Pointer<NodeData<NDIM, double>> q_data,
     TBOX_ASSERT(Q_size / Q_depth == X_size / X_depth);
 #else
     NULL_USE(Q_size);
+    NULL_USE(X_depth);
 #endif
     // Determine the patch geometry.
     const Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
@@ -4206,6 +4215,8 @@ LEInteractor::spread(Pointer<SideData<NDIM, double>> q_data,
     TBOX_ASSERT(patch);
     TBOX_ASSERT(Q_depth == NDIM);
     TBOX_ASSERT(X_depth == NDIM);
+#else
+    NULL_USE(X_depth);
 #endif
     // Determine the patch geometry.
     const Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
@@ -4285,6 +4296,7 @@ LEInteractor::spread(Pointer<SideData<NDIM, double>> mask_data,
     TBOX_ASSERT(mask_data);
 #else
     NULL_USE(Q_size);
+    NULL_USE(X_depth);
 #endif
     // Determine the patch geometry.
     const Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
@@ -4404,6 +4416,8 @@ LEInteractor::spread(Pointer<EdgeData<NDIM, double>> q_data,
     TBOX_ASSERT(patch);
     TBOX_ASSERT(Q_depth == NDIM);
     TBOX_ASSERT(X_depth == NDIM);
+#else
+    NULL_USE(X_depth);
 #endif
     // Determine the patch geometry.
     const Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();

--- a/ibtk/src/solvers/impls/CCLaplaceOperator.cpp
+++ b/ibtk/src/solvers/impls/CCLaplaceOperator.cpp
@@ -186,6 +186,8 @@ CCLaplaceOperator::initializeOperatorState(const SAMRAIVectorReal<NDIM, double>&
     TBOX_ASSERT(d_coarsest_ln == out.getCoarsestLevelNumber());
     TBOX_ASSERT(d_finest_ln == out.getFinestLevelNumber());
     TBOX_ASSERT(d_ncomp == out.getNumberOfComponents());
+#else
+    NULL_USE(out);
 #endif
 
     if (!d_hier_math_ops_external)

--- a/ibtk/src/solvers/impls/SCLaplaceOperator.cpp
+++ b/ibtk/src/solvers/impls/SCLaplaceOperator.cpp
@@ -185,6 +185,8 @@ SCLaplaceOperator::initializeOperatorState(const SAMRAIVectorReal<NDIM, double>&
     TBOX_ASSERT(d_coarsest_ln == out.getCoarsestLevelNumber());
     TBOX_ASSERT(d_finest_ln == out.getFinestLevelNumber());
     TBOX_ASSERT(d_ncomp == out.getNumberOfComponents());
+#else
+    NULL_USE(out);
 #endif
 
     if (!d_hier_math_ops_external)

--- a/ibtk/src/solvers/impls/VCSCViscousOperator.cpp
+++ b/ibtk/src/solvers/impls/VCSCViscousOperator.cpp
@@ -211,6 +211,8 @@ VCSCViscousOperator::initializeOperatorState(const SAMRAIVectorReal<NDIM, double
     TBOX_ASSERT(d_coarsest_ln == out.getCoarsestLevelNumber());
     TBOX_ASSERT(d_finest_ln == out.getFinestLevelNumber());
     TBOX_ASSERT(d_ncomp == out.getNumberOfComponents());
+#else
+    NULL_USE(out);
 #endif
 
     if (!d_hier_math_ops_external)

--- a/ibtk/src/utilities/MarkerPatchHierarchy.cpp
+++ b/ibtk/src/utilities/MarkerPatchHierarchy.cpp
@@ -1127,6 +1127,8 @@ MarkerPatchHierarchy::pruneAndRedistribute()
                        << " patches. The most likely cause of this error is that the CFL number is greater than 1.");
         }
     }
+#else
+    NULL_USE(num_emplaced_markers);
 #endif
     IBTK_TIMER_STOP(t_prune_and_redistribute);
 }

--- a/src/IB/IIMethod.cpp
+++ b/src/IB/IIMethod.cpp
@@ -1268,7 +1268,7 @@ IIMethod::interpolateVelocity(const int u_data_idx,
                     for (unsigned int k = 0; k < local_indices.size(); ++k)
                     {
                         const int s = local_indices[k];
-                        IBTK::Point x, x_cell, xo, x_cell_o;
+                        IBTK::Point x, x_cell;
                         const double* const dx = patch_dx;
                         for (unsigned int d = 0; d < NDIM; ++d)
                         {

--- a/src/adv_diff/AdvDiffCenteredConvectiveOperator.cpp
+++ b/src/adv_diff/AdvDiffCenteredConvectiveOperator.cpp
@@ -99,6 +99,8 @@ AdvDiffCenteredConvectiveOperator::interpolateToFaceOnPatch(FaceData<NDIM, doubl
     const IntVector<NDIM>& u_data_gcw = u_data.getGhostCellWidth();
 #if !defined(NDEBUG)
     TBOX_ASSERT(u_data_gcw.min() == u_data_gcw.max());
+#else
+    NULL_USE(u_data_gcw);
 #endif
     const IntVector<NDIM>& q_interp_data_gcw = q_interp_data.getGhostCellWidth();
 #if !defined(NDEBUG)

--- a/src/level_set/FESurfaceDistanceEvaluator.cpp
+++ b/src/level_set/FESurfaceDistanceEvaluator.cpp
@@ -399,13 +399,14 @@ FESurfaceDistanceEvaluator::computeSignedDistance(int n_idx, int d_idx)
 
                 for (const auto& elem : elem_set)
                 {
-                    IBTK::VectorNd v, w, proj;
+                    IBTK::VectorNd proj;
                     double dist = std::numeric_limits<double>::max();
 #if (NDIM == 2)
                     // Get the nodes.
                     const libMesh::Point& n0 = elem->point(0);
                     const libMesh::Point& n1 = elem->point(1);
 
+                    IBTK::VectorNd v, w;
                     v << n0(0), n0(1);
                     w << n1(0), n1(1);
 

--- a/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSCollocatedHierarchyIntegrator.cpp
@@ -1665,6 +1665,8 @@ INSCollocatedHierarchyIntegrator::applyGradientDetectorSpecialized(const Pointer
     TBOX_ASSERT(d_hierarchy == hierarchy);
     TBOX_ASSERT((level_number >= 0) && (level_number <= hierarchy->getFinestLevelNumber()));
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
+#else
+    NULL_USE(hierarchy);
 #endif
 
     if (d_using_vorticity_tagging)

--- a/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSStaggeredHierarchyIntegrator.cpp
@@ -1983,6 +1983,8 @@ INSStaggeredHierarchyIntegrator::applyGradientDetectorSpecialized(const Pointer<
     TBOX_ASSERT(d_hierarchy == hierarchy);
     TBOX_ASSERT((level_number >= 0) && (level_number <= hierarchy->getFinestLevelNumber()));
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
+#else
+    NULL_USE(hierarchy);
 #endif
 
     if (d_using_vorticity_tagging)

--- a/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
+++ b/src/navier_stokes/INSVCStaggeredHierarchyIntegrator.cpp
@@ -1781,6 +1781,8 @@ INSVCStaggeredHierarchyIntegrator::applyGradientDetectorSpecialized(const Pointe
     TBOX_ASSERT(d_hierarchy == hierarchy);
     TBOX_ASSERT((level_number >= 0) && (level_number <= hierarchy->getFinestLevelNumber()));
     TBOX_ASSERT(hierarchy->getPatchLevel(level_number));
+#else
+    NULL_USE(hierarchy);
 #endif
 
     if (d_using_vorticity_tagging)

--- a/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
@@ -800,6 +800,9 @@ StaggeredStokesPETScMatUtilities::constructPatchLevelASMSubdomains(std::vector<s
     }
 #if !defined(NDEBUG)
     TBOX_ASSERT(local_dof_count == nonoverlap_dof_counter);
+#else
+    NULL_USE(local_dof_count);
+    NULL_USE(nonoverlap_dof_counter);
 #endif
 
     // Deallocate patch_num variable data.

--- a/src/phase_change/AllenCahnHierarchyIntegrator.cpp
+++ b/src/phase_change/AllenCahnHierarchyIntegrator.cpp
@@ -1198,6 +1198,8 @@ AllenCahnHierarchyIntegrator::setLiquidFractionPhysicalBcCoef(Pointer<CellVariab
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(lf_var);
+#else
+    NULL_USE(lf_var);
 #endif
     d_lf_bc_coef = lf_bc_coef;
     return;

--- a/src/phase_change/PhaseChangeHierarchyIntegrator.cpp
+++ b/src/phase_change/PhaseChangeHierarchyIntegrator.cpp
@@ -703,6 +703,8 @@ PhaseChangeHierarchyIntegrator::setLiquidFractionInitialCondition(Pointer<CellVa
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(lf_var);
+#else
+    NULL_USE(lf_var);
 #endif
     d_lf_init = lf_init;
     return;
@@ -714,6 +716,8 @@ PhaseChangeHierarchyIntegrator::setTemperatureInitialCondition(Pointer<CellVaria
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(T_var);
+#else
+    NULL_USE(T_var);
 #endif
     d_T_init = T_init;
     return;
@@ -725,6 +729,8 @@ PhaseChangeHierarchyIntegrator::setDensityInitialCondition(Pointer<CellVariable<
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(rho_var);
+#else
+    NULL_USE(rho_var);
 #endif
     d_rho_init = rho_init;
     return;
@@ -736,6 +742,8 @@ PhaseChangeHierarchyIntegrator::setTemperaturePhysicalBcCoef(Pointer<CellVariabl
 {
 #if !defined(NDEBUG)
     TBOX_ASSERT(T_var);
+#else
+    NULL_USE(T_var);
 #endif
     d_T_bc_coef = T_bc_coef;
     return;

--- a/tests/fe_mechanics/fe_mechanics_ex0.cpp
+++ b/tests/fe_mechanics/fe_mechanics_ex0.cpp
@@ -174,6 +174,7 @@ void
 apply_initial_jacobian(EquationSystems& es, const string& system_name)
 {
     libmesh_assert_equal_to(system_name, "JacobianDeterminant");
+    NULL_USE(system_name);
     ExplicitSystem& system = es.get_system<ExplicitSystem>("JacobianDeterminant");
     es.parameters.set<Real>("time") = system.time = 0;
     system.project_solution(initial_jacobian, nullptr, es.parameters);


### PR DESCRIPTION
Fix unused-variable and unused-parameter warnings in Release builds while preserving Debug checks.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [x] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
