### PR TITLE
[CAV R03-preA] Fix out-of-domain transfer indexing

### DIFF
--- a/doc/news/changes/minor/20260909BoyceGriffith-index-mapping
+++ b/doc/news/changes/minor/20260909BoyceGriffith-index-mapping
@@ -1,0 +1,3 @@
+Fix: Correct out-of-domain index mappings and side prolongation boundary weights.
+<br>
+(Boyce Griffith, 2026/09/09)

--- a/ibtk/include/ibtk/IndexUtilities.h
+++ b/ibtk/include/ibtk/IndexUtilities.h
@@ -269,8 +269,8 @@ public:
      *
      * \param periodic_shift Periodic shift in each direction.
      *
-     * \return The linear mapping of an AMR index to a continuous non-negative
-     * integer space.
+     * \return The nonnegative linear index, or -1 if the index is outside
+     * the supplied array extent after periodic adjustment.
      */
     static int
     mapIndexToInteger(const SAMRAI::hier::Index<NDIM>& i,

--- a/ibtk/include/ibtk/private/IndexUtilities-inl.h
+++ b/ibtk/include/ibtk/private/IndexUtilities-inl.h
@@ -282,6 +282,14 @@ IndexUtilities::mapIndexToInteger(const SAMRAI::hier::Index<NDIM>& i,
         }
     }
 
+    for (int d = 0; d < NDIM; ++d)
+    {
+        if (idx(d) < domain_lower(d) || idx(d) - domain_lower(d) >= n_cells(d))
+        {
+            return -1;
+        }
+    }
+
 #if (NDIM == 1)
     return (idx(0) - domain_lower(0) + depth * n_cells(0) + offset);
 #elif (NDIM == 2)

--- a/ibtk/src/math/PETScMatUtilities.cpp
+++ b/ibtk/src/math/PETScMatUtilities.cpp
@@ -2131,12 +2131,13 @@ PETScMatUtilities::constructLinearProlongationOp_side(Mat& mat,
                         values[6] = w0 * (1.0 - w1) * (1.0 - w2);
                         if (samrai_petsc_map[d * n_interpolants + 6] < 0)
                         {
-                            values[4] += values[6];
+                            // Preserve the mapped tangential neighbor when folding a corner weight.
+                            values[samrai_petsc_map[d * n_interpolants + 2] < 0 ? 4 : 2] += values[6];
                         }
                         values[7] = (1.0 - w0) * (1.0 - w1) * (1.0 - w2);
                         if (samrai_petsc_map[d * n_interpolants + 7] < 0)
                         {
-                            values[5] += values[7];
+                            values[samrai_petsc_map[d * n_interpolants + 3] < 0 ? 5 : 3] += values[7];
                         }
                         if (samrai_petsc_map[d * n_interpolants + 4] < 0)
                         {
@@ -2191,12 +2192,12 @@ PETScMatUtilities::constructLinearProlongationOp_side(Mat& mat,
                         values[6] = (1.0 - w0) * w1 * (1.0 - w2);
                         if (samrai_petsc_map[d * n_interpolants + 6] < 0)
                         {
-                            values[4] += values[6];
+                            values[samrai_petsc_map[d * n_interpolants + 2] < 0 ? 4 : 2] += values[6];
                         }
                         values[7] = (1.0 - w0) * (1.0 - w1) * (1.0 - w2);
                         if (samrai_petsc_map[d * n_interpolants + 7] < 0)
                         {
-                            values[5] += values[7];
+                            values[samrai_petsc_map[d * n_interpolants + 3] < 0 ? 5 : 3] += values[7];
                         }
                         if (samrai_petsc_map[d * n_interpolants + 4] < 0)
                         {
@@ -2249,12 +2250,12 @@ PETScMatUtilities::constructLinearProlongationOp_side(Mat& mat,
                         values[6] = (1.0 - w0) * (1.0 - w1) * w2;
                         if (samrai_petsc_map[d * n_interpolants + 6] < 0)
                         {
-                            values[4] += values[6];
+                            values[samrai_petsc_map[d * n_interpolants + 2] < 0 ? 4 : 2] += values[6];
                         }
                         values[7] = (1.0 - w0) * (1.0 - w1) * (1.0 - w2);
                         if (samrai_petsc_map[d * n_interpolants + 7] < 0)
                         {
-                            values[5] += values[7];
+                            values[samrai_petsc_map[d * n_interpolants + 3] < 0 ? 5 : 3] += values[7];
                         }
                         if (samrai_petsc_map[d * n_interpolants + 4] < 0)
                         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,6 +152,8 @@ SETUP(multiphase_flow high_density_droplet.cpp IBAMR2d)
 SETUP(multiphase_flow water_entry_circular_cylinder.cpp IBAMR2d)
 
 # navier_stokes:
+SETUP_2D(navier_stokes side_prolongation.cpp)
+SETUP_3D(navier_stokes side_prolongation.cpp)
 SETUP_2D(navier_stokes navier_stokes_01.cpp)
 SETUP_3D(navier_stokes navier_stokes_01.cpp)
 SETUP_2D(navier_stokes poiseuille_flow_2d.cpp)

--- a/tests/IBTK/index_utilities.cpp
+++ b/tests/IBTK/index_utilities.cpp
@@ -1,10 +1,13 @@
 #include <ibtk/AppInitializer.h>
 #include <ibtk/HierarchyMathOps.h>
 #include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_CHKERRQ.h>
 #include <ibtk/IndexUtilities.h>
 
 #include <tbox/Database.h>
 #include <tbox/Pointer.h>
+
+#include <petscao.h>
 
 #include <HierarchyDataOpsManager.h>
 
@@ -23,6 +26,64 @@ main(int argc, char** argv)
 
     IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
     tbox::Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv);
+
+    if (app_initializer->getInputDatabase()->getBoolWithDefault("test_mapping", false))
+    {
+        hier::Index<NDIM> lower(-3), extent(4);
+        lower(1) = 2;
+        extent(1) = 3;
+#if (NDIM == 3)
+        lower(2) = -1;
+        extent(2) = 2;
+#endif
+        const hier::Index<NDIM> upper = lower + extent - 1;
+        const int volume = extent.getProduct();
+        const int offset = 17;
+        const int depth = 2;
+        const int first = offset + depth * volume;
+        int mismatches = 0;
+        mismatches += IndexUtilities::mapIndexToInteger(lower, lower, extent, depth, offset) != first;
+        mismatches += IndexUtilities::mapIndexToInteger(upper, lower, extent, depth, offset) != first + volume - 1;
+        mismatches += IndexUtilities::mapIndexToInteger(lower - 1, lower, extent, depth, offset) != -1;
+        mismatches += IndexUtilities::mapIndexToInteger(upper + 1, lower, extent, depth, offset) != -1;
+        for (int axis = 0; axis < NDIM; ++axis)
+        {
+            hier::Index<NDIM> below = lower, above = upper;
+            --below(axis);
+            ++above(axis);
+            mismatches += IndexUtilities::mapIndexToInteger(below, lower, extent, depth, offset) != -1;
+            mismatches += IndexUtilities::mapIndexToInteger(above, lower, extent, depth, offset) != -1;
+            hier::IntVector<NDIM> periodic(0);
+            periodic(axis) = extent(axis);
+            hier::Index<NDIM> partner = below;
+            partner(axis) = upper(axis);
+            mismatches += IndexUtilities::mapIndexToInteger(below, lower, extent, depth, offset, periodic) !=
+                          IndexUtilities::mapIndexToInteger(partner, lower, extent, depth, offset);
+            partner = above;
+            partner(axis) = lower(axis);
+            mismatches += IndexUtilities::mapIndexToInteger(above, lower, extent, depth, offset, periodic) !=
+                          IndexUtilities::mapIndexToInteger(partner, lower, extent, depth, offset);
+            --below((axis + 1) % NDIM);
+            mismatches += IndexUtilities::mapIndexToInteger(below, lower, extent, depth, offset, periodic) != -1;
+        }
+        hier::IntVector<NDIM> periodic(extent);
+        mismatches +=
+            IndexUtilities::mapIndexToInteger(lower - 1, lower, extent, depth, offset, periodic) != first + volume - 1;
+        mismatches += IndexUtilities::mapIndexToInteger(upper + 1, lower, extent, depth, offset, periodic) != first;
+        PetscInt application[2] = { first, first + volume - 1 };
+        PetscInt petsc[2] = { 1, 0 };
+        AO ordering = nullptr;
+        int ierr = AOCreateMapping(PETSC_COMM_SELF, 2, application, petsc, &ordering);
+        IBTK_CHKERRQ(ierr);
+        PetscInt indices[3] = { -1, application[0], application[1] };
+        ierr = AOApplicationToPetsc(ordering, 3, indices);
+        IBTK_CHKERRQ(ierr);
+        mismatches += indices[0] != -1 || indices[1] != 1 || indices[2] != 0;
+        ierr = AODestroy(&ordering);
+        IBTK_CHKERRQ(ierr);
+        tbox::plog << "mapping mismatches = " << mismatches << '\n';
+        return mismatches ? 1 : 0;
+    }
 
     auto tuple = setup_hierarchy<NDIM>(app_initializer);
     auto patch_hierarchy = std::get<0>(tuple);

--- a/tests/IBTK/index_utilities_2d.mapping.input
+++ b/tests/IBTK/index_utilities_2d.mapping.input
@@ -1,0 +1,5 @@
+test_mapping = TRUE
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}

--- a/tests/IBTK/index_utilities_2d.mapping.output
+++ b/tests/IBTK/index_utilities_2d.mapping.output
@@ -1,0 +1,1 @@
+mapping mismatches = 0

--- a/tests/IBTK/index_utilities_3d.mapping.input
+++ b/tests/IBTK/index_utilities_3d.mapping.input
@@ -1,0 +1,5 @@
+test_mapping = TRUE
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+}

--- a/tests/IBTK/index_utilities_3d.mapping.output
+++ b/tests/IBTK/index_utilities_3d.mapping.output
@@ -1,0 +1,1 @@
+mapping mismatches = 0

--- a/tests/navier_stokes/side_prolongation.cpp
+++ b/tests/navier_stokes/side_prolongation.cpp
@@ -1,0 +1,269 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2026 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#include <ibamr/StaggeredStokesPETScVecUtilities.h>
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/CartExtrapPhysBdryOp.h>
+#include <ibtk/CartSideDoubleRT0Refine.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_CHKERRQ.h>
+#include <ibtk/IBTK_MPI.h>
+#include <ibtk/PETScMatUtilities.h>
+
+#include <CartesianGridGeometry.h>
+#include <CellData.h>
+#include <CellVariable.h>
+#include <RefineAlgorithm.h>
+#include <RefineSchedule.h>
+#include <SideData.h>
+#include <SideGeometry.h>
+#include <SideIndex.h>
+#include <SideVariable.h>
+#include <VariableDatabase.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <numeric>
+
+#include "../tests.h"
+
+#include <ibtk/app_namespaces.h>
+
+namespace
+{
+// A separable profile gives independent one-dimensional interpolation weights.
+double
+profile_factor(int index, int axis, int direction, const Box<NDIM>& domain, const IntVector<NDIM>& periodic)
+{
+    if (!periodic(direction))
+    {
+        index = std::max(domain.lower()(direction), std::min(index, domain.upper()(direction) + (direction == axis)));
+    }
+    const double coordinate = index - domain.lower()(direction) + (direction == axis ? 0.0 : 0.5);
+    const int extent = domain.upper()(direction) - domain.lower()(direction) + 1;
+    return 1.0 + 0.1 * (direction + 1) * std::cos(2.0 * std::acos(-1.0) * coordinate / extent);
+}
+
+double
+profile_value(const hier::Index<NDIM>& index,
+              int axis,
+              const Box<NDIM>& domain,
+              const IntVector<NDIM>& periodic,
+              bool normal_only)
+{
+    double value = axis + 1.0;
+    for (int d = 0; d < NDIM; ++d)
+    {
+        if (!normal_only || d == axis)
+        {
+            value *= profile_factor(index(d), axis, d, domain, periodic);
+        }
+    }
+    return value;
+}
+
+double
+interpolated_value(const hier::Index<NDIM>& fine_index,
+                   int axis,
+                   const Box<NDIM>& domain,
+                   const IntVector<NDIM>& periodic,
+                   const IntVector<NDIM>& ratio,
+                   bool rt0)
+{
+    double value = axis + 1.0;
+    for (int d = 0; d < NDIM; ++d)
+    {
+        const double shift = d == axis ? 0.0 : 0.5;
+        const double coordinate = (fine_index(d) + shift) / ratio(d) - shift;
+        if (rt0 && d != axis)
+        {
+            const int coarse_index = static_cast<int>(std::floor(static_cast<double>(fine_index(d)) / ratio(d)));
+            value *= profile_factor(coarse_index, axis, d, domain, periodic);
+        }
+        else
+        {
+            const int left = static_cast<int>(std::floor(coordinate));
+            const double right_weight = coordinate - left;
+            value *= (1.0 - right_weight) * profile_factor(left, axis, d, domain, periodic) +
+                     right_weight * profile_factor(left + 1, axis, d, domain, periodic);
+        }
+    }
+    return value;
+}
+} // namespace
+
+int
+main(int argc, char* argv[])
+{
+    IBTKInit init(argc, argv, MPI_COMM_WORLD);
+    Pointer<AppInitializer> app = new AppInitializer(argc, argv, "output");
+    Pointer<Database> test_db = app->getInputDatabase()->getDatabase("test");
+    const bool rt0 = test_db->getStringWithDefault("operator", "LINEAR") == "RT0";
+    const auto hierarchy_tuple = setup_hierarchy<NDIM>(app);
+    Pointer<PatchHierarchy<NDIM>> hierarchy = std::get<0>(hierarchy_tuple);
+    if (hierarchy->getFinestLevelNumber() != 1)
+    {
+        TBOX_ERROR("Side prolongation test requires two levels.\n");
+    }
+    Pointer<PatchLevel<NDIM>> coarse = hierarchy->getPatchLevel(0);
+    Pointer<PatchLevel<NDIM>> fine = hierarchy->getPatchLevel(1);
+    const Box<NDIM>& domain = coarse->getPhysicalDomain()[0];
+    const IntVector<NDIM> ratio = fine->getRatio() / coarse->getRatio();
+    Pointer<CartesianGridGeometry<NDIM>> geometry = hierarchy->getGridGeometry();
+    const IntVector<NDIM> periodic = geometry->getPeriodicShift(coarse->getRatio());
+    VariableDatabase<NDIM>* db = VariableDatabase<NDIM>::getDatabase();
+    Pointer<VariableContext> context = db->getContext("side_prolongation");
+    Pointer<SideVariable<NDIM, int>> u_dof = new SideVariable<NDIM, int>("u_dof");
+    Pointer<CellVariable<NDIM, int>> p_dof = new CellVariable<NDIM, int>("p_dof");
+    Pointer<SideVariable<NDIM, double>> u_var = new SideVariable<NDIM, double>("u");
+    Pointer<CellVariable<NDIM, double>> p_var = new CellVariable<NDIM, double>("p");
+    Pointer<SideVariable<NDIM, double>> expected_var = new SideVariable<NDIM, double>("expected_u");
+    const int u_dof_idx = db->registerVariableAndContext(u_dof, context, IntVector<NDIM>(1));
+    const int p_dof_idx = db->registerVariableAndContext(p_dof, context, IntVector<NDIM>(1));
+    const int u_idx = db->registerVariableAndContext(u_var, context, IntVector<NDIM>(1));
+    const int p_idx = db->registerVariableAndContext(p_var, context, IntVector<NDIM>(1));
+    const int expected_idx = db->registerVariableAndContext(expected_var, context, IntVector<NDIM>(1));
+    for (int ln = 0; ln < 2; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+        for (const int idx : { u_dof_idx, p_dof_idx, u_idx, p_idx, expected_idx })
+        {
+            level->allocatePatchData(idx);
+        }
+    }
+    std::vector<int> coarse_counts, fine_counts;
+    IBAMR::StaggeredStokesPETScVecUtilities::constructPatchLevelDOFIndices(coarse_counts, u_dof_idx, p_dof_idx, coarse);
+    IBAMR::StaggeredStokesPETScVecUtilities::constructPatchLevelDOFIndices(fine_counts, u_dof_idx, p_dof_idx, fine);
+    if (*std::min_element(coarse_counts.begin(), coarse_counts.end()) <= 0 ||
+        *std::min_element(fine_counts.begin(), fine_counts.end()) <= 0)
+    {
+        TBOX_ERROR("Side prolongation test requires DOFs on every rank at both levels.\n");
+    }
+    AO ordering = nullptr;
+    int u_offset = 0, p_offset = 0;
+    IBAMR::StaggeredStokesPETScVecUtilities::constructPatchLevelAO(
+        ordering, coarse_counts, u_dof_idx, p_dof_idx, coarse, u_offset, p_offset);
+    Mat prolongation = nullptr;
+    PETScMatUtilities::constructProlongationOp(
+        prolongation, rt0 ? "RT0" : "LINEAR", u_dof_idx, fine_counts, coarse_counts, fine, coarse, ordering, u_offset);
+    Vec x = nullptr, result = nullptr, expected = nullptr;
+    int ierr = MatCreateVecs(prolongation, &x, &result);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDuplicate(result, &expected);
+    IBTK_CHKERRQ(ierr);
+    double reference_error = 0.0, pressure_leak = 0.0, schedule_error = 0.0, result_norm = 0.0;
+    // Exercise each component separately, then pressure, then the RT0 subspace.
+    for (int component = 0; component < NDIM + 2; ++component)
+    {
+        const bool normal_only = component == NDIM + 1;
+        for (PatchLevel<NDIM>::Iterator p(coarse); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = coarse->getPatch(p());
+            Pointer<SideData<NDIM, double>> u = patch->getPatchData(u_idx);
+            Pointer<CellData<NDIM, double>> pressure = patch->getPatchData(p_idx);
+            u->fillAll(0.0);
+            pressure->fillAll(component == NDIM ? 2.0 : 0.0);
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                if (!normal_only && component != axis)
+                {
+                    continue;
+                }
+                for (Box<NDIM>::Iterator b(SideGeometry<NDIM>::toSideBox(u->getGhostBox(), axis)); b; b++)
+                {
+                    (*u)(SideIndex<NDIM>(b(), axis, SideIndex<NDIM>::Lower)) =
+                        profile_value(b(), axis, domain, periodic, normal_only);
+                }
+            }
+        }
+        for (PatchLevel<NDIM>::Iterator p(fine); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = fine->getPatch(p());
+            Pointer<SideData<NDIM, double>> u = patch->getPatchData(expected_idx);
+            Pointer<CellData<NDIM, double>> pressure = patch->getPatchData(p_idx);
+            u->fillAll(0.0);
+            pressure->fillAll(0.0);
+            if (component < NDIM)
+            {
+                for (Box<NDIM>::Iterator b(SideGeometry<NDIM>::toSideBox(patch->getBox(), component)); b; b++)
+                {
+                    (*u)(SideIndex<NDIM>(b(), component, SideIndex<NDIM>::Lower)) =
+                        interpolated_value(b(), component, domain, periodic, ratio, rt0);
+                }
+            }
+        }
+        if (normal_only)
+        {
+            // Tangentially constant data make LINEAR and RT0 refinement identical.
+            Pointer<RefineAlgorithm<NDIM>> algorithm = new RefineAlgorithm<NDIM>();
+            algorithm->registerRefine(expected_idx, u_idx, expected_idx, new CartSideDoubleRT0Refine());
+            CartExtrapPhysBdryOp boundary(expected_idx, "CONSTANT");
+            Pointer<RefineSchedule<NDIM>> schedule =
+                algorithm->createSchedule(fine, Pointer<PatchLevel<NDIM>>(), 0, hierarchy, &boundary);
+            schedule->fillData(0.0);
+        }
+        IBAMR::StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(x, u_idx, u_dof_idx, p_idx, p_dof_idx, coarse);
+        IBAMR::StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(
+            expected, expected_idx, u_dof_idx, p_idx, p_dof_idx, fine);
+        ierr = MatMult(prolongation, x, result);
+        IBTK_CHKERRQ(ierr);
+        double norm = 0.0;
+        ierr = VecNorm(result, NORM_INFINITY, &norm);
+        IBTK_CHKERRQ(ierr);
+        if (!std::isfinite(norm))
+        {
+            TBOX_ERROR("Side prolongation produced a nonfinite norm.\n");
+        }
+        result_norm = std::max(result_norm, norm);
+        ierr = VecAXPY(result, -1.0, expected);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecNorm(result, NORM_INFINITY, &norm);
+        IBTK_CHKERRQ(ierr);
+        if (!std::isfinite(norm))
+        {
+            TBOX_ERROR("Side prolongation error has a nonfinite norm.\n");
+        }
+        if (normal_only)
+        {
+            schedule_error = norm;
+        }
+        else if (component == NDIM)
+        {
+            pressure_leak = norm;
+        }
+        else
+        {
+            reference_error = std::max(reference_error, norm);
+        }
+    }
+    plog << std::setprecision(12) << "result norm = " << result_norm << '\n'
+         << "interpolation error = " << reference_error << '\n'
+         << "pressure leakage = " << pressure_leak << '\n'
+         << "schedule error = " << schedule_error << '\n';
+    ierr = VecDestroy(&x);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&result);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&expected);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDestroy(&prolongation);
+    IBTK_CHKERRQ(ierr);
+    ierr = AODestroy(&ordering);
+    IBTK_CHKERRQ(ierr);
+    return std::isfinite(reference_error) && std::isfinite(schedule_error) && result_norm > 0.0 &&
+                   reference_error < 1.0e-12 && schedule_error < 1.0e-12 && pressure_leak < 1.0e-12 ?
+               0 :
+               1;
+}

--- a/tests/navier_stokes/side_prolongation_2d.mixed.input
+++ b/tests/navier_stokes/side_prolongation_2d.mixed.input
@@ -1,0 +1,27 @@
+test { operator = "LINEAR" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (7, 7)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 0
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2 }
+   largest_patch_size { level_0 = 128, 128 }
+   smallest_patch_size { level_0 = 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (7, 7)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_2d.mixed.output
+++ b/tests/navier_stokes/side_prolongation_2d.mixed.output
@@ -1,0 +1,4 @@
+result norm = 2.6217310878
+interpolation error = 4.4408920985e-16
+pressure leakage = 0
+schedule error = 0

--- a/tests/navier_stokes/side_prolongation_2d.partitioned.mpirun=2.input
+++ b/tests/navier_stokes/side_prolongation_2d.partitioned.mpirun=2.input
@@ -1,0 +1,27 @@
+test { operator = "LINEAR" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (7, 7)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 0, 0
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2 }
+   largest_patch_size { level_0 = 8, 8 }
+   smallest_patch_size { level_0 = 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (7, 7)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_2d.partitioned.mpirun=2.output
+++ b/tests/navier_stokes/side_prolongation_2d.partitioned.mpirun=2.output
@@ -1,0 +1,4 @@
+result norm = 2.6217310878
+interpolation error = 4.4408920985e-16
+pressure leakage = 0
+schedule error = 4.4408920985e-16

--- a/tests/navier_stokes/side_prolongation_2d.periodic.input
+++ b/tests/navier_stokes/side_prolongation_2d.periodic.input
@@ -1,0 +1,27 @@
+test { operator = "LINEAR" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (7, 7)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2 }
+   largest_patch_size { level_0 = 128, 128 }
+   smallest_patch_size { level_0 = 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (7, 7)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_2d.periodic.output
+++ b/tests/navier_stokes/side_prolongation_2d.periodic.output
@@ -1,0 +1,4 @@
+result norm = 2.6217310878
+interpolation error = 4.4408920985e-16
+pressure leakage = 0
+schedule error = 0

--- a/tests/navier_stokes/side_prolongation_2d.physical.input
+++ b/tests/navier_stokes/side_prolongation_2d.physical.input
@@ -1,0 +1,27 @@
+test { operator = "LINEAR" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (7, 7)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 0, 0
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2 }
+   largest_patch_size { level_0 = 128, 128 }
+   smallest_patch_size { level_0 = 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (7, 7)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_2d.physical.output
+++ b/tests/navier_stokes/side_prolongation_2d.physical.output
@@ -1,0 +1,4 @@
+result norm = 2.6217310878
+interpolation error = 4.4408920985e-16
+pressure leakage = 0
+schedule error = 0

--- a/tests/navier_stokes/side_prolongation_2d.rt0.input
+++ b/tests/navier_stokes/side_prolongation_2d.rt0.input
@@ -1,0 +1,27 @@
+test { operator = "RT0" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (7, 7)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 0, 0
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2 }
+   largest_patch_size { level_0 = 128, 128 }
+   smallest_patch_size { level_0 = 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (7, 7)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_2d.rt0.output
+++ b/tests/navier_stokes/side_prolongation_2d.rt0.output
@@ -1,0 +1,4 @@
+result norm = 2.6217310878
+interpolation error = 2.22044604925e-16
+pressure leakage = 0
+schedule error = 0

--- a/tests/navier_stokes/side_prolongation_2d.translated_anisotropic.input
+++ b/tests/navier_stokes/side_prolongation_2d.translated_anisotropic.input
@@ -1,0 +1,27 @@
+test { operator = "LINEAR" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(-4, 2), (3, 9)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 0, 0
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 4, 2 }
+   largest_patch_size { level_0 = 128, 128 }
+   smallest_patch_size { level_0 = 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(-4, 2), (3, 9)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_2d.translated_anisotropic.output
+++ b/tests/navier_stokes/side_prolongation_2d.translated_anisotropic.output
@@ -1,0 +1,4 @@
+result norm = 2.6217310878
+interpolation error = 4.4408920985e-16
+pressure leakage = 0
+schedule error = 2.22044604925e-16

--- a/tests/navier_stokes/side_prolongation_3d.mixed.input
+++ b/tests/navier_stokes/side_prolongation_3d.mixed.input
@@ -1,0 +1,27 @@
+test { operator = "LINEAR" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (5, 5, 5)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 1, 0, 0
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2, 2 }
+   largest_patch_size { level_0 = 128, 128, 128 }
+   smallest_patch_size { level_0 = 2, 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0, 0), (5, 5, 5)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_3d.mixed.output
+++ b/tests/navier_stokes/side_prolongation_3d.mixed.output
@@ -1,0 +1,4 @@
+result norm = 4.97174972243
+interpolation error = 8.881784197e-16
+pressure leakage = 0
+schedule error = 4.4408920985e-16

--- a/tests/navier_stokes/side_prolongation_3d.partitioned.mpirun=2.input
+++ b/tests/navier_stokes/side_prolongation_3d.partitioned.mpirun=2.input
@@ -1,0 +1,27 @@
+test { operator = "LINEAR" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (5, 5, 5)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 0, 0, 0
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2, 2 }
+   largest_patch_size { level_0 = 6, 6, 6 }
+   smallest_patch_size { level_0 = 2, 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0, 0), (5, 5, 5)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_3d.partitioned.mpirun=2.output
+++ b/tests/navier_stokes/side_prolongation_3d.partitioned.mpirun=2.output
@@ -1,0 +1,4 @@
+result norm = 4.97174972243
+interpolation error = 8.881784197e-16
+pressure leakage = 0
+schedule error = 4.4408920985e-16

--- a/tests/navier_stokes/side_prolongation_3d.periodic.input
+++ b/tests/navier_stokes/side_prolongation_3d.periodic.input
@@ -1,0 +1,27 @@
+test { operator = "LINEAR" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (5, 5, 5)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 1, 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2, 2 }
+   largest_patch_size { level_0 = 128, 128, 128 }
+   smallest_patch_size { level_0 = 2, 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0, 0), (5, 5, 5)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_3d.periodic.output
+++ b/tests/navier_stokes/side_prolongation_3d.periodic.output
@@ -1,0 +1,4 @@
+result norm = 4.97174972243
+interpolation error = 1.33226762955e-15
+pressure leakage = 0
+schedule error = 4.4408920985e-16

--- a/tests/navier_stokes/side_prolongation_3d.physical.input
+++ b/tests/navier_stokes/side_prolongation_3d.physical.input
@@ -1,0 +1,27 @@
+test { operator = "LINEAR" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (5, 5, 5)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 0, 0, 0
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2, 2 }
+   largest_patch_size { level_0 = 128, 128, 128 }
+   smallest_patch_size { level_0 = 2, 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0, 0), (5, 5, 5)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_3d.physical.output
+++ b/tests/navier_stokes/side_prolongation_3d.physical.output
@@ -1,0 +1,4 @@
+result norm = 4.97174972243
+interpolation error = 8.881784197e-16
+pressure leakage = 0
+schedule error = 4.4408920985e-16

--- a/tests/navier_stokes/side_prolongation_3d.rt0.input
+++ b/tests/navier_stokes/side_prolongation_3d.rt0.input
@@ -1,0 +1,27 @@
+test { operator = "RT0" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (5, 5, 5)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 0, 0, 0
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2, 2 }
+   largest_patch_size { level_0 = 128, 128, 128 }
+   smallest_patch_size { level_0 = 2, 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0, 0), (5, 5, 5)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_3d.rt0.output
+++ b/tests/navier_stokes/side_prolongation_3d.rt0.output
@@ -1,0 +1,4 @@
+result norm = 4.97174972243
+interpolation error = 8.881784197e-16
+pressure leakage = 0
+schedule error = 0

--- a/tests/navier_stokes/side_prolongation_3d.translated_anisotropic.input
+++ b/tests/navier_stokes/side_prolongation_3d.translated_anisotropic.input
@@ -1,0 +1,27 @@
+test { operator = "LINEAR" }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(-4, 2, -2), (1, 7, 3)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 0, 0, 0
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 4, 2, 3 }
+   largest_patch_size { level_0 = 128, 128, 128 }
+   smallest_patch_size { level_0 = 2, 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(-4, 2, -2), (1, 7, 3)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_3d.translated_anisotropic.output
+++ b/tests/navier_stokes/side_prolongation_3d.translated_anisotropic.output
@@ -1,0 +1,4 @@
+result norm = 4.97174972243
+interpolation error = 1.7763568394e-15
+pressure leakage = 0
+schedule error = 8.881784197e-16


### PR DESCRIPTION
Reject out-of-domain indices before flattening and correct physical-boundary weights in side-centered linear prolongation.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
