### PR TITLE
[CAV R04] Add Stokes transfer parity coverage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -208,6 +208,7 @@ SETUP(ConstraintIB oscillating_rigid_cylinder.cpp IBAMR2d)
 SETUP(IB explicit_ex0.cpp IBAMR2d)
 SETUP(IB explicit_ex1.cpp IBAMR2d)
 SETUP(IB implicit_stokes_ib_01.cpp IBAMR2d)
+SETUP(IB implicit_stokes_ib_coarse_saj_transfer_parity_01.cpp IBAMR2d)
 SETUP(IB implicit_stokes_ib_solver_components_01.cpp IBAMR2d)
 TARGET_COMPILE_DEFINITIONS(tests-IB_implicit_stokes_ib_solver_components_01 PRIVATE
   IBTK_MAX_BSPLINE_ORDER=${IBTK_MAX_BSPLINE_ORDER})

--- a/tests/IB/implicit_stokes_ib_coarse_saj_transfer_parity_01.cpp
+++ b/tests/IB/implicit_stokes_ib_coarse_saj_transfer_parity_01.cpp
@@ -1,0 +1,607 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2026 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+/*
+ * Compare the complete coarse SAJ matrix with composition through RT0 schedules.
+ */
+
+#include <ibamr/IBMethod.h>
+#include <ibamr/IBRedundantInitializer.h>
+#include <ibamr/IBStandardForceGen.h>
+#include <ibamr/StaggeredStokesPETScMatUtilities.h>
+#include <ibamr/StaggeredStokesPETScVecUtilities.h>
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/CartSideDoubleRT0Coarsen.h>
+#include <ibtk/CartSideDoubleRT0Refine.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_CHKERRQ.h>
+#include <ibtk/IBTK_MPI.h>
+#include <ibtk/LDataManager.h>
+#include <ibtk/PETScMatUtilities.h>
+#include <ibtk/PETScVecUtilities.h>
+#include <ibtk/ibtk_utilities.h>
+
+#include <petscmat.h>
+#include <petscsys.h>
+#include <petscvec.h>
+
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <CellVariable.h>
+#include <CoarsenAlgorithm.h>
+#include <CoarsenOperator.h>
+#include <CoarsenSchedule.h>
+#include <GriddingAlgorithm.h>
+#include <HierarchySideDataOpsReal.h>
+#include <IntVector.h>
+#include <LoadBalancer.h>
+#include <PatchHierarchy.h>
+#include <PatchLevel.h>
+#include <RefineAlgorithm.h>
+#include <RefineOperator.h>
+#include <RefineSchedule.h>
+#include <SAMRAI_config.h>
+#include <SideVariable.h>
+#include <StandardTagAndInitialize.h>
+#include <VariableContext.h>
+#include <VariableDatabase.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <numeric>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <ibamr/app_namespaces.h>
+
+namespace
+{
+struct StructureSpec
+{
+    int num_curve_points = 64;
+    double ds = 1.0 / 64.0;
+    double x_center = 0.5;
+    double y_center = 0.5;
+    double x_radius = 0.2;
+    double y_radius = 0.2;
+    double spring_stiffness = 2.0e2;
+    int finest_ln = 0;
+};
+
+void
+generate_structure(const unsigned int& strct_num,
+                   const int& ln,
+                   int& num_vertices,
+                   std::vector<IBTK::Point>& vertex_posn,
+                   void* ctx)
+{
+    auto* spec = static_cast<StructureSpec*>(ctx);
+    if (!spec)
+    {
+        TBOX_ERROR("generate_structure(): missing structure specification context\n");
+    }
+
+    if (ln != spec->finest_ln || strct_num != 0)
+    {
+        num_vertices = 0;
+        vertex_posn.clear();
+        return;
+    }
+
+    num_vertices = spec->num_curve_points;
+    vertex_posn.resize(num_vertices);
+    for (int k = 0; k < num_vertices; ++k)
+    {
+        const double theta = 2.0 * M_PI * static_cast<double>(k) / static_cast<double>(num_vertices);
+        vertex_posn[k](0) = spec->x_center + spec->x_radius * std::cos(theta);
+        vertex_posn[k](1) = spec->y_center + spec->y_radius * std::sin(theta);
+    }
+}
+
+void
+generate_springs(
+    const unsigned int& strct_num,
+    const int& ln,
+    std::multimap<int, IBRedundantInitializer::Edge>& spring_map,
+    std::map<IBRedundantInitializer::Edge, IBRedundantInitializer::SpringSpec, IBRedundantInitializer::EdgeComp>&
+        spring_spec,
+    void* ctx)
+{
+    auto* spec = static_cast<StructureSpec*>(ctx);
+    if (!spec)
+    {
+        TBOX_ERROR("generate_springs(): missing structure specification context\n");
+    }
+
+    if (ln != spec->finest_ln || strct_num != 0)
+    {
+        return;
+    }
+    for (int k = 0; k < spec->num_curve_points; ++k)
+    {
+        IBRedundantInitializer::Edge edge = { k, (k + 1) % spec->num_curve_points };
+        if (edge.first > edge.second)
+        {
+            std::swap(edge.first, edge.second);
+        }
+        spring_map.insert(std::make_pair(edge.first, edge));
+
+        IBRedundantInitializer::SpringSpec spec_data;
+        spec_data.force_fcn_idx = 0;
+        spec_data.parameters.resize(2);
+        spec_data.parameters[0] = spec->spring_stiffness;
+        spec_data.parameters[1] = 0.0;
+        spring_spec.insert(std::make_pair(edge, spec_data));
+    }
+}
+
+void
+build_coarse_op_from_samrai_transfers(Mat coarse_op,
+                                      Mat fine_op,
+                                      const std::vector<int>& coarse_num_dofs_per_proc,
+                                      const std::vector<int>& fine_num_dofs_per_proc,
+                                      Pointer<SideVariable<NDIM, double>> u_var,
+                                      const int u_idx,
+                                      const int u_dof_index_idx,
+                                      Pointer<PatchHierarchy<NDIM>> patch_hierarchy,
+                                      IntVector<NDIM> gcw)
+{
+    const int coarsest_ln = 0;
+    const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+
+    Pointer<PatchLevel<NDIM>> coarse_level = patch_hierarchy->getPatchLevel(coarsest_ln);
+    Pointer<PatchLevel<NDIM>> fine_level = patch_hierarchy->getPatchLevel(finest_ln);
+
+    Pointer<CartesianGridGeometry<NDIM>> geometry = patch_hierarchy->getGridGeometry();
+    geometry->addSpatialCoarsenOperator(new CartSideDoubleRT0Coarsen(gcw));
+    geometry->addSpatialRefineOperator(new CartSideDoubleRT0Refine());
+
+    Pointer<RefineOperator<NDIM>> prolongation_op = geometry->lookupRefineOperator(u_var, "RT0_REFINE");
+    Pointer<CoarsenOperator<NDIM>> restriction_op = geometry->lookupCoarsenOperator(u_var, "RT0_COARSEN");
+
+    Pointer<RefineAlgorithm<NDIM>> prolongation_refine_algorithm = new RefineAlgorithm<NDIM>();
+    Pointer<CoarsenAlgorithm<NDIM>> restriction_coarsen_algorithm = new CoarsenAlgorithm<NDIM>();
+    prolongation_refine_algorithm->registerRefine(u_idx, u_idx, u_idx, prolongation_op, nullptr);
+    restriction_coarsen_algorithm->registerCoarsen(u_idx, u_idx, restriction_op, IntVector<NDIM>(0));
+
+    Pointer<RefineSchedule<NDIM>> prolongation_schedule = prolongation_refine_algorithm->createSchedule(
+        fine_level, Pointer<PatchLevel<NDIM>>(), coarsest_ln, patch_hierarchy, nullptr);
+    Pointer<CoarsenSchedule<NDIM>> restriction_schedule =
+        restriction_coarsen_algorithm->createSchedule(coarse_level, fine_level);
+
+    const int mpi_rank = IBTK_MPI::getRank();
+    const int n_local_coarse = coarse_num_dofs_per_proc[mpi_rank];
+    const int i_lower_coarse =
+        std::accumulate(coarse_num_dofs_per_proc.begin(), coarse_num_dofs_per_proc.begin() + mpi_rank, 0);
+    const int n_total_coarse = std::accumulate(coarse_num_dofs_per_proc.begin(), coarse_num_dofs_per_proc.end(), 0);
+
+    const int n_local_fine = fine_num_dofs_per_proc[mpi_rank];
+    const int n_total_fine = std::accumulate(fine_num_dofs_per_proc.begin(), fine_num_dofs_per_proc.end(), 0);
+
+    Vec x = nullptr, y = nullptr, X = nullptr, Y = nullptr;
+    int ierr = VecCreateMPI(PETSC_COMM_WORLD, n_local_coarse, n_total_coarse, &x);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecCreateMPI(PETSC_COMM_WORLD, n_local_coarse, n_total_coarse, &y);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecCreateMPI(PETSC_COMM_WORLD, n_local_fine, n_total_fine, &X);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecCreateMPI(PETSC_COMM_WORLD, n_local_fine, n_total_fine, &Y);
+    IBTK_CHKERRQ(ierr);
+
+    Pointer<RefineSchedule<NDIM>> ghost_fill_sched_coarse =
+        IBTK::PETScVecUtilities::constructGhostFillSchedule(u_idx, coarse_level);
+    Pointer<RefineSchedule<NDIM>> ghost_fill_sched_fine =
+        IBTK::PETScVecUtilities::constructGhostFillSchedule(u_idx, fine_level);
+    Pointer<RefineSchedule<NDIM>> data_synch_sched_coarse =
+        IBTK::PETScVecUtilities::constructDataSynchSchedule(u_idx, coarse_level);
+    Pointer<RefineSchedule<NDIM>> data_synch_sched_fine =
+        IBTK::PETScVecUtilities::constructDataSynchSchedule(u_idx, fine_level);
+
+    Pointer<HierarchySideDataOpsReal<NDIM, double>> hier_velocity_data_ops =
+        new HierarchySideDataOpsReal<NDIM, double>(patch_hierarchy, coarsest_ln, finest_ln);
+
+    for (int col = 0; col < n_total_coarse; ++col)
+    {
+        ierr = VecZeroEntries(x);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecSetValue(x, col, 1.0, INSERT_VALUES);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecAssemblyBegin(x);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecAssemblyEnd(x);
+        IBTK_CHKERRQ(ierr);
+
+        IBTK::PETScVecUtilities::copyFromPatchLevelVec(
+            x, u_idx, u_dof_index_idx, coarse_level, data_synch_sched_coarse, ghost_fill_sched_coarse);
+
+        hier_velocity_data_ops->resetLevels(finest_ln, finest_ln);
+        hier_velocity_data_ops->setToScalar(u_idx, 0.0, false);
+        hier_velocity_data_ops->resetLevels(coarsest_ln, finest_ln);
+
+        prolongation_schedule->fillData(0.0);
+
+        IBTK::PETScVecUtilities::copyToPatchLevelVec(X, u_idx, u_dof_index_idx, fine_level);
+        ierr = MatMult(fine_op, X, Y);
+        IBTK_CHKERRQ(ierr);
+
+        hier_velocity_data_ops->resetLevels(finest_ln, finest_ln);
+        hier_velocity_data_ops->setToScalar(u_idx, 0.0, false);
+        hier_velocity_data_ops->resetLevels(coarsest_ln, finest_ln);
+
+        IBTK::PETScVecUtilities::copyFromPatchLevelVec(
+            Y, u_idx, u_dof_index_idx, fine_level, data_synch_sched_fine, ghost_fill_sched_fine);
+
+        hier_velocity_data_ops->resetLevels(coarsest_ln, coarsest_ln);
+        hier_velocity_data_ops->setToScalar(u_idx, 0.0, false);
+        hier_velocity_data_ops->resetLevels(coarsest_ln, finest_ln);
+
+        restriction_schedule->coarsenData();
+        IBTK::PETScVecUtilities::copyToPatchLevelVec(y, u_idx, u_dof_index_idx, coarse_level);
+
+        const PetscScalar* y_array = nullptr;
+        ierr = VecGetArrayRead(y, &y_array);
+        IBTK_CHKERRQ(ierr);
+
+        std::vector<PetscInt> nnz_indices;
+        std::vector<PetscScalar> nnz_values;
+        nnz_indices.reserve(static_cast<std::size_t>(n_local_coarse));
+        nnz_values.reserve(static_cast<std::size_t>(n_local_coarse));
+
+        for (int j = 0; j < n_local_coarse; ++j)
+        {
+            const PetscScalar val = y_array[j];
+            if (IBTK::abs_equal_eps(val, 0.0))
+            {
+                continue;
+            }
+            const PetscInt global_idx = i_lower_coarse + j;
+            nnz_indices.push_back(global_idx);
+            nnz_values.push_back(val);
+        }
+
+        if (!nnz_indices.empty())
+        {
+            const PetscInt nnz_size = static_cast<PetscInt>(nnz_indices.size());
+            const PetscInt col_idx = static_cast<PetscInt>(col);
+            ierr = MatSetValues(coarse_op, nnz_size, nnz_indices.data(), 1, &col_idx, nnz_values.data(), INSERT_VALUES);
+            IBTK_CHKERRQ(ierr);
+        }
+
+        ierr = VecRestoreArrayRead(y, &y_array);
+        IBTK_CHKERRQ(ierr);
+    }
+
+    ierr = MatAssemblyBegin(coarse_op, MAT_FINAL_ASSEMBLY);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatAssemblyEnd(coarse_op, MAT_FINAL_ASSEMBLY);
+    IBTK_CHKERRQ(ierr);
+
+    ierr = VecDestroy(&x);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&y);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&X);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&Y);
+    IBTK_CHKERRQ(ierr);
+}
+} // namespace
+
+int
+main(int argc, char* argv[])
+{
+    IBTK::IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+
+    if (IBTK_MPI::getNodes() != 1)
+    {
+        TBOX_ERROR("implicit_stokes_ib_coarse_saj_transfer_parity_01 requires serial execution (np=1).\n");
+    }
+
+#ifndef IBTK_HAVE_SILO
+    SAMRAI::tbox::Logger::getInstance()->setWarning(false);
+#endif
+
+    Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "output");
+    Pointer<Database> input_db = app_initializer->getInputDatabase();
+
+    const double current_time = input_db->getDoubleWithDefault("START_TIME", 0.0);
+    const double dt = input_db->getDoubleWithDefault("DT", 0.03125);
+    const double new_time = current_time + dt;
+    const int num_cycles = input_db->getIntegerWithDefault("NUM_CYCLES", 1);
+    const int tag_buffer = input_db->getIntegerWithDefault("TAG_BUFFER", 1);
+    StructureSpec structure_spec;
+    structure_spec.ds = input_db->getDouble("DS");
+    structure_spec.x_center = input_db->getDouble("X_CENTER");
+    structure_spec.y_center = input_db->getDouble("Y_CENTER");
+    structure_spec.x_radius = input_db->getDouble("X_RADIUS");
+    structure_spec.y_radius = input_db->getDouble("Y_RADIUS");
+    structure_spec.spring_stiffness = input_db->getDouble("SPRING_STIFFNESS");
+    if (!(structure_spec.ds > 0.0))
+    {
+        TBOX_ERROR("DS must be positive\n");
+    }
+    if (!(structure_spec.x_radius > 0.0) || !(structure_spec.y_radius > 0.0))
+    {
+        TBOX_ERROR("X_RADIUS and Y_RADIUS must be positive\n");
+    }
+    if (!(structure_spec.spring_stiffness > 0.0))
+    {
+        TBOX_ERROR("SPRING_STIFFNESS must be positive\n");
+    }
+
+    const double a = structure_spec.x_radius;
+    const double b = structure_spec.y_radius;
+    const double h = std::pow((a - b) / (a + b), 2.0);
+    const double circumference = M_PI * (a + b) * (1.0 + 3.0 * h / (10.0 + std::sqrt(std::max(0.0, 4.0 - 3.0 * h))));
+    structure_spec.num_curve_points = std::max(3, static_cast<int>(circumference / structure_spec.ds));
+
+    Pointer<IBMethod> ib_method_ops = new IBMethod("IBMethod", app_initializer->getComponentDatabase("IBMethod"));
+    ib_method_ops->setUseFixedLEOperators(true);
+
+    Pointer<CartesianGridGeometry<NDIM>> grid_geometry = new CartesianGridGeometry<NDIM>(
+        "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+    Pointer<PatchHierarchy<NDIM>> patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+    Pointer<StandardTagAndInitialize<NDIM>> error_detector = new StandardTagAndInitialize<NDIM>(
+        "StandardTagAndInitialize", ib_method_ops, app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+    Pointer<BergerRigoutsos<NDIM>> box_generator = new BergerRigoutsos<NDIM>();
+    Pointer<LoadBalancer<NDIM>> load_balancer =
+        new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+    Pointer<GriddingAlgorithm<NDIM>> gridding_algorithm =
+        new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                    app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                    error_detector,
+                                    box_generator,
+                                    load_balancer);
+
+    Pointer<IBRedundantInitializer> ib_initializer = new IBRedundantInitializer(
+        "IBRedundantInitializer", app_initializer->getComponentDatabase("IBRedundantInitializer"));
+    structure_spec.finest_ln = input_db->getIntegerWithDefault("MAX_LEVELS", 1) - 1;
+    ib_initializer->setStructureNamesOnLevel(structure_spec.finest_ln, { "parity_curve2d" });
+    ib_initializer->registerInitStructureFunction(generate_structure, &structure_spec);
+    ib_initializer->registerInitSpringDataFunction(generate_springs, &structure_spec);
+    ib_method_ops->registerLInitStrategy(ib_initializer);
+    Pointer<IBStandardForceGen> ib_force_fcn = new IBStandardForceGen();
+    ib_method_ops->registerIBLagrangianForceFunction(ib_force_fcn);
+
+    gridding_algorithm->makeCoarsestLevel(patch_hierarchy, current_time);
+    int level_number = 0;
+    bool done = false;
+    while (!done && gridding_algorithm->levelCanBeRefined(level_number))
+    {
+        gridding_algorithm->makeFinerLevel(patch_hierarchy, current_time, true, tag_buffer);
+        done = !patch_hierarchy->finerLevelExists(level_number);
+        ++level_number;
+    }
+
+    const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+    if (finest_ln < 1)
+    {
+        TBOX_ERROR("implicit_stokes_ib_coarse_saj_transfer_parity_01 requires at least two levels.\n");
+    }
+
+    const int coarsest_ln = 0;
+    const double data_time = new_time;
+
+    VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
+    Pointer<VariableContext> current_ctx = var_db->getContext("coarse_saj_transfer_parity_current_ctx");
+    Pointer<VariableContext> scratch_ctx = var_db->getContext("coarse_saj_transfer_parity_scratch_ctx");
+    IntVector<NDIM> gcw = ib_method_ops->getMinimumGhostCellWidth();
+
+    Pointer<SideVariable<NDIM, int>> u_full_dof_var = new SideVariable<NDIM, int>("coarse_saj_u_full_dof");
+    Pointer<CellVariable<NDIM, int>> p_full_dof_var = new CellVariable<NDIM, int>("coarse_saj_p_full_dof");
+    Pointer<SideVariable<NDIM, int>> u_vel_dof_var = new SideVariable<NDIM, int>("coarse_saj_u_vel_dof");
+    Pointer<SideVariable<NDIM, double>> u_data_var = new SideVariable<NDIM, double>("coarse_saj_u_data");
+
+    const int u_current_idx = var_db->registerVariableAndContext(u_data_var, current_ctx, gcw);
+    const int u_data_idx = var_db->registerVariableAndContext(u_data_var, scratch_ctx, gcw);
+    const int u_full_dof_index_idx =
+        var_db->registerVariableAndContext(u_full_dof_var, scratch_ctx, IntVector<NDIM>(1));
+    const int p_full_dof_index_idx =
+        var_db->registerVariableAndContext(p_full_dof_var, scratch_ctx, IntVector<NDIM>(1));
+    const int u_vel_dof_index_idx = var_db->registerVariableAndContext(u_vel_dof_var, scratch_ctx, IntVector<NDIM>(1));
+
+    for (int ln = 0; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+        level->allocatePatchData(u_current_idx, current_time);
+        level->allocatePatchData(u_data_idx, current_time);
+        level->allocatePatchData(u_full_dof_index_idx, data_time);
+        level->allocatePatchData(p_full_dof_index_idx, data_time);
+        level->allocatePatchData(u_vel_dof_index_idx, data_time);
+    }
+
+    Pointer<HierarchySideDataOpsReal<NDIM, double>> hier_velocity_data_ops =
+        new HierarchySideDataOpsReal<NDIM, double>(patch_hierarchy, 0, finest_ln);
+    hier_velocity_data_ops->setToScalar(u_current_idx, 0.0, false);
+    hier_velocity_data_ops->setToScalar(u_data_idx, 0.0, false);
+
+    std::vector<Pointer<CoarsenSchedule<NDIM>>> u_synch_scheds(finest_ln + 1);
+    std::vector<Pointer<RefineSchedule<NDIM>>> u_ghost_fill_scheds(finest_ln + 1);
+    ib_method_ops->beginDataRedistribution(patch_hierarchy, gridding_algorithm);
+    ib_method_ops->endDataRedistribution(patch_hierarchy, gridding_algorithm);
+    ib_method_ops->initializePatchHierarchy(
+        patch_hierarchy, gridding_algorithm, u_current_idx, u_synch_scheds, u_ghost_fill_scheds, 0, current_time, true);
+    ib_method_ops->freeLInitStrategy();
+    ib_initializer.setNull();
+    ib_method_ops->preprocessIntegrateData(current_time, new_time, num_cycles);
+
+    LDataManager* l_data_manager = ib_method_ops->getLDataManager();
+    gcw = l_data_manager->getGhostCellWidth();
+
+    Mat A = nullptr;
+    ib_method_ops->updateFixedLEOperators();
+    ib_method_ops->constructLagrangianForceJacobian(A, MATAIJ, data_time);
+
+    Pointer<PatchLevel<NDIM>> fine_level = patch_hierarchy->getPatchLevel(finest_ln);
+    std::vector<int> full_num_dofs_fine;
+    IBAMR::StaggeredStokesPETScVecUtilities::constructPatchLevelDOFIndices(
+        full_num_dofs_fine, u_full_dof_index_idx, p_full_dof_index_idx, fine_level);
+
+    Mat J = nullptr;
+    ib_method_ops->constructInterpOp(J, IBKernel::IB_4, full_num_dofs_fine, u_full_dof_index_idx, data_time);
+
+    Mat SAJ_full = nullptr;
+    int ierr = MatPtAP(A, J, MAT_INITIAL_MATRIX, 1.0, &SAJ_full);
+    IBTK_CHKERRQ(ierr);
+
+    std::vector<std::set<int>> full_field_is;
+    std::vector<std::string> full_field_names;
+    IBAMR::StaggeredStokesPETScMatUtilities::constructPatchLevelFields(
+        full_field_is, full_field_names, full_num_dofs_fine, u_full_dof_index_idx, p_full_dof_index_idx, fine_level);
+    const std::vector<std::string>::const_iterator velocity_name_it =
+        std::find(full_field_names.begin(), full_field_names.end(), "velocity");
+    if (velocity_name_it == full_field_names.end())
+    {
+        TBOX_ERROR("implicit_stokes_ib_coarse_saj_transfer_parity_01: velocity field not found.\n");
+    }
+    const std::size_t velocity_idx =
+        static_cast<std::size_t>(std::distance(full_field_names.cbegin(), velocity_name_it));
+    std::vector<PetscInt> velocity_dofs(full_field_is[velocity_idx].begin(), full_field_is[velocity_idx].end());
+    IS velocity_is = nullptr;
+    ierr = ISCreateGeneral(PETSC_COMM_WORLD,
+                           static_cast<PetscInt>(velocity_dofs.size()),
+                           velocity_dofs.empty() ? nullptr : velocity_dofs.data(),
+                           PETSC_COPY_VALUES,
+                           &velocity_is);
+    IBTK_CHKERRQ(ierr);
+
+    Mat SAJ_u_fine = nullptr;
+    ierr = MatCreateSubMatrix(SAJ_full, velocity_is, velocity_is, MAT_INITIAL_MATRIX, &SAJ_u_fine);
+    IBTK_CHKERRQ(ierr);
+    ierr = ISDestroy(&velocity_is);
+    IBTK_CHKERRQ(ierr);
+    Vec saj_row_max_abs = nullptr;
+    ierr = MatCreateVecs(SAJ_u_fine, &saj_row_max_abs, nullptr);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatGetRowMaxAbs(SAJ_u_fine, saj_row_max_abs, nullptr);
+    IBTK_CHKERRQ(ierr);
+    PetscReal saj_inf_norm = 0.0;
+    ierr = VecNorm(saj_row_max_abs, NORM_INFINITY, &saj_inf_norm);
+    IBTK_CHKERRQ(ierr);
+    const double saj_nontrivial_tol = input_db->getDoubleWithDefault("SAJ_NONTRIVIAL_TOL", 1.0e-14);
+    int test_failures = 0;
+    if (!std::isfinite(saj_inf_norm) || saj_inf_norm <= saj_nontrivial_tol)
+    {
+        ++test_failures;
+    }
+    std::vector<int> num_u_dofs_coarse;
+    std::vector<int> num_u_dofs_fine;
+    Pointer<PatchLevel<NDIM>> coarse_level = patch_hierarchy->getPatchLevel(coarsest_ln);
+    IBTK::PETScVecUtilities::constructPatchLevelDOFIndices(num_u_dofs_coarse, u_vel_dof_index_idx, coarse_level);
+    IBTK::PETScVecUtilities::constructPatchLevelDOFIndices(num_u_dofs_fine, u_vel_dof_index_idx, fine_level);
+
+    AO coarse_u_ao = nullptr;
+    IBTK::PETScVecUtilities::constructPatchLevelAO(
+        coarse_u_ao, num_u_dofs_coarse, u_vel_dof_index_idx, coarse_level, 0);
+
+    Mat u_prolong = nullptr;
+    IBTK::PETScMatUtilities::constructProlongationOp(u_prolong,
+                                                     "RT0",
+                                                     u_vel_dof_index_idx,
+                                                     num_u_dofs_fine,
+                                                     num_u_dofs_coarse,
+                                                     fine_level,
+                                                     coarse_level,
+                                                     coarse_u_ao,
+                                                     0);
+
+    Vec u_restriction_scale = nullptr;
+    IBTK::PETScMatUtilities::constructRestrictionScalingOp(u_prolong, u_restriction_scale);
+
+    Mat SAJ_coarse_matrix = nullptr;
+    ierr = MatPtAP(SAJ_u_fine, u_prolong, MAT_INITIAL_MATRIX, 1.0, &SAJ_coarse_matrix);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDiagonalScale(SAJ_coarse_matrix, u_restriction_scale, nullptr);
+    IBTK_CHKERRQ(ierr);
+
+    Mat SAJ_coarse_samrai = nullptr;
+    ierr = MatDuplicate(SAJ_coarse_matrix, MAT_DO_NOT_COPY_VALUES, &SAJ_coarse_samrai);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatZeroEntries(SAJ_coarse_samrai);
+    IBTK_CHKERRQ(ierr);
+
+    build_coarse_op_from_samrai_transfers(SAJ_coarse_samrai,
+                                          SAJ_u_fine,
+                                          num_u_dofs_coarse,
+                                          num_u_dofs_fine,
+                                          u_data_var,
+                                          u_data_idx,
+                                          u_vel_dof_index_idx,
+                                          patch_hierarchy,
+                                          gcw);
+
+    Mat diff = nullptr;
+    ierr = MatDuplicate(SAJ_coarse_matrix, MAT_COPY_VALUES, &diff);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatAXPY(diff, -1.0, SAJ_coarse_samrai, DIFFERENT_NONZERO_PATTERN);
+    IBTK_CHKERRQ(ierr);
+    Vec row_max_abs = nullptr;
+    ierr = MatCreateVecs(diff, &row_max_abs, nullptr);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatGetRowMaxAbs(diff, row_max_abs, nullptr);
+    IBTK_CHKERRQ(ierr);
+    PetscReal inf_norm = 0.0;
+    ierr = VecNorm(row_max_abs, NORM_INFINITY, &inf_norm);
+    IBTK_CHKERRQ(ierr);
+
+    const double parity_tol = input_db->getDoubleWithDefault("PARITY_TOL", 1.0e-12);
+    if (!std::isfinite(inf_norm) || inf_norm > parity_tol)
+    {
+        ++test_failures;
+    }
+    plog << std::setprecision(12) << "fine coupling max entry = " << saj_inf_norm << '\n'
+         << "coarse matrix/schedule max entry error = " << inf_norm << '\n';
+
+    ierr = MatDestroy(&diff);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&row_max_abs);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDestroy(&SAJ_coarse_samrai);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDestroy(&SAJ_coarse_matrix);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&u_restriction_scale);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDestroy(&u_prolong);
+    IBTK_CHKERRQ(ierr);
+    ierr = AODestroy(&coarse_u_ao);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDestroy(&SAJ_u_fine);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&saj_row_max_abs);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDestroy(&SAJ_full);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDestroy(&J);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDestroy(&A);
+    IBTK_CHKERRQ(ierr);
+
+    ib_method_ops->postprocessIntegrateData(current_time, new_time, num_cycles);
+
+    for (int ln = 0; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+        level->deallocatePatchData(u_current_idx);
+        level->deallocatePatchData(u_full_dof_index_idx);
+        level->deallocatePatchData(p_full_dof_index_idx);
+        level->deallocatePatchData(u_vel_dof_index_idx);
+        level->deallocatePatchData(u_data_idx);
+    }
+
+    return test_failures;
+}

--- a/tests/IB/implicit_stokes_ib_coarse_saj_transfer_parity_01.multilevel_l2.input
+++ b/tests/IB/implicit_stokes_ib_coarse_saj_transfer_parity_01.multilevel_l2.input
@@ -1,0 +1,84 @@
+// 2D coarse-SAJ transfer parity on the multilevel L2 setup.
+
+MAX_LEVELS = 2
+REF_RATIO = 2
+N         = 4
+L         = 1.0
+
+START_TIME = 0.0
+DT         = 0.03125
+
+NUM_CYCLES = 1
+TAG_BUFFER = 2
+
+PARITY_TOL = 1.0e-12
+DS         = 0.125
+X_CENTER   = 0.5
+Y_CENTER   = 0.5
+X_RADIUS   = 0.23
+Y_RADIUS   = 0.2717391304347826
+
+SPRING_STIFFNESS = 1.0e2
+
+IBMethod {
+   delta_fcn = "IB_4"
+}
+
+IBRedundantInitializer {
+   max_levels       = MAX_LEVELS
+   base_filenames_0 = "x"
+   base_filenames_1 = "x"
+}
+
+Main {
+   log_file_name         = "output"
+   log_all_nodes         = FALSE
+   viz_dump_interval     = 0
+   viz_dump_dirname      = "viz"
+   restart_dump_interval = 0
+   restart_dump_dirname = "restart"
+   data_dump_interval    = 0
+   data_dump_dirname     = "hier_data"
+   timer_dump_interval   = 0
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0, 0), (N - 1, N - 1)]
+   x_lo               = 0.0, 0.0
+   x_up               = L, L
+   periodic_dimension = 1, 1
+}
+
+RR = REF_RATIO
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = RR, RR
+   }
+   largest_patch_size {
+      level_0 = 512, 512
+      level_1 = 512, 512
+   }
+   smallest_patch_size {
+      level_0 = 4, 4
+      level_1 = 4, 4
+   }
+   efficiency_tolerance = 0.85
+   combine_efficiency   = 0.85
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+
+LoadBalancer {
+   processor_mapping        = "SFC"
+   max_workload_factor      = 1.0
+   workload_patch_data_index = -1
+   workload_tolerance      = 0.0
+   bin_pack_method         = "SPATIAL"
+}

--- a/tests/IB/implicit_stokes_ib_coarse_saj_transfer_parity_01.multilevel_l2.output
+++ b/tests/IB/implicit_stokes_ib_coarse_saj_transfer_parity_01.multilevel_l2.output
@@ -1,0 +1,3 @@
+IBRedundantInitializer:  Deallocating initialization data.
+fine coupling max entry = 6.14301966531
+coarse matrix/schedule max entry error = 2.22044604925e-16

--- a/tests/navier_stokes/side_prolongation.cpp
+++ b/tests/navier_stokes/side_prolongation.cpp
@@ -15,15 +15,19 @@
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/CartExtrapPhysBdryOp.h>
+#include <ibtk/CartSideDoubleRT0Coarsen.h>
 #include <ibtk/CartSideDoubleRT0Refine.h>
 #include <ibtk/IBTKInit.h>
 #include <ibtk/IBTK_CHKERRQ.h>
 #include <ibtk/IBTK_MPI.h>
 #include <ibtk/PETScMatUtilities.h>
+#include <ibtk/PETScVecUtilities.h>
 
 #include <CartesianGridGeometry.h>
 #include <CellData.h>
 #include <CellVariable.h>
+#include <CoarsenAlgorithm.h>
+#include <CoarsenSchedule.h>
 #include <RefineAlgorithm.h>
 #include <RefineSchedule.h>
 #include <SideData.h>
@@ -35,6 +39,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iomanip>
+#include <limits>
 #include <numeric>
 
 #include "../tests.h"
@@ -102,6 +107,126 @@ interpolated_value(const hier::Index<NDIM>& fine_index,
     }
     return value;
 }
+
+// Test a second depth independently: the transfer must not mix axes or depths.
+int
+test_rt0_depth(Pointer<AppInitializer> app)
+{
+    const auto hierarchy_tuple = setup_hierarchy<NDIM>(app);
+    Pointer<PatchHierarchy<NDIM>> hierarchy = std::get<0>(hierarchy_tuple);
+    Pointer<PatchLevel<NDIM>> coarse = hierarchy->getPatchLevel(0);
+    Pointer<PatchLevel<NDIM>> fine = hierarchy->getPatchLevel(1);
+    VariableDatabase<NDIM>* db = VariableDatabase<NDIM>::getDatabase();
+    Pointer<VariableContext> context = db->getContext("rt0_depth");
+    Pointer<SideVariable<NDIM, int>> dof_var = new SideVariable<NDIM, int>("dof", 2);
+    Pointer<SideVariable<NDIM, double>> u_var = new SideVariable<NDIM, double>("u", 2);
+    const int dof = db->registerVariableAndContext(dof_var, context, IntVector<NDIM>(1));
+    const int u = db->registerVariableAndContext(u_var, context, IntVector<NDIM>(1));
+    std::vector<int> counts[2];
+    for (int ln = 0; ln < 2; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+        level->allocatePatchData(dof);
+        level->allocatePatchData(u);
+        PETScVecUtilities::constructPatchLevelDOFIndices(counts[ln], dof, level);
+    }
+    AO ordering = nullptr;
+    PETScVecUtilities::constructPatchLevelAO(ordering, counts[0], dof, coarse, 0);
+    Mat P = nullptr;
+    PETScMatUtilities::constructProlongationOp(P, "RT0", dof, counts[1], counts[0], fine, coarse, ordering, 0);
+    MatInfo info = {};
+    int ierr = MatGetInfo(P, MAT_GLOBAL_SUM, &info);
+    IBTK_CHKERRQ(ierr);
+    // PETSc counts reallocations during AIJ insertion, before final assembly.
+#if defined(PETSC_USE_LOG)
+    plog << "assembly reallocations = " << info.mallocs << '\n';
+    if (info.mallocs != 0.0)
+    {
+        TBOX_ERROR("RT0 preallocation required additional storage.\n");
+    }
+#else
+    plog << "assembly reallocations unavailable without PETSc logging\n";
+#endif
+    PetscInt first = 0, last = 0;
+    ierr = MatGetOwnershipRange(P, &first, &last);
+    IBTK_CHKERRQ(ierr);
+    for (PetscInt row = first; row < last; ++row)
+    {
+        PetscInt n = 0;
+        ierr = MatGetRow(P, row, &n, nullptr, nullptr);
+        IBTK_CHKERRQ(ierr);
+        if (n < 1 || n > 2)
+        {
+            TBOX_ERROR("Unexpected RT0 row sparsity.\n");
+        }
+        ierr = MatRestoreRow(P, row, &n, nullptr, nullptr);
+        IBTK_CHKERRQ(ierr);
+    }
+    Vec x = nullptr, y = nullptr, expected = nullptr;
+    ierr = MatCreateVecs(P, &x, &y);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDuplicate(y, &expected);
+    IBTK_CHKERRQ(ierr);
+    double error = 0.0;
+    for (int component = 0; component < 2 * NDIM; ++component)
+    {
+        for (int ln = 0; ln < 2; ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+            for (PatchLevel<NDIM>::Iterator patch_it(level); patch_it; patch_it++)
+            {
+                Pointer<SideData<NDIM, double>> data = level->getPatch(patch_it())->getPatchData(u);
+                data->fillAll(0.0);
+                const int axis = component / 2;
+                for (Box<NDIM>::Iterator b(SideGeometry<NDIM>::toSideBox(data->getGhostBox(), axis)); b; b++)
+                {
+                    (*data)(SideIndex<NDIM>(b(), axis, SideIndex<NDIM>::Lower), component % 2) = component + 1.0;
+                }
+            }
+        }
+        PETScVecUtilities::copyToPatchLevelVec(x, u, dof, coarse);
+        PETScVecUtilities::copyToPatchLevelVec(expected, u, dof, fine);
+        ierr = MatMult(P, x, y);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecAXPY(y, -1.0, expected);
+        IBTK_CHKERRQ(ierr);
+        double norm = 0.0;
+        ierr = VecNorm(y, NORM_INFINITY, &norm);
+        IBTK_CHKERRQ(ierr);
+        if (!std::isfinite(norm))
+        {
+            TBOX_ERROR("Nonfinite RT0 depth error.\n");
+        }
+        error = std::max(error, norm);
+    }
+    plog << "axis/depth isolation error = " << error << '\n';
+    ierr = VecDestroy(&x);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&y);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&expected);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDestroy(&P);
+    IBTK_CHKERRQ(ierr);
+    ierr = AODestroy(&ordering);
+    IBTK_CHKERRQ(ierr);
+    return error < 1.0e-12 ? 0 : 1;
+}
+
+double
+transfer_profile(const hier::Index<NDIM>& i, int axis, const Box<NDIM>& domain, bool piecewise)
+{
+    double value = axis + 1.0;
+    for (int d = 0; d < NDIM; ++d)
+    {
+        double x = (i(d) - domain.lower()(d) + (d == axis ? 0.0 : 0.5)) / static_cast<double>(domain.numberCells(d));
+        x -= std::floor(x);
+        value += piecewise ? (d == axis ? 0.3 * std::abs(2.0 * x - 1.0) : 0.2 * std::floor(4.0 * x)) :
+                             0.2 * (d + 1) * std::sin(2.0 * std::acos(-1.0) * x);
+    }
+    return value;
+}
+
 } // namespace
 
 int
@@ -110,6 +235,10 @@ main(int argc, char* argv[])
     IBTKInit init(argc, argv, MPI_COMM_WORLD);
     Pointer<AppInitializer> app = new AppInitializer(argc, argv, "output");
     Pointer<Database> test_db = app->getInputDatabase()->getDatabase("test");
+    if (test_db->getBoolWithDefault("depth_test", false))
+    {
+        return test_rt0_depth(app);
+    }
     const bool rt0 = test_db->getStringWithDefault("operator", "LINEAR") == "RT0";
     const auto hierarchy_tuple = setup_hierarchy<NDIM>(app);
     Pointer<PatchHierarchy<NDIM>> hierarchy = std::get<0>(hierarchy_tuple);
@@ -252,6 +381,143 @@ main(int argc, char* argv[])
          << "interpolation error = " << reference_error << '\n'
          << "pressure leakage = " << pressure_leak << '\n'
          << "schedule error = " << schedule_error << '\n';
+
+    if (test_db->getBoolWithDefault("transfer_parity", false))
+    {
+        Vec scale = nullptr, coarse_result = nullptr, coarse_expected = nullptr;
+        PETScMatUtilities::constructRestrictionScalingOp(prolongation, scale);
+        ierr = VecDuplicate(x, &coarse_result);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDuplicate(x, &coarse_expected);
+        IBTK_CHKERRQ(ierr);
+        Pointer<RefineAlgorithm<NDIM>> refine = new RefineAlgorithm<NDIM>();
+        refine->registerRefine(expected_idx, u_idx, expected_idx, new CartSideDoubleRT0Refine());
+        Pointer<RefineSchedule<NDIM>> refine_schedule =
+            refine->createSchedule(fine, Pointer<PatchLevel<NDIM>>(), 0, hierarchy);
+        Pointer<CoarsenAlgorithm<NDIM>> coarsen = new CoarsenAlgorithm<NDIM>();
+        coarsen->registerCoarsen(expected_idx, u_idx, new CartSideDoubleRT0Coarsen(IntVector<NDIM>(1)));
+        Pointer<CoarsenSchedule<NDIM>> coarsen_schedule = coarsen->createSchedule(coarse, fine);
+        double prolongation_error = 0.0, restriction_error = 0.0;
+        double minimum_transfer_norm = std::numeric_limits<double>::max();
+        for (const bool piecewise : { false, true })
+        {
+            for (int ln = 0; ln < 2; ++ln)
+            {
+                Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+                const Box<NDIM>& level_domain = level->getPhysicalDomain()[0];
+                for (PatchLevel<NDIM>::Iterator patch_it(level); patch_it; patch_it++)
+                {
+                    Pointer<Patch<NDIM>> patch = level->getPatch(patch_it());
+                    Pointer<SideData<NDIM, double>> data = patch->getPatchData(u_idx);
+                    Pointer<CellData<NDIM, double>> pressure = patch->getPatchData(p_idx);
+                    pressure->fillAll(0.0);
+                    for (int axis = 0; axis < NDIM; ++axis)
+                    {
+                        for (Box<NDIM>::Iterator b(SideGeometry<NDIM>::toSideBox(data->getGhostBox(), axis)); b; b++)
+                        {
+                            (*data)(SideIndex<NDIM>(b(), axis, SideIndex<NDIM>::Lower)) =
+                                transfer_profile(b(), axis, level_domain, piecewise);
+                        }
+                    }
+                }
+            }
+            IBAMR::StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(x, u_idx, u_dof_idx, p_idx, p_dof_idx, coarse);
+            refine_schedule->fillData(0.0);
+            IBAMR::StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(
+                expected, expected_idx, u_dof_idx, p_idx, p_dof_idx, fine);
+            double transfer_norm = 0.0;
+            ierr = VecNorm(expected, NORM_INFINITY, &transfer_norm);
+            IBTK_CHKERRQ(ierr);
+            if (!std::isfinite(transfer_norm) || transfer_norm <= 1.0e-14)
+            {
+                TBOX_ERROR("RT0 refined profile is zero or nonfinite.\n");
+            }
+            minimum_transfer_norm = std::min(minimum_transfer_norm, transfer_norm);
+            ierr = MatMult(prolongation, x, result);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecAXPY(result, -1.0, expected);
+            IBTK_CHKERRQ(ierr);
+            double error = 0.0;
+            ierr = VecNorm(result, NORM_INFINITY, &error);
+            IBTK_CHKERRQ(ierr);
+            if (!std::isfinite(error))
+            {
+                TBOX_ERROR("Nonfinite RT0 prolongation error.\n");
+            }
+            prolongation_error = std::max(prolongation_error, error);
+            IBAMR::StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(
+                result, u_idx, u_dof_idx, p_idx, p_dof_idx, fine);
+            coarsen_schedule->coarsenData();
+            IBAMR::StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(
+                coarse_expected, expected_idx, u_dof_idx, p_idx, p_dof_idx, coarse);
+            ierr = VecNorm(coarse_expected, NORM_INFINITY, &transfer_norm);
+            IBTK_CHKERRQ(ierr);
+            if (!std::isfinite(transfer_norm) || transfer_norm <= 1.0e-14)
+            {
+                TBOX_ERROR("RT0 restricted profile is zero or nonfinite.\n");
+            }
+            minimum_transfer_norm = std::min(minimum_transfer_norm, transfer_norm);
+            ierr = MatMultTranspose(prolongation, result, coarse_result);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecPointwiseMult(coarse_result, scale, coarse_result);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecAXPY(coarse_result, -1.0, coarse_expected);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecNorm(coarse_result, NORM_INFINITY, &error);
+            IBTK_CHKERRQ(ierr);
+            if (!std::isfinite(error))
+            {
+                TBOX_ERROR("Nonfinite RT0 restriction error.\n");
+            }
+            restriction_error = std::max(restriction_error, error);
+        }
+        // P has zero pressure rows/columns, so P^T P is the velocity RIDP product before scaling.
+        Mat ridp = nullptr;
+        ierr = MatTransposeMatMult(prolongation, prolongation, MAT_INITIAL_MATRIX, PETSC_DEFAULT, &ridp);
+        IBTK_CHKERRQ(ierr);
+        ierr = MatDiagonalScale(ridp, scale, nullptr);
+        IBTK_CHKERRQ(ierr);
+        for (PatchLevel<NDIM>::Iterator patch_it(coarse); patch_it; patch_it++)
+        {
+            Pointer<SideData<NDIM, double>> data = coarse->getPatch(patch_it())->getPatchData(u_idx);
+            data->fillAll(1.0);
+        }
+        IBAMR::StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(
+            coarse_expected, u_idx, u_dof_idx, p_idx, p_dof_idx, coarse);
+        ierr = VecSet(x, 1.0);
+        IBTK_CHKERRQ(ierr);
+        ierr = MatMult(ridp, x, coarse_result);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecAXPY(coarse_result, -1.0, coarse_expected);
+        IBTK_CHKERRQ(ierr);
+        double row_error = 0.0, column_error = 0.0;
+        ierr = VecNorm(coarse_result, NORM_INFINITY, &row_error);
+        IBTK_CHKERRQ(ierr);
+        ierr = MatMultTranspose(ridp, x, coarse_result);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecAXPY(coarse_result, -1.0, coarse_expected);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecNorm(coarse_result, NORM_INFINITY, &column_error);
+        IBTK_CHKERRQ(ierr);
+        plog << "minimum transfer norm = " << minimum_transfer_norm << '\n'
+             << "RT0 prolongation error = " << prolongation_error << '\n'
+             << "RT0 restriction error = " << restriction_error << '\n'
+             << "RIDP row sum error = " << row_error << '\n'
+             << "RIDP column sum error = " << column_error << '\n';
+        if (!(prolongation_error < 1.0e-12 && restriction_error < 1.0e-12 && row_error < 1.0e-12 &&
+              column_error < 1.0e-12))
+        {
+            TBOX_ERROR("RT0 transfer parity failed.\n");
+        }
+        ierr = MatDestroy(&ridp);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&scale);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&coarse_result);
+        IBTK_CHKERRQ(ierr);
+        ierr = VecDestroy(&coarse_expected);
+        IBTK_CHKERRQ(ierr);
+    }
     ierr = VecDestroy(&x);
     IBTK_CHKERRQ(ierr);
     ierr = VecDestroy(&result);

--- a/tests/navier_stokes/side_prolongation_2d.rt0_depth_preallocation.input
+++ b/tests/navier_stokes/side_prolongation_2d.rt0_depth_preallocation.input
@@ -1,0 +1,27 @@
+test { operator = "RT0" depth_test = TRUE }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (7, 7)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2 }
+   largest_patch_size { level_0 = 128, 128 }
+   smallest_patch_size { level_0 = 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (7, 7)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_2d.rt0_depth_preallocation.output
+++ b/tests/navier_stokes/side_prolongation_2d.rt0_depth_preallocation.output
@@ -1,0 +1,2 @@
+assembly reallocations = 0
+axis/depth isolation error = 0

--- a/tests/navier_stokes/side_prolongation_2d.rt0_transfer_parity.input
+++ b/tests/navier_stokes/side_prolongation_2d.rt0_transfer_parity.input
@@ -1,0 +1,27 @@
+test { operator = "RT0" transfer_parity = TRUE }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (7, 7)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2 }
+   largest_patch_size { level_0 = 128, 128 }
+   smallest_patch_size { level_0 = 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (7, 7)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_2d.rt0_transfer_parity.output
+++ b/tests/navier_stokes/side_prolongation_2d.rt0_transfer_parity.output
@@ -1,0 +1,9 @@
+result norm = 2.6217310878
+interpolation error = 2.22044604925e-16
+pressure leakage = 0
+schedule error = 0
+minimum transfer norm = 2.56600139577
+RT0 prolongation error = 0
+RT0 restriction error = 4.4408920985e-16
+RIDP row sum error = 0
+RIDP column sum error = 0

--- a/tests/navier_stokes/side_prolongation_3d.rt0_depth_preallocation.input
+++ b/tests/navier_stokes/side_prolongation_3d.rt0_depth_preallocation.input
@@ -1,0 +1,27 @@
+test { operator = "RT0" depth_test = TRUE }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (5, 5, 5)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 1, 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2, 2 }
+   largest_patch_size { level_0 = 128, 128, 128 }
+   smallest_patch_size { level_0 = 2, 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0, 0), (5, 5, 5)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_3d.rt0_depth_preallocation.output
+++ b/tests/navier_stokes/side_prolongation_3d.rt0_depth_preallocation.output
@@ -1,0 +1,2 @@
+assembly reallocations = 0
+axis/depth isolation error = 0

--- a/tests/navier_stokes/side_prolongation_3d.rt0_transfer_parity.input
+++ b/tests/navier_stokes/side_prolongation_3d.rt0_transfer_parity.input
@@ -1,0 +1,27 @@
+test { operator = "RT0" transfer_parity = TRUE }
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz"
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (5, 5, 5)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 1, 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 2
+   ratio_to_coarser { level_1 = 2, 2, 2 }
+   largest_patch_size { level_0 = 128, 128, 128 }
+   smallest_patch_size { level_0 = 2, 2, 2 }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0, 0), (5, 5, 5)] }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/side_prolongation_3d.rt0_transfer_parity.output
+++ b/tests/navier_stokes/side_prolongation_3d.rt0_transfer_parity.output
@@ -1,0 +1,9 @@
+result norm = 4.97174972243
+interpolation error = 8.881784197e-16
+pressure leakage = 0
+schedule error = 0
+minimum transfer norm = 4.06436311691
+RT0 prolongation error = 0
+RT0 restriction error = 1.33226762955e-15
+RIDP row sum error = 0
+RIDP column sum error = 0

--- a/tests/refine/rt0_refine_01.cpp
+++ b/tests/refine/rt0_refine_01.cpp
@@ -21,9 +21,12 @@
 // Headers for major SAMRAI objects
 #include <BergerRigoutsos.h>
 #include <CartesianGridGeometry.h>
+#include <CartesianPatchGeometry.h>
 #include <CellVariable.h>
 #include <GriddingAlgorithm.h>
 #include <LoadBalancer.h>
+#include <RefineAlgorithm.h>
+#include <RefineSchedule.h>
 #include <SAMRAIVectorReal.h>
 #include <SideGeometry.h>
 #include <SideVariable.h>
@@ -37,10 +40,12 @@
 #include <ibtk/HierarchyMathOps.h>
 #include <ibtk/IBTKInit.h>
 #include <ibtk/IBTK_MPI.h>
+#include <ibtk/IndexUtilities.h>
 #include <ibtk/muParserCartGridFunction.h>
 
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
 
 // Set up application namespace declarations
 #include <ibtk/app_namespaces.h>
@@ -146,6 +151,106 @@ test_specialized_linear_refine()
         }
     }
 }
+
+// The fine-cell divergence equals the parent-cell divergence for RT0 refinement.
+int
+test_rt0_schedule(Pointer<PatchHierarchy<NDIM>> hierarchy, int u_idx, int refined_idx)
+{
+    Pointer<PatchLevel<NDIM>> coarse = hierarchy->getPatchLevel(0);
+    Pointer<PatchLevel<NDIM>> fine = hierarchy->getPatchLevel(1);
+    if (coarse->getNumberOfPatches() != 1 || fine->getNumberOfPatches() != 1)
+    {
+        TBOX_ERROR("RT0 invariant fixture requires one patch per level.\n");
+    }
+    Pointer<Patch<NDIM>> coarse_patch = coarse->getPatch(0);
+    Pointer<Patch<NDIM>> fine_patch = fine->getPatch(0);
+    Pointer<SideData<NDIM, double>> coarse_data = coarse_patch->getPatchData(u_idx);
+    Pointer<SideData<NDIM, double>> refined_data = fine_patch->getPatchData(refined_idx);
+    Pointer<CartesianPatchGeometry<NDIM>> coarse_geom = coarse_patch->getPatchGeometry();
+    Pointer<CartesianPatchGeometry<NDIM>> fine_geom = fine_patch->getPatchGeometry();
+    const IntVector<NDIM> ratio = fine->getRatioToCoarserLevel();
+    Pointer<RefineAlgorithm<NDIM>> algorithm = new RefineAlgorithm<NDIM>();
+    algorithm->registerRefine(refined_idx, u_idx, refined_idx, new CartSideDoubleRT0Refine());
+    Pointer<RefineSchedule<NDIM>> schedule = algorithm->createSchedule(fine, Pointer<PatchLevel<NDIM>>(), 0, hierarchy);
+    double affine_error = 0.0, divergence_error = 0.0, divergence_norm = 0.0;
+    for (int profile = 0; profile < 3; ++profile)
+    {
+        coarse_data->fillAll(0.0);
+        for (int axis = 0; axis < NDIM; ++axis)
+        {
+            for (Box<NDIM>::Iterator b(SideGeometry<NDIM>::toSideBox(coarse_patch->getBox(), axis)); b; b++)
+            {
+                double value = axis + 1.0;
+                for (int d = 0; d < NDIM; ++d)
+                {
+                    const double x = coarse_geom->getXLower()[d] +
+                                     coarse_geom->getDx()[d] *
+                                         (b()(d) - coarse_patch->getBox().lower()(d) + (d == axis ? 0.0 : 0.5));
+                    if (profile == 0 && d == axis)
+                    {
+                        value += 0.3 * (axis + 1) * x;
+                    }
+                    else if (profile == 1)
+                    {
+                        value += 0.2 * (d + 1) * std::sin(2.0 * std::acos(-1.0) * x);
+                    }
+                    else if (profile == 2)
+                    {
+                        value += d == axis ? 0.3 * std::abs(2.0 * x - 1.0) : 0.2 * std::floor(4.0 * x);
+                    }
+                }
+                (*coarse_data)(SideIndex<NDIM>(b(), axis, SideIndex<NDIM>::Lower)) = value;
+            }
+        }
+        refined_data->fillAll(0.0);
+        schedule->fillData(0.0);
+        if (profile == 0)
+        {
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                for (Box<NDIM>::Iterator b(SideGeometry<NDIM>::toSideBox(fine_patch->getBox(), axis)); b; b++)
+                {
+                    const double x = fine_geom->getXLower()[axis] +
+                                     fine_geom->getDx()[axis] * (b()(axis) - fine_patch->getBox().lower()(axis));
+                    const double exact = axis + 1.0 + 0.3 * (axis + 1) * x;
+                    const double error =
+                        std::abs((*refined_data)(SideIndex<NDIM>(b(), axis, SideIndex<NDIM>::Lower)) - exact);
+                    if (!std::isfinite(error))
+                    {
+                        TBOX_ERROR("Nonfinite RT0 affine error.\n");
+                    }
+                    affine_error = std::max(affine_error, error);
+                }
+            }
+        }
+        for (Box<NDIM>::Iterator b(fine_patch->getBox()); b; b++)
+        {
+            const hier::Index<NDIM> coarse_index = IndexUtilities::coarsen(b(), ratio);
+            double coarse_div = 0.0, fine_div = 0.0;
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                coarse_div += ((*coarse_data)(SideIndex<NDIM>(coarse_index, axis, SideIndex<NDIM>::Upper)) -
+                               (*coarse_data)(SideIndex<NDIM>(coarse_index, axis, SideIndex<NDIM>::Lower))) /
+                              coarse_geom->getDx()[axis];
+                fine_div += ((*refined_data)(SideIndex<NDIM>(b(), axis, SideIndex<NDIM>::Upper)) -
+                             (*refined_data)(SideIndex<NDIM>(b(), axis, SideIndex<NDIM>::Lower))) /
+                            fine_geom->getDx()[axis];
+            }
+            const double error = std::abs(fine_div - coarse_div);
+            if (!std::isfinite(error))
+            {
+                TBOX_ERROR("Nonfinite RT0 divergence error.\n");
+            }
+            divergence_error = std::max(divergence_error, error);
+            divergence_norm = std::max(divergence_norm, std::abs(coarse_div));
+        }
+    }
+    plog << std::setprecision(12) << "affine schedule error = " << affine_error << '\n'
+         << "divergence error = " << divergence_error << '\n'
+         << "coarse divergence norm = " << divergence_norm << '\n';
+    return affine_error < 1.0e-12 && divergence_error < 1.0e-12 && divergence_norm > 0.0 ? 0 : 1;
+}
+
 } // namespace
 
 int
@@ -191,9 +296,10 @@ main(int argc, char* argv[])
         VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
         Pointer<VariableContext> ctx = var_db->getContext("context");
         Pointer<SideVariable<NDIM, double>> u_sc_var = new SideVariable<NDIM, double>("u_sc");
-        const int u_sc_idx = var_db->registerVariableAndContext(u_sc_var, ctx);
+        const IntVector<NDIM> ghosts(input_db->getBoolWithDefault("test_rt0_schedule", false) ? 1 : 0);
+        const int u_sc_idx = var_db->registerVariableAndContext(u_sc_var, ctx, ghosts);
         Pointer<SideVariable<NDIM, double>> exact_sc_var = new SideVariable<NDIM, double>("exact_sc");
-        const int exact_sc_idx = var_db->registerVariableAndContext(exact_sc_var, ctx);
+        const int exact_sc_idx = var_db->registerVariableAndContext(exact_sc_var, ctx, ghosts);
         // u_cc_var is only for plotting (and testing): uncomment if output is desired
 // #define DO_PLOT
 #ifdef DO_PLOT
@@ -225,6 +331,11 @@ main(int argc, char* argv[])
         }
 
         Pointer<VisItDataWriter<NDIM>> visit_writer = app_initializer->getVisItDataWriter();
+
+        if (input_db->getBoolWithDefault("test_rt0_schedule", false))
+        {
+            return test_rt0_schedule(patch_hierarchy, u_sc_idx, exact_sc_idx);
+        }
 
         // The rest is just book-keeping, this is the actual test:
         auto do_test = [&](const std::string& db_u_fcn_name, const int coarse_level_n)

--- a/tests/refine/rt0_refine_01_2d.schedule_invariants.input
+++ b/tests/refine/rt0_refine_01_2d.schedule_invariants.input
@@ -1,0 +1,58 @@
+test_rt0_schedule = TRUE
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 2
+   viz_dump_dirname            = "viz_advect2d"
+   visit_number_procs_per_file = 1
+
+}
+
+N = 4
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0   // lower end of computational domain.
+   x_up               = 1, 1   // upper end of computational domain.
+}
+
+GriddingAlgorithm {
+   max_levels = 6                 // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {
+      level_1 = 2, 2           // vector ratio to next coarser level
+   }
+
+   largest_patch_size {
+      level_0 = 2^8, 2^8     // largest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 =   1,   1     // smallest patch allowed in hierarchy
+                             // all finer levels will use same values as level_0...
+   }
+
+   efficiency_tolerance = 0.70e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller
+                                  // boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+      level_1 = [(0, 0), (2^1*N - 1, 2^1*N - 1)]
+      level_2 = [(0, 0), (2^2*N - 1, 2^2*N - 1)]
+      level_3 = [(0, 0), (2^3*N - 1, 2^3*N - 1)]
+      level_4 = [(0, 0), (2^4*N - 1, 2^4*N - 1)]
+      level_5 = [(0, 0), (2^5*N - 1, 2^5*N - 1)]
+      level_6 = [(0, 0), (2^5*N - 1, 2^5*N - 1)]
+   }
+}
+
+LoadBalancer {}

--- a/tests/refine/rt0_refine_01_2d.schedule_invariants.output
+++ b/tests/refine/rt0_refine_01_2d.schedule_invariants.output
@@ -1,0 +1,3 @@
+affine schedule error = 4.4408920985e-16
+divergence error = 2.6645352591e-15
+coarse divergence norm = 2.4

--- a/tests/refine/rt0_refine_01_3d.schedule_invariants.input
+++ b/tests/refine/rt0_refine_01_3d.schedule_invariants.input
@@ -1,0 +1,57 @@
+test_rt0_schedule = TRUE
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 2
+   viz_dump_dirname            = "viz_advect2d"
+   visit_number_procs_per_file = 1
+
+}
+
+N = 4
+
+CartesianGeometry {
+   domain_boxes       = [(0,0,0), (N - 1, N - 1, N - 1)]
+   x_lo               = 0, 0, 0   // lower end of computational domain.
+   x_up               = 1, 1, 1   // upper end of computational domain.
+}
+
+GriddingAlgorithm {
+   max_levels = 5                 // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {
+      level_1 = 2, 2, 2           // vector ratio to next coarser level
+   }
+
+   largest_patch_size {
+      level_0 = 2^8, 2^8, 2^8     // largest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 = 1, 1, 1      // smallest patch allowed in hierarchy
+                             // all finer levels will use same values as level_0...
+   }
+
+   efficiency_tolerance = 0.70e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller
+                                  // boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+      level_1 = [(0, 0, 0), (2^1*N - 1, 2^1*N - 1, 2^1*N - 1)]
+      level_2 = [(0, 0, 0), (2^2*N - 1, 2^2*N - 1, 2^2*N - 1)]
+      level_3 = [(0, 0, 0), (2^3*N - 1, 2^3*N - 1, 2^3*N - 1)]
+      level_4 = [(0, 0, 0), (2^4*N - 1, 2^4*N - 1, 2^4*N - 1)]
+      level_5 = [(0, 0, 0), (2^5*N - 1, 2^5*N - 1, 2^5*N - 1)]
+   }
+}
+
+LoadBalancer {}

--- a/tests/refine/rt0_refine_01_3d.schedule_invariants.output
+++ b/tests/refine/rt0_refine_01_3d.schedule_invariants.output
@@ -1,0 +1,3 @@
+affine schedule error = 4.4408920985e-16
+divergence error = 7.1054273576e-15
+coarse divergence norm = 4.8


### PR DESCRIPTION
Add native regression coverage for RT0 Stokes transfers, refinement invariants, and coarse-SAJ transfer composition.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [ ] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
