### PR TITLE
[CAV R13] Add pressure-seeded coupling-aware Vanka patches

### DIFF
--- a/doc/news/changes/minor/20260910Griffith-R13
+++ b/doc/news/changes/minor/20260910Griffith-R13
@@ -1,0 +1,3 @@
+New: Add pressure-seeded CAV patch construction.
+<br>
+(Boyce Griffith, 2026/09/10)

--- a/include/ibamr/StaggeredStokesPETScMatUtilities.h
+++ b/include/ibamr/StaggeredStokesPETScMatUtilities.h
@@ -134,6 +134,44 @@ public:
         CouplingAwareASMClosurePolicy policy = CouplingAwareASMClosurePolicy::RELAXED,
         double relative_zero_tol = 1.0e-14);
 
+    /*! \brief Construct ordered pressure-cell-seeded CAV patches.
+     *
+     * The borrowed elasticity matrix uses full global velocity-pressure IDs,
+     * supports row access, and has numerically zero pressure rows and columns.
+     * An entry is retained when its magnitude exceeds
+     * max(n * epsilon, relative_zero_tol) times its row maximum, where n counts
+     * all stored entries, including zeros. Each seed's incident MAC velocities
+     * expand once through the retained row-or-column graph. Without expansion,
+     * both policies return the standard Vanka patch. Otherwise RELAXED closes
+     * all incident cells and retains expanded velocities; STRICT retains only
+     * cells whose complete velocity stencil is supported.
+     *
+     * Pressure seeds are sorted in logical traversal order and de-duplicated
+     * before applying the positive seed_stride. patches[k] corresponds to
+     * pressure_seeds[k]; each set contains increasing unique global IDs.
+     * The traversal order must match NDIM and relative_zero_tol must be finite
+     * and nonnegative. DOF data need valid adjacent-cell ghosts and must remain
+     * unchanged during construction. Only one MPI rank is supported.
+     * The matrix is read anew on each call and is not retained. This operation
+     * constructs patches, without partitioning ownership or applying corrections.
+     */
+    static void construct_patch_level_pressure_cell_seeded_cav_patches(
+        std::vector<std::set<int>>& patches,
+        std::vector<int>& pressure_seeds,
+        const std::vector<int>& num_dofs_per_proc,
+        int u_dof_index_idx,
+        int p_dof_index_idx,
+        SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>> patch_level,
+        Mat elasticity,
+        int seed_stride = 1,
+#if (NDIM == 2)
+        CouplingAwareASMSeedTraversalOrder order = CouplingAwareASMSeedTraversalOrder::I_J,
+#else
+        CouplingAwareASMSeedTraversalOrder order = CouplingAwareASMSeedTraversalOrder::I_J_K,
+#endif
+        CouplingAwareASMClosurePolicy policy = CouplingAwareASMClosurePolicy::RELAXED,
+        double relative_zero_tol = 1.0e-14);
+
     /*!
      * \brief Partition the patch level into subdomains suitable to be used for
      * PCFieldSplit preconditioner.

--- a/include/ibamr/private/CouplingAwareASMSubdomains.h
+++ b/include/ibamr/private/CouplingAwareASMSubdomains.h
@@ -31,11 +31,12 @@
 
 namespace IBAMR
 {
-/*! \brief Cached level geometry for velocity-seeded ASM construction.
+/*! \brief Cached level geometry for coupling-aware patch construction.
  *
  * Recreate after changing the level or DOF data. The supplied patch data must
  * outlive this object. Construction semantics are defined by
- * StaggeredStokesPETScMatUtilities::construct_patch_level_coupling_aware_asm_subdomains().
+ * StaggeredStokesPETScMatUtilities::construct_patch_level_coupling_aware_asm_subdomains()
+ * and StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches().
  */
 class CouplingAwareASMSubdomains
 {
@@ -54,12 +55,24 @@ public:
                              CouplingAwareASMClosurePolicy policy,
                              double relative_zero_tol);
 
+    /*! \brief Construct pressure patches as defined by
+     * StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches().
+     */
+    void constructPressureCellPatches(std::vector<std::set<int>>& patches,
+                                      std::vector<int>& pressure_seeds,
+                                      const std::vector<int>& num_dofs_per_proc,
+                                      Mat elasticity,
+                                      int seed_stride,
+                                      CouplingAwareASMSeedTraversalOrder order,
+                                      CouplingAwareASMClosurePolicy policy,
+                                      double relative_zero_tol);
+
 private:
     /*! \brief Add lower-face component pairing when STRICT first needs it. */
     void buildSeedPairs();
 
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>> d_level;
-    int d_u_idx;
+    int d_u_idx, d_p_idx;
     std::unordered_map<int, std::set<int>> d_adjacent_cells, d_cell_closures, d_seed_pairs;
     std::unordered_set<int> d_velocity_dofs;
     bool d_pairs_built = false;

--- a/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScMatUtilities.cpp
@@ -929,10 +929,47 @@ enum_to_string<CouplingAwareASMSeedTraversalOrder>(CouplingAwareASMSeedTraversal
     return "UNKNOWN";
 }
 
+namespace
+{
+std::array<int, NDIM>
+get_coupling_aware_axis_order(const CouplingAwareASMSeedTraversalOrder order)
+{
+    std::array<int, NDIM> axis_order{};
+#if (NDIM == 2)
+    if (order == CouplingAwareASMSeedTraversalOrder::I_J)
+    {
+        axis_order = { 0, 1 };
+    }
+    else if (order == CouplingAwareASMSeedTraversalOrder::J_I)
+    {
+        axis_order = { 1, 0 };
+    }
+#else
+    if (order == CouplingAwareASMSeedTraversalOrder::I_J_K)
+    {
+        axis_order = { 0, 1, 2 };
+    }
+    else if (order == CouplingAwareASMSeedTraversalOrder::J_K_I)
+    {
+        axis_order = { 1, 2, 0 };
+    }
+    else if (order == CouplingAwareASMSeedTraversalOrder::K_I_J)
+    {
+        axis_order = { 2, 0, 1 };
+    }
+#endif
+    else
+    {
+        TBOX_ERROR("CouplingAwareASMSubdomains: invalid logical traversal order.\n");
+    }
+    return axis_order;
+}
+} // namespace
+
 CouplingAwareASMSubdomains::CouplingAwareASMSubdomains(const int u_idx,
                                                        const int p_idx,
                                                        Pointer<PatchLevel<NDIM>> level)
-    : d_level(level), d_u_idx(u_idx)
+    : d_level(level), d_u_idx(u_idx), d_p_idx(p_idx)
 {
     if (!level || u_idx < 0 || p_idx < 0 || !level->checkAllocated(u_idx) || !level->checkAllocated(p_idx))
     {
@@ -1029,34 +1066,7 @@ CouplingAwareASMSubdomains::constructSubdomains(std::vector<std::set<int>>& over
                                                 const CouplingAwareASMClosurePolicy policy,
                                                 const double relative_zero_tol)
 {
-    std::array<int, NDIM> axis_order{};
-#if (NDIM == 2)
-    if (order == CouplingAwareASMSeedTraversalOrder::I_J)
-    {
-        axis_order = { 0, 1 };
-    }
-    else if (order == CouplingAwareASMSeedTraversalOrder::J_I)
-    {
-        axis_order = { 1, 0 };
-    }
-#else
-    if (order == CouplingAwareASMSeedTraversalOrder::I_J_K)
-    {
-        axis_order = { 0, 1, 2 };
-    }
-    else if (order == CouplingAwareASMSeedTraversalOrder::J_K_I)
-    {
-        axis_order = { 1, 2, 0 };
-    }
-    else if (order == CouplingAwareASMSeedTraversalOrder::K_I_J)
-    {
-        axis_order = { 2, 0, 1 };
-    }
-#endif
-    else
-    {
-        TBOX_ERROR("CouplingAwareASMSubdomains: invalid logical traversal order.\n");
-    }
+    const std::array<int, NDIM> axis_order = get_coupling_aware_axis_order(order);
     if (seed_axis < 0 || seed_axis >= NDIM || seed_stride < 1 ||
         (policy != CouplingAwareASMClosurePolicy::RELAXED && policy != CouplingAwareASMClosurePolicy::STRICT) ||
         !std::isfinite(relative_zero_tol) || relative_zero_tol < 0.0 || !matrix ||
@@ -1210,6 +1220,165 @@ CouplingAwareASMSubdomains::constructSubdomains(std::vector<std::set<int>>& over
 }
 
 void
+CouplingAwareASMSubdomains::constructPressureCellPatches(std::vector<std::set<int>>& patches,
+                                                         std::vector<int>& pressure_seeds,
+                                                         const std::vector<int>& num_dofs_per_proc,
+                                                         Mat elasticity,
+                                                         const int seed_stride,
+                                                         const CouplingAwareASMSeedTraversalOrder order,
+                                                         const CouplingAwareASMClosurePolicy policy,
+                                                         const double relative_zero_tol)
+{
+    if (IBTK_MPI::getNodes() != 1)
+    {
+        TBOX_ERROR("CouplingAwareASMSubdomains: pressure-cell CAV construction requires one MPI rank.\n");
+    }
+    const std::array<int, NDIM> axis_order = get_coupling_aware_axis_order(order);
+    if (!elasticity || num_dofs_per_proc.size() != 1 || seed_stride < 1 ||
+        (policy != CouplingAwareASMClosurePolicy::RELAXED && policy != CouplingAwareASMClosurePolicy::STRICT) ||
+        !std::isfinite(relative_zero_tol) || relative_zero_tol < 0.0)
+    {
+        TBOX_ERROR("CouplingAwareASMSubdomains: invalid pressure-cell CAV construction arguments.\n");
+    }
+    PetscInt rows = 0, columns = 0, first = 0, last = 0;
+    int ierr = MatGetSize(elasticity, &rows, &columns);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatGetOwnershipRange(elasticity, &first, &last);
+    IBTK_CHKERRQ(ierr);
+    if (rows != num_dofs_per_proc.front() || rows != columns || first != 0 || last != rows)
+    {
+        TBOX_ERROR("CouplingAwareASMSubdomains: elasticity must use full coupled numbering and ownership.\n");
+    }
+
+    // Each retained entry adds both directions without materializing a transpose.
+    std::vector<std::set<int>> adjacency(rows);
+    for (PetscInt row = 0; row < rows; ++row)
+    {
+        PetscInt count = 0;
+        const PetscInt* cols = nullptr;
+        const PetscScalar* values = nullptr;
+        ierr = MatGetRow(elasticity, row, &count, &cols, &values);
+        IBTK_CHKERRQ(ierr);
+        double row_max = 0.0;
+        for (PetscInt k = 0; k < count; ++k)
+        {
+            row_max = std::max(row_max, static_cast<double>(PetscAbsScalar(values[k])));
+        }
+        const double threshold = std::max(count * std::numeric_limits<double>::epsilon(), relative_zero_tol) * row_max;
+        bool invalid_pressure_entry = false;
+        for (PetscInt k = 0; k < count; ++k)
+        {
+            if (PetscAbsScalar(values[k]) <= threshold)
+            {
+                continue;
+            }
+            if (!d_velocity_dofs.count(row) || !d_velocity_dofs.count(cols[k]))
+            {
+                invalid_pressure_entry = true;
+                break;
+            }
+            adjacency[row].insert(cols[k]);
+            adjacency[cols[k]].insert(row);
+        }
+        ierr = MatRestoreRow(elasticity, row, &count, &cols, &values);
+        IBTK_CHKERRQ(ierr);
+        if (invalid_pressure_entry)
+        {
+            TBOX_ERROR("CouplingAwareASMSubdomains: elasticity pressure rows and columns must be numerically zero.\n");
+        }
+    }
+
+    std::vector<std::pair<std::array<int, NDIM>, int>> records;
+    for (PatchLevel<NDIM>::Iterator p(d_level); p; p++)
+    {
+        Pointer<Patch<NDIM>> patch = d_level->getPatch(p());
+        Pointer<CellData<NDIM, int>> pressure = patch->getPatchData(d_p_idx);
+        for (Box<NDIM>::Iterator b(patch->getBox()); b; b++)
+        {
+            const int seed = (*pressure)(b());
+            if (seed < 0)
+            {
+                continue;
+            }
+            std::array<int, NDIM> index{};
+            for (int d = 0; d < NDIM; ++d)
+            {
+                index[d] = b()(axis_order[d]);
+            }
+            records.emplace_back(index, seed);
+        }
+    }
+    std::sort(records.begin(), records.end());
+    std::set<int> seen;
+    patches.clear();
+    pressure_seeds.clear();
+    for (const auto& record : records)
+    {
+        if (!seen.insert(record.second).second || (seen.size() - 1) % seed_stride != 0)
+        {
+            continue;
+        }
+        const int seed = record.second;
+        const std::set<int>& standard_patch = d_cell_closures.at(seed);
+        std::set<int> velocities;
+        for (const int dof : standard_patch)
+        {
+            if (d_velocity_dofs.count(dof))
+            {
+                velocities.insert(dof);
+            }
+        }
+        if (velocities.size() != 2 * NDIM)
+        {
+            TBOX_ERROR("CouplingAwareASMSubdomains: pressure seed requires a complete MAC velocity stencil.\n");
+        }
+        std::set<int> expanded = velocities;
+        for (const int velocity : velocities)
+        {
+            expanded.insert(adjacency[velocity].begin(), adjacency[velocity].end());
+        }
+        pressure_seeds.push_back(seed);
+        // Even RELAXED must not close neighboring cells when elasticity adds nothing.
+        if (expanded == velocities)
+        {
+            patches.push_back(standard_patch);
+            continue;
+        }
+        std::set<int> cells{ seed };
+        for (const int velocity : expanded)
+        {
+            const auto adjacent = d_adjacent_cells.find(velocity);
+            if (adjacent != d_adjacent_cells.end())
+            {
+                cells.insert(adjacent->second.begin(), adjacent->second.end());
+            }
+        }
+        std::set<int> closure;
+        for (const int cell : cells)
+        {
+            const auto found = d_cell_closures.find(cell);
+            if (found == d_cell_closures.end())
+            {
+                continue;
+            }
+            if (policy == CouplingAwareASMClosurePolicy::STRICT &&
+                std::any_of(found->second.begin(),
+                            found->second.end(),
+                            [&](const int dof) { return d_velocity_dofs.count(dof) && !expanded.count(dof); }))
+            {
+                continue;
+            }
+            closure.insert(found->second.begin(), found->second.end());
+        }
+        if (policy == CouplingAwareASMClosurePolicy::RELAXED)
+        {
+            closure.insert(expanded.begin(), expanded.end());
+        }
+        patches.push_back(std::move(closure));
+    }
+}
+
+void
 StaggeredStokesPETScMatUtilities::construct_patch_level_coupling_aware_asm_subdomains(
     std::vector<std::set<int>>& overlap,
     std::vector<std::set<int>>& nonoverlap,
@@ -1227,6 +1396,25 @@ StaggeredStokesPETScMatUtilities::construct_patch_level_coupling_aware_asm_subdo
     CouplingAwareASMSubdomains maps(u_idx, p_idx, level);
     maps.constructSubdomains(
         overlap, nonoverlap, num_dofs_per_proc, matrix, seed_axis, seed_stride, order, policy, relative_zero_tol);
+}
+
+void
+StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches(
+    std::vector<std::set<int>>& patches,
+    std::vector<int>& pressure_seeds,
+    const std::vector<int>& num_dofs_per_proc,
+    const int u_idx,
+    const int p_idx,
+    Pointer<PatchLevel<NDIM>> level,
+    Mat elasticity,
+    const int seed_stride,
+    const CouplingAwareASMSeedTraversalOrder order,
+    const CouplingAwareASMClosurePolicy policy,
+    const double relative_zero_tol)
+{
+    CouplingAwareASMSubdomains maps(u_idx, p_idx, level);
+    maps.constructPressureCellPatches(
+        patches, pressure_seeds, num_dofs_per_proc, elasticity, seed_stride, order, policy, relative_zero_tol);
 }
 
 void

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell.cpp
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell.cpp
@@ -511,6 +511,381 @@ check_ca_construction(Pointer<AppInitializer> app, Pointer<Database> test)
     return failures ? 1 : 0;
 }
 
+/*! \brief Check pressure-seeded patches against small periodic cell stencils. */
+int
+check_cav_construction(Pointer<AppInitializer> app, Pointer<Database> test)
+{
+    const auto hierarchy_data = setup_hierarchy<NDIM>(app);
+    Pointer<PatchHierarchy<NDIM>> hierarchy = std::get<0>(hierarchy_data);
+    Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(0);
+    VariableDatabase<NDIM>* variables = VariableDatabase<NDIM>::getDatabase();
+    Pointer<VariableContext> context = variables->getContext("cav_test");
+    Pointer<SideVariable<NDIM, int>> u_dof = new SideVariable<NDIM, int>("cav_u_dof");
+    Pointer<CellVariable<NDIM, int>> p_dof = new CellVariable<NDIM, int>("cav_p_dof");
+    const int udi = variables->registerVariableAndContext(u_dof, context, IntVector<NDIM>(1));
+    const int pdi = variables->registerVariableAndContext(p_dof, context, IntVector<NDIM>(1));
+    level->allocatePatchData(udi);
+    level->allocatePatchData(pdi);
+    std::vector<int> counts;
+    StaggeredStokesPETScVecUtilities::constructPatchLevelDOFIndices(counts, udi, pdi, level);
+    std::vector<std::set<int>> patches;
+    std::vector<int> seeds;
+    const std::string scenario = test->getString("cav_construction");
+    if (scenario == "parallel")
+    {
+        // Valid distributed DOF setup reaches the serial guard before matrix access.
+        StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches(
+            patches, seeds, counts, udi, pdi, level, nullptr);
+        level->deallocatePatchData(udi);
+        level->deallocatePatchData(pdi);
+        return 0;
+    }
+    const int total = counts.front();
+    const int n = app->getInputDatabase()->getInteger("N");
+    CAFields fields;
+    for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+    {
+        Pointer<Patch<NDIM>> patch = level->getPatch(p());
+        Pointer<SideData<NDIM, int>> u = patch->getPatchData(udi);
+        Pointer<CellData<NDIM, int>> pressure = patch->getPatchData(pdi);
+        // Interleave the full coupled IDs, including all shared/periodic ghosts.
+        for (int axis = 0; axis < NDIM; ++axis)
+        {
+            const Box<NDIM> sides = SideGeometry<NDIM>::toSideBox(u->getGhostBox(), axis);
+            for (Box<NDIM>::Iterator b(sides); b; b++)
+            {
+                int& dof = (*u)(SideIndex<NDIM>(b(), axis, SideIndex<NDIM>::Lower));
+                if (dof >= 0)
+                {
+                    dof = (5 * dof + 1) % total;
+                }
+            }
+        }
+        for (Box<NDIM>::Iterator b(pressure->getGhostBox()); b; b++)
+        {
+            int& dof = (*pressure)(b());
+            if (dof >= 0)
+            {
+                dof = (5 * dof + 1) % total;
+            }
+        }
+        for (Box<NDIM>::Iterator b(patch->getBox()); b; b++)
+        {
+            CACell cell{};
+            for (int d = 0; d < NDIM; ++d)
+            {
+                cell[d] = b()(d);
+            }
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                fields[cell][axis] = (*u)(SideIndex<NDIM>(b(), axis, SideIndex<NDIM>::Lower));
+            }
+            fields[cell][NDIM] = (*pressure)(b());
+        }
+    }
+    int failures = 0;
+    Mat elasticity = nullptr;
+    int ierr = MatCreateSeqAIJ(PETSC_COMM_WORLD, total, total, 2 * NDIM + 3, nullptr, &elasticity);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatSetOption(elasticity, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatSetOption(elasticity, MAT_IGNORE_ZERO_ENTRIES, PETSC_FALSE);
+    IBTK_CHKERRQ(ierr);
+    const auto assemble = [&]()
+    {
+        int error = MatAssemblyBegin(elasticity, MAT_FINAL_ASSEMBLY);
+        IBTK_CHKERRQ(error);
+        error = MatAssemblyEnd(elasticity, MAT_FINAL_ASSEMBLY);
+        IBTK_CHKERRQ(error);
+    };
+    const CACell origin{};
+    const int origin_velocity = fields.at(origin)[0];
+    if (scenario == "pressure_row" || scenario == "pressure_column")
+    {
+        const int pressure = fields.at(origin)[NDIM];
+        ierr = MatSetValue(elasticity,
+                           scenario == "pressure_row" ? pressure : origin_velocity,
+                           scenario == "pressure_row" ? origin_velocity : pressure,
+                           1.0,
+                           INSERT_VALUES);
+        IBTK_CHKERRQ(ierr);
+        assemble();
+        StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches(
+            patches, seeds, counts, udi, pdi, level, elasticity);
+        ierr = MatDestroy(&elasticity);
+        IBTK_CHKERRQ(ierr);
+        level->deallocatePatchData(udi);
+        level->deallocatePatchData(pdi);
+        return 0;
+    }
+    assemble();
+#if (NDIM == 2)
+    const CouplingAwareASMSeedTraversalOrder default_order = CouplingAwareASMSeedTraversalOrder::I_J;
+    const CouplingAwareASMSeedTraversalOrder alternate_order = CouplingAwareASMSeedTraversalOrder::J_I;
+#else
+    const CouplingAwareASMSeedTraversalOrder default_order = CouplingAwareASMSeedTraversalOrder::I_J_K;
+    const CouplingAwareASMSeedTraversalOrder alternate_order = CouplingAwareASMSeedTraversalOrder::J_K_I;
+#endif
+    std::vector<std::set<int>> standard;
+    std::vector<int> expected_seeds;
+    for (const auto& cell : fields)
+    {
+        standard.push_back(ca_cell_stencil(fields, cell.first, n));
+        expected_seeds.push_back(cell.second[NDIM]);
+    }
+    // Exact outer-vector equality detects missing, duplicated, or reordered patches.
+    for (const CouplingAwareASMClosurePolicy policy :
+         { CouplingAwareASMClosurePolicy::RELAXED, CouplingAwareASMClosurePolicy::STRICT })
+    {
+        for (const CouplingAwareASMSeedTraversalOrder order : { default_order, alternate_order })
+        {
+            std::vector<CACell> ordered;
+            for (const auto& cell : fields)
+            {
+                ordered.push_back(cell.first);
+            }
+            if (order == alternate_order)
+            {
+                std::sort(ordered.begin(),
+                          ordered.end(),
+                          [](const CACell& a, const CACell& b)
+                          {
+                              for (int d = 0; d < NDIM; ++d)
+                              {
+                                  const int axis = (d + 1) % NDIM;
+                                  if (a[axis] != b[axis])
+                                  {
+                                      return a[axis] < b[axis];
+                                  }
+                              }
+                              return false;
+                          });
+            }
+            for (const int stride : { 1, 2 })
+            {
+                std::vector<int> ordered_seeds;
+                std::vector<std::set<int>> expected;
+                for (std::size_t k = 0; k < ordered.size(); k += stride)
+                {
+                    ordered_seeds.push_back(fields.at(ordered[k])[NDIM]);
+                    expected.push_back(ca_cell_stencil(fields, ordered[k], n));
+                }
+                StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches(
+                    patches, seeds, counts, udi, pdi, level, elasticity, stride, order, policy);
+                if (patches != expected || seeds != ordered_seeds)
+                {
+                    ++failures;
+                }
+            }
+        }
+    }
+    std::vector<std::set<int>> velocity_patches, partition;
+    StaggeredStokesPETScMatUtilities::construct_patch_level_coupling_aware_asm_subdomains(
+        velocity_patches, partition, counts, udi, pdi, level, elasticity);
+    if (velocity_patches == standard)
+    {
+        ++failures;
+    }
+
+    CACell remote{}, weak{};
+    remote.fill(2);
+    weak.fill(1);
+    const int remote_velocity = fields.at(remote)[0];
+    const int weak_velocity = fields.at(weak)[0];
+    std::vector<std::set<int>> expected_relaxed;
+    // A single distant face edge affects precisely the cells touching either end.
+    for (const auto& cell : fields)
+    {
+        std::set<int> expected = ca_cell_stencil(fields, cell.first, n);
+        const bool at_origin = expected.count(origin_velocity);
+        const bool at_remote = expected.count(remote_velocity);
+        if (at_origin || at_remote)
+        {
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                for (const int sign : { -1, 1 })
+                {
+                    CACell neighbor = cell.first;
+                    neighbor[axis] += sign;
+                    const std::set<int> stencil = ca_cell_stencil(fields, neighbor, n);
+                    expected.insert(stencil.begin(), stencil.end());
+                }
+            }
+            const std::set<int> extra = ca_face_stencil(fields, at_origin ? remote : origin, 0, n);
+            expected.insert(extra.begin(), extra.end());
+        }
+        expected_relaxed.push_back(std::move(expected));
+    }
+    for (const bool column_edge : { false, true })
+    {
+        ierr = MatZeroEntries(elasticity);
+        IBTK_CHKERRQ(ierr);
+        const int row = column_edge ? remote_velocity : origin_velocity;
+        const int column = column_edge ? origin_velocity : remote_velocity;
+        ierr = MatSetValue(elasticity, row, column, 1.0, INSERT_VALUES);
+        IBTK_CHKERRQ(ierr);
+        // Omit this row-relative weak edge, even though it is structurally present.
+        ierr = MatSetValue(elasticity, row, weak_velocity, 5.0e-4, INSERT_VALUES);
+        IBTK_CHKERRQ(ierr);
+        assemble();
+        for (const CouplingAwareASMClosurePolicy policy :
+             { CouplingAwareASMClosurePolicy::RELAXED, CouplingAwareASMClosurePolicy::STRICT })
+        {
+            StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches(
+                patches, seeds, counts, udi, pdi, level, elasticity, 1, default_order, policy, 1.0e-3);
+            if (seeds != expected_seeds ||
+                patches != (policy == CouplingAwareASMClosurePolicy::RELAXED ? expected_relaxed : standard))
+            {
+                ++failures;
+            }
+        }
+    }
+    if (expected_relaxed == standard || !expected_relaxed.front().count(remote_velocity) ||
+        standard.front().count(remote_velocity))
+    {
+        ++failures;
+    }
+    // Changing the same borrowed matrix must remove the previous expansion.
+    ierr = MatZeroEntries(elasticity);
+    IBTK_CHKERRQ(ierr);
+    assemble();
+    StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches(
+        patches, seeds, counts, udi, pdi, level, elasticity);
+    if (patches != standard || seeds != expected_seeds)
+    {
+        ++failures;
+    }
+    const std::set<int> remote_patch = ca_cell_stencil(fields, remote, n);
+    for (const int dof : remote_patch)
+    {
+        if (dof != fields.at(remote)[NDIM])
+        {
+            ierr = MatSetValue(elasticity, origin_velocity, dof, 1.0, INSERT_VALUES);
+            IBTK_CHKERRQ(ierr);
+        }
+    }
+    // A second-hop edge must not expand the origin seed recursively.
+    ierr = MatSetValue(elasticity, remote_velocity, weak_velocity, 1.0, INSERT_VALUES);
+    IBTK_CHKERRQ(ierr);
+    assemble();
+    StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches(
+        patches, seeds, counts, udi, pdi, level, elasticity, 1, default_order, CouplingAwareASMClosurePolicy::STRICT);
+    std::set<int> complete = standard.front();
+    complete.insert(remote_patch.begin(), remote_patch.end());
+    if (patches.size() != standard.size() || seeds != expected_seeds || patches.front() != complete)
+    {
+        ++failures;
+    }
+    // In RELAXED, the one-hop stencil closes neighboring cells around both cells.
+    std::set<int> complete_relaxed = complete;
+    for (const CACell center : { origin, remote })
+    {
+        for (int axis = 0; axis < NDIM; ++axis)
+        {
+            for (const int sign : { -1, 1 })
+            {
+                CACell neighbor = center;
+                neighbor[axis] += sign;
+                const std::set<int> stencil = ca_cell_stencil(fields, neighbor, n);
+                complete_relaxed.insert(stencil.begin(), stencil.end());
+            }
+        }
+    }
+    StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches(
+        patches, seeds, counts, udi, pdi, level, elasticity);
+    if (patches.size() != standard.size() || seeds != expected_seeds || patches.front() != complete_relaxed)
+    {
+        ++failures;
+    }
+
+    PoissonSpecifications coefficients("cav_mac");
+    coefficients.setCConstant(1.0);
+    coefficients.setDConstant(-1.0);
+    std::vector<RobinBcCoefStrategy<NDIM>*> boundary(NDIM, nullptr);
+    Mat mac = nullptr;
+    StaggeredStokesPETScMatUtilities::constructPatchLevelMACStokesOp(
+        mac, coefficients, boundary, 0.0, counts, udi, pdi, level);
+    double pressure_row_error = 0.0;
+    for (const auto& cell : fields)
+    {
+        std::map<int, double> expected;
+        for (int axis = 0; axis < NDIM; ++axis)
+        {
+            CACell upper = cell.first;
+            ++upper[axis];
+            expected[cell.second[axis]] = n;
+            expected[fields.at(ca_wrap(upper, n))[axis]] = -n;
+        }
+        PetscInt count = 0;
+        const PetscInt* columns = nullptr;
+        const PetscScalar* values = nullptr;
+        ierr = MatGetRow(mac, cell.second[NDIM], &count, &columns, &values);
+        IBTK_CHKERRQ(ierr);
+        for (PetscInt k = 0; k < count; ++k)
+        {
+            pressure_row_error =
+                std::max(pressure_row_error, static_cast<double>(PetscAbsScalar(values[k] - expected[columns[k]])));
+            expected.erase(columns[k]);
+        }
+        for (const auto& missing : expected)
+        {
+            pressure_row_error = std::max(pressure_row_error, std::abs(missing.second));
+        }
+        ierr = MatRestoreRow(mac, cell.second[NDIM], &count, &columns, &values);
+        IBTK_CHKERRQ(ierr);
+    }
+    plog << "pressure_row_error = " << pressure_row_error << '\n';
+#if (NDIM == 3)
+    Vec pressure_shift = nullptr, action = nullptr;
+    ierr = MatCreateVecs(mac, &pressure_shift, &action);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecSet(pressure_shift, 0.0);
+    IBTK_CHKERRQ(ierr);
+    for (const auto& cell : fields)
+    {
+        ierr = VecSetValue(pressure_shift, cell.second[NDIM], 1.0, INSERT_VALUES);
+        IBTK_CHKERRQ(ierr);
+    }
+    ierr = VecAssemblyBegin(pressure_shift);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecAssemblyEnd(pressure_shift);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecNormalize(pressure_shift, nullptr);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatMult(mac, pressure_shift, action);
+    IBTK_CHKERRQ(ierr);
+    PetscReal shift_error = 0.0;
+    ierr = VecNorm(action, NORM_INFINITY, &shift_error);
+    IBTK_CHKERRQ(ierr);
+    MatNullSpace nullspace = nullptr;
+    ierr = MatNullSpaceCreate(PETSC_COMM_WORLD, PETSC_FALSE, 1, &pressure_shift, &nullspace);
+    IBTK_CHKERRQ(ierr);
+    PetscBool valid = PETSC_FALSE;
+    ierr = MatNullSpaceTest(nullspace, mac, &valid);
+    IBTK_CHKERRQ(ierr);
+    if (!valid)
+    {
+        ++failures;
+    }
+    plog << "pressure_shift_error = " << shift_error << '\n';
+    ierr = MatNullSpaceDestroy(&nullspace);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&pressure_shift);
+    IBTK_CHKERRQ(ierr);
+    ierr = VecDestroy(&action);
+    IBTK_CHKERRQ(ierr);
+#endif
+    ierr = MatDestroy(&mac);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatDestroy(&elasticity);
+    IBTK_CHKERRQ(ierr);
+    level->deallocatePatchData(udi);
+    level->deallocatePatchData(pdi);
+    plog << "pressure_patches = " << standard.size() << '\n';
+    plog << "failures = " << failures << '\n';
+    return failures ? 1 : 0;
+}
+
 double
 norm_inf(Vec x)
 {
@@ -1298,6 +1673,10 @@ main(int argc, char* argv[])
     Pointer<AppInitializer> app = new AppInitializer(argc, argv, "output");
     Pointer<Database> input = app->getInputDatabase();
     Pointer<Database> test = input->getDatabase("test");
+    if (test->keyExists("cav_construction"))
+    {
+        return check_cav_construction(app, test);
+    }
     if (test->keyExists("ca_construction"))
     {
         return check_ca_construction(app, test);

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.parallel.mpirun=2.expect_error=true.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.parallel.mpirun=2.expect_error=true.input
@@ -1,0 +1,39 @@
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_construction = "parallel"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.parallel.mpirun=2.expect_error=true.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.parallel.mpirun=2.expect_error=true.output
@@ -1,0 +1,4 @@
+Program abort called with error message
+
+    CouplingAwareASMSubdomains: pressure-cell CAV construction requires one MPI rank.
+

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.pressure_column.expect_error=true.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.pressure_column.expect_error=true.input
@@ -1,0 +1,39 @@
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_construction = "pressure_column"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.pressure_column.expect_error=true.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.pressure_column.expect_error=true.output
@@ -1,0 +1,4 @@
+Program abort called with error message
+
+    CouplingAwareASMSubdomains: elasticity pressure rows and columns must be numerically zero.
+

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.pressure_row.expect_error=true.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.pressure_row.expect_error=true.input
@@ -1,0 +1,39 @@
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_construction = "pressure_row"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.pressure_row.expect_error=true.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.pressure_row.expect_error=true.output
@@ -1,0 +1,4 @@
+Program abort called with error message
+
+    CouplingAwareASMSubdomains: elasticity pressure rows and columns must be numerically zero.
+

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.reference.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.reference.input
@@ -1,0 +1,39 @@
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_construction = "reference"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.reference.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.reference.output
@@ -1,0 +1,3 @@
+pressure_row_error = 0
+pressure_patches = 16
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.reference.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.reference.input
@@ -1,0 +1,39 @@
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_construction = "reference"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 1, 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.reference.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.reference.output
@@ -1,0 +1,4 @@
+pressure_row_error = 0
+pressure_shift_error = 0
+pressure_patches = 64
+failures = 0


### PR DESCRIPTION
Add construction of pressure-cell-seeded coupling-aware Vanka (CAV) patches (Gruninger and Griffith, arXiv:2608.14310) from the elasticity matrix and the full global DOF numbering.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?

