### PR TITLE
[CAV R02] Route the implicit IB integrator through shared components

### DIFF
--- a/doc/news/changes/major/20260909Griffith
+++ b/doc/news/changes/major/20260909Griffith
@@ -1,0 +1,5 @@
+Changed (incompatible): Reimplement IBImplicitStaggeredHierarchyIntegrator for
+the velocity-pressure formulation, removing the position formulation and its
+selection inputs.
+<br>
+(Boyce Griffith, 2026/09/09)

--- a/examples/IB/implicit/CMakeLists.txt
+++ b/examples/IB/implicit/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (c) 2020 - 2020 by the IBAMR developers
+## Copyright (c) 2026 by the IBAMR developers
 ## All rights reserved.
 ##
 ## This file is part of IBAMR.
@@ -11,5 +11,4 @@
 ##
 ## ---------------------------------------------------------------------
 
-ADD_SUBDIRECTORY(explicit)
-ADD_SUBDIRECTORY(implicit)
+ADD_SUBDIRECTORY(ex0)

--- a/examples/IB/implicit/ex0/CMakeLists.txt
+++ b/examples/IB/implicit/ex0/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (c) 2020 - 2020 by the IBAMR developers
+## Copyright (c) 2026 by the IBAMR developers
 ## All rights reserved.
 ##
 ## This file is part of IBAMR.
@@ -11,5 +11,18 @@
 ##
 ## ---------------------------------------------------------------------
 
-ADD_SUBDIRECTORY(explicit)
-ADD_SUBDIRECTORY(implicit)
+IBAMR_ADD_EXAMPLE(
+  TARGET_NAME
+    "IB-implicit-ex0"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/IB/implicit/ex0"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples-IB
+  SOURCES
+    example.cpp
+  LINK_TARGETS
+    IBAMR2d
+  INPUT_FILES
+    input2d)

--- a/examples/IB/implicit/ex0/example.cpp
+++ b/examples/IB/implicit/ex0/example.cpp
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2026 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#include <ibamr/IBImplicitStaggeredHierarchyIntegrator.h>
+#include <ibamr/IBMethod.h>
+#include <ibamr/IBRedundantInitializer.h>
+#include <ibamr/IBStandardForceGen.h>
+#include <ibamr/INSStaggeredHierarchyIntegrator.h>
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/muParserCartGridFunction.h>
+
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <GriddingAlgorithm.h>
+#include <HierarchyCellDataOpsReal.h>
+#include <HierarchySideDataOpsReal.h>
+#include <LoadBalancer.h>
+#include <StandardTagAndInitialize.h>
+#include <VariableDatabase.h>
+
+#include <cmath>
+#include <iomanip>
+#include <map>
+#include <vector>
+
+#include <ibamr/app_namespaces.h>
+
+namespace
+{
+constexpr int NUM_POINTS = 16;
+void
+generate_structure(const unsigned int& structure,
+                   const int& level,
+                   int& num_vertices,
+                   std::vector<IBTK::Point>& positions,
+                   void*)
+{
+    num_vertices = (structure == 0 && level == 0) ? NUM_POINTS : 0;
+    positions.resize(num_vertices);
+    for (int k = 0; k < num_vertices; ++k)
+    {
+        const double theta = 2.0 * M_PI * k / NUM_POINTS;
+        positions[k](0) = 0.5 + 0.18 * std::cos(theta);
+        positions[k](1) = 0.5 + 0.25 * std::sin(theta);
+    }
+}
+
+void
+generate_springs(
+    const unsigned int& structure,
+    const int& level,
+    std::multimap<int, IBRedundantInitializer::Edge>& spring_map,
+    std::map<IBRedundantInitializer::Edge, IBRedundantInitializer::SpringSpec, IBRedundantInitializer::EdgeComp>& specs,
+    void*)
+{
+    if (structure != 0 || level != 0)
+    {
+        return;
+    }
+    for (int k = 0; k < NUM_POINTS; ++k)
+    {
+        IBRedundantInitializer::Edge edge = { k, (k + 1) % NUM_POINTS };
+        if (edge.first > edge.second)
+        {
+            std::swap(edge.first, edge.second);
+        }
+        spring_map.emplace(edge.first, edge);
+        IBRedundantInitializer::SpringSpec spec;
+        spec.force_fcn_idx = 0;
+        spec.parameters = { 5.0, 0.0 };
+        specs.emplace(edge, spec);
+    }
+}
+} // namespace
+
+int
+main(int argc, char* argv[])
+{
+    IBTKInit init(argc, argv, MPI_COMM_WORLD);
+    {
+        Pointer<AppInitializer> app = new AppInitializer(argc, argv, "output");
+        Pointer<INSStaggeredHierarchyIntegrator> ins = new INSStaggeredHierarchyIntegrator(
+            "INSStaggeredHierarchyIntegrator", app->getComponentDatabase("INSStaggeredHierarchyIntegrator"));
+        Pointer<IBMethod> method = new IBMethod("IBMethod", app->getComponentDatabase("IBMethod"));
+        Pointer<IBImplicitStaggeredHierarchyIntegrator> integrator = new IBImplicitStaggeredHierarchyIntegrator(
+            "IBHierarchyIntegrator", app->getComponentDatabase("IBHierarchyIntegrator"), method, ins);
+        Pointer<CartesianGridGeometry<NDIM>> geometry =
+            new CartesianGridGeometry<NDIM>("CartesianGeometry", app->getComponentDatabase("CartesianGeometry"));
+        Pointer<PatchHierarchy<NDIM>> hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", geometry);
+        Pointer<StandardTagAndInitialize<NDIM>> tagging = new StandardTagAndInitialize<NDIM>(
+            "StandardTagAndInitialize", integrator, app->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<BergerRigoutsos<NDIM>> boxes = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM>> load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM>> gridding = new GriddingAlgorithm<NDIM>(
+            "GriddingAlgorithm", app->getComponentDatabase("GriddingAlgorithm"), tagging, boxes, load_balancer);
+        Pointer<IBRedundantInitializer> initializer =
+            new IBRedundantInitializer("IBRedundantInitializer", app->getComponentDatabase("IBRedundantInitializer"));
+        initializer->setStructureNamesOnLevel(0, { "ellipse" });
+        initializer->registerInitStructureFunction(generate_structure);
+        initializer->registerInitSpringDataFunction(generate_springs);
+        method->registerLInitStrategy(initializer);
+        method->registerIBLagrangianForceFunction(new IBStandardForceGen());
+        ins->registerVelocityInitialConditions(new muParserCartGridFunction(
+            "initial_velocity", app->getComponentDatabase("VelocityInitialConditions"), geometry));
+        integrator->initializePatchHierarchy(hierarchy, gridding);
+        method->freeLInitStrategy();
+        initializer.setNull();
+
+        VariableDatabase<NDIM>* variables = VariableDatabase<NDIM>::getDatabase();
+        const int u = variables->mapVariableAndContextToIndex(ins->getVelocityVariable(), ins->getCurrentContext());
+        const int p = variables->mapVariableAndContextToIndex(ins->getPressureVariable(), ins->getCurrentContext());
+        HierarchySideDataOpsReal<NDIM, double> velocity_ops(hierarchy, 0, 0);
+        HierarchyCellDataOpsReal<NDIM, double> pressure_ops(hierarchy, 0, 0);
+        Pointer<HierarchyMathOps> math_ops = ins->getHierarchyMathOps();
+        plog << std::scientific << std::setprecision(8);
+        while (integrator->stepsRemaining())
+        {
+            integrator->advanceHierarchy(integrator->getMaximumTimeStepSize());
+            plog << "time " << integrator->getIntegratorTime() << " velocity_L2 "
+                 << velocity_ops.L2Norm(u, math_ops->getSideWeightPatchDescriptorIndex()) << " pressure_L2 "
+                 << pressure_ops.L2Norm(p, math_ops->getCellWeightPatchDescriptorIndex()) << '\n';
+        }
+    }
+    return 0;
+}

--- a/examples/IB/implicit/ex0/input2d
+++ b/examples/IB/implicit/ex0/input2d
@@ -1,0 +1,77 @@
+N = 8
+IB_RULE = "MIDPOINT_RULE"
+JAC_KERNEL = "IB_4"
+IBHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.02
+   dt_max = 0.001
+   num_cycles = 1
+   regrid_interval = 0
+   error_on_dt_change = FALSE
+   warn_on_dt_change = FALSE
+   time_stepping_type = IB_RULE
+   jacobian_delta_fcn = JAC_KERNEL
+   rel_residual_tol = 1.0e-10
+   abs_residual_tol = 1.0e-12
+   max_iterations = 20
+   stokes_ib_precond_db {
+      has_pressure_nullspace = TRUE
+      num_pre_sweeps = 1
+      num_post_sweeps = 1
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         ksp_type = "preonly"
+         pc_type = "svd"
+         initial_guess_nonzero = FALSE
+      }
+   }
+}
+INSStaggeredHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.02
+   mu = 0.01
+   rho = 1.0
+   creeping_flow = TRUE
+   viscous_time_stepping_type = "TRAPEZOIDAL_RULE"
+   normalize_pressure = TRUE
+   num_cycles = 1
+   dt_max = 0.001
+   enable_logging_solver_iterations = FALSE
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = 1
+   base_filenames_0 = "ellipse"
+}
+VelocityInitialConditions {
+   function_0 = "0.1*sin(2*pi*X_1)"
+   function_1 = "0.05*cos(2*pi*X_0)"
+}
+Main {
+   log_file_name = "IB.log"
+   log_all_nodes = FALSE
+   petsc_settings {
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "100"
+      stokes_ib_pc_level_0_ksp_type = "preonly"
+      stokes_ib_pc_level_0_pc_type = "svd"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size { level_0 = N,N }
+   smallest_patch_size { level_0 = N,N }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (N - 1, N - 1)] }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h
@@ -162,7 +162,7 @@ protected:
      */
     void putToDatabaseSpecialized(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
 
-    //! Strategy advanced by the coupled solve.
+    //! Typed view of d_ib_method_ops for implicit strategy operations.
     SAMRAI::tbox::Pointer<IBImplicitStrategy> d_ib_implicit_ops;
 
 private:
@@ -211,9 +211,9 @@ private:
     SAMRAI::tbox::Pointer<IBTK::PETScNewtonKrylovSolver> d_ib_solver;
     SAMRAI::tbox::Pointer<StaggeredStokesPhysicalBoundaryHelper> d_stokes_bc_helper;
     //! References INS-owned velocity/pressure scratch components.
-    SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_eul_sol_vec;
+    SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_sol_vec;
     //! Owns cloned components whose descriptors persist between advances.
-    SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_eul_rhs_vec;
+    SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_rhs_vec;
     //! Owned matrices borrowed by FAC until solver state is deallocated.
     Mat d_ib_force_jac = nullptr;
     Mat d_ib_interp_op = nullptr;

--- a/include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h
+++ b/include/ibamr/IBImplicitStaggeredHierarchyIntegrator.h
@@ -22,19 +22,16 @@
 
 #include <ibamr/IBHierarchyIntegrator.h>
 #include <ibamr/IBImplicitStrategy.h>
-#include <ibamr/StaggeredStokesFACPreconditioner.h>
+#include <ibamr/StaggeredStokesIBJacobianFACPreconditioner.h>
+#include <ibamr/StaggeredStokesIBJacobianOperator.h>
 #include <ibamr/StaggeredStokesIBLevelRelaxationFACOperator.h>
+#include <ibamr/StaggeredStokesIBOperator.h>
 #include <ibamr/StaggeredStokesOperator.h>
-#include <ibamr/StaggeredStokesSolver.h>
+
+#include <ibtk/IBKernelTensorProduct.h>
+#include <ibtk/PETScNewtonKrylovSolver.h>
 
 #include <tbox/Pointer.h>
-
-#include <petscksp.h>
-#include <petscmat.h>
-#include <petscpc.h>
-#include <petscsnes.h>
-#include <petscsys.h>
-#include <petscvec.h>
 
 #include <IntVector.h>
 #include <SAMRAIVectorReal.h>
@@ -49,6 +46,8 @@ namespace SAMRAI
 {
 namespace hier
 {
+template <int DIM>
+class BasePatchHierarchy;
 template <int DIM>
 class PatchHierarchy;
 } // namespace hier
@@ -72,9 +71,24 @@ class Database;
 namespace IBAMR
 {
 /*!
- * \brief Class IBImplicitStaggeredHierarchyIntegrator is an implementation of a
- * formally second-order accurate, nonlinearly-implicit version of the immersed
- * boundary method.
+ * \brief Implicit immersed boundary time integration with shared Stokes-IB operators.
+ *
+ * Uses the velocity-pressure formulation of StaggeredStokesIBOperator with
+ * backward Euler, trapezoidal, or midpoint IB stepping. The INS integrator
+ * supplies fluid time-stepping terms and boundary conditions. The hierarchy
+ * Jacobian applies the analytic IB linearization; FAC uses assembled coupling.
+ *
+ * Configure the nonlinear solver in this object's input database (PETSc prefix
+ * \c ib_) and FAC in \c stokes_ib_precond_db (prefix \c stokes_ib_pc_).
+ * \c jacobian_delta_fcn selects an IBTK::IBKernelTensorProduct registered for
+ * interpolation-matrix construction. The strategy's minimum ghost width must
+ * cover that kernel; with IBMethod, set \c min_ghost_cell_width when needed.
+ * Application evaluators must be registered before hierarchy advancement.
+ *
+ * Fixed coupling is enabled on the supplied strategy at construction. Subclasses
+ * overriding time-step or hierarchy hooks must call the corresponding base
+ * implementation to prepare and release solver state. See
+ * StaggeredStokesIBOperator::Context for the shared operator requirements.
  */
 class IBImplicitStaggeredHierarchyIntegrator : public IBHierarchyIntegrator
 {
@@ -84,12 +98,6 @@ public:
      * some default values, reads in configuration information from input and
      * restart databases, and registers the integrator object with the restart
      * manager when requested.
-     *
-     * The minimum ghost width supplied by ib_method_ops must cover the kernel
-     * selected by \c jacobian_delta_fcn, which may differ from the coupling
-     * kernels. With IBMethod, set \c min_ghost_cell_width in its input database
-     * when necessary; for example, BSPLINE_8 requires a width of at least four.
-     * See IBMethod::getMinimumGhostCellWidth().
      */
     IBImplicitStaggeredHierarchyIntegrator(const std::string& object_name,
                                            SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db,
@@ -102,7 +110,7 @@ public:
      * unregisters the integrator object with the restart manager when the
      * object is so registered.
      */
-    ~IBImplicitStaggeredHierarchyIntegrator() = default;
+    ~IBImplicitStaggeredHierarchyIntegrator() override;
 
     /*!
      * Prepare to advance the data from current_time to new_time.
@@ -143,131 +151,24 @@ protected:
     void integrateHierarchySpecialized(double current_time, double new_time, int cycle_num = 0) override;
 
     /*!
+     * Reset cached hierarchy dependent data.
+     */
+    void resetHierarchyConfigurationSpecialized(SAMRAI::tbox::Pointer<SAMRAI::hier::BasePatchHierarchy<NDIM>> hierarchy,
+                                                int coarsest_level,
+                                                int finest_level) override;
+
+    /*!
      * Write out specialized object state to the given database.
      */
     void putToDatabaseSpecialized(SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> db) override;
 
+    //! Strategy advanced by the coupled solve.
     SAMRAI::tbox::Pointer<IBImplicitStrategy> d_ib_implicit_ops;
 
 private:
-    /*!
-     * \brief Partial solver for the Stokes-IB equations.
-     *
-     * \note This class is designed to be used internally by class IBImplicitStaggeredHierarchyIntegrator.  It is not
-     * meant to be a stand-alone solver.
-     */
-    class IBImplicitStaggeredStokesSolver : public IBAMR::StaggeredStokesSolver
-    {
-    public:
-        /*!
-         * \brief Class constructor.
-         */
-        IBImplicitStaggeredStokesSolver(const std::string& object_name,
-                                        SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db)
-            : StaggeredStokesSolver()
-        {
-            d_stokes_op = new StaggeredStokesOperator(object_name + "::stokes_op", false);
-            SAMRAI::tbox::Pointer<StaggeredStokesIBLevelRelaxationFACOperator> fac_op =
-                new StaggeredStokesIBLevelRelaxationFACOperator(object_name + "::fac_op", input_db, "stokes_ib_pc_");
-            d_stokes_fac_pc =
-                new StaggeredStokesFACPreconditioner(object_name + "::fac_pc", fac_op, input_db, "stokes_ib_pc_");
-            return;
-        }
-
-        /*!
-         * \brief Class desctructor.
-         */
-        ~IBImplicitStaggeredStokesSolver()
-        {
-            // intentionally left blank
-            return;
-        }
-
-        // \{ Implementation of IBAMR::StaggeredStokesSolver class.
-
-        void setVelocityPoissonSpecifications(const SAMRAI::solv::PoissonSpecifications& U_problem_coefs) override
-        {
-            StaggeredStokesSolver::setVelocityPoissonSpecifications(U_problem_coefs);
-            d_stokes_op->setVelocityPoissonSpecifications(U_problem_coefs);
-            d_stokes_fac_pc->setVelocityPoissonSpecifications(U_problem_coefs);
-            return;
-        }
-
-        void setPhysicalBcCoefs(const std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*>& U_bc_coefs,
-                                SAMRAI::solv::RobinBcCoefStrategy<NDIM>* P_bc_coef) override
-        {
-            StaggeredStokesSolver::setPhysicalBcCoefs(U_bc_coefs, P_bc_coef);
-            d_stokes_op->setPhysicalBcCoefs(U_bc_coefs, P_bc_coef);
-            d_stokes_fac_pc->setPhysicalBcCoefs(U_bc_coefs, P_bc_coef);
-            return;
-        }
-
-        void setPhysicalBoundaryHelper(SAMRAI::tbox::Pointer<StaggeredStokesPhysicalBoundaryHelper> bc_helper) override
-        {
-            StaggeredStokesSolver::setPhysicalBoundaryHelper(bc_helper);
-            d_stokes_op->setPhysicalBoundaryHelper(bc_helper);
-            d_stokes_fac_pc->setPhysicalBoundaryHelper(bc_helper);
-            return;
-        }
-
-        void setComponentsHaveNullSpace(const bool has_velocity_nullspace, const bool has_pressure_nullspace) override
-        {
-            StaggeredStokesSolver::setComponentsHaveNullSpace(has_velocity_nullspace, has_pressure_nullspace);
-            d_stokes_fac_pc->setComponentsHaveNullSpace(d_has_velocity_nullspace, d_has_pressure_nullspace);
-            return;
-        }
-
-        // \}
-
-        // \{ Implementation of IBTK::GeneralSolver class.
-
-        bool solveSystem(SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& /*x*/,
-                         SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& /*b*/) override
-        {
-            TBOX_ERROR("StaggeredStokesIBSolver::solveSystem(): unimplemented.\n");
-            return false;
-        }
-
-        // \}
-
-        SAMRAI::tbox::Pointer<StaggeredStokesOperator> getStaggeredStokesOperator()
-        {
-            return d_stokes_op;
-        }
-
-        SAMRAI::tbox::Pointer<StaggeredStokesFACPreconditioner> getStaggeredStokesFACPreconditioner()
-        {
-            return d_stokes_fac_pc;
-        }
-
-    private:
-        IBImplicitStaggeredStokesSolver() = delete;
-        IBImplicitStaggeredStokesSolver(const IBImplicitStaggeredStokesSolver& from) = delete;
-        IBImplicitStaggeredStokesSolver& operator=(const IBImplicitStaggeredStokesSolver& that) = delete;
-
-        // Operators and solvers maintained by this class.
-        SAMRAI::tbox::Pointer<StaggeredStokesOperator> d_stokes_op;
-        SAMRAI::tbox::Pointer<StaggeredStokesFACPreconditioner> d_stokes_fac_pc;
-    };
-
-    /*!
-     * \brief Copy constructor.
-     *
-     * \note This constructor is not implemented and should not be used.
-     *
-     * \param from The value to copy to this object.
-     */
+    /*! \brief Copy construction is disabled. */
     IBImplicitStaggeredHierarchyIntegrator(const IBImplicitStaggeredHierarchyIntegrator& from) = delete;
-
-    /*!
-     * \brief Assignment operator.
-     *
-     * \note This operator is not implemented and should not be used.
-     *
-     * \param that The value to assign to this object.
-     *
-     * \return A reference to this object.
-     */
+    /*! \brief Copy assignment is disabled. */
     IBImplicitStaggeredHierarchyIntegrator& operator=(const IBImplicitStaggeredHierarchyIntegrator& that) = delete;
 
     /*!
@@ -277,99 +178,45 @@ private:
     void getFromRestart();
 
     /*!
-     * \brief Solve for position along with fluid variables.
+     * Setup and allocate Eulerian solver vectors used in implicit solves.
      */
-    void integrateHierarchy_position(double current_time, double new_time, int cycle_num);
+    void setupSolverVectors(double current_time, int coarsest_ln, int finest_ln);
 
     /*!
-     * \brief Solve for fluid variables only.
+     * Setup hierarchy dependent operators and solvers used in implicit solves.
      */
-    void integrateHierarchy_velocity(double current_time, double new_time, int cycle_num);
+    void reinitializeOperatorsAndSolvers(double current_time, double new_time);
 
     /*!
-     * Static function for implicit formulation.
+     * Deallocate hierarchy dependent operators and solvers used in implicit solves.
      */
-    static PetscErrorCode IBFunction_SAMRAI(SNES snes, Vec x, Vec f, void* ctx);
-
-    /*!
-     * Function for implicit formulation that solves for u,p and X.
-     */
-    PetscErrorCode IBFunction_position(SNES snes, Vec x, Vec f);
-
-    /*!
-     * Function for implicit formulation that solves for u and p.
-     */
-    PetscErrorCode IBFunction_velocity(SNES snes, Vec x, Vec f);
-
-    /*!
-     * Static function for setting up implicit formulation Jacobian.
-     */
-    static PetscErrorCode IBJacobianSetup_SAMRAI(SNES snes, Vec x, Mat A, Mat B, void* p_ctx);
-
-    /*!
-     * Static function for setting up implicit formulation Jacobian that solves for u, p, and X.
-     */
-    PetscErrorCode IBJacobianSetup_position(SNES snes, Vec x, Mat A, Mat B);
-
-    /*!
-     * Static function for setting up implicit formulation Jacobian that solves for u and p.
-     */
-    PetscErrorCode IBJacobianSetup_velocity(SNES snes, Vec x, Mat A, Mat B);
-
-    /*!
-     * Static function for implicit formulation Jacobian.
-     */
-    static PetscErrorCode IBJacobianApply_SAMRAI(Mat A, Vec x, Vec y);
-
-    /*!
-     * Function for implicit formulation Jacobian that solves for u, p, and X.
-     */
-    PetscErrorCode IBJacobianApply_position(Vec x, Vec y);
-
-    /*
-     * Function for implicit formulation Jacobian that solves for u and p.
-     */
-    PetscErrorCode IBJacobianApply_velocity(Vec x, Vec y);
-
-    /*!
-     * Static function for implicit formulation preconditioner.
-     */
-    static PetscErrorCode IBPCApply_SAMRAI(PC pc, Vec x, Vec y);
-
-    /*!
-     * Function for implicit formulation preconditioner that solves for u, p, and X.
-     */
-    PetscErrorCode IBPCApply_position(Vec x, Vec y);
-
-    /*!
-     * Function for implicit formulation preconditioner that solves for u and p.
-     */
-    PetscErrorCode IBPCApply_velocity(Vec x, Vec y);
-
-    /*!
-     * Static function for implicit formulation Lagrangian Schur complement.
-     */
-    static PetscErrorCode lagrangianSchurApply_SAMRAI(Mat A, Vec x, Vec y);
-
-    /*!
-     * Function for implicit formulation Lagrangian Schur complement.
-     */
-    PetscErrorCode lagrangianSchurApply(Vec x, Vec y);
+    void deallocateOperatorsAndSolvers();
 
     // Eulerian data for storing u and p DOFs indexing.
-    std::vector<std::vector<int>> d_num_dofs_per_proc;
-    int d_u_dof_index_idx, d_p_dof_index_idx;
+    std::vector<int> d_num_dofs_per_proc;
+    int d_u_dof_index_idx = IBTK::invalid_index, d_p_dof_index_idx = IBTK::invalid_index;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, int>> d_u_dof_index_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, int>> d_p_dof_index_var;
 
     // Solvers and associated vectors.
-    bool d_solve_for_position = false;
-    std::string d_jac_delta_fcn = "IB_4";
-    SAMRAI::tbox::Pointer<StaggeredStokesSolver> d_stokes_solver;
+    //! Kernel used to assemble the FAC interpolation matrix.
+    IBTK::IBKernelTensorProduct d_jac_kernel = IBTK::IBKernel::IB_4;
+    bool d_vectors_need_init = true;
+    bool d_has_velocity_nullspace = false;
+    bool d_has_pressure_nullspace = true;
     SAMRAI::tbox::Pointer<StaggeredStokesOperator> d_stokes_op;
-    KSP d_schur_solver;
-    SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_u_scratch_vec, d_f_scratch_vec;
-    Vec d_X_current;
+    SAMRAI::tbox::Pointer<StaggeredStokesIBOperator> d_ib_op;
+    SAMRAI::tbox::Pointer<StaggeredStokesIBJacobianOperator> d_ib_jac_op;
+    SAMRAI::tbox::Pointer<StaggeredStokesIBJacobianFACPreconditioner> d_ib_jac_pc;
+    SAMRAI::tbox::Pointer<IBTK::PETScNewtonKrylovSolver> d_ib_solver;
+    SAMRAI::tbox::Pointer<StaggeredStokesPhysicalBoundaryHelper> d_stokes_bc_helper;
+    //! References INS-owned velocity/pressure scratch components.
+    SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_eul_sol_vec;
+    //! Owns cloned components whose descriptors persist between advances.
+    SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_eul_rhs_vec;
+    //! Owned matrices borrowed by FAC until solver state is deallocated.
+    Mat d_ib_force_jac = nullptr;
+    Mat d_ib_interp_op = nullptr;
 };
 } // namespace IBAMR
 

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -90,11 +90,11 @@ constexpr int IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION = 1;
 IBImplicitStaggeredHierarchyIntegrator::IBImplicitStaggeredHierarchyIntegrator(
     const std::string& object_name,
     Pointer<Database> input_db,
-    Pointer<IBImplicitStrategy> ib_implicit_ops,
+    Pointer<IBImplicitStrategy> ib_method_ops,
     Pointer<INSStaggeredHierarchyIntegrator> ins_hier_integrator,
     bool register_for_restart)
-    : IBHierarchyIntegrator(object_name, input_db, ib_implicit_ops, ins_hier_integrator, register_for_restart),
-      d_ib_implicit_ops(ib_implicit_ops)
+    : IBHierarchyIntegrator(object_name, input_db, ib_method_ops, ins_hier_integrator, register_for_restart),
+      d_ib_implicit_ops(ib_method_ops)
 {
     d_ib_implicit_ops->setUseFixedLEOperators(true);
 
@@ -153,9 +153,9 @@ IBImplicitStaggeredHierarchyIntegrator::IBImplicitStaggeredHierarchyIntegrator(
 IBImplicitStaggeredHierarchyIntegrator::~IBImplicitStaggeredHierarchyIntegrator()
 {
     deallocateOperatorsAndSolvers();
-    if (d_eul_rhs_vec)
+    if (d_rhs_vec)
     {
-        free_vector_components(*d_eul_rhs_vec);
+        free_vector_components(*d_rhs_vec);
     }
     return;
 } // ~IBImplicitStaggeredHierarchyIntegrator
@@ -203,11 +203,11 @@ IBImplicitStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
 
     if (d_time_stepping_type == TRAPEZOIDAL_RULE)
     {
-        d_ib_implicit_ops->computeLagrangianForce(current_time);
+        d_ib_method_ops->computeLagrangianForce(current_time);
         d_hier_velocity_data_ops->setToScalar(d_f_current_idx, 0.0, false);
         d_u_phys_bdry_op->setPatchDataIndex(d_f_current_idx);
         d_u_phys_bdry_op->setHomogeneousBc(true);
-        d_ib_implicit_ops->spreadForce(
+        d_ib_method_ops->spreadForce(
             d_f_current_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), current_time);
     }
 
@@ -217,7 +217,7 @@ IBImplicitStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
         {
             plog << d_object_name << "::preprocessIntegrateHierarchy(): Lagrangian forward Euler predictor\n";
         }
-        d_ib_implicit_ops->forwardEulerStep(current_time, new_time);
+        d_ib_method_ops->forwardEulerStep(current_time, new_time);
     }
 
     executePreprocessIntegrateHierarchyCallbackFcns(current_time, new_time, num_cycles);
@@ -240,10 +240,10 @@ IBImplicitStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const doub
     }
     d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
     d_u_phys_bdry_op->setHomogeneousBc(false);
-    d_ib_implicit_ops->interpolateVelocity(d_u_idx,
-                                           getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
-                                           getGhostfillRefineSchedules(d_object_name + "::u"),
-                                           new_time);
+    d_ib_method_ops->interpolateVelocity(d_u_idx,
+                                         getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
+                                         getGhostfillRefineSchedules(d_object_name + "::u"),
+                                         new_time);
 
     deallocateOperatorsAndSolvers();
 
@@ -257,9 +257,9 @@ IBImplicitStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const doub
     {
         finest_level->deallocatePatchData(d_p_dof_index_idx);
     }
-    if (d_eul_rhs_vec)
+    if (d_rhs_vec)
     {
-        d_eul_rhs_vec->deallocateVectorData();
+        d_rhs_vec->deallocateVectorData();
     }
     IBHierarchyIntegrator::postprocessIntegrateHierarchy(
         current_time, new_time, skip_synchronize_new_state_data, num_cycles);
@@ -314,49 +314,49 @@ IBImplicitStaggeredHierarchyIntegrator::integrateHierarchySpecialized(const doub
         d_time_stepping_type, current_time, new_time, d_object_name + "::integrateHierarchySpecialized()");
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    Pointer<VariableContext> current_ctx = ins_hier_integrator->getCurrentContext();
-    Pointer<Variable<NDIM>> u_var = ins_hier_integrator->getVelocityVariable();
-    const int u_current_idx = var_db->mapVariableAndContextToIndex(u_var, current_ctx);
+    const int u_current_idx = var_db->mapVariableAndContextToIndex(d_ins_hier_integrator->getVelocityVariable(),
+                                                                   d_ins_hier_integrator->getCurrentContext());
+    const int u_new_idx = var_db->mapVariableAndContextToIndex(d_ins_hier_integrator->getVelocityVariable(),
+                                                               d_ins_hier_integrator->getNewContext());
 
+    // Solve the coupled velocity-pressure equations.
     ins_hier_integrator->skipCycle(current_time, new_time, cycle_num);
 
-    TBOX_ASSERT(d_eul_sol_vec && d_eul_rhs_vec);
+    TBOX_ASSERT(d_sol_vec && d_rhs_vec);
 
-    ins_hier_integrator->setupSolverVectors(d_eul_sol_vec, d_eul_rhs_vec, current_time, new_time, cycle_num);
+    ins_hier_integrator->setupSolverVectors(d_sol_vec, d_rhs_vec, current_time, new_time, cycle_num);
     if (d_time_stepping_type == TRAPEZOIDAL_RULE)
     {
-        d_hier_velocity_data_ops->axpy(d_eul_rhs_vec->getComponentDescriptorIndex(0),
-                                       0.5,
-                                       d_f_current_idx,
-                                       d_eul_rhs_vec->getComponentDescriptorIndex(0));
+        d_hier_velocity_data_ops->axpy(
+            d_rhs_vec->getComponentDescriptorIndex(0), 0.5, d_f_current_idx, d_rhs_vec->getComponentDescriptorIndex(0));
     }
     reinitializeOperatorsAndSolvers(current_time, new_time);
 
-    d_ib_implicit_ops->preprocessSolveFluidEquations(current_time, new_time, cycle_num);
+    d_ib_method_ops->preprocessSolveFluidEquations(current_time, new_time, cycle_num);
     // Keep the hierarchy Jacobian analytic and matrix-free; FAC owns assembled level coupling.
-    d_ib_solver->initializeSolverState(*d_eul_sol_vec, *d_eul_rhs_vec);
-    if (!d_ib_solver->solveSystem(*d_eul_sol_vec, *d_eul_rhs_vec))
+    d_ib_solver->initializeSolverState(*d_sol_vec, *d_rhs_vec);
+    if (!d_ib_solver->solveSystem(*d_sol_vec, *d_rhs_vec))
     {
         TBOX_ERROR(d_object_name << "::integrateHierarchySpecialized(): nonlinear Stokes-IB solve failed\n");
     }
 
-    d_stokes_op->imposeSolBcs(*d_eul_sol_vec);
+    d_stokes_op->imposeSolBcs(*d_sol_vec);
     if (d_has_velocity_nullspace || d_has_pressure_nullspace)
     {
-        ins_hier_integrator->removeNullSpace(d_eul_sol_vec);
+        ins_hier_integrator->removeNullSpace(d_sol_vec);
     }
-    d_ib_implicit_ops->postprocessSolveFluidEquations(current_time, new_time, cycle_num);
+    d_ib_method_ops->postprocessSolveFluidEquations(current_time, new_time, cycle_num);
 
-    ins_hier_integrator->resetSolverVectors(d_eul_sol_vec, d_eul_rhs_vec, current_time, new_time, cycle_num);
+    ins_hier_integrator->resetSolverVectors(d_sol_vec, d_rhs_vec, current_time, new_time, cycle_num);
     deallocateOperatorsAndSolvers();
 
+    // Interpolate the Eulerian velocity to the Lagrangian mesh.
     if (d_enable_logging)
     {
         plog << d_object_name
              << "::integrateHierarchySpecialized(): interpolating "
                 "Eulerian velocity to the Lagrangian mesh\n";
     }
-    const int u_new_idx = d_eul_sol_vec->getComponentDescriptorIndex(0);
     if (d_time_stepping_type == MIDPOINT_RULE)
     {
         d_hier_velocity_data_ops->linearSum(d_u_idx, 0.5, u_current_idx, 0.5, u_new_idx);
@@ -367,11 +367,12 @@ IBImplicitStaggeredHierarchyIntegrator::integrateHierarchySpecialized(const doub
     }
     d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
     d_u_phys_bdry_op->setHomogeneousBc(false);
-    d_ib_implicit_ops->interpolateVelocity(d_u_idx,
-                                           getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
-                                           getGhostfillRefineSchedules(d_object_name + "::u"),
-                                           schedule.evaluation_time);
+    d_ib_method_ops->interpolateVelocity(d_u_idx,
+                                         getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
+                                         getGhostfillRefineSchedules(d_object_name + "::u"),
+                                         schedule.evaluation_time);
 
+    // Update the positions of the Lagrangian structure.
     advance_staggered_stokes_ib_strategy(*d_ib_implicit_ops,
                                          d_time_stepping_type,
                                          current_time,
@@ -444,27 +445,26 @@ IBImplicitStaggeredHierarchyIntegrator::setupSolverVectors(const double current_
     Pointer<Variable<NDIM>> p_var = ins_hier_integrator->getPressureVariable();
     const int p_scratch_idx = var_db->mapVariableAndContextToIndex(p_var, scratch_ctx);
 
-    const bool reset_solver_vecs = d_vectors_need_init || !d_eul_sol_vec || !d_eul_rhs_vec ||
-                                   d_eul_sol_vec->getCoarsestLevelNumber() != coarsest_ln ||
-                                   d_eul_sol_vec->getFinestLevelNumber() != finest_ln ||
-                                   d_eul_sol_vec->getComponentDescriptorIndex(0) != u_scratch_idx ||
-                                   d_eul_sol_vec->getComponentDescriptorIndex(1) != p_scratch_idx;
+    const bool reset_solver_vecs =
+        d_vectors_need_init || !d_sol_vec || !d_rhs_vec || d_sol_vec->getCoarsestLevelNumber() != coarsest_ln ||
+        d_sol_vec->getFinestLevelNumber() != finest_ln || d_sol_vec->getComponentDescriptorIndex(0) != u_scratch_idx ||
+        d_sol_vec->getComponentDescriptorIndex(1) != p_scratch_idx;
     if (reset_solver_vecs)
     {
-        if (d_eul_rhs_vec)
+        if (d_rhs_vec)
         {
-            free_vector_components(*d_eul_rhs_vec);
+            free_vector_components(*d_rhs_vec);
         }
-        d_eul_sol_vec = new SAMRAIVectorReal<NDIM, double>(
+        d_sol_vec = new SAMRAIVectorReal<NDIM, double>(
             d_object_name + "::eulerian_sol_vec", d_hierarchy, coarsest_ln, finest_ln);
-        d_eul_sol_vec->addComponent(u_var, u_scratch_idx, wgt_sc_idx, d_hier_velocity_data_ops);
-        d_eul_sol_vec->addComponent(p_var, p_scratch_idx, wgt_cc_idx, d_hier_pressure_data_ops);
+        d_sol_vec->addComponent(u_var, u_scratch_idx, wgt_sc_idx, d_hier_velocity_data_ops);
+        d_sol_vec->addComponent(p_var, p_scratch_idx, wgt_cc_idx, d_hier_pressure_data_ops);
 
-        d_eul_rhs_vec = d_eul_sol_vec->cloneVector(d_object_name + "::eulerian_rhs_vec");
+        d_rhs_vec = d_sol_vec->cloneVector(d_object_name + "::eulerian_rhs_vec");
         d_vectors_need_init = false;
     }
 
-    d_eul_rhs_vec->allocateVectorData(current_time);
+    d_rhs_vec->allocateVectorData(current_time);
     return;
 } // setupSolverVectors
 
@@ -480,7 +480,7 @@ IBImplicitStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const do
         deallocateOperatorsAndSolvers();
     }
 
-    TBOX_ASSERT(d_eul_sol_vec && d_eul_rhs_vec);
+    TBOX_ASSERT(d_sol_vec && d_rhs_vec);
 
     const double dt = new_time - current_time;
 

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -377,7 +377,6 @@ IBImplicitStaggeredHierarchyIntegrator::integrateHierarchySpecialized(const doub
                                          current_time,
                                          new_time,
                                          d_object_name + "::integrateHierarchySpecialized()");
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
 } // integrateHierarchySpecialized
 

--- a/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
+++ b/src/IB/IBImplicitStaggeredHierarchyIntegrator.cpp
@@ -16,22 +16,23 @@
 #include <ibamr/IBHierarchyIntegrator.h>
 #include <ibamr/IBImplicitStaggeredHierarchyIntegrator.h>
 #include <ibamr/IBImplicitStrategy.h>
-#include <ibamr/IBStrategy.h>
-#include <ibamr/INSHierarchyIntegrator.h>
 #include <ibamr/INSStaggeredHierarchyIntegrator.h>
-#include <ibamr/StaggeredStokesFACPreconditioner.h>
+#include <ibamr/StaggeredStokesIBJacobianFACPreconditioner.h>
+#include <ibamr/StaggeredStokesIBJacobianOperator.h>
 #include <ibamr/StaggeredStokesIBLevelRelaxationFACOperator.h>
-#include <ibamr/StaggeredStokesOperator.h>
+#include <ibamr/StaggeredStokesIBOperator.h>
 #include <ibamr/StaggeredStokesPETScVecUtilities.h>
-#include <ibamr/StaggeredStokesSolver.h>
+#include <ibamr/StaggeredStokesPhysicalBoundaryHelper.h>
+#include <ibamr/StokesSpecifications.h>
 #include <ibamr/ibamr_enums.h>
+#include <ibamr/private/StaggeredStokesIBTimeSteppingUtilities.h>
 
 #include <ibtk/CartGridFunction.h>
 #include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBKernelTensorProduct.h>
 #include <ibtk/IBTK_CHKERRQ.h>
-#include <ibtk/IBTK_MPI.h>
 #include <ibtk/KrylovLinearSolver.h>
-#include <ibtk/PETScSAMRAIVectorReal.h>
+#include <ibtk/PETScNewtonKrylovSolver.h>
 #include <ibtk/RobinPhysBdryPatchStrategy.h>
 #include <ibtk/ibtk_enums.h>
 
@@ -41,38 +42,23 @@
 #include <tbox/RestartManager.h>
 #include <tbox/Utilities.h>
 
-#include <petscksp.h>
-#include <petsclog.h>
 #include <petscmat.h>
-#include <petscpc.h>
-#include <petscpctypes.h>
-#include <petscsnes.h>
-#include <petscsys.h>
-#include <petscvec.h>
 
-#include <CartesianPatchGeometry.h>
-#include <CellData.h>
 #include <CellVariable.h>
 #include <GriddingAlgorithm.h>
+#include <HierarchyCellDataOpsReal.h>
 #include <HierarchyDataOpsReal.h>
 #include <IntVector.h>
-#include <MultiblockDataTranslator.h>
 #include <Patch.h>
-#include <PatchCellDataOpsReal.h>
 #include <PatchHierarchy.h>
 #include <PatchLevel.h>
-#include <PatchSideDataOpsReal.h>
 #include <SAMRAIVectorReal.h>
 #include <SideData.h>
 #include <SideVariable.h>
 #include <Variable.h>
 #include <VariableContext.h>
-#include <VariableDatabase.h>
-#include <math.h>
 
-#include <algorithm>
-#include <limits>
-#include <ostream>
+#include <cmath>
 #include <string>
 #include <vector>
 
@@ -95,8 +81,7 @@ namespace IBAMR
 
 namespace
 {
-// Version of IBImplicitStaggeredHierarchyIntegrator restart file data.
-static const int IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION = 1;
+constexpr int IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION = 1;
 
 } // namespace
 
@@ -111,23 +96,31 @@ IBImplicitStaggeredHierarchyIntegrator::IBImplicitStaggeredHierarchyIntegrator(
     : IBHierarchyIntegrator(object_name, input_db, ib_implicit_ops, ins_hier_integrator, register_for_restart),
       d_ib_implicit_ops(ib_implicit_ops)
 {
-    // Setup IB ops object to use "fixed" Lagrangian-Eulerian coupling
-    // operators.
     d_ib_implicit_ops->setUseFixedLEOperators(true);
 
-    // Set default configuration options.
     d_use_structure_predictor = false;
 
-    // Set options from input.
+    Pointer<Database> stokes_ib_pc_db = nullptr;
     if (input_db)
     {
-        if (input_db->keyExists("eliminate_eulerian_vars"))
-            d_solve_for_position = input_db->getBool("eliminate_eulerian_vars");
-        else if (input_db->keyExists("eliminate_lagrangian_vars"))
-            d_solve_for_position = !input_db->getBool("eliminate_lagrangian_vars");
         if (input_db->keyExists("use_structure_predictor"))
+        {
             d_use_structure_predictor = input_db->getBool("use_structure_predictor");
-        if (input_db->keyExists("jacobian_delta_fcn")) d_jac_delta_fcn = input_db->getString("jacobian_delta_fcn");
+        }
+        if (input_db->keyExists("jacobian_delta_fcn"))
+        {
+            d_jac_kernel = IBKernelTensorProduct(input_db->getString("jacobian_delta_fcn"));
+        }
+        if (input_db->isDatabase("stokes_ib_precond_db"))
+        {
+            stokes_ib_pc_db = input_db->getDatabase("stokes_ib_precond_db");
+        }
+    }
+
+    if (stokes_ib_pc_db)
+    {
+        d_has_velocity_nullspace = stokes_ib_pc_db->getBoolWithDefault("has_velocity_nullspace", false);
+        d_has_pressure_nullspace = stokes_ib_pc_db->getBoolWithDefault("has_pressure_nullspace", true);
     }
 
     if (d_use_structure_predictor)
@@ -136,18 +129,36 @@ IBImplicitStaggeredHierarchyIntegrator::IBImplicitStaggeredHierarchyIntegrator(
                 "appears to be nonlinearly unstable!\n";
     }
 
-    if (!d_solve_for_position)
-    {
-        Pointer<Database> stokes_ib_pc_db = input_db->getDatabase("stokes_ib_precond_db");
-        d_stokes_solver = new IBImplicitStaggeredStokesSolver(object_name, stokes_ib_pc_db);
-        ins_hier_integrator->setStokesSolver(d_stokes_solver);
-    }
+    d_stokes_op = new StaggeredStokesOperator(d_object_name + "::stokes_op", false);
+    d_ib_op = new StaggeredStokesIBOperator(d_object_name + "::ib_op", false);
+    d_ib_jac_op = new StaggeredStokesIBJacobianOperator(d_object_name + "::ib_jac_op");
+    Pointer<StaggeredStokesIBLevelRelaxationFACOperator> ib_fac_op = new StaggeredStokesIBLevelRelaxationFACOperator(
+        d_object_name + "::ib_fac_op", stokes_ib_pc_db, "stokes_ib_pc_");
+    d_ib_jac_pc = new StaggeredStokesIBJacobianFACPreconditioner(
+        d_object_name + "::ib_fac_pc", ib_fac_op, stokes_ib_pc_db, "stokes_ib_pc_");
+    d_stokes_bc_helper = new StaggeredStokesPhysicalBoundaryHelper();
+    d_ib_solver = new IBTK::PETScNewtonKrylovSolver(d_object_name + "::ib_solver", input_db, "ib_");
+    d_ib_solver->setOperator(d_ib_op);
+    d_ib_solver->setJacobian(d_ib_jac_op);
+    d_ib_solver->getLinearSolver()->setPreconditioner(d_ib_jac_pc);
 
-    // Initialize object with data read from the input and restart databases.
-    bool from_restart = RestartManager::getManager()->isFromRestart();
-    if (from_restart) getFromRestart();
+    const bool from_restart = RestartManager::getManager()->isFromRestart();
+    if (from_restart)
+    {
+        getFromRestart();
+    }
     return;
 } // IBImplicitStaggeredHierarchyIntegrator
+
+IBImplicitStaggeredHierarchyIntegrator::~IBImplicitStaggeredHierarchyIntegrator()
+{
+    deallocateOperatorsAndSolvers();
+    if (d_eul_rhs_vec)
+    {
+        free_vector_components(*d_eul_rhs_vec);
+    }
+    return;
+} // ~IBImplicitStaggeredHierarchyIntegrator
 
 void
 IBImplicitStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const double current_time,
@@ -176,62 +187,42 @@ IBImplicitStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
     const int coarsest_ln = 0;
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
 
-    // Allocate Eulerian scratch and new data.
-    d_num_dofs_per_proc.resize(finest_ln + 1);
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    Pointer<PatchLevel<NDIM>> finest_level = d_hierarchy->getPatchLevel(finest_ln);
+    if (!finest_level->checkAllocated(d_u_dof_index_idx))
     {
-        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
-        level->allocatePatchData(d_u_idx, current_time);
-        level->allocatePatchData(d_f_idx, current_time);
-        level->allocatePatchData(d_scratch_data, current_time);
-        level->allocatePatchData(d_new_data, new_time);
-        if (!d_solve_for_position && ln == finest_ln)
-        {
-            level->allocatePatchData(d_u_dof_index_idx, current_time);
-            level->allocatePatchData(d_p_dof_index_idx, current_time);
-            StaggeredStokesPETScVecUtilities::constructPatchLevelDOFIndices(
-                d_num_dofs_per_proc[ln], d_u_dof_index_idx, d_p_dof_index_idx, level);
-        }
+        finest_level->allocatePatchData(d_u_dof_index_idx, current_time);
+    }
+    if (!finest_level->checkAllocated(d_p_dof_index_idx))
+    {
+        finest_level->allocatePatchData(d_p_dof_index_idx, current_time);
+    }
+    StaggeredStokesPETScVecUtilities::constructPatchLevelDOFIndices(
+        d_num_dofs_per_proc, d_u_dof_index_idx, d_p_dof_index_idx, finest_level);
+
+    setupSolverVectors(current_time, coarsest_ln, finest_ln);
+
+    if (d_time_stepping_type == TRAPEZOIDAL_RULE)
+    {
+        d_ib_implicit_ops->computeLagrangianForce(current_time);
+        d_hier_velocity_data_ops->setToScalar(d_f_current_idx, 0.0, false);
+        d_u_phys_bdry_op->setPatchDataIndex(d_f_current_idx);
+        d_u_phys_bdry_op->setHomogeneousBc(true);
+        d_ib_implicit_ops->spreadForce(
+            d_f_current_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), current_time);
     }
 
-    // Initialize IB data.
-    d_ib_implicit_ops->preprocessIntegrateData(current_time, new_time, num_cycles);
-
-    // Compute an initial prediction of the updated positions of the Lagrangian
-    // structure.
-    //
-    // NOTE: The velocity should already have been interpolated to the
-    // curvilinear mesh and should not need to be re-interpolated.
     if (d_use_structure_predictor)
     {
         if (d_enable_logging)
-            plog << d_object_name
-                 << "::preprocessIntegrateHierarchy(): performing "
-                    "Lagrangian forward Euler step\n";
+        {
+            plog << d_object_name << "::preprocessIntegrateHierarchy(): Lagrangian forward Euler predictor\n";
+        }
         d_ib_implicit_ops->forwardEulerStep(current_time, new_time);
     }
 
-    // Execute any registered callbacks.
     executePreprocessIntegrateHierarchyCallbackFcns(current_time, new_time, num_cycles);
     return;
 } // preprocessIntegrateHierarchy
-
-void
-IBImplicitStaggeredHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
-                                                                      const double new_time,
-                                                                      const int cycle_num)
-{
-    IBHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
-    if (d_solve_for_position)
-    {
-        integrateHierarchy_position(current_time, new_time, cycle_num);
-    }
-    else
-    {
-        integrateHierarchy_velocity(current_time, new_time, cycle_num);
-    }
-    return;
-} // integrateHierarchy
 
 void
 IBImplicitStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const double current_time,
@@ -239,15 +230,14 @@ IBImplicitStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const doub
                                                                       const bool skip_synchronize_new_state_data,
                                                                       const int num_cycles)
 {
-    // The last thing we need to do (before we really postprocess) is update the structure velocity:
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     const int u_new_idx = var_db->mapVariableAndContextToIndex(d_ins_hier_integrator->getVelocityVariable(),
                                                                d_ins_hier_integrator->getNewContext());
     d_hier_velocity_data_ops->copyData(d_u_idx, u_new_idx);
     if (d_enable_logging)
-        plog << d_object_name
-             << "::postprocessIntegrateHierarchy(): interpolating Eulerian "
-                "velocity to the Lagrangian mesh\n";
+    {
+        plog << d_object_name << "::postprocessIntegrateHierarchy(): interpolating velocity to the Lagrangian mesh\n";
+    }
     d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
     d_u_phys_bdry_op->setHomogeneousBc(false);
     d_ib_implicit_ops->interpolateVelocity(d_u_idx,
@@ -255,26 +245,25 @@ IBImplicitStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const doub
                                            getGhostfillRefineSchedules(d_object_name + "::u"),
                                            new_time);
 
-    // postprocess the objects this class manages...
-    const int coarsest_ln = 0;
-    const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
-        level->deallocatePatchData(d_u_idx);
-        level->deallocatePatchData(d_f_idx);
-        if (!d_solve_for_position && ln == finest_ln)
-        {
-            level->deallocatePatchData(d_u_dof_index_idx);
-            level->deallocatePatchData(d_p_dof_index_idx);
-        }
-    }
+    deallocateOperatorsAndSolvers();
 
-    // ... and postprocess ourself.
+    const int finest_ln = d_hierarchy->getFinestLevelNumber();
+    Pointer<PatchLevel<NDIM>> finest_level = d_hierarchy->getPatchLevel(finest_ln);
+    if (finest_level->checkAllocated(d_u_dof_index_idx))
+    {
+        finest_level->deallocatePatchData(d_u_dof_index_idx);
+    }
+    if (finest_level->checkAllocated(d_p_dof_index_idx))
+    {
+        finest_level->deallocatePatchData(d_p_dof_index_idx);
+    }
+    if (d_eul_rhs_vec)
+    {
+        d_eul_rhs_vec->deallocateVectorData();
+    }
     IBHierarchyIntegrator::postprocessIntegrateHierarchy(
         current_time, new_time, skip_synchronize_new_state_data, num_cycles);
 
-    // Execute any registered callbacks.
     executePostprocessIntegrateHierarchyCallbackFcns(
         current_time, new_time, skip_synchronize_new_state_data, num_cycles);
     return;
@@ -284,10 +273,10 @@ void
 IBImplicitStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<PatchHierarchy<NDIM>> hierarchy,
                                                                       Pointer<GriddingAlgorithm<NDIM>> gridding_alg)
 {
-    if (d_integrator_is_initialized) return;
-
-    // The configured minimum must also cover the independently selected Jacobian kernel.
-    // Register u and p DOF variables.
+    if (d_integrator_is_initialized)
+    {
+        return;
+    }
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     d_u_dof_index_var = new SideVariable<NDIM, int>(d_object_name + "::u_dof_index");
     d_p_dof_index_var = new CellVariable<NDIM, int>(d_object_name + "::p_dof_index");
@@ -296,11 +285,10 @@ IBImplicitStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<Pa
     d_u_dof_index_idx = var_db->registerVariableAndContext(d_u_dof_index_var, getScratchContext(), ib_ghosts);
     d_p_dof_index_idx = var_db->registerVariableAndContext(d_p_dof_index_var, getScratchContext(), no_ghosts);
 
-    // Register body force function with INSHierarchyIntegrator
     d_ins_hier_integrator->registerBodyForceFunction(d_body_force_fcn);
 
-    // Finish initializing the hierarchy integrator.
     IBHierarchyIntegrator::initializeHierarchyIntegrator(hierarchy, gridding_alg);
+    d_ib_solver->setHierarchyMathOps(d_hier_math_ops);
     return;
 } // initializeHierarchyIntegrator
 
@@ -311,6 +299,101 @@ IBImplicitStaggeredHierarchyIntegrator::getNumberOfCycles() const
 } // getNumberOfCycles
 
 /////////////////////////////// PROTECTED ////////////////////////////////////
+
+void
+IBImplicitStaggeredHierarchyIntegrator::integrateHierarchySpecialized(const double current_time,
+                                                                      const double new_time,
+                                                                      const int cycle_num)
+{
+    IBHierarchyIntegrator::integrateHierarchySpecialized(current_time, new_time, cycle_num);
+
+    Pointer<INSStaggeredHierarchyIntegrator> ins_hier_integrator = d_ins_hier_integrator;
+    TBOX_ASSERT(ins_hier_integrator);
+
+    const StaggeredStokesIBTimeStepParameters schedule = get_staggered_stokes_ib_time_step_parameters(
+        d_time_stepping_type, current_time, new_time, d_object_name + "::integrateHierarchySpecialized()");
+
+    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
+    Pointer<VariableContext> current_ctx = ins_hier_integrator->getCurrentContext();
+    Pointer<Variable<NDIM>> u_var = ins_hier_integrator->getVelocityVariable();
+    const int u_current_idx = var_db->mapVariableAndContextToIndex(u_var, current_ctx);
+
+    ins_hier_integrator->skipCycle(current_time, new_time, cycle_num);
+
+    TBOX_ASSERT(d_eul_sol_vec && d_eul_rhs_vec);
+
+    ins_hier_integrator->setupSolverVectors(d_eul_sol_vec, d_eul_rhs_vec, current_time, new_time, cycle_num);
+    if (d_time_stepping_type == TRAPEZOIDAL_RULE)
+    {
+        d_hier_velocity_data_ops->axpy(d_eul_rhs_vec->getComponentDescriptorIndex(0),
+                                       0.5,
+                                       d_f_current_idx,
+                                       d_eul_rhs_vec->getComponentDescriptorIndex(0));
+    }
+    reinitializeOperatorsAndSolvers(current_time, new_time);
+
+    d_ib_implicit_ops->preprocessSolveFluidEquations(current_time, new_time, cycle_num);
+    // Keep the hierarchy Jacobian analytic and matrix-free; FAC owns assembled level coupling.
+    d_ib_solver->initializeSolverState(*d_eul_sol_vec, *d_eul_rhs_vec);
+    if (!d_ib_solver->solveSystem(*d_eul_sol_vec, *d_eul_rhs_vec))
+    {
+        TBOX_ERROR(d_object_name << "::integrateHierarchySpecialized(): nonlinear Stokes-IB solve failed\n");
+    }
+
+    d_stokes_op->imposeSolBcs(*d_eul_sol_vec);
+    if (d_has_velocity_nullspace || d_has_pressure_nullspace)
+    {
+        ins_hier_integrator->removeNullSpace(d_eul_sol_vec);
+    }
+    d_ib_implicit_ops->postprocessSolveFluidEquations(current_time, new_time, cycle_num);
+
+    ins_hier_integrator->resetSolverVectors(d_eul_sol_vec, d_eul_rhs_vec, current_time, new_time, cycle_num);
+    deallocateOperatorsAndSolvers();
+
+    if (d_enable_logging)
+    {
+        plog << d_object_name
+             << "::integrateHierarchySpecialized(): interpolating "
+                "Eulerian velocity to the Lagrangian mesh\n";
+    }
+    const int u_new_idx = d_eul_sol_vec->getComponentDescriptorIndex(0);
+    if (d_time_stepping_type == MIDPOINT_RULE)
+    {
+        d_hier_velocity_data_ops->linearSum(d_u_idx, 0.5, u_current_idx, 0.5, u_new_idx);
+    }
+    else
+    {
+        d_hier_velocity_data_ops->copyData(d_u_idx, u_new_idx);
+    }
+    d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
+    d_u_phys_bdry_op->setHomogeneousBc(false);
+    d_ib_implicit_ops->interpolateVelocity(d_u_idx,
+                                           getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
+                                           getGhostfillRefineSchedules(d_object_name + "::u"),
+                                           schedule.evaluation_time);
+
+    advance_staggered_stokes_ib_strategy(*d_ib_implicit_ops,
+                                         d_time_stepping_type,
+                                         current_time,
+                                         new_time,
+                                         d_object_name + "::integrateHierarchySpecialized()");
+    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
+    return;
+} // integrateHierarchySpecialized
+
+void
+IBImplicitStaggeredHierarchyIntegrator::resetHierarchyConfigurationSpecialized(
+    const Pointer<BasePatchHierarchy<NDIM>> hierarchy,
+    const int coarsest_level,
+    const int finest_level)
+{
+    IBHierarchyIntegrator::resetHierarchyConfigurationSpecialized(hierarchy, coarsest_level, finest_level);
+
+    d_num_dofs_per_proc.clear();
+    d_vectors_need_init = true;
+    deallocateOperatorsAndSolvers();
+    return;
+} // resetHierarchyConfigurationSpecialized
 
 void
 IBImplicitStaggeredHierarchyIntegrator::putToDatabaseSpecialized(Pointer<Database> db)
@@ -337,7 +420,7 @@ IBImplicitStaggeredHierarchyIntegrator::getFromRestart()
         TBOX_ERROR(d_object_name << ":  Restart database corresponding to " << d_object_name
                                  << " not found in restart file." << std::endl);
     }
-    int ver = db->getInteger("IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION");
+    const int ver = db->getInteger("IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION");
     if (ver != IB_IMPLICIT_STAGGERED_HIERARCHY_INTEGRATOR_VERSION)
     {
         TBOX_ERROR(d_object_name << ":  Restart file version different than class version." << std::endl);
@@ -346,1110 +429,182 @@ IBImplicitStaggeredHierarchyIntegrator::getFromRestart()
 } // getFromRestart
 
 void
-IBImplicitStaggeredHierarchyIntegrator::integrateHierarchy_position(const double current_time,
-                                                                    const double new_time,
-                                                                    const int cycle_num)
+IBImplicitStaggeredHierarchyIntegrator::setupSolverVectors(const double current_time,
+                                                           const int coarsest_ln,
+                                                           const int finest_ln)
 {
-    IBHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
-
     Pointer<INSStaggeredHierarchyIntegrator> ins_hier_integrator = d_ins_hier_integrator;
     TBOX_ASSERT(ins_hier_integrator);
-
-    PetscErrorCode ierr;
-    int n_local;
-
-    const int coarsest_ln = 0;
-    const int finest_ln = d_hierarchy->getFinestLevelNumber();
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     Pointer<VariableContext> scratch_ctx = ins_hier_integrator->getScratchContext();
-
     const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
     const int wgt_sc_idx = d_hier_math_ops->getSideWeightPatchDescriptorIndex();
-
     Pointer<Variable<NDIM>> u_var = ins_hier_integrator->getVelocityVariable();
     const int u_scratch_idx = var_db->mapVariableAndContextToIndex(u_var, scratch_ctx);
-
     Pointer<Variable<NDIM>> p_var = ins_hier_integrator->getPressureVariable();
     const int p_scratch_idx = var_db->mapVariableAndContextToIndex(p_var, scratch_ctx);
 
-    // Skip all cycles in the INS solver --- we advance the state data here.
-    ins_hier_integrator->skipCycle(current_time, new_time, cycle_num);
+    const bool reset_solver_vecs = d_vectors_need_init || !d_eul_sol_vec || !d_eul_rhs_vec ||
+                                   d_eul_sol_vec->getCoarsestLevelNumber() != coarsest_ln ||
+                                   d_eul_sol_vec->getFinestLevelNumber() != finest_ln ||
+                                   d_eul_sol_vec->getComponentDescriptorIndex(0) != u_scratch_idx ||
+                                   d_eul_sol_vec->getComponentDescriptorIndex(1) != p_scratch_idx;
+    if (reset_solver_vecs)
+    {
+        if (d_eul_rhs_vec)
+        {
+            free_vector_components(*d_eul_rhs_vec);
+        }
+        d_eul_sol_vec = new SAMRAIVectorReal<NDIM, double>(
+            d_object_name + "::eulerian_sol_vec", d_hierarchy, coarsest_ln, finest_ln);
+        d_eul_sol_vec->addComponent(u_var, u_scratch_idx, wgt_sc_idx, d_hier_velocity_data_ops);
+        d_eul_sol_vec->addComponent(p_var, p_scratch_idx, wgt_cc_idx, d_hier_pressure_data_ops);
 
-    // Setup Eulerian vectors used in solving the implicit IB equations.
-    Pointer<SAMRAIVectorReal<NDIM, double>> eul_sol_vec =
-        new SAMRAIVectorReal<NDIM, double>(d_object_name + "::eulerian_sol_vec", d_hierarchy, coarsest_ln, finest_ln);
-    eul_sol_vec->addComponent(u_var, u_scratch_idx, wgt_sc_idx, d_hier_velocity_data_ops);
-    eul_sol_vec->addComponent(p_var, p_scratch_idx, wgt_cc_idx, d_hier_pressure_data_ops);
+        d_eul_rhs_vec = d_eul_sol_vec->cloneVector(d_object_name + "::eulerian_rhs_vec");
+        d_vectors_need_init = false;
+    }
 
-    Pointer<SAMRAIVectorReal<NDIM, double>> eul_rhs_vec =
-        eul_sol_vec->cloneVector(d_object_name + "::eulerian_rhs_vec");
-    eul_rhs_vec->allocateVectorData(current_time);
-
-    d_u_scratch_vec = eul_sol_vec->cloneVector(d_object_name + "::u_scratch_vec");
-    d_f_scratch_vec = eul_rhs_vec->cloneVector(d_object_name + "::f_scratch_vec");
-    d_u_scratch_vec->allocateVectorData(current_time);
-    d_f_scratch_vec->allocateVectorData(current_time);
-
-    ins_hier_integrator->setupSolverVectors(eul_sol_vec, eul_rhs_vec, current_time, new_time, cycle_num);
-
-    d_stokes_solver = ins_hier_integrator->getStokesSolver();
-    Pointer<KrylovLinearSolver> p_stokes_solver = d_stokes_solver;
-    TBOX_ASSERT(p_stokes_solver);
-    d_stokes_op = p_stokes_solver->getOperator();
-    TBOX_ASSERT(d_stokes_op);
-
-    // Setup Lagrangian vectors used in solving the implicit IB equations.
-    Vec lag_sol_petsc_vec, lag_rhs_petsc_vec;
-    d_ib_implicit_ops->createSolverVecs(&lag_sol_petsc_vec, &lag_rhs_petsc_vec);
-    d_ib_implicit_ops->setupSolverVecs(&lag_sol_petsc_vec, &lag_rhs_petsc_vec);
-
-    // Indicate that the current approximation to position of the structure
-    // should be used for Lagrangian-Eulerian coupling.
-    d_ib_implicit_ops->updateFixedLEOperators();
-
-    // Setup VecNest objects to store the composite solution and
-    // right-hand-side vectors.
-    Vec eul_sol_petsc_vec = PETScSAMRAIVectorReal::createPETScVector(eul_sol_vec, PETSC_COMM_WORLD);
-    Vec eul_rhs_petsc_vec = PETScSAMRAIVectorReal::createPETScVector(eul_rhs_vec, PETSC_COMM_WORLD);
-
-    Vec sol_petsc_vecs[] = { eul_sol_petsc_vec, lag_sol_petsc_vec };
-    Vec rhs_petsc_vecs[] = { eul_rhs_petsc_vec, lag_rhs_petsc_vec };
-
-    Vec composite_sol_petsc_vec, composite_rhs_petsc_vec, composite_res_petsc_vec;
-    ierr = VecCreateNest(PETSC_COMM_WORLD, 2, nullptr, sol_petsc_vecs, &composite_sol_petsc_vec);
-    IBTK_CHKERRQ(ierr);
-    ierr = VecCreateNest(PETSC_COMM_WORLD, 2, nullptr, rhs_petsc_vecs, &composite_rhs_petsc_vec);
-    IBTK_CHKERRQ(ierr);
-    ierr = VecDuplicate(composite_rhs_petsc_vec, &composite_res_petsc_vec);
-    IBTK_CHKERRQ(ierr);
-
-    // Solve the implicit IB equations.
-    d_ib_implicit_ops->preprocessSolveFluidEquations(current_time, new_time, cycle_num);
-
-    SNES snes;
-    ierr = SNESCreate(PETSC_COMM_WORLD, &snes);
-    IBTK_CHKERRQ(ierr);
-    ierr = SNESSetFunction(snes, composite_res_petsc_vec, IBFunction_SAMRAI, this);
-    IBTK_CHKERRQ(ierr);
-    ierr = SNESSetOptionsPrefix(snes, "ib_");
-    IBTK_CHKERRQ(ierr);
-
-    Mat jac;
-    ierr = VecGetLocalSize(composite_sol_petsc_vec, &n_local);
-    IBTK_CHKERRQ(ierr);
-    ierr = MatCreateShell(PETSC_COMM_WORLD, n_local, n_local, PETSC_DETERMINE, PETSC_DETERMINE, this, &jac);
-    IBTK_CHKERRQ(ierr);
-    ierr = MatShellSetOperation(jac, MATOP_MULT, reinterpret_cast<void (*)(void)>(IBJacobianApply_SAMRAI));
-    IBTK_CHKERRQ(ierr);
-    ierr = SNESSetJacobian(snes, jac, jac, IBJacobianSetup_SAMRAI, this);
-    IBTK_CHKERRQ(ierr);
-
-    Mat schur;
-    ierr = VecGetLocalSize(lag_sol_petsc_vec, &n_local);
-    IBTK_CHKERRQ(ierr);
-    ierr = MatCreateShell(PETSC_COMM_WORLD, n_local, n_local, PETSC_DETERMINE, PETSC_DETERMINE, this, &schur);
-    IBTK_CHKERRQ(ierr);
-    ierr = MatShellSetOperation(schur, MATOP_MULT, reinterpret_cast<void (*)(void)>(lagrangianSchurApply_SAMRAI));
-    IBTK_CHKERRQ(ierr);
-    ierr = KSPCreate(PETSC_COMM_WORLD, &d_schur_solver);
-    IBTK_CHKERRQ(ierr);
-    ierr = KSPSetOptionsPrefix(d_schur_solver, "ib_schur_");
-    IBTK_CHKERRQ(ierr);
-    ierr = KSPSetOperators(d_schur_solver, schur, schur);
-    IBTK_CHKERRQ(ierr);
-    ierr = KSPSetReusePreconditioner(d_schur_solver, PETSC_TRUE);
-    IBTK_CHKERRQ(ierr);
-    PC schur_pc;
-    ierr = KSPGetPC(d_schur_solver, &schur_pc);
-    IBTK_CHKERRQ(ierr);
-    ierr = PCSetType(schur_pc, PCNONE);
-    IBTK_CHKERRQ(ierr);
-    ierr = KSPSetFromOptions(d_schur_solver);
-    IBTK_CHKERRQ(ierr);
-
-    KSP snes_ksp;
-    ierr = SNESGetKSP(snes, &snes_ksp);
-    IBTK_CHKERRQ(ierr);
-    ierr = KSPSetType(snes_ksp, KSPFGMRES);
-    IBTK_CHKERRQ(ierr);
-    PC snes_pc;
-    ierr = KSPGetPC(snes_ksp, &snes_pc);
-    IBTK_CHKERRQ(ierr);
-    ierr = PCSetType(snes_pc, PCSHELL);
-    IBTK_CHKERRQ(ierr);
-    ierr = PCShellSetContext(snes_pc, this);
-    IBTK_CHKERRQ(ierr);
-    ierr = PCShellSetApply(snes_pc, IBPCApply_SAMRAI);
-    IBTK_CHKERRQ(ierr);
-
-    ierr = SNESSetFromOptions(snes);
-    IBTK_CHKERRQ(ierr);
-    ierr = SNESSolve(snes, composite_rhs_petsc_vec, composite_sol_petsc_vec);
-    IBTK_CHKERRQ(ierr);
-    ierr = SNESDestroy(&snes);
-    IBTK_CHKERRQ(ierr);
-    ierr = MatDestroy(&jac);
-    IBTK_CHKERRQ(ierr);
-    ierr = MatDestroy(&schur);
-    IBTK_CHKERRQ(ierr);
-    ierr = KSPDestroy(&d_schur_solver);
-    IBTK_CHKERRQ(ierr);
-
-    d_ib_implicit_ops->postprocessSolveFluidEquations(current_time, new_time, cycle_num);
-
-    // Reset Eulerian solver vectors and Eulerian state data.
-    ins_hier_integrator->resetSolverVectors(eul_sol_vec, eul_rhs_vec, current_time, new_time, cycle_num);
-
-    // Interpolate the Eulerian velocity to the curvilinear mesh.
-    d_ib_implicit_ops->setUpdatedPosition(lag_sol_petsc_vec);
-
-    // Deallocate temporary data.
-    ierr = VecDestroy(&composite_sol_petsc_vec);
-    IBTK_CHKERRQ(ierr);
-    ierr = VecDestroy(&composite_rhs_petsc_vec);
-    IBTK_CHKERRQ(ierr);
-    ierr = VecDestroy(&composite_res_petsc_vec);
-    IBTK_CHKERRQ(ierr);
-    PETScSAMRAIVectorReal::destroyPETScVector(eul_sol_petsc_vec);
-    PETScSAMRAIVectorReal::destroyPETScVector(eul_rhs_petsc_vec);
-    free_vector_components(*eul_rhs_vec);
-    free_vector_components(*d_u_scratch_vec);
-    free_vector_components(*d_f_scratch_vec);
-    ierr = VecDestroy(&lag_sol_petsc_vec);
-    IBTK_CHKERRQ(ierr);
-    ierr = VecDestroy(&lag_rhs_petsc_vec);
-    IBTK_CHKERRQ(ierr);
-
-    // Execute any registered callbacks.
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
+    d_eul_rhs_vec->allocateVectorData(current_time);
     return;
-} // integrateHierarchy_position
+} // setupSolverVectors
 
 void
-IBImplicitStaggeredHierarchyIntegrator::integrateHierarchy_velocity(const double current_time,
-                                                                    const double new_time,
-                                                                    const int cycle_num)
+IBImplicitStaggeredHierarchyIntegrator::reinitializeOperatorsAndSolvers(const double current_time,
+                                                                        const double new_time)
 {
-    IBHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
-
     Pointer<INSStaggeredHierarchyIntegrator> ins_hier_integrator = d_ins_hier_integrator;
     TBOX_ASSERT(ins_hier_integrator);
 
-    PetscErrorCode ierr;
-    int n_local;
+    if (d_ib_solver->getIsInitialized() || d_ib_force_jac || d_ib_interp_op)
+    {
+        deallocateOperatorsAndSolvers();
+    }
 
-    const int coarsest_ln = 0;
-    const int finest_ln = d_hierarchy->getFinestLevelNumber();
-    const double half_time = current_time + 0.5 * (new_time - current_time);
+    TBOX_ASSERT(d_eul_sol_vec && d_eul_rhs_vec);
+
+    const double dt = new_time - current_time;
 
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     Pointer<VariableContext> current_ctx = ins_hier_integrator->getCurrentContext();
-    Pointer<VariableContext> scratch_ctx = ins_hier_integrator->getScratchContext();
-
-    const int wgt_cc_idx = d_hier_math_ops->getCellWeightPatchDescriptorIndex();
-    const int wgt_sc_idx = d_hier_math_ops->getSideWeightPatchDescriptorIndex();
-
     Pointer<Variable<NDIM>> u_var = ins_hier_integrator->getVelocityVariable();
     const int u_current_idx = var_db->mapVariableAndContextToIndex(u_var, current_ctx);
-    const int u_scratch_idx = var_db->mapVariableAndContextToIndex(u_var, scratch_ctx);
 
-    Pointer<Variable<NDIM>> p_var = ins_hier_integrator->getPressureVariable();
-    const int p_scratch_idx = var_db->mapVariableAndContextToIndex(p_var, scratch_ctx);
-
-    // Skip all cycles in the INS solver --- we advance the state data here.
-    ins_hier_integrator->skipCycle(current_time, new_time, cycle_num);
-
-    // Setup Eulerian vectors used in solving the implicit IB equations.
-    Pointer<SAMRAIVectorReal<NDIM, double>> eul_sol_vec =
-        new SAMRAIVectorReal<NDIM, double>(d_object_name + "::eulerian_sol_vec", d_hierarchy, coarsest_ln, finest_ln);
-    eul_sol_vec->addComponent(u_var, u_scratch_idx, wgt_sc_idx, d_hier_velocity_data_ops);
-    eul_sol_vec->addComponent(p_var, p_scratch_idx, wgt_cc_idx, d_hier_pressure_data_ops);
-
-    Pointer<SAMRAIVectorReal<NDIM, double>> eul_rhs_vec =
-        eul_sol_vec->cloneVector(d_object_name + "::eulerian_rhs_vec");
-    eul_rhs_vec->allocateVectorData(current_time);
-
-    d_f_scratch_vec = eul_rhs_vec->cloneVector(d_object_name + "::f_scratch_vec");
-    d_f_scratch_vec->allocateVectorData(current_time);
-
-    // Compute convective and previous time-step diffusive terms in the rhs vec.
-    ins_hier_integrator->setupSolverVectors(eul_sol_vec, eul_rhs_vec, current_time, new_time, cycle_num);
-
-    // Setup Stokes operator.
-    Pointer<IBImplicitStaggeredStokesSolver> p_stokes_solver = d_stokes_solver;
-    TBOX_ASSERT(p_stokes_solver);
-    d_stokes_op = p_stokes_solver->getStaggeredStokesOperator();
-    d_stokes_op->setSolutionTime(new_time);
-    d_stokes_op->setTimeInterval(current_time, new_time);
-    d_stokes_op->initializeOperatorState(*eul_sol_vec, *eul_rhs_vec);
-
-    // Setup Stokes-IB preconditioner.
-    Pointer<StaggeredStokesFACPreconditioner> stokes_fac_pc = p_stokes_solver->getStaggeredStokesFACPreconditioner();
-    stokes_fac_pc->setSolutionTime(new_time);
-    stokes_fac_pc->setTimeInterval(current_time, new_time);
-    stokes_fac_pc->setPhysicalBcCoefs(d_ins_hier_integrator->getIntermediateVelocityBoundaryConditions(),
-                                      d_ins_hier_integrator->getProjectionBoundaryConditions());
-    Pointer<StaggeredStokesIBLevelRelaxationFACOperator> stokes_fac_op = stokes_fac_pc->getFACPreconditionerStrategy();
-    Mat elastic_op = nullptr;
-    double data_time = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
+    const StokesSpecifications* stokes_specs = ins_hier_integrator->getStokesSpecifications();
+    TBOX_ASSERT(stokes_specs);
+    PoissonSpecifications U_problem_coefs(d_object_name + "::U_problem_coefs");
+    // Match the INS right-hand side, whose viscous rule is independent of the IB rule.
+    double mass_factor = 1.0;
+    double implicit_fraction = 1.0;
+    switch (ins_hier_integrator->getViscousTimeSteppingType())
     {
     case BACKWARD_EULER:
-    case TRAPEZOIDAL_RULE:
-        data_time = new_time;
         break;
-    case MIDPOINT_RULE:
-        data_time = half_time;
+    case FORWARD_EULER:
+        implicit_fraction = 0.0;
+        break;
+    case TRAPEZOIDAL_RULE:
+        implicit_fraction = 0.5;
+        break;
+    case BDF2:
+        if (getIntegratorStep() > 0)
+        {
+            const double omega = dt / d_dt_previous[0];
+            mass_factor = (1.0 + 2.0 * omega) / (1.0 + omega);
+        }
         break;
     default:
-        TBOX_ERROR("unsupported time stepping type\n");
+        TBOX_ERROR(d_object_name << "::reinitializeOperatorsAndSolvers(): unsupported viscous time stepping type\n");
     }
-    stokes_fac_op->setIBTimeSteppingType(d_time_stepping_type);
-    d_ib_implicit_ops->constructLagrangianForceJacobian(elastic_op, MATAIJ, data_time);
-    stokes_fac_op->setIBForceJacobian(elastic_op);
-    Mat interp_op = nullptr;
-    d_ib_implicit_ops->constructInterpOp(interp_op,
-                                         IBKernelTensorProduct(d_jac_delta_fcn),
-                                         d_num_dofs_per_proc[finest_ln],
-                                         d_u_dof_index_idx,
-                                         data_time);
-    stokes_fac_op->setIBInterpOp(interp_op);
-    stokes_fac_pc->initializeSolverState(*eul_sol_vec, *eul_rhs_vec);
+    U_problem_coefs.setCConstant(mass_factor * stokes_specs->getRho() / dt +
+                                 implicit_fraction * stokes_specs->getLambda());
+    U_problem_coefs.setDConstant(-implicit_fraction * stokes_specs->getMu());
 
-    // Indicate that the current approximation to position of the structure
-    // should be used for Lagrangian-Eulerian coupling.
     d_ib_implicit_ops->updateFixedLEOperators();
 
-    // Setup right-hand-side vectors.
-    d_ib_implicit_ops->preprocessSolveFluidEquations(current_time, new_time, cycle_num);
-    d_stokes_op->setHomogeneousBc(false);
-    d_stokes_op->modifyRhsForBcs(*eul_rhs_vec);
-    d_stokes_solver->setHomogeneousBc(true);
-    d_stokes_op->setHomogeneousBc(true);
+    d_stokes_bc_helper->cacheBcCoefData(ins_hier_integrator->getVelocityBoundaryConditions(), new_time, d_hierarchy);
 
-    // Create PETSc Vecs to be used with PETSc solvers.
-    d_ib_implicit_ops->createSolverVecs(&d_X_current, nullptr);
-    d_ib_implicit_ops->setupSolverVecs(&d_X_current, nullptr);
-    Vec eul_sol_petsc_vec = PETScSAMRAIVectorReal::createPETScVector(eul_sol_vec, PETSC_COMM_WORLD);
-    Vec eul_rhs_petsc_vec = PETScSAMRAIVectorReal::createPETScVector(eul_rhs_vec, PETSC_COMM_WORLD);
-    Vec eul_res_petsc_vec = PETScSAMRAIVectorReal::createPETScVector(d_f_scratch_vec, PETSC_COMM_WORLD);
+    d_stokes_op->setVelocityPoissonSpecifications(U_problem_coefs);
+    d_stokes_op->setPhysicalBcCoefs(ins_hier_integrator->getVelocityBoundaryConditions(),
+                                    ins_hier_integrator->getPressureBoundaryConditions());
+    d_stokes_op->setPhysicalBoundaryHelper(d_stokes_bc_helper);
+    d_stokes_op->setTimeInterval(current_time, new_time);
+    d_stokes_op->setSolutionTime(new_time);
 
-    // Create the outer nonlinear solver.
-    SNES snes;
-    ierr = SNESCreate(PETSC_COMM_WORLD, &snes);
-    IBTK_CHKERRQ(ierr);
-    ierr = SNESSetFunction(snes, eul_res_petsc_vec, IBFunction_SAMRAI, this);
-    IBTK_CHKERRQ(ierr);
-    ierr = SNESSetOptionsPrefix(snes, "ib_");
-    IBTK_CHKERRQ(ierr);
+    StaggeredStokesIBOperator::Context ctx;
+    ctx.ib_implicit_ops = d_ib_implicit_ops;
+    ctx.stokes_op = d_stokes_op;
+    ctx.u_phys_bdry_op = d_u_phys_bdry_op;
+    ctx.hier_velocity_data_ops = d_hier_velocity_data_ops;
+    ctx.u_synch_scheds = getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN");
+    ctx.u_ghost_fill_scheds = getGhostfillRefineSchedules(d_object_name + "::u");
+    ctx.f_prolongation_scheds = getProlongRefineSchedules(d_object_name + "::f");
+    ctx.u_idx = d_u_idx;
+    ctx.f_idx = d_f_idx;
+    ctx.u_current_idx = u_current_idx;
+    ctx.u_dof_index_idx = d_u_dof_index_idx;
+    ctx.p_dof_index_idx = d_p_dof_index_idx;
+    ctx.use_fixed_le_operators = true;
+    ctx.time_stepping_type = d_time_stepping_type;
 
-    // Create the Jacobian for Newton iterations.
-    Mat jac;
-    ierr = VecGetLocalSize(eul_sol_petsc_vec, &n_local);
-    IBTK_CHKERRQ(ierr);
-    ierr = MatCreateShell(PETSC_COMM_WORLD, n_local, n_local, PETSC_DETERMINE, PETSC_DETERMINE, this, &jac);
-    IBTK_CHKERRQ(ierr);
-    ierr = MatShellSetOperation(jac, MATOP_MULT, reinterpret_cast<void (*)(void)>(IBJacobianApply_SAMRAI));
-    IBTK_CHKERRQ(ierr);
-    ierr = SNESSetJacobian(snes, jac, jac, IBJacobianSetup_SAMRAI, this);
-    IBTK_CHKERRQ(ierr);
+    d_ib_op->setOperatorContext(ctx);
+    d_ib_jac_op->setOperatorContext(ctx);
+    const StaggeredStokesIBTimeStepParameters schedule = get_staggered_stokes_ib_time_step_parameters(
+        d_time_stepping_type, current_time, new_time, d_object_name + "::reinitializeOperatorsAndSolvers()");
+    d_ib_implicit_ops->constructLagrangianForceJacobian(d_ib_force_jac, MATAIJ, schedule.evaluation_time);
 
-    // Create the KSP for Jacobian setup for SNES.
-    KSP snes_ksp;
-    ierr = SNESGetKSP(snes, &snes_ksp);
-    IBTK_CHKERRQ(ierr);
-    ierr = KSPSetType(snes_ksp, KSPFGMRES);
-    IBTK_CHKERRQ(ierr);
-    PC snes_pc;
-    ierr = KSPGetPC(snes_ksp, &snes_pc);
-    IBTK_CHKERRQ(ierr);
-    ierr = PCSetType(snes_pc, PCSHELL);
-    IBTK_CHKERRQ(ierr);
-    ierr = PCShellSetContext(snes_pc, this);
-    IBTK_CHKERRQ(ierr);
-    ierr = PCShellSetApply(snes_pc, IBPCApply_SAMRAI);
-    IBTK_CHKERRQ(ierr);
+    d_ib_implicit_ops->constructInterpOp(
+        d_ib_interp_op, d_jac_kernel, d_num_dofs_per_proc, d_u_dof_index_idx, schedule.evaluation_time);
 
-    // Solve the system.
-    ierr = SNESSetFromOptions(snes);
-    IBTK_CHKERRQ(ierr);
-    ierr = SNESSolve(snes, eul_rhs_petsc_vec, eul_sol_petsc_vec);
-    IBTK_CHKERRQ(ierr);
-    ierr = SNESDestroy(&snes);
-    IBTK_CHKERRQ(ierr);
-    ierr = MatDestroy(&jac);
-    IBTK_CHKERRQ(ierr);
+    d_ib_jac_pc->setVelocityPoissonSpecifications(U_problem_coefs);
+    d_ib_jac_pc->setPhysicalBcCoefs(ins_hier_integrator->getIntermediateVelocityBoundaryConditions(),
+                                    ins_hier_integrator->getProjectionBoundaryConditions());
+    d_ib_jac_pc->setPhysicalBoundaryHelper(d_stokes_bc_helper);
+    d_ib_jac_pc->setComponentsHaveNullSpace(d_has_velocity_nullspace, d_has_pressure_nullspace);
+    d_ib_jac_pc->setIBTimeSteppingType(d_time_stepping_type);
+    d_ib_jac_pc->setIBForceJacobian(d_ib_force_jac);
+    d_ib_jac_pc->setIBInterpOp(d_ib_interp_op);
+    d_ib_jac_pc->setIBImplicitStrategy(d_ib_implicit_ops);
+    d_ib_jac_pc->setTimeInterval(current_time, new_time);
+    d_ib_jac_pc->setSolutionTime(new_time);
+    d_ib_jac_pc->setHomogeneousBc(true);
 
-    d_stokes_op->imposeSolBcs(*eul_sol_vec);
-    d_ib_implicit_ops->postprocessSolveFluidEquations(current_time, new_time, cycle_num);
+    d_ib_solver->setHomogeneousBc(false);
+    d_ib_solver->setSolutionTime(new_time);
+    d_ib_solver->setTimeInterval(current_time, new_time);
+    d_ib_op->setHomogeneousBc(false);
+    d_ib_op->setSolutionTime(new_time);
+    d_ib_op->setTimeInterval(current_time, new_time);
+    d_ib_jac_op->setHomogeneousBc(true);
+    d_ib_jac_op->setSolutionTime(new_time);
+    d_ib_jac_op->setTimeInterval(current_time, new_time);
+    Pointer<IBTK::KrylovLinearSolver> linear_solver = d_ib_solver->getLinearSolver();
+    linear_solver->setInitialGuessNonzero(false);
 
-    // Reset Eulerian solver vectors and Eulerian state data.
-    ins_hier_integrator->resetSolverVectors(eul_sol_vec, eul_rhs_vec, current_time, new_time, cycle_num);
-
-    // Interpolate the Eulerian velocity to the curvilinear mesh.
-    if (d_enable_logging)
-    {
-        plog << d_object_name
-             << "::integrateHierarchy_velocity(): interpolating "
-                "Eulerian velocity to the Lagrangian mesh\n";
-    }
-    int u_new_idx = eul_sol_vec->getComponentDescriptorIndex(0);
-    double velocity_time = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-    case TRAPEZOIDAL_RULE:
-        d_hier_velocity_data_ops->copyData(d_u_idx, u_new_idx);
-        velocity_time = new_time;
-        break;
-    case MIDPOINT_RULE:
-        d_hier_velocity_data_ops->linearSum(d_u_idx, 0.5, u_current_idx, 0.5, u_new_idx);
-        velocity_time = half_time;
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-    d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(false);
-    d_ib_implicit_ops->interpolateVelocity(d_u_idx,
-                                           getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
-                                           getGhostfillRefineSchedules(d_object_name + "::u"),
-                                           velocity_time);
-
-    // Compute the final value of the updated positions of the Lagrangian
-    // structure.
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-        d_ib_implicit_ops->backwardEulerStep(current_time, new_time);
-        break;
-    case TRAPEZOIDAL_RULE:
-        d_ib_implicit_ops->trapezoidalStep(current_time, new_time);
-        break;
-    case MIDPOINT_RULE:
-        d_ib_implicit_ops->midpointStep(current_time, new_time);
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-
-    // Deallocate PETSc Vecs.
-    ierr = VecDestroy(&d_X_current);
-    IBTK_CHKERRQ(ierr);
-    PETScSAMRAIVectorReal::destroyPETScVector(eul_sol_petsc_vec);
-    PETScSAMRAIVectorReal::destroyPETScVector(eul_rhs_petsc_vec);
-    PETScSAMRAIVectorReal::destroyPETScVector(eul_res_petsc_vec);
-
-    // Deallocate Eulerian components.
-    free_vector_components(*eul_rhs_vec);
-    free_vector_components(*d_f_scratch_vec);
-
-    // Deallocate solvers and operators.
-    p_stokes_solver->deallocateSolverState();
-    d_stokes_op->deallocateOperatorState();
-    stokes_fac_pc->deallocateSolverState();
-    stokes_fac_op->deallocateOperatorState();
-    ierr = MatDestroy(&elastic_op);
-    IBTK_CHKERRQ(ierr);
-    ierr = MatDestroy(&interp_op);
-    IBTK_CHKERRQ(ierr);
-
-    // Execute any registered callbacks.
-    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
-} // integrateHierarchy_velocity
+} // reinitializeOperatorsAndSolvers
 
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBFunction_SAMRAI(SNES snes, Vec x, Vec f, void* ctx)
+void
+IBImplicitStaggeredHierarchyIntegrator::deallocateOperatorsAndSolvers()
 {
-    auto ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
-
-    PetscErrorCode ierr = 1;
-    if (ib_integrator->d_solve_for_position)
+    if (d_ib_solver && d_ib_solver->getIsInitialized())
     {
-        ierr = ib_integrator->IBFunction_position(snes, x, f);
+        d_ib_solver->deallocateSolverState();
     }
-    else
+    if (d_ib_force_jac)
     {
-        ierr = ib_integrator->IBFunction_velocity(snes, x, f);
+        const int ierr = MatDestroy(&d_ib_force_jac);
+        IBTK_CHKERRQ(ierr);
+        d_ib_force_jac = nullptr;
     }
-
-    return ierr;
-} // IBFunction_SAMRAI
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBFunction_position(SNES /*snes*/, Vec x, Vec f)
-{
-    PetscErrorCode ierr;
-    const double current_time = d_integrator_time;
-    const double new_time = current_time + d_current_dt;
-    const double half_time = current_time + 0.5 * d_current_dt;
-
-    Vec* component_sol_vecs;
-    ierr = VecNestGetSubVecs(x, nullptr, &component_sol_vecs);
-    CHKERRQ(ierr);
-    Vec* component_rhs_vecs;
-    ierr = VecNestGetSubVecs(f, nullptr, &component_rhs_vecs);
-    CHKERRQ(ierr);
-
-    Pointer<SAMRAIVectorReal<NDIM, double>> u, f_u;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(component_sol_vecs[0], &u);
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_rhs_vecs[0], &f_u);
-
-    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    Pointer<VariableContext> current_ctx = d_ins_hier_integrator->getCurrentContext();
-    Pointer<Variable<NDIM>> u_var = d_ins_hier_integrator->getVelocityVariable();
-    const int u_current_idx = var_db->mapVariableAndContextToIndex(u_var, current_ctx);
-    const int u_new_idx = u->getComponentDescriptorIndex(0);
-    const int f_u_idx = f_u->getComponentDescriptorIndex(0);
-
-    Vec X = component_sol_vecs[1];
-    Vec R = component_rhs_vecs[1];
-
-    // Evaluate the Eulerian terms.
-    d_stokes_op->setHomogeneousBc(true);
-    d_stokes_op->apply(*u, *f_u);
-
-    double force_time = std::numeric_limits<double>::quiet_NaN();
-    double kappa = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
+    if (d_ib_interp_op)
     {
-    case BACKWARD_EULER:
-        force_time = new_time;
-        kappa = 1.0;
-        break;
-    case TRAPEZOIDAL_RULE:
-        force_time = new_time;
-        kappa = 0.5;
-        break;
-    case MIDPOINT_RULE:
-        force_time = half_time;
-        kappa = 1.0;
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
+        const int ierr = MatDestroy(&d_ib_interp_op);
+        IBTK_CHKERRQ(ierr);
+        d_ib_interp_op = nullptr;
     }
-    d_ib_implicit_ops->setUpdatedPosition(X);
-    d_ib_implicit_ops->computeLagrangianForce(force_time);
-    if (d_enable_logging)
-    {
-        plog << d_object_name
-             << "::integrateHierarchy_position(): spreading "
-                "Lagrangian force to the Eulerian grid\n";
-        plog << "Spreading being done from " << d_object_name << "::IBFunction_position().\n";
-    }
-    d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0, /*interior_only*/ false);
-    d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(true); // use homogeneous BCs to define spreading at physical boundaries
-    d_ib_implicit_ops->spreadForce(
-        d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), force_time);
-    d_hier_velocity_data_ops->axpy(f_u_idx, -kappa, d_f_idx, f_u_idx);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(component_sol_vecs[0], &u);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_rhs_vecs[0], &f_u);
-
-    // Evaluate the Lagrangian terms.
-    double velocity_time = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-    case TRAPEZOIDAL_RULE:
-        d_hier_velocity_data_ops->copyData(d_u_idx, u_new_idx);
-        velocity_time = new_time;
-        break;
-    case MIDPOINT_RULE:
-        d_hier_velocity_data_ops->linearSum(d_u_idx, 0.5, u_current_idx, 0.5, u_new_idx);
-        velocity_time = half_time;
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-    d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(false);
-    d_ib_implicit_ops->interpolateVelocity(d_u_idx,
-                                           getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
-                                           getGhostfillRefineSchedules(d_object_name + "::u"),
-                                           velocity_time);
-    d_ib_implicit_ops->computeResidual(R);
-    return ierr;
-} // IBFunction_position
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBFunction_velocity(SNES /*snes*/, Vec x, Vec f)
-{
-    PetscErrorCode ierr = 0;
-    const double current_time = d_integrator_time;
-    const double new_time = current_time + d_current_dt;
-    const double half_time = current_time + 0.5 * d_current_dt;
-
-    Pointer<SAMRAIVectorReal<NDIM, double>> u, f_u;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &u);
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(f, &f_u);
-
-    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    Pointer<VariableContext> current_ctx = d_ins_hier_integrator->getCurrentContext();
-    Pointer<Variable<NDIM>> u_var = d_ins_hier_integrator->getVelocityVariable();
-    const int u_current_idx = var_db->mapVariableAndContextToIndex(u_var, current_ctx);
-    const int u_new_idx = u->getComponentDescriptorIndex(0);
-    const int f_u_idx = f_u->getComponentDescriptorIndex(0);
-
-    // Apply the Stokes part.
-    d_stokes_op->setHomogeneousBc(true);
-    d_stokes_op->apply(*u, *f_u);
-
-    // Compute the new position of the structure.
-    double velocity_time = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-    case TRAPEZOIDAL_RULE:
-        d_hier_velocity_data_ops->copyData(d_u_idx, u_new_idx);
-        velocity_time = new_time;
-        break;
-    case MIDPOINT_RULE:
-        d_hier_velocity_data_ops->linearSum(d_u_idx, 0.5, u_new_idx, 0.5, u_current_idx);
-        velocity_time = half_time;
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-    d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(false);
-    d_ib_implicit_ops->interpolateVelocity(d_u_idx,
-                                           getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
-                                           getGhostfillRefineSchedules(d_object_name + "::u"),
-                                           velocity_time);
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-        d_ib_implicit_ops->backwardEulerStep(current_time, new_time);
-        break;
-    case TRAPEZOIDAL_RULE:
-        d_ib_implicit_ops->trapezoidalStep(current_time, new_time);
-        break;
-    case MIDPOINT_RULE:
-        d_ib_implicit_ops->midpointStep(current_time, new_time);
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-
-    // Subtract f = S[F] from the RHS.
-    double force_time = std::numeric_limits<double>::quiet_NaN();
-    double kappa = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-        force_time = new_time;
-        kappa = 1.0;
-        break;
-    case TRAPEZOIDAL_RULE:
-        force_time = new_time;
-        kappa = 0.5;
-        break;
-    case MIDPOINT_RULE:
-        force_time = half_time;
-        kappa = 1.0;
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-    d_ib_implicit_ops->computeLagrangianForce(force_time);
-    if (d_enable_logging)
-    {
-        plog << d_object_name
-             << "::integrateHierarchy_velocity(): spreading "
-                "Lagrangian force to the Eulerian grid\n";
-        plog << "Spreading being done from " << d_object_name << "::IBFunction_velocity().\n";
-    }
-    d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0, /*interior_only*/ false);
-    d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(true); // use homogeneous BCs to define spreading at physical boundaries
-    d_ib_implicit_ops->spreadForce(
-        d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), force_time);
-    d_hier_velocity_data_ops->axpy(f_u_idx, -kappa, d_f_idx, f_u_idx);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &u);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(f, &f_u);
-    return ierr;
-} // IBFunction_velocity
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_SAMRAI(SNES snes, Vec x, Mat A, Mat B, void* ctx)
-{
-    auto ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
-
-    PetscErrorCode ierr = 1;
-    if (ib_integrator->d_solve_for_position)
-    {
-        ierr = ib_integrator->IBJacobianSetup_position(snes, x, A, B);
-    }
-    else
-    {
-        ierr = ib_integrator->IBJacobianSetup_velocity(snes, x, A, B);
-    }
-
-    return ierr;
-} // IBJacobianSetup_SAMRAI
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_position(SNES /*snes*/, Vec x, Mat A, Mat /*B*/)
-{
-    PetscErrorCode ierr;
-    const double current_time = d_integrator_time;
-    const double new_time = current_time + d_current_dt;
-    const double half_time = current_time + 0.5 * d_current_dt;
-
-    double data_time = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-    case TRAPEZOIDAL_RULE:
-        data_time = new_time;
-        break;
-    case MIDPOINT_RULE:
-        data_time = half_time;
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-
-    ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
-    ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
-
-    Vec* component_sol_vecs;
-    ierr = VecNestGetSubVecs(x, nullptr, &component_sol_vecs);
-    CHKERRQ(ierr);
-    Vec X = component_sol_vecs[1];
-    d_ib_implicit_ops->setLinearizedPosition(X, data_time);
-    return ierr;
-} // IBJacobianSetup_position
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBJacobianSetup_velocity(SNES /*snes*/, Vec x, Mat A, Mat /*B*/)
-{
-    PetscErrorCode ierr;
-    const double current_time = d_integrator_time;
-    const double new_time = current_time + d_current_dt;
-    const double half_time = current_time + 0.5 * d_current_dt;
-
-    ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
-    ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
-
-    // Get the estimate of X^{n+1} from the current iterate U^{n+1} and set as it
-    // as a base vector in matrix-free Lagrangian force Jacobian.
-    Vec X_new;
-    ierr = VecDuplicate(d_X_current, &X_new);
-    CHKERRQ(ierr);
-
-    Pointer<SAMRAIVectorReal<NDIM, double>> u;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &u);
-    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
-    Pointer<VariableContext> current_ctx = d_ins_hier_integrator->getCurrentContext();
-    Pointer<Variable<NDIM>> u_var = d_ins_hier_integrator->getVelocityVariable();
-    const int u_current_idx = var_db->mapVariableAndContextToIndex(u_var, current_ctx);
-    const int u_new_idx = u->getComponentDescriptorIndex(0);
-    double velocity_time = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-    case TRAPEZOIDAL_RULE:
-        d_hier_velocity_data_ops->copyData(d_u_idx, u_new_idx);
-        velocity_time = new_time;
-        break;
-    case MIDPOINT_RULE:
-        d_hier_velocity_data_ops->linearSum(d_u_idx, 0.5, u_new_idx, 0.5, u_current_idx);
-        velocity_time = half_time;
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-    d_hier_velocity_data_ops->scale(d_u_idx, -1.0, d_u_idx);
-    d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(true);
-    d_ib_implicit_ops->interpolateLinearizedVelocity(d_u_idx,
-                                                     getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
-                                                     getGhostfillRefineSchedules(d_object_name + "::u"),
-                                                     velocity_time);
-    d_ib_implicit_ops->computeLinearizedResidual(d_X_current, X_new);
-    d_ib_implicit_ops->setLinearizedPosition(X_new, velocity_time);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &u);
-
-    ierr = VecDestroy(&X_new);
-    CHKERRQ(ierr);
-    return ierr;
-} // IBJacobianSetup_velocity
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_SAMRAI(Mat A, Vec x, Vec f)
-{
-    PetscErrorCode ierr = 1;
-    void* ctx;
-    ierr = MatShellGetContext(A, &ctx);
-    CHKERRQ(ierr);
-    auto ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
-    if (ib_integrator->d_solve_for_position)
-    {
-        ierr = ib_integrator->IBJacobianApply_position(x, f);
-    }
-    else
-    {
-        ierr = ib_integrator->IBJacobianApply_velocity(x, f);
-    }
-
-    return ierr;
-} // IBJacobianApply_SAMRAI
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_position(Vec x, Vec f)
-{
-    PetscErrorCode ierr;
-    const double current_time = d_integrator_time;
-    const double new_time = current_time + d_current_dt;
-    const double half_time = current_time + 0.5 * d_current_dt;
-
-    Vec* component_sol_vecs;
-    Vec* component_rhs_vecs;
-    ierr = VecNestGetSubVecs(x, nullptr, &component_sol_vecs);
-    CHKERRQ(ierr);
-    ierr = VecNestGetSubVecs(f, nullptr, &component_rhs_vecs);
-    CHKERRQ(ierr);
-
-    Pointer<SAMRAIVectorReal<NDIM, double>> u, f_u;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(component_sol_vecs[0], &u);
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_rhs_vecs[0], &f_u);
-
-    Pointer<Variable<NDIM>> u_var = d_ins_hier_integrator->getVelocityVariable();
-    const int u_idx = u->getComponentDescriptorIndex(0);
-    const int f_u_idx = f_u->getComponentDescriptorIndex(0);
-
-    Vec X = component_sol_vecs[1];
-    Vec R = component_rhs_vecs[1];
-
-    // Evaluate the Eulerian terms.
-    d_stokes_op->setHomogeneousBc(true);
-    d_stokes_op->apply(*u, *f_u);
-    double force_time = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-    case TRAPEZOIDAL_RULE:
-        force_time = new_time;
-        break;
-    case MIDPOINT_RULE:
-        force_time = half_time;
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-    d_ib_implicit_ops->computeLinearizedLagrangianForce(X, force_time);
-    if (d_enable_logging)
-    {
-        plog << d_object_name
-             << "::integrateHierarchy_position(): spreading "
-                "Lagrangian force to the Eulerian grid\n";
-        plog << "Spreading being done from " << d_object_name << "::IBJacobianApply_position().\n";
-    }
-    d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0, /*interior_only*/ false);
-    d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(true); // use homogeneous BCs to define spreading at physical boundaries
-    d_ib_implicit_ops->spreadLinearizedForce(
-        d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), force_time);
-    d_hier_velocity_data_ops->subtract(f_u_idx, f_u_idx, d_f_idx);
-
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(component_sol_vecs[0], &u);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_rhs_vecs[0], &f_u);
-
-    // Evaluate the Lagrangian terms.
-    double velocity_time = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-    case TRAPEZOIDAL_RULE:
-        d_hier_velocity_data_ops->copyData(d_u_idx, u_idx);
-        velocity_time = new_time;
-        break;
-    case MIDPOINT_RULE:
-        d_hier_velocity_data_ops->scale(d_u_idx, 0.5, u_idx);
-        velocity_time = half_time;
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-    d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(true);
-    d_ib_implicit_ops->interpolateLinearizedVelocity(d_u_idx,
-                                                     getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
-                                                     getGhostfillRefineSchedules(d_object_name + "::u"),
-                                                     velocity_time);
-    d_ib_implicit_ops->computeLinearizedResidual(X, R);
-    return ierr;
-} // IBJacobianApply_position
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBJacobianApply_velocity(Vec x, Vec f)
-{
-    const double current_time = d_integrator_time;
-    const double new_time = current_time + d_current_dt;
-    const double half_time = current_time + 0.5 * d_current_dt;
-
-    Pointer<SAMRAIVectorReal<NDIM, double>> u, f_u;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &u);
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(f, &f_u);
-
-    const int u_idx = u->getComponentDescriptorIndex(0);
-    const int f_u_idx = f_u->getComponentDescriptorIndex(0);
-
-    // Evaluate the Eulerian terms.
-    d_stokes_op->setHomogeneousBc(true);
-    d_stokes_op->apply(*u, *f_u);
-
-    // Compute position residual X = dt*kappa*J[u] = 0 - (-kappa)*dt*J[u].
-    double force_time = std::numeric_limits<double>::quiet_NaN();
-    double velocity_time = std::numeric_limits<double>::quiet_NaN();
-    double kappa = std::numeric_limits<double>::quiet_NaN();
-    switch (d_time_stepping_type)
-    {
-    case BACKWARD_EULER:
-        force_time = new_time;
-        velocity_time = new_time;
-        kappa = 1.0;
-        break;
-    case TRAPEZOIDAL_RULE:
-        force_time = new_time;
-        velocity_time = new_time;
-        kappa = 0.5;
-        break;
-    case MIDPOINT_RULE:
-        force_time = half_time;
-        velocity_time = half_time;
-        kappa = 0.5;
-        break;
-    default:
-        TBOX_ERROR("unsupported time stepping type\n");
-    }
-    Vec X, X0;
-    d_ib_implicit_ops->createSolverVecs(&X, &X0);
-    d_ib_implicit_ops->setupSolverVecs(nullptr, &X0);
-    d_hier_velocity_data_ops->scale(d_u_idx, -kappa, u_idx);
-    d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(true);
-    d_ib_implicit_ops->interpolateLinearizedVelocity(d_u_idx,
-                                                     getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
-                                                     getGhostfillRefineSchedules(d_object_name + "::u"),
-                                                     velocity_time);
-    d_ib_implicit_ops->computeLinearizedResidual(X0, X);
-
-    // Compute linearized force F = kappa*A*X.
-    d_ib_implicit_ops->computeLinearizedLagrangianForce(X, force_time);
-    if (d_enable_logging)
-    {
-        plog << d_object_name
-             << "::integrateHierarchy_velocity(): spreading "
-                "Lagrangian force to the Eulerian grid\n";
-        plog << "Spreading being done from " << d_object_name << "::IBJacobianApply_velocity().\n";
-    }
-    d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0, /*interior_only*/ false);
-    d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(true); // use homogeneous BCs to define spreading at physical boundaries
-    d_ib_implicit_ops->spreadLinearizedForce(
-        d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), force_time);
-    d_hier_velocity_data_ops->axpy(f_u_idx, -kappa, d_f_idx, f_u_idx);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &u);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(f, &f_u);
-    return 0;
-} // IBJacobianApply_velocity
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBPCApply_SAMRAI(PC pc, Vec x, Vec y)
-{
-    PetscErrorCode ierr = 1;
-    void* ctx;
-    ierr = PCShellGetContext(pc, &ctx);
-    CHKERRQ(ierr);
-    auto ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
-    if (ib_integrator->d_solve_for_position)
-    {
-        ierr = ib_integrator->IBPCApply_position(x, y);
-    }
-    else
-    {
-        ierr = ib_integrator->IBPCApply_velocity(x, y);
-    }
-    CHKERRQ(ierr);
-    return ierr;
-} // IBPCApply_SAMRAI
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBPCApply_position(Vec x, Vec y)
-{
-    TBOX_ASSERT(d_time_stepping_type == MIDPOINT_RULE);
-
-    PetscErrorCode ierr;
-    const double half_time = d_integrator_time + 0.5 * d_current_dt;
-
-    Vec* component_x_vecs;
-    Vec* component_y_vecs;
-    ierr = VecNestGetSubVecs(x, nullptr, &component_x_vecs);
-    CHKERRQ(ierr);
-    ierr = VecNestGetSubVecs(y, nullptr, &component_y_vecs);
-    CHKERRQ(ierr);
-
-    Pointer<SAMRAIVectorReal<NDIM, double>> eul_x, eul_y;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(component_x_vecs[0], &eul_x);
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(component_y_vecs[0], &eul_y);
-
-    Vec lag_x = component_x_vecs[1];
-    Vec lag_y = component_y_vecs[1];
-
-    // The full (nonlinear) system is:
-    //
-    //   L u(n+1) = S*F[X(n+1/2)] + f
-    //   X(n+1) - X(n) = dt*U(n+1/2)
-    //
-    // where:
-    //
-    //   L = Eulerian operator (i.e. Stokes)
-    //   F = Lagrangian force operator (potentially nonlinear)
-    //   S = spreading operator
-    //   J = interpolation operator = S^*
-    //   X(n+1/2) = (X(n+1)+X(n))/2
-    //   f = explicit right-hand side term
-    //
-    // For simplicity, only "lagged" S and J are considered, i.e., S and J are
-    // not functions of the unknown X(n+1/2), but rather of some lagged
-    // approximation to X(n+1/2).  This does not affect the stability of the
-    // time stepping scheme, and the lagged values can be chosen so that the
-    // overall scheme is second-order accurate.
-    //
-    // The linearized system is:
-    //
-    //   [L         -S*A/2] [u]
-    //   [-dt*J/2   I     ] [X]
-    //
-    // where:
-    //
-    //   L = Eulerian operator
-    //   A = dF/dX = Lagrangian operator
-    //   S = spreading operator
-    //   J = interpolation operator = S^*
-    //
-    // The Lagrangian Schur complement preconditioner is P = (4)*(3)*(2)*(1),
-    // which is the inverse of the linearized system.
-    //
-    // (1) = [inv(L)  0]  ==>  [I         -inv(L)*S*A/2]
-    //       [0       I]       [-dt*J/2   I            ]
-    //
-    // (2) = [I        0]  ==>  [I   -inv(L)*S*A/2      ]
-    //       [dt*J/2   I]       [0   I-dt*J*inv(L)*S*A/4]
-    //
-    // Sc = Schur complement = I-dt*J*inv(L)*S*A/4
-    //
-    // (3) = [I   0      ]  ==>  [I   -inv(L)*S*A/2]
-    //       [0   inv(Sc)]       [0   I            ]
-    //
-    // (4) = [I   inv(L)*S*A/2]  ==>  [I   0]
-    //       [0   I           ]       [0   I]
-
-    // Step 1: eul_y := inv(L)*eul_x
-    eul_y->setToScalar(0.0);
-    d_stokes_solver->setHomogeneousBc(true);
-    d_stokes_solver->solveSystem(*eul_y, *eul_x);
-
-    // Step 2: lag_y := lag_x + dt*J*eul_y/2
-    d_hier_velocity_data_ops->scale(d_u_idx, -0.5, eul_y->getComponentDescriptorIndex(0));
-    d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(true);
-    d_ib_implicit_ops->interpolateLinearizedVelocity(d_u_idx,
-                                                     getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
-                                                     getGhostfillRefineSchedules(d_object_name + "::u"),
-                                                     half_time);
-    d_ib_implicit_ops->computeLinearizedResidual(lag_x, lag_y);
-
-    // Step 3: lag_y := inv(Sc)*lag_y
-    ierr = KSPSolve(d_schur_solver, lag_y, lag_y);
-    CHKERRQ(ierr);
-
-    // Step 4: eul_y := eul_y + inv(L)*S*A*lag_y/2
-    d_ib_implicit_ops->computeLinearizedLagrangianForce(lag_y, half_time);
-    ierr = VecScale(lag_y, 0.5);
-    CHKERRQ(ierr);
-    d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0, /*interior_only*/ false);
-    d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(true); // use homogeneous BCs to define spreading at physical boundaries
-    d_ib_implicit_ops->spreadLinearizedForce(
-        d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), half_time);
-    d_u_scratch_vec->setToScalar(0.0);
-    d_f_scratch_vec->setToScalar(0.0);
-    d_hier_velocity_data_ops->copyData(d_f_scratch_vec->getComponentDescriptorIndex(0), d_f_idx);
-    d_stokes_solver->setHomogeneousBc(true);
-    d_stokes_solver->solveSystem(*d_u_scratch_vec, *d_f_scratch_vec);
-    eul_y->add(eul_y, d_u_scratch_vec);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(component_x_vecs[0], &eul_x);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(component_y_vecs[0], &eul_y);
-    return ierr;
-} // IBPCApply_position
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::IBPCApply_velocity(Vec x, Vec y)
-{
-    Pointer<SAMRAIVectorReal<NDIM, double>> f_g, u_p;
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVectorRead(x, &f_g);
-    IBTK::PETScSAMRAIVectorReal::getSAMRAIVector(y, &u_p);
-    Pointer<IBImplicitStaggeredStokesSolver> p_stokes_solver = d_stokes_solver;
-#if !defined(NDEBUG)
-    TBOX_ASSERT(p_stokes_solver);
-#endif
-    bool converged = p_stokes_solver->getStaggeredStokesFACPreconditioner()->solveSystem(*u_p, *f_g);
-    PetscErrorCode ierr = !converged;
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVectorRead(x, &f_g);
-    IBTK::PETScSAMRAIVectorReal::restoreSAMRAIVector(y, &u_p);
-    return ierr;
-} // IBPCApply_velocity
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::lagrangianSchurApply_SAMRAI(Mat A, Vec x, Vec y)
-{
-    PetscErrorCode ierr;
-    void* ctx;
-    ierr = MatShellGetContext(A, &ctx);
-    CHKERRQ(ierr);
-    auto ib_integrator = static_cast<IBImplicitStaggeredHierarchyIntegrator*>(ctx);
-    ierr = ib_integrator->lagrangianSchurApply(x, y);
-    return ierr;
-} // lagrangianSchurApply_SAMRAI
-
-PetscErrorCode
-IBImplicitStaggeredHierarchyIntegrator::lagrangianSchurApply(Vec X, Vec Y)
-{
-    TBOX_ASSERT(d_time_stepping_type == MIDPOINT_RULE);
-
-    const double half_time = d_integrator_time + 0.5 * d_current_dt;
-
-    // The Schur complement is: I-dt*J*inv(L)*S*A/4
-    d_ib_implicit_ops->computeLinearizedLagrangianForce(X, half_time);
-    d_hier_velocity_data_ops->setToScalar(d_f_idx, 0.0, /*interior_only*/ false);
-    d_u_phys_bdry_op->setPatchDataIndex(d_f_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(true); // use homogeneous BCs to define spreading at physical boundaries
-    d_ib_implicit_ops->spreadLinearizedForce(
-        d_f_idx, d_u_phys_bdry_op, getProlongRefineSchedules(d_object_name + "::f"), half_time);
-    d_u_scratch_vec->setToScalar(0.0);
-    d_hier_velocity_data_ops->copyData(d_f_scratch_vec->getComponentDescriptorIndex(0), d_f_idx);
-    d_stokes_solver->setHomogeneousBc(true);
-    d_stokes_solver->solveSystem(*d_u_scratch_vec, *d_f_scratch_vec);
-    d_hier_velocity_data_ops->scale(d_u_idx, 0.25, d_u_scratch_vec->getComponentDescriptorIndex(0));
-    d_u_phys_bdry_op->setPatchDataIndex(d_u_idx);
-    d_u_phys_bdry_op->setHomogeneousBc(false);
-    d_ib_implicit_ops->interpolateLinearizedVelocity(d_u_idx,
-                                                     getCoarsenSchedules(d_object_name + "::u::CONSERVATIVE_COARSEN"),
-                                                     getGhostfillRefineSchedules(d_object_name + "::u"),
-                                                     half_time);
-    d_ib_implicit_ops->computeLinearizedResidual(X, Y);
-    return 0;
-} // lagrangianSchurApply
+    return;
+} // deallocateOperatorsAndSolvers
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -203,6 +203,7 @@ SETUP(ConstraintIB oscillating_rigid_cylinder.cpp IBAMR2d)
 # IB:
 SETUP(IB explicit_ex0.cpp IBAMR2d)
 SETUP(IB explicit_ex1.cpp IBAMR2d)
+SETUP(IB implicit_stokes_ib_01.cpp IBAMR2d)
 SETUP(IB implicit_stokes_ib_solver_components_01.cpp IBAMR2d)
 TARGET_COMPILE_DEFINITIONS(tests-IB_implicit_stokes_ib_solver_components_01 PRIVATE
   IBTK_MAX_BSPLINE_ORDER=${IBTK_MAX_BSPLINE_ORDER})

--- a/tests/IB/implicit_stokes_ib_01.backward_euler.input
+++ b/tests/IB/implicit_stokes_ib_01.backward_euler.input
@@ -1,0 +1,78 @@
+N = 8
+IB_RULE = "BACKWARD_EULER"
+JAC_KERNEL = "IB_4"
+custom_kernel = FALSE
+IBHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.0025
+   dt_max = 0.001
+   num_cycles = 1
+   regrid_interval = 0
+   error_on_dt_change = FALSE
+   warn_on_dt_change = FALSE
+   time_stepping_type = IB_RULE
+   jacobian_delta_fcn = JAC_KERNEL
+   rel_residual_tol = 1.0e-10
+   abs_residual_tol = 1.0e-12
+   max_iterations = 20
+   stokes_ib_precond_db {
+      has_pressure_nullspace = TRUE
+      num_pre_sweeps = 1
+      num_post_sweeps = 1
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         ksp_type = "preonly"
+         pc_type = "svd"
+         initial_guess_nonzero = FALSE
+      }
+   }
+}
+INSStaggeredHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.0025
+   mu = 0.01
+   rho = 1.0
+   creeping_flow = TRUE
+   viscous_time_stepping_type = "BACKWARD_EULER"
+   normalize_pressure = TRUE
+   num_cycles = 1
+   dt_max = 0.001
+   enable_logging_solver_iterations = FALSE
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = 1
+   base_filenames_0 = "ellipse"
+}
+VelocityInitialConditions {
+   function_0 = "0.1*sin(2*pi*X_1)"
+   function_1 = "0.05*cos(2*pi*X_0)"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "100"
+      stokes_ib_pc_level_0_ksp_type = "preonly"
+      stokes_ib_pc_level_0_pc_type = "svd"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size { level_0 = N,N }
+   smallest_patch_size { level_0 = N,N }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (N - 1, N - 1)] }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_01.backward_euler.output
+++ b/tests/IB/implicit_stokes_ib_01.backward_euler.output
@@ -1,0 +1,7 @@
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
+  projecting the interpolated velocity field
+IBRedundantInitializer:  Deallocating initialization data.
+step 1 time 1.00000000e-03 velocity_L2 7.90301526e-02 pressure_L2 4.87540972e-01 radius_L2 8.71320010e-01
+step 2 time 2.00000000e-03 velocity_L2 7.90098886e-02 pressure_L2 4.87540330e-01 radius_L2 8.71318409e-01
+step 3 time 2.50000000e-03 velocity_L2 7.90023052e-02 pressure_L2 4.87540055e-01 radius_L2 8.71317429e-01

--- a/tests/IB/implicit_stokes_ib_01.cpp
+++ b/tests/IB/implicit_stokes_ib_01.cpp
@@ -28,6 +28,8 @@
 #include <ibtk/LDataManager.h>
 #include <ibtk/muParserCartGridFunction.h>
 
+#include <tbox/Logger.h>
+
 #include <BergerRigoutsos.h>
 #include <CartesianGridGeometry.h>
 #include <GriddingAlgorithm.h>
@@ -123,6 +125,10 @@ int
 main(int argc, char* argv[])
 {
     IBTKInit init(argc, argv, MPI_COMM_WORLD);
+#ifndef IBTK_HAVE_SILO
+    // Suppress warnings caused by running without Silo.
+    SAMRAI::tbox::Logger::getInstance()->setWarning(false);
+#endif
     {
         Pointer<AppInitializer> app = new AppInitializer(argc, argv, "output");
         Pointer<Database> input = app->getInputDatabase();

--- a/tests/IB/implicit_stokes_ib_01.cpp
+++ b/tests/IB/implicit_stokes_ib_01.cpp
@@ -64,6 +64,17 @@ CustomKernel::operator()(const double r) const
 }
 
 void
+count_integration_cycles(double /*current_time*/, double /*new_time*/, const int cycle_num, void* ctx)
+{
+    int* callback_count = static_cast<int*>(ctx);
+    if (cycle_num != *callback_count)
+    {
+        TBOX_ERROR("Integration callback did not run exactly once per cycle.\n");
+    }
+    ++*callback_count;
+}
+
+void
 generate_structure(const unsigned int& structure,
                    const int& level,
                    int& num_vertices,
@@ -126,6 +137,8 @@ main(int argc, char* argv[])
         Pointer<IBMethod> method = new IBMethod("IBMethod", app->getComponentDatabase("IBMethod"));
         Pointer<IBImplicitStaggeredHierarchyIntegrator> integrator = new IBImplicitStaggeredHierarchyIntegrator(
             "IBHierarchyIntegrator", app->getComponentDatabase("IBHierarchyIntegrator"), method, ins);
+        int callback_count = 0;
+        integrator->registerIntegrateHierarchyCallback(count_integration_cycles, &callback_count);
         Pointer<CartesianGridGeometry<NDIM>> geometry =
             new CartesianGridGeometry<NDIM>("CartesianGeometry", app->getComponentDatabase("CartesianGeometry"));
         Pointer<PatchHierarchy<NDIM>> hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", geometry);
@@ -162,8 +175,13 @@ main(int argc, char* argv[])
         for (int step = 0; step < 3; ++step)
         {
             const int previous_calls = evaluator_calls;
+            callback_count = 0;
             // A shorter final step also exercises timestep-dependent matrix setup.
             integrator->advanceHierarchy(step < 2 ? 0.001 : 0.0005);
+            if (callback_count != integrator->getNumberOfCycles())
+            {
+                TBOX_ERROR("Integration callback count does not match the number of cycles.\n");
+            }
             // Geometric norms are independent of redistribution's Lagrangian vector ordering.
             ierr = VecCopy(method->getLDataManager()->getLData("X", 0)->getVec(), centered_positions);
             IBTK_CHKERRQ(ierr);

--- a/tests/IB/implicit_stokes_ib_01.cpp
+++ b/tests/IB/implicit_stokes_ib_01.cpp
@@ -1,0 +1,188 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2019 - 2026 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#include <ibamr/IBImplicitStaggeredHierarchyIntegrator.h>
+#include <ibamr/IBMethod.h>
+#include <ibamr/IBRedundantInitializer.h>
+#include <ibamr/IBStandardForceGen.h>
+#include <ibamr/INSStaggeredHierarchyIntegrator.h>
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/HierarchyMathOps.h>
+#include <ibtk/IBKernelEvaluators.h>
+#include <ibtk/IBKernelTensorProductEvaluator.h>
+#include <ibtk/IBOperatorRegistry.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_CHKERRQ.h>
+#include <ibtk/LData.h>
+#include <ibtk/LDataManager.h>
+#include <ibtk/muParserCartGridFunction.h>
+
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <GriddingAlgorithm.h>
+#include <HierarchyCellDataOpsReal.h>
+#include <HierarchySideDataOpsReal.h>
+#include <LoadBalancer.h>
+#include <StandardTagAndInitialize.h>
+#include <VariableDatabase.h>
+
+#include <array>
+#include <cmath>
+#include <iomanip>
+#include <map>
+#include <vector>
+
+#include <ibamr/app_namespaces.h>
+
+namespace
+{
+constexpr int NUM_POINTS = 16;
+int evaluator_calls = 0;
+
+// An application-compiled evaluator with the supplied four-point kernel's weights.
+struct CustomKernel
+{
+    std::array<double, 4> operator()(double r) const;
+};
+
+std::array<double, 4>
+CustomKernel::operator()(const double r) const
+{
+    ++evaluator_calls;
+    return IBKernelEvaluatorIB4{}(r);
+}
+
+void
+generate_structure(const unsigned int& structure,
+                   const int& level,
+                   int& num_vertices,
+                   std::vector<IBTK::Point>& positions,
+                   void*)
+{
+    num_vertices = (structure == 0 && level == 0) ? NUM_POINTS : 0;
+    positions.resize(num_vertices);
+    for (int k = 0; k < num_vertices; ++k)
+    {
+        const double theta = 2.0 * M_PI * k / NUM_POINTS;
+        positions[k](0) = 0.5 + 0.18 * std::cos(theta);
+        positions[k](1) = 0.5 + 0.25 * std::sin(theta);
+    }
+}
+
+void
+generate_springs(
+    const unsigned int& structure,
+    const int& level,
+    std::multimap<int, IBRedundantInitializer::Edge>& spring_map,
+    std::map<IBRedundantInitializer::Edge, IBRedundantInitializer::SpringSpec, IBRedundantInitializer::EdgeComp>& specs,
+    void*)
+{
+    if (structure != 0 || level != 0)
+    {
+        return;
+    }
+    for (int k = 0; k < NUM_POINTS; ++k)
+    {
+        IBRedundantInitializer::Edge edge = { k, (k + 1) % NUM_POINTS };
+        if (edge.first > edge.second)
+        {
+            std::swap(edge.first, edge.second);
+        }
+        spring_map.emplace(edge.first, edge);
+        IBRedundantInitializer::SpringSpec spec;
+        spec.force_fcn_idx = 0;
+        spec.parameters = { 5.0, 0.0 };
+        specs.emplace(edge, spec);
+    }
+}
+} // namespace
+
+int
+main(int argc, char* argv[])
+{
+    IBTKInit init(argc, argv, MPI_COMM_WORLD);
+    {
+        Pointer<AppInitializer> app = new AppInitializer(argc, argv, "output");
+        Pointer<Database> input = app->getInputDatabase();
+        const bool custom_kernel = input->getBoolWithDefault("custom_kernel", false);
+        if (custom_kernel)
+        {
+            IBOperatorRegistry::register_interpolation_matrix_sc(IBKernel("APP_FOUR_POINT"),
+                                                                 IBKernelTensorProductEvaluator{ CustomKernel{} });
+        }
+        Pointer<INSStaggeredHierarchyIntegrator> ins = new INSStaggeredHierarchyIntegrator(
+            "INSStaggeredHierarchyIntegrator", app->getComponentDatabase("INSStaggeredHierarchyIntegrator"));
+        Pointer<IBMethod> method = new IBMethod("IBMethod", app->getComponentDatabase("IBMethod"));
+        Pointer<IBImplicitStaggeredHierarchyIntegrator> integrator = new IBImplicitStaggeredHierarchyIntegrator(
+            "IBHierarchyIntegrator", app->getComponentDatabase("IBHierarchyIntegrator"), method, ins);
+        Pointer<CartesianGridGeometry<NDIM>> geometry =
+            new CartesianGridGeometry<NDIM>("CartesianGeometry", app->getComponentDatabase("CartesianGeometry"));
+        Pointer<PatchHierarchy<NDIM>> hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", geometry);
+        Pointer<StandardTagAndInitialize<NDIM>> tagging = new StandardTagAndInitialize<NDIM>(
+            "StandardTagAndInitialize", integrator, app->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<BergerRigoutsos<NDIM>> boxes = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM>> load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM>> gridding = new GriddingAlgorithm<NDIM>(
+            "GriddingAlgorithm", app->getComponentDatabase("GriddingAlgorithm"), tagging, boxes, load_balancer);
+        Pointer<IBRedundantInitializer> initializer =
+            new IBRedundantInitializer("IBRedundantInitializer", app->getComponentDatabase("IBRedundantInitializer"));
+        initializer->setStructureNamesOnLevel(0, { "ellipse" });
+        initializer->registerInitStructureFunction(generate_structure);
+        initializer->registerInitSpringDataFunction(generate_springs);
+        method->registerLInitStrategy(initializer);
+        method->registerIBLagrangianForceFunction(new IBStandardForceGen());
+        ins->registerVelocityInitialConditions(new muParserCartGridFunction(
+            "initial_velocity", app->getComponentDatabase("VelocityInitialConditions"), geometry));
+        integrator->initializePatchHierarchy(hierarchy, gridding);
+        method->freeLInitStrategy();
+        initializer.setNull();
+
+        VariableDatabase<NDIM>* variables = VariableDatabase<NDIM>::getDatabase();
+        const int u = variables->mapVariableAndContextToIndex(ins->getVelocityVariable(), ins->getCurrentContext());
+        const int p = variables->mapVariableAndContextToIndex(ins->getPressureVariable(), ins->getCurrentContext());
+        HierarchySideDataOpsReal<NDIM, double> velocity_ops(hierarchy, 0, 0);
+        HierarchyCellDataOpsReal<NDIM, double> pressure_ops(hierarchy, 0, 0);
+        Pointer<HierarchyMathOps> math_ops = ins->getHierarchyMathOps();
+        Vec centered_positions = nullptr;
+        PetscErrorCode ierr = VecDuplicate(method->getLDataManager()->getLData("X", 0)->getVec(), &centered_positions);
+        IBTK_CHKERRQ(ierr);
+        plog << std::scientific << std::setprecision(8);
+        for (int step = 0; step < 3; ++step)
+        {
+            const int previous_calls = evaluator_calls;
+            // A shorter final step also exercises timestep-dependent matrix setup.
+            integrator->advanceHierarchy(step < 2 ? 0.001 : 0.0005);
+            // Geometric norms are independent of redistribution's Lagrangian vector ordering.
+            ierr = VecCopy(method->getLDataManager()->getLData("X", 0)->getVec(), centered_positions);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecShift(centered_positions, -0.5);
+            IBTK_CHKERRQ(ierr);
+            double radius_norm = 0.0;
+            ierr = VecNorm(centered_positions, NORM_2, &radius_norm);
+            IBTK_CHKERRQ(ierr);
+            plog << "step " << step + 1 << " time " << integrator->getIntegratorTime() << " velocity_L2 "
+                 << velocity_ops.L2Norm(u, math_ops->getSideWeightPatchDescriptorIndex()) << " pressure_L2 "
+                 << pressure_ops.L2Norm(p, math_ops->getCellWeightPatchDescriptorIndex()) << " radius_L2 "
+                 << radius_norm << '\n';
+            if (custom_kernel && evaluator_calls == previous_calls)
+            {
+                TBOX_ERROR("The selected application evaluator was not used during advancement.\n");
+            }
+        }
+        ierr = VecDestroy(&centered_positions);
+        IBTK_CHKERRQ(ierr);
+    }
+    return 0;
+}

--- a/tests/IB/implicit_stokes_ib_01.custom_kernel.input
+++ b/tests/IB/implicit_stokes_ib_01.custom_kernel.input
@@ -1,0 +1,78 @@
+N = 8
+IB_RULE = "MIDPOINT_RULE"
+JAC_KERNEL = "APP_FOUR_POINT"
+custom_kernel = TRUE
+IBHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.0025
+   dt_max = 0.001
+   num_cycles = 1
+   regrid_interval = 0
+   error_on_dt_change = FALSE
+   warn_on_dt_change = FALSE
+   time_stepping_type = IB_RULE
+   jacobian_delta_fcn = JAC_KERNEL
+   rel_residual_tol = 1.0e-10
+   abs_residual_tol = 1.0e-12
+   max_iterations = 20
+   stokes_ib_precond_db {
+      has_pressure_nullspace = TRUE
+      num_pre_sweeps = 1
+      num_post_sweeps = 1
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         ksp_type = "preonly"
+         pc_type = "svd"
+         initial_guess_nonzero = FALSE
+      }
+   }
+}
+INSStaggeredHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.0025
+   mu = 0.01
+   rho = 1.0
+   creeping_flow = TRUE
+   viscous_time_stepping_type = "TRAPEZOIDAL_RULE"
+   normalize_pressure = TRUE
+   num_cycles = 1
+   dt_max = 0.001
+   enable_logging_solver_iterations = FALSE
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = 1
+   base_filenames_0 = "ellipse"
+}
+VelocityInitialConditions {
+   function_0 = "0.1*sin(2*pi*X_1)"
+   function_1 = "0.05*cos(2*pi*X_0)"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "100"
+      stokes_ib_pc_level_0_ksp_type = "preonly"
+      stokes_ib_pc_level_0_pc_type = "svd"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size { level_0 = N,N }
+   smallest_patch_size { level_0 = N,N }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (N - 1, N - 1)] }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_01.custom_kernel.output
+++ b/tests/IB/implicit_stokes_ib_01.custom_kernel.output
@@ -1,0 +1,7 @@
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
+  projecting the interpolated velocity field
+IBRedundantInitializer:  Deallocating initialization data.
+step 1 time 1.00000000e-03 velocity_L2 7.90305725e-02 pressure_L2 4.87541265e-01 radius_L2 8.71320449e-01
+step 2 time 2.00000000e-03 velocity_L2 7.90107347e-02 pressure_L2 4.87540947e-01 radius_L2 8.71319287e-01
+step 3 time 2.50000000e-03 velocity_L2 7.90032606e-02 pressure_L2 4.87540601e-01 radius_L2 8.71318415e-01

--- a/tests/IB/implicit_stokes_ib_01.midpoint.input
+++ b/tests/IB/implicit_stokes_ib_01.midpoint.input
@@ -1,0 +1,78 @@
+N = 8
+IB_RULE = "MIDPOINT_RULE"
+JAC_KERNEL = "IB_4"
+custom_kernel = FALSE
+IBHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.0025
+   dt_max = 0.001
+   num_cycles = 1
+   regrid_interval = 0
+   error_on_dt_change = FALSE
+   warn_on_dt_change = FALSE
+   time_stepping_type = IB_RULE
+   jacobian_delta_fcn = JAC_KERNEL
+   rel_residual_tol = 1.0e-10
+   abs_residual_tol = 1.0e-12
+   max_iterations = 20
+   stokes_ib_precond_db {
+      has_pressure_nullspace = TRUE
+      num_pre_sweeps = 1
+      num_post_sweeps = 1
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         ksp_type = "preonly"
+         pc_type = "svd"
+         initial_guess_nonzero = FALSE
+      }
+   }
+}
+INSStaggeredHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.0025
+   mu = 0.01
+   rho = 1.0
+   creeping_flow = TRUE
+   viscous_time_stepping_type = "TRAPEZOIDAL_RULE"
+   normalize_pressure = TRUE
+   num_cycles = 1
+   dt_max = 0.001
+   enable_logging_solver_iterations = FALSE
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = 1
+   base_filenames_0 = "ellipse"
+}
+VelocityInitialConditions {
+   function_0 = "0.1*sin(2*pi*X_1)"
+   function_1 = "0.05*cos(2*pi*X_0)"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "100"
+      stokes_ib_pc_level_0_ksp_type = "preonly"
+      stokes_ib_pc_level_0_pc_type = "svd"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size { level_0 = N,N }
+   smallest_patch_size { level_0 = N,N }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (N - 1, N - 1)] }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_01.midpoint.output
+++ b/tests/IB/implicit_stokes_ib_01.midpoint.output
@@ -1,0 +1,7 @@
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
+  projecting the interpolated velocity field
+IBRedundantInitializer:  Deallocating initialization data.
+step 1 time 1.00000000e-03 velocity_L2 7.90305725e-02 pressure_L2 4.87541265e-01 radius_L2 8.71320449e-01
+step 2 time 2.00000000e-03 velocity_L2 7.90107347e-02 pressure_L2 4.87540947e-01 radius_L2 8.71319287e-01
+step 3 time 2.50000000e-03 velocity_L2 7.90032606e-02 pressure_L2 4.87540601e-01 radius_L2 8.71318415e-01

--- a/tests/IB/implicit_stokes_ib_01.trapezoidal.input
+++ b/tests/IB/implicit_stokes_ib_01.trapezoidal.input
@@ -1,0 +1,78 @@
+N = 8
+IB_RULE = "TRAPEZOIDAL_RULE"
+JAC_KERNEL = "IB_4"
+custom_kernel = FALSE
+IBHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.0025
+   dt_max = 0.001
+   num_cycles = 1
+   regrid_interval = 0
+   error_on_dt_change = FALSE
+   warn_on_dt_change = FALSE
+   time_stepping_type = IB_RULE
+   jacobian_delta_fcn = JAC_KERNEL
+   rel_residual_tol = 1.0e-10
+   abs_residual_tol = 1.0e-12
+   max_iterations = 20
+   stokes_ib_precond_db {
+      has_pressure_nullspace = TRUE
+      num_pre_sweeps = 1
+      num_post_sweeps = 1
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         ksp_type = "preonly"
+         pc_type = "svd"
+         initial_guess_nonzero = FALSE
+      }
+   }
+}
+INSStaggeredHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.0025
+   mu = 0.01
+   rho = 1.0
+   creeping_flow = TRUE
+   viscous_time_stepping_type = "TRAPEZOIDAL_RULE"
+   normalize_pressure = TRUE
+   num_cycles = 1
+   dt_max = 0.001
+   enable_logging_solver_iterations = FALSE
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = 1
+   base_filenames_0 = "ellipse"
+}
+VelocityInitialConditions {
+   function_0 = "0.1*sin(2*pi*X_1)"
+   function_1 = "0.05*cos(2*pi*X_0)"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "100"
+      stokes_ib_pc_level_0_ksp_type = "preonly"
+      stokes_ib_pc_level_0_pc_type = "svd"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size { level_0 = N,N }
+   smallest_patch_size { level_0 = N,N }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (N - 1, N - 1)] }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_01.trapezoidal.output
+++ b/tests/IB/implicit_stokes_ib_01.trapezoidal.output
@@ -1,0 +1,7 @@
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 0
+INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
+  projecting the interpolated velocity field
+IBRedundantInitializer:  Deallocating initialization data.
+step 1 time 1.00000000e-03 velocity_L2 7.90305725e-02 pressure_L2 4.87541265e-01 radius_L2 8.71320449e-01
+step 2 time 2.00000000e-03 velocity_L2 7.90107347e-02 pressure_L2 4.87540947e-01 radius_L2 8.71319287e-01
+step 3 time 2.50000000e-03 velocity_L2 7.90032606e-02 pressure_L2 4.87540601e-01 radius_L2 8.71318415e-01

--- a/tests/unfinished-tests/Stokes-IB/test0/input2d
+++ b/tests/unfinished-tests/Stokes-IB/test0/input2d
@@ -96,49 +96,48 @@ IBHierarchyIntegrator {
    max_integrator_steps = 1
 
    // Setting for implicit integrator
-    eliminate_eulerian_vars  = TRUE
-    jacobian_delta_fcn       = "IB_4"
-}
+   jacobian_delta_fcn = "IB_4"
 
-stokes_ib_precond_db
-{
-	num_pre_sweeps  = 1
-	num_post_sweeps = 1
-	//U_prolongation_method = "LINEAR_REFINE"
-	//P_prolongation_method = "LINEAR_REFINE"
-	//U_restriction_method  = "CONSERVATIVE_COARSEN"
-	//P_restriction_method  = "CONSERVATIVE_COARSEN"
-    smoother_type           = "REDBLACK"
+   stokes_ib_precond_db
+   {
+      num_pre_sweeps  = 1
+      num_post_sweeps = 1
+      //U_prolongation_method = "LINEAR_REFINE"
+      //P_prolongation_method = "LINEAR_REFINE"
+      //U_restriction_method  = "CONSERVATIVE_COARSEN"
+      //P_restriction_method  = "CONSERVATIVE_COARSEN"
+      smoother_type           = "REDBLACK"
 
-	level_solver_type   = "PETSC_LEVEL_SOLVER"
-	level_solver_rel_residual_tol = 1.0e-9
-	level_solver_abs_residual_tol = 1.0e-50
-	level_solver_max_iterations = 1000
-        level_solver_db
-	{
-        use_ksp_as_smoother   = TRUE
-	    initial_guess_nonzero = TRUE
-	    ksp_type              = "fgmres"
-	    pc_type               = "asm"
+      level_solver_type   = "PETSC_LEVEL_SOLVER"
+      level_solver_rel_residual_tol = 1.0e-9
+      level_solver_abs_residual_tol = 1.0e-50
+      level_solver_max_iterations = 1000
+      level_solver_db
+      {
+         use_ksp_as_smoother   = TRUE
+         initial_guess_nonzero = TRUE
+         ksp_type              = "fgmres"
+         pc_type               = "asm"
 
-            subdomain_box_size      = 8, 8
-            subdomain_overlap_size  = 1, 1
-	}
+         subdomain_box_size      = 8, 8
+         subdomain_overlap_size  = 1, 1
+      }
 
-	coarse_solver_type  = "PETSC_LEVEL_SOLVER"
-	coarse_solver_rel_residual_tol = 1.0e-12
-	coarse_solver_abs_residual_tol = 1.0e-50
-	coarse_solver_max_iterations = 1
-	coarse_solver_db
-	{
+      coarse_solver_type  = "PETSC_LEVEL_SOLVER"
+      coarse_solver_rel_residual_tol = 1.0e-12
+      coarse_solver_abs_residual_tol = 1.0e-50
+      coarse_solver_max_iterations = 1
+      coarse_solver_db
+      {
          use_ksp_as_smoother   = FALSE
-	     initial_guess_nonzero = TRUE
-	     ksp_type              = "gmres"
-	     pc_type               = "asm"
+         initial_guess_nonzero = TRUE
+         ksp_type              = "gmres"
+         pc_type               = "asm"
 
-             subdomain_box_size     = 2*N, N
-             subdomain_overlap_size = 0, 0
-	}
+         subdomain_box_size     = 2*N, N
+         subdomain_overlap_size = 0, 0
+      }
+   }
 }
 
 IBMethod {

--- a/tests/unfinished-tests/Stokes-IB/test0/main.cpp
+++ b/tests/unfinished-tests/Stokes-IB/test0/main.cpp
@@ -544,7 +544,8 @@ main(int argc, char* argv[])
         ib_method_ops->registerIBLagrangianForceFunction(ib_force_fcn);
 
         // Create the IB FAC op/pc and StokesIBSolver.
-        Pointer<Database> stokes_ib_precond_db = input_db->getDatabase("stokes_ib_precond_db");
+        Pointer<Database> stokes_ib_precond_db =
+            input_db->getDatabase("IBHierarchyIntegrator")->getDatabase("stokes_ib_precond_db");
         Pointer<StaggeredStokesIBLevelRelaxationFACOperator> fac_op = new StaggeredStokesIBLevelRelaxationFACOperator(
             "StaggeredStokesIBBoxRelaxationFACOperator", stokes_ib_precond_db, "stokes_ib_pc_");
         Pointer<StaggeredStokesFACPreconditioner> fac_pc =

--- a/tests/unfinished-tests/Stokes-IB/test1/input2d.shell
+++ b/tests/unfinished-tests/Stokes-IB/test1/input2d.shell
@@ -93,7 +93,6 @@ IBHierarchyIntegrator {
    max_integrator_steps = 1
 
    // Setting for implicit integrator
-   eliminate_eulerian_vars    = FALSE
    jacobian_delta_fcn         = "IB_4"
    stokes_ib_precond_db
    {

--- a/tests/unfinished-tests/Stokes-IB/test2/input2d.cylinder
+++ b/tests/unfinished-tests/Stokes-IB/test2/input2d.cylinder
@@ -89,7 +89,6 @@ IBHierarchyIntegrator {
    max_integrator_steps = 20
 
    // Setting for implicit integrator
-   eliminate_eulerian_vars    = FALSE
    jacobian_delta_fcn         = "IB_4"
    stokes_ib_precond_db
    {

--- a/tests/unfinished-tests/Stokes-IB/test2/input2d.leaf-FS
+++ b/tests/unfinished-tests/Stokes-IB/test2/input2d.leaf-FS
@@ -93,7 +93,6 @@ IBHierarchyIntegrator {
    enable_logging      = ENABLE_LOGGING
 
    // Setting for implicit integrator
-   eliminate_eulerian_vars    = FALSE
    jacobian_delta_fcn         = "IB_4"
    stokes_ib_precond_db
    {


### PR DESCRIPTION
Use the shared Stokes-IB operators and FAC preconditioner to advance the implicit IB hierarchy in the velocity-pressure formulation.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
