### PR TITLE
[CAV R14] Add the coupling-aware Vanka level smoother

### DIFF
--- a/doc/news/changes/minor/20260910Boyce_R14
+++ b/doc/news/changes/minor/20260910Boyce_R14
@@ -1,0 +1,3 @@
+New: Add the pressure-CAV level smoother.
+<br>
+(Boyce Griffith, 2026/09/10)

--- a/ibtk/src/solvers/impls/PETScLevelSolverBlasLapackShellBackend.cpp
+++ b/ibtk/src/solvers/impls/PETScLevelSolverBlasLapackShellBackend.cpp
@@ -121,14 +121,12 @@ PETScLevelSolverBlasLapackShellBackend::initializeSolverState(Mat mat,
     {
         TBOX_ERROR(d_options_prefix << " BLAS/LAPACK shell backend requires a serial square operator.\n");
     }
-    TBOX_ASSERT(overlap.size() == nonoverlap.size());
+    TBOX_ASSERT(use_multiplicative || overlap.size() == nonoverlap.size());
     d_subdomains.resize(overlap.size());
     for (std::size_t i = 0; i < overlap.size(); ++i)
     {
         PetscInt n = 0, m = 0;
         ierr = ISGetLocalSize(overlap[i], &n);
-        IBTK_CHKERRQ(ierr);
-        ierr = ISGetLocalSize(nonoverlap[i], &m);
         IBTK_CHKERRQ(ierr);
         ierr = PetscBLASIntCast(n, &d_subdomains[i].local_size);
         IBTK_CHKERRQ(ierr);
@@ -141,18 +139,23 @@ PETScLevelSolverBlasLapackShellBackend::initializeSolverState(Mat mat,
         }
         ierr = ISRestoreIndices(overlap[i], &indices);
         IBTK_CHKERRQ(ierr);
-        ierr = ISGetIndices(nonoverlap[i], &indices);
-        IBTK_CHKERRQ(ierr);
-        for (PetscInt j = 0; j < m; ++j)
+        if (!use_multiplicative)
         {
-            const std::vector<PetscInt>::const_iterator position = std::lower_bound(
-                d_subdomains[i].overlap_dofs.cbegin(), d_subdomains[i].overlap_dofs.cend(), indices[j]);
-            TBOX_ASSERT(position != d_subdomains[i].overlap_dofs.cend() && *position == indices[j]);
-            d_subdomains[i].update_local_positions.push_back(
-                static_cast<PetscBLASInt>(position - d_subdomains[i].overlap_dofs.cbegin()));
+            ierr = ISGetLocalSize(nonoverlap[i], &m);
+            IBTK_CHKERRQ(ierr);
+            ierr = ISGetIndices(nonoverlap[i], &indices);
+            IBTK_CHKERRQ(ierr);
+            for (PetscInt j = 0; j < m; ++j)
+            {
+                const std::vector<PetscInt>::const_iterator position = std::lower_bound(
+                    d_subdomains[i].overlap_dofs.cbegin(), d_subdomains[i].overlap_dofs.cend(), indices[j]);
+                TBOX_ASSERT(position != d_subdomains[i].overlap_dofs.cend() && *position == indices[j]);
+                d_subdomains[i].update_local_positions.push_back(
+                    static_cast<PetscBLASInt>(position - d_subdomains[i].overlap_dofs.cbegin()));
+            }
+            ierr = ISRestoreIndices(nonoverlap[i], &indices);
+            IBTK_CHKERRQ(ierr);
         }
-        ierr = ISRestoreIndices(nonoverlap[i], &indices);
-        IBTK_CHKERRQ(ierr);
         if (use_multiplicative)
         {
             d_subdomains[i].update_local_positions.resize(n);

--- a/ibtk/src/solvers/impls/PETScLevelSolverPetscShellBackend.cpp
+++ b/ibtk/src/solvers/impls/PETScLevelSolverPetscShellBackend.cpp
@@ -112,7 +112,7 @@ PETScLevelSolverPetscShellBackend::initializeSolverState(Mat mat,
     deallocateSolverState();
     initializeComposition(mat, x, b, use_multiplicative, traversal);
     d_multiplicative = use_multiplicative;
-    TBOX_ASSERT(overlap.size() == nonoverlap.size());
+    TBOX_ASSERT(use_multiplicative || overlap.size() == nonoverlap.size());
     const int n_local = static_cast<int>(overlap.size());
     const int n_max = IBTK_MPI::maxReduction(n_local);
     Mat* sub_mat = nullptr;
@@ -132,27 +132,30 @@ PETScLevelSolverPetscShellBackend::initializeSolverState(Mat mat,
         {
             ierr = ISGetLocalSize(overlap[i], &n_overlap);
             IBTK_CHKERRQ(ierr);
-            ierr = ISGetLocalSize(nonoverlap[i], &n_nonoverlap);
-            IBTK_CHKERRQ(ierr);
             const PetscInt* overlap_indices = nullptr;
             const PetscInt* nonoverlap_indices = nullptr;
             ierr = ISGetIndices(overlap[i], &overlap_indices);
             IBTK_CHKERRQ(ierr);
-            ierr = ISGetIndices(nonoverlap[i], &nonoverlap_indices);
-            IBTK_CHKERRQ(ierr);
-            for (PetscInt j = 0; j < n_nonoverlap; ++j)
+            if (!use_multiplicative)
             {
-                const PetscInt* position =
-                    std::lower_bound(overlap_indices, overlap_indices + n_overlap, nonoverlap_indices[j]);
-                TBOX_ASSERT(position != overlap_indices + n_overlap && *position == nonoverlap_indices[j]);
-                local_nonoverlap.push_back(static_cast<PetscInt>(position - overlap_indices));
+                ierr = ISGetLocalSize(nonoverlap[i], &n_nonoverlap);
+                IBTK_CHKERRQ(ierr);
+                ierr = ISGetIndices(nonoverlap[i], &nonoverlap_indices);
+                IBTK_CHKERRQ(ierr);
+                for (PetscInt j = 0; j < n_nonoverlap; ++j)
+                {
+                    const PetscInt* position =
+                        std::lower_bound(overlap_indices, overlap_indices + n_overlap, nonoverlap_indices[j]);
+                    TBOX_ASSERT(position != overlap_indices + n_overlap && *position == nonoverlap_indices[j]);
+                    local_nonoverlap.push_back(static_cast<PetscInt>(position - overlap_indices));
+                }
+                ierr = ISRestoreIndices(nonoverlap[i], &nonoverlap_indices);
+                IBTK_CHKERRQ(ierr);
             }
             if (use_multiplicative && n_overlap > 0)
             {
                 d_correction_dofs[i].assign(overlap_indices, overlap_indices + n_overlap);
             }
-            ierr = ISRestoreIndices(nonoverlap[i], &nonoverlap_indices);
-            IBTK_CHKERRQ(ierr);
             ierr = ISRestoreIndices(overlap[i], &overlap_indices);
             IBTK_CHKERRQ(ierr);
             ierr = MatCreateVecs(sub_mat[i], &d_sub_x[i], &d_sub_y[i]);
@@ -191,11 +194,14 @@ PETScLevelSolverPetscShellBackend::initializeSolverState(Mat mat,
         IS local_overlap = nullptr, local_partition = nullptr;
         ierr = ISCreateStride(PETSC_COMM_WORLD, n_overlap, 0, 1, &local_overlap);
         IBTK_CHKERRQ(ierr);
-        ierr = ISCreateGeneral(
-            PETSC_COMM_WORLD, n_nonoverlap, local_nonoverlap.data(), PETSC_COPY_VALUES, &local_partition);
-        IBTK_CHKERRQ(ierr);
+        if (!use_multiplicative)
+        {
+            ierr = ISCreateGeneral(
+                PETSC_COMM_WORLD, n_nonoverlap, local_nonoverlap.data(), PETSC_COPY_VALUES, &local_partition);
+            IBTK_CHKERRQ(ierr);
+        }
         IS global_overlap = i < n_local ? overlap[i] : local_overlap;
-        IS global_partition = i < n_local ? nonoverlap[i] : local_partition;
+        IS global_partition = !use_multiplicative && i < n_local ? nonoverlap[i] : local_partition;
         ierr = VecScatterCreate(x, global_overlap, d_sub_x[i], local_overlap, &d_restriction[i]);
         IBTK_CHKERRQ(ierr);
         ierr = VecScatterCreate(d_sub_y[i],

--- a/include/ibamr/StaggeredStokesPETScLevelSolver.h
+++ b/include/ibamr/StaggeredStokesPETScLevelSolver.h
@@ -68,12 +68,20 @@ class CouplingAwareASMSubdomains;
  * equations.
  *
  * asm_subdomain_construction_mode defaults to GEOMETRICAL; COUPLING_AWARE
- * selects velocity-seeded subdomains with the construction contract in
+ * selects coupling-aware subdomains. coupling_aware_asm_patch_seed_type defaults
+ * to VELOCITY_COMPONENT, with the construction contract in
  * StaggeredStokesPETScMatUtilities::construct_patch_level_coupling_aware_asm_subdomains().
  * coupling_aware_asm_seed_axis defaults to 0, seed_stride to 1, closure_policy
  * to RELAXED and relative_zero_tol to 1.0e-14 (all with the
  * coupling_aware_asm_ prefix). coupling_aware_asm_seed_traversal_order
  * defaults to I_J in 2D and I_J_K in 3D; J_I and J_K_I/K_I_J are alternatives.
+ * PRESSURE_CELL selects the patches defined by
+ * StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches().
+ * Pressure-patch application requires pc_type=shell, multiplicative composition
+ * and a matrix supplied through setCouplingAwareASMConstructionMat(); no
+ * nonoverlap partition is formed. Other PETSc-selected PCs bypass construction,
+ * except PCASM, which rejects pressure-cell patches.
+ * The local solves and residual updates use the coupled level operator.
  * Construction settings are read at construction. Cached geometry is rebuilt
  * with solver state; velocity pairing is built only for STRICT construction.
  *
@@ -152,6 +160,19 @@ public:
      * independently to this handle.
      */
     void setAugmentedOperatorMat(Mat augmented_operator_mat);
+
+    /*!
+     * \brief Set the Eulerian elasticity matrix used to construct pressure-cell patches.
+     *
+     * The matrix uses full coupled level numbering with zero pressure rows and
+     * columns, as required by
+     * StaggeredStokesPETScMatUtilities::construct_patch_level_pressure_cell_seeded_cav_patches().
+     * The solver borrows it without copying, modifying or retaining a reference.
+     * Keep it alive and unchanged until deallocateSolverState(), which clears the
+     * borrowed handle. Set, replace or clear it only while deallocated, and resupply
+     * it before reinitialization. Passing nullptr clears the construction matrix.
+     */
+    void setCouplingAwareASMConstructionMat(Mat construction_mat);
 
 protected:
     /*! \copydoc IBTK::PETScLevelSolver::initializeShellBackend */
@@ -246,6 +267,8 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_p_nullspace_var;
     SAMRAI::tbox::Pointer<SAMRAI::xfer::RefineSchedule<NDIM>> d_data_synch_sched, d_ghost_fill_sched;
     ASMSubdomainConstructionMode d_asm_mode = ASMSubdomainConstructionMode::GEOMETRICAL;
+    CouplingAwareASMPatchSeedType d_ca_seed_type = CouplingAwareASMPatchSeedType::VELOCITY_COMPONENT;
+    Mat d_ca_construction_mat = nullptr; // Borrowed for one solver-state lifetime.
     int d_ca_seed_axis = 0, d_ca_seed_stride = 1;
 #if (NDIM == 2)
     CouplingAwareASMSeedTraversalOrder d_ca_order = CouplingAwareASMSeedTraversalOrder::I_J;

--- a/include/ibamr/ibamr_enums.h
+++ b/include/ibamr/ibamr_enums.h
@@ -628,7 +628,7 @@ enum_to_string<IndicatorFunctionType>(IndicatorFunctionType val)
     return "UNKNOWN_INDICATOR_FUNC_TYPE";
 } // enum_to_string
 
-/*! \brief Geometrical or velocity-coupling-based ASM construction. */
+/*! \brief Geometrical or coupling-based ASM construction. */
 enum class ASMSubdomainConstructionMode
 {
     GEOMETRICAL,
@@ -640,6 +640,19 @@ template <>
 ASMSubdomainConstructionMode string_to_enum<ASMSubdomainConstructionMode>(const std::string& val);
 template <>
 std::string enum_to_string<ASMSubdomainConstructionMode>(ASMSubdomainConstructionMode val);
+
+/*! \brief Velocity-component or pressure-cell seeds for coupling-aware patches. */
+enum class CouplingAwareASMPatchSeedType
+{
+    VELOCITY_COMPONENT,
+    PRESSURE_CELL,
+    UNKNOWN
+};
+
+template <>
+CouplingAwareASMPatchSeedType string_to_enum<CouplingAwareASMPatchSeedType>(const std::string& val);
+template <>
+std::string enum_to_string<CouplingAwareASMPatchSeedType>(CouplingAwareASMPatchSeedType val);
 
 /*! \brief Incident-cell closure or complete-stencil filtering. */
 enum class CouplingAwareASMClosurePolicy

--- a/src/navier_stokes/StaggeredStokesPETScLevelSolver.cpp
+++ b/src/navier_stokes/StaggeredStokesPETScLevelSolver.cpp
@@ -54,6 +54,7 @@
 #include <Variable.h>
 #include <VariableContext.h>
 #include <VariableDatabase.h>
+#include <strings.h>
 
 #include <algorithm>
 #include <cmath>
@@ -193,6 +194,36 @@ const bool registered_eigen_schur = []()
 }();
 } // namespace
 
+template <>
+CouplingAwareASMPatchSeedType
+string_to_enum<CouplingAwareASMPatchSeedType>(const std::string& val)
+{
+    if (strcasecmp(val.c_str(), "VELOCITY_COMPONENT") == 0)
+    {
+        return CouplingAwareASMPatchSeedType::VELOCITY_COMPONENT;
+    }
+    if (strcasecmp(val.c_str(), "PRESSURE_CELL") == 0)
+    {
+        return CouplingAwareASMPatchSeedType::PRESSURE_CELL;
+    }
+    return CouplingAwareASMPatchSeedType::UNKNOWN;
+}
+
+template <>
+std::string
+enum_to_string<CouplingAwareASMPatchSeedType>(CouplingAwareASMPatchSeedType val)
+{
+    if (val == CouplingAwareASMPatchSeedType::VELOCITY_COMPONENT)
+    {
+        return "VELOCITY_COMPONENT";
+    }
+    if (val == CouplingAwareASMPatchSeedType::PRESSURE_CELL)
+    {
+        return "PRESSURE_CELL";
+    }
+    return "UNKNOWN";
+}
+
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
 StaggeredStokesPETScLevelSolver::StaggeredStokesPETScLevelSolver(const std::string& object_name,
@@ -205,6 +236,8 @@ StaggeredStokesPETScLevelSolver::StaggeredStokesPETScLevelSolver(const std::stri
     {
         d_asm_mode = string_to_enum<ASMSubdomainConstructionMode>(
             input_db->getStringWithDefault("asm_subdomain_construction_mode", "GEOMETRICAL"));
+        d_ca_seed_type = string_to_enum<CouplingAwareASMPatchSeedType>(
+            input_db->getStringWithDefault("coupling_aware_asm_patch_seed_type", "VELOCITY_COMPONENT"));
         d_ca_seed_axis = input_db->getIntegerWithDefault("coupling_aware_asm_seed_axis", d_ca_seed_axis);
         d_ca_seed_stride = input_db->getIntegerWithDefault("coupling_aware_asm_seed_stride", d_ca_seed_stride);
         d_ca_order = string_to_enum<CouplingAwareASMSeedTraversalOrder>(
@@ -222,7 +255,8 @@ StaggeredStokesPETScLevelSolver::StaggeredStokesPETScLevelSolver(const std::stri
                              d_ca_order == CouplingAwareASMSeedTraversalOrder::J_K_I ||
                              d_ca_order == CouplingAwareASMSeedTraversalOrder::K_I_J;
 #endif
-    if (d_asm_mode == ASMSubdomainConstructionMode::UNKNOWN || d_ca_policy == CouplingAwareASMClosurePolicy::UNKNOWN ||
+    if (d_ca_seed_type == CouplingAwareASMPatchSeedType::UNKNOWN ||
+        d_asm_mode == ASMSubdomainConstructionMode::UNKNOWN || d_ca_policy == CouplingAwareASMClosurePolicy::UNKNOWN ||
         !valid_order || d_ca_seed_axis < 0 || d_ca_seed_axis >= NDIM || d_ca_seed_stride < 1 ||
         !std::isfinite(d_ca_relative_zero_tol) || d_ca_relative_zero_tol < 0.0)
     {
@@ -312,6 +346,17 @@ StaggeredStokesPETScLevelSolver::setAugmentedOperatorMat(Mat augmented_operator_
     return;
 } // setAugmentedOperatorMat
 
+void
+StaggeredStokesPETScLevelSolver::setCouplingAwareASMConstructionMat(Mat construction_mat)
+{
+    if (d_is_initialized)
+    {
+        TBOX_ERROR(d_object_name
+                   << "::setCouplingAwareASMConstructionMat(): deallocate solver state before changing the matrix.\n");
+    }
+    d_ca_construction_mat = construction_mat;
+}
+
 /////////////////////////////// PROTECTED ////////////////////////////////////
 
 void
@@ -319,6 +364,11 @@ StaggeredStokesPETScLevelSolver::initializeShellBackend(IBTK::PETScLevelSolverSh
                                                         const bool use_multiplicative,
                                                         const IBTK::PETScLevelSolverShellTraversal traversal)
 {
+    if (d_asm_mode == ASMSubdomainConstructionMode::COUPLING_AWARE &&
+        d_ca_seed_type == CouplingAwareASMPatchSeedType::PRESSURE_CELL && !use_multiplicative)
+    {
+        TBOX_ERROR(d_object_name << ": pressure-cell CAV requires an unrestricted multiplicative shell smoother.\n");
+    }
     StaggeredStokesEigenSchurComplementShellBackend* schur =
         dynamic_cast<StaggeredStokesEigenSchurComplementShellBackend*>(&backend);
     if (!schur)
@@ -361,6 +411,28 @@ StaggeredStokesPETScLevelSolver::generateASMSubdomains(std::vector<std::set<int>
         {
             d_ca_subdomains =
                 std::make_unique<CouplingAwareASMSubdomains>(d_u_dof_index_idx, d_p_dof_index_idx, d_level);
+        }
+        if (d_ca_seed_type == CouplingAwareASMPatchSeedType::PRESSURE_CELL)
+        {
+            if (d_pc_type != "shell")
+            {
+                TBOX_ERROR(d_object_name << ": pressure-cell CAV requires pc_type=shell.\n");
+            }
+            if (!d_ca_construction_mat)
+            {
+                TBOX_ERROR(d_object_name << ": pressure-cell CAV requires a live elasticity construction matrix.\n");
+            }
+            std::vector<int> pressure_seeds;
+            d_ca_subdomains->constructPressureCellPatches(overlap_is,
+                                                          pressure_seeds,
+                                                          d_num_dofs_per_proc,
+                                                          d_ca_construction_mat,
+                                                          d_ca_seed_stride,
+                                                          d_ca_order,
+                                                          d_ca_policy,
+                                                          d_ca_relative_zero_tol);
+            nonoverlap_is.clear();
+            return;
         }
         d_ca_subdomains->constructSubdomains(overlap_is,
                                              nonoverlap_is,
@@ -592,6 +664,7 @@ StaggeredStokesPETScLevelSolver::deallocateSolverStateSpecialized()
         d_nonoverlap_is.clear();
     }
     d_ca_subdomains.reset();
+    d_ca_construction_mat = nullptr;
 
     // Deallocate DOF index data.
     if (d_level->checkAllocated(d_u_dof_index_idx)) d_level->deallocatePatchData(d_u_dof_index_idx);

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell.cpp
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell.cpp
@@ -1351,12 +1351,18 @@ reference_action(Mat mat,
             const PetscInt* owned = nullptr;
             ierr = ISGetLocalSize(overlap[i], &n);
             IBTK_CHKERRQ(ierr);
-            ierr = ISGetLocalSize(partition[i], &m);
-            IBTK_CHKERRQ(ierr);
+            if (!multiplicative)
+            {
+                ierr = ISGetLocalSize(partition[i], &m);
+                IBTK_CHKERRQ(ierr);
+            }
             ierr = ISGetIndices(overlap[i], &indices);
             IBTK_CHKERRQ(ierr);
-            ierr = ISGetIndices(partition[i], &owned);
-            IBTK_CHKERRQ(ierr);
+            if (!multiplicative)
+            {
+                ierr = ISGetIndices(partition[i], &owned);
+                IBTK_CHKERRQ(ierr);
+            }
             Vec local_rhs = nullptr, local_solution = nullptr;
             ierr = MatCreateVecs(submat[i], &local_solution, &local_rhs);
             IBTK_CHKERRQ(ierr);
@@ -1405,8 +1411,11 @@ reference_action(Mat mat,
             }
             ierr = VecRestoreArrayRead(local_solution, &solution_values);
             IBTK_CHKERRQ(ierr);
-            ierr = ISRestoreIndices(partition[i], &owned);
-            IBTK_CHKERRQ(ierr);
+            if (!multiplicative)
+            {
+                ierr = ISRestoreIndices(partition[i], &owned);
+                IBTK_CHKERRQ(ierr);
+            }
             ierr = ISRestoreIndices(overlap[i], &indices);
             IBTK_CHKERRQ(ierr);
             ierr = KSPDestroy(&ksp);
@@ -1436,6 +1445,76 @@ reference_action(Mat mat,
     IBTK_CHKERRQ(ierr);
     ierr = VecDestroy(&residual);
     IBTK_CHKERRQ(ierr);
+}
+
+// The application fixture has one distant face edge initially and a complete
+// remote velocity stencil after reinitialization. Enumerate logical cell supports
+// independently of the production geometry owner and its global-index closure.
+std::vector<std::set<int>>
+cav_application_patches(const CAFields& fields, const int n, const bool strict, const int cycle, Mat elasticity)
+{
+    const CACell origin{};
+    CACell remote{};
+    remote.fill(2);
+    const int source = fields.at(origin)[0];
+    std::set<int> targets{ fields.at(remote)[0] };
+    if (cycle == 1)
+    {
+        targets = ca_cell_stencil(fields, remote, n);
+        targets.erase(fields.at(remote)[NDIM]);
+    }
+    int ierr = MatZeroEntries(elasticity);
+    IBTK_CHKERRQ(ierr);
+    for (const int target : targets)
+    {
+        // A symmetric positive semidefinite spring couples the two velocities.
+        ierr = MatSetValue(elasticity, source, source, 0.25, ADD_VALUES);
+        IBTK_CHKERRQ(ierr);
+        ierr = MatSetValue(elasticity, target, target, 0.25, ADD_VALUES);
+        IBTK_CHKERRQ(ierr);
+        ierr = MatSetValue(elasticity, source, target, -0.25, ADD_VALUES);
+        IBTK_CHKERRQ(ierr);
+        ierr = MatSetValue(elasticity, target, source, -0.25, ADD_VALUES);
+        IBTK_CHKERRQ(ierr);
+    }
+    ierr = MatAssemblyBegin(elasticity, MAT_FINAL_ASSEMBLY);
+    IBTK_CHKERRQ(ierr);
+    ierr = MatAssemblyEnd(elasticity, MAT_FINAL_ASSEMBLY);
+    IBTK_CHKERRQ(ierr);
+    std::vector<std::set<int>> patches;
+    for (const auto& seed : fields)
+    {
+        std::set<int> patch = ca_cell_stencil(fields, seed.first, n);
+        std::set<int> velocities = patch;
+        velocities.erase(seed.second[NDIM]);
+        const std::set<int> original = velocities;
+        if (original.count(source))
+        {
+            velocities.insert(targets.begin(), targets.end());
+        }
+        if (std::any_of(targets.begin(), targets.end(), [&](int dof) { return original.count(dof); }))
+        {
+            velocities.insert(source);
+        }
+        if (velocities != original)
+        {
+            for (const auto& candidate : fields)
+            {
+                const std::set<int> stencil = ca_cell_stencil(fields, candidate.first, n);
+                int incident = 0;
+                for (const int dof : stencil)
+                {
+                    incident += velocities.count(dof);
+                }
+                if (strict ? incident == 2 * NDIM : incident > 0)
+                {
+                    patch.insert(stencil.begin(), stencil.end());
+                }
+            }
+        }
+        patches.push_back(std::move(patch));
+    }
+    return patches;
 }
 
 class FieldCheckingSolver : public StaggeredStokesPETScLevelSolver
@@ -1686,8 +1765,12 @@ main(int argc, char* argv[])
         plog << std::setprecision(12);
         return check_eigen_local(test);
     }
+    const bool cav = test->keyExists("cav_application");
+    const std::string cav_scenario = cav ? test->getString("cav_application") : "";
+    const bool cav_override = cav_scenario == "pc_override";
+    const bool cav_strict = test->getStringWithDefault("coupling_aware_asm_closure_policy", "RELAXED") == "STRICT";
     const bool boundary = test->getBoolWithDefault("boundary", false);
-    const bool lifetime = test->getBoolWithDefault("lifetime", false);
+    const bool lifetime = (cav && !cav_override) || test->getBoolWithDefault("lifetime", false);
     const bool invalid = test->getBoolWithDefault("invalid", false);
     const std::string shell_type = test->getStringWithDefault("shell_pc_type", "multiplicative");
     const bool multiplicative = shell_type.rfind("multiplicative", 0) == 0;
@@ -1778,8 +1861,33 @@ main(int argc, char* argv[])
             }
         }
     }
+    CAFields cav_fields;
     std::vector<int> dofs;
     StaggeredStokesPETScVecUtilities::constructPatchLevelDOFIndices(dofs, udi, pdi, level);
+    if (cav)
+    {
+        for (PatchLevel<NDIM>::Iterator patch_number(level); patch_number; patch_number++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(patch_number());
+            Pointer<SideData<NDIM, int>> velocity = patch->getPatchData(udi);
+            Pointer<CellData<NDIM, int>> pressure = patch->getPatchData(pdi);
+            Pointer<CellData<NDIM, double>> pressure_rhs = patch->getPatchData(hi);
+            for (Box<NDIM>::Iterator it(patch->getBox()); it; it++)
+            {
+                CACell cell{};
+                for (int axis = 0; axis < NDIM; ++axis)
+                {
+                    cell[axis] = it()(axis);
+                }
+                for (int axis = 0; axis < NDIM; ++axis)
+                {
+                    cav_fields[cell][axis] = (*velocity)(SideIndex<NDIM>(it(), axis, SideIndex<NDIM>::Lower));
+                }
+                cav_fields[cell][NDIM] = (*pressure)(it());
+                (*pressure_rhs)(it()) = 0.125 * std::sin(wavenumber * it()(0));
+            }
+        }
+    }
     Vec rhs = nullptr, expected = nullptr, actual = nullptr;
     int ierr = VecCreateMPI(PETSC_COMM_WORLD, dofs[IBTK_MPI::getRank()], PETSC_DETERMINE, &rhs);
     IBTK_CHKERRQ(ierr);
@@ -1807,6 +1915,12 @@ main(int argc, char* argv[])
     }
     db->putBool("initial_guess_nonzero", false);
     db->putInteger("max_iterations", 1);
+    if (cav)
+    {
+        db->putString("asm_subdomain_construction_mode", "COUPLING_AWARE");
+        db->putString("coupling_aware_asm_patch_seed_type", "PRESSURE_CELL");
+        db->putString("coupling_aware_asm_closure_policy", cav_strict ? "STRICT" : "RELAXED");
+    }
     int box_size[NDIM];
     std::fill_n(box_size, NDIM, test->getIntegerWithDefault("box_size", boundary ? input->getInteger("N") : 4));
     db->putIntegerArray("subdomain_box_size", box_size, NDIM);
@@ -1847,6 +1961,32 @@ main(int argc, char* argv[])
             solver.setPhysicalBoundaryHelper(helper);
             solver.setHomogeneousBc(false);
         }
+        Mat elasticity = nullptr;
+        std::vector<std::set<int>> cav_expected, previous_patches;
+        if (cav && !cav_override)
+        {
+            ierr = MatCreateSeqDense(PETSC_COMM_WORLD, dofs.front(), dofs.front(), nullptr, &elasticity);
+            IBTK_CHKERRQ(ierr);
+            ierr = MatAssemblyBegin(elasticity, MAT_FINAL_ASSEMBLY);
+            IBTK_CHKERRQ(ierr);
+            ierr = MatAssemblyEnd(elasticity, MAT_FINAL_ASSEMBLY);
+            IBTK_CHKERRQ(ierr);
+            cav_expected = cav_application_patches(cav_fields, input->getInteger("N"), cav_strict, 0, elasticity);
+            if (cav_scenario != "missing_matrix")
+            {
+                PetscInt before = 0, after = 0;
+                ierr = PetscObjectGetReference(reinterpret_cast<PetscObject>(elasticity), &before);
+                IBTK_CHKERRQ(ierr);
+                solver.setCouplingAwareASMConstructionMat(elasticity);
+                ierr = PetscObjectGetReference(reinterpret_cast<PetscObject>(elasticity), &after);
+                IBTK_CHKERRQ(ierr);
+                if (before != after)
+                {
+                    ++failures;
+                }
+            }
+            solver.setAugmentedOperatorMat(elasticity);
+        }
         Mat supplied = nullptr;
         if (diagonal_operator)
         {
@@ -1886,12 +2026,23 @@ main(int argc, char* argv[])
             db->putString("shell_pc_subdomain_traversal", test->getString("shell_pc_subdomain_traversal"));
         }
         solver.initializeSolverState(x, b);
+        if (cav_scenario == "initialized_setter")
+        {
+            solver.setCouplingAwareASMConstructionMat(elasticity);
+        }
+        if (cav && !cav_override && cav_scenario != "apply")
+        {
+            solver.deallocateSolverState();
+            ierr = MatDestroy(&elasticity);
+            IBTK_CHKERRQ(ierr);
+            return 0;
+        }
         if (invalid)
         {
             solver.deallocateSolverState();
             return 0;
         }
-        if (lifetime && !diagonal_operator)
+        if (lifetime && !diagonal_operator && !cav)
         {
             Mat assembled = nullptr;
             ierr = KSPGetOperators(solver.getPETScKSP(), &assembled, nullptr);
@@ -1941,7 +2092,7 @@ main(int argc, char* argv[])
             PCType pc_type = nullptr;
             ierr = PCGetType(pc, &pc_type);
             IBTK_CHKERRQ(ierr);
-            if (std::string(pc_type) != "shell" || (lifetime && mat != supplied))
+            if (std::string(pc_type) != (cav_override ? "none" : "shell") || (lifetime && !cav && mat != supplied))
             {
                 ++failures;
             }
@@ -1970,7 +2121,34 @@ main(int argc, char* argv[])
                 std::vector<IS>* overlap = nullptr;
                 std::vector<IS>* partition = nullptr;
                 solver.getASMSubdomains(&partition, &overlap);
-                reference_action(mat, rhs, expected, *overlap, *partition, multiplicative, traversal);
+                if (cav_override)
+                {
+                    if (!partition->empty() || !overlap->empty())
+                    {
+                        ++failures;
+                    }
+                    plog << "effective_pc = " << pc_type << '\n';
+                }
+                else if (cav)
+                {
+                    const std::vector<std::set<int>> patches = ca_read_sets(*overlap);
+                    if (!partition->empty() || patches != cav_expected || (cycle == 1 && patches == previous_patches))
+                    {
+                        ++failures;
+                    }
+                    previous_patches = patches;
+                    plog << "pressure_patches = " << patches.size() << "\npartition_size = " << partition->size()
+                         << '\n';
+                }
+                if (cav_override)
+                {
+                    ierr = VecCopy(rhs, expected);
+                    IBTK_CHKERRQ(ierr);
+                }
+                else
+                {
+                    reference_action(mat, rhs, expected, *overlap, *partition, multiplicative, traversal);
+                }
                 // Left-preconditioned PETSc KSP removes the operator nullspace after PCApply.
                 MatNullSpace nullspace = nullptr;
                 ierr = MatGetNullSpace(mat, &nullspace);
@@ -1988,6 +2166,25 @@ main(int argc, char* argv[])
             }
             StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(actual, ui, udi, pi, pdi, level);
             const double action_norm = norm_inf(actual);
+            if (cav)
+            {
+                PetscScalar pressure_sum = 0.0;
+                const PetscScalar* values = nullptr;
+                ierr = VecGetArrayRead(actual, &values);
+                IBTK_CHKERRQ(ierr);
+                for (const auto& cell : cav_fields)
+                {
+                    pressure_sum += values[cell.second[NDIM]];
+                }
+                ierr = VecRestoreArrayRead(actual, &values);
+                IBTK_CHKERRQ(ierr);
+                const double pressure_mean = static_cast<double>(PetscRealPart(pressure_sum)) / cav_fields.size();
+                if (!std::isfinite(pressure_mean) || std::abs(pressure_mean) > 1.0e-9)
+                {
+                    ++failures;
+                }
+                plog << "pressure_mean = " << pressure_mean << '\n';
+            }
             if (default_forward)
             {
                 ierr = VecAXPY(default_forward, -1.0, actual);
@@ -2031,8 +2228,41 @@ main(int argc, char* argv[])
                 }
                 plog << "repeated_error = " << repeated_error << '\n';
             }
+            std::vector<IS>* cav_overlap = nullptr;
+            std::vector<IS>* cav_partition = nullptr;
+            if (cav)
+            {
+                // Query while initialized; the returned containers outlive solver state.
+                solver.getASMSubdomains(&cav_partition, &cav_overlap);
+            }
             solver.deallocateSolverState();
-            if (lifetime)
+            if (cav)
+            {
+                if (!cav_overlap->empty() || !cav_partition->empty())
+                {
+                    ++failures;
+                }
+                if (!cav_override)
+                {
+                    PetscReal matrix_norm = 0.0;
+                    ierr = MatNorm(elasticity, NORM_INFINITY, &matrix_norm);
+                    IBTK_CHKERRQ(ierr);
+                    if (matrix_norm != 0.5 * (cycle == 0 ? 1 : 2 * NDIM))
+                    {
+                        ++failures;
+                    }
+                }
+                if (cycle == 0 && !cav_override)
+                {
+                    solver.setAugmentedOperatorMat(nullptr);
+                    cav_expected =
+                        cav_application_patches(cav_fields, input->getInteger("N"), cav_strict, 1, elasticity);
+                    solver.setCouplingAwareASMConstructionMat(elasticity);
+                    solver.setAugmentedOperatorMat(elasticity);
+                    solver.initializeSolverState(x, b);
+                }
+            }
+            else if (lifetime)
             {
                 PetscReal matrix_norm = 0.0;
                 ierr = MatNorm(supplied, NORM_INFINITY, &matrix_norm);
@@ -2052,6 +2282,8 @@ main(int argc, char* argv[])
                 }
             }
         }
+        ierr = MatDestroy(&elasticity);
+        IBTK_CHKERRQ(ierr);
         ierr = VecDestroy(&default_forward);
         IBTK_CHKERRQ(ierr);
         ierr = MatDestroy(&supplied);

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_additive.expect_error=true.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_additive.expect_error=true.input
@@ -1,0 +1,42 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "additive"
+ coupling_aware_asm_closure_policy = "RELAXED"
+ shell_pc_type = "additive"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_additive.expect_error=true.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_additive.expect_error=true.output
@@ -1,0 +1,4 @@
+Program abort called with error message
+
+    shell_solver: pressure-cell CAV requires an unrestricted multiplicative shell smoother.
+

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_asm.expect_error=true.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_asm.expect_error=true.input
@@ -1,0 +1,42 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell_cav_asm.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "asm"
+ coupling_aware_asm_closure_policy = "RELAXED"
+ shell_pc_type = "multiplicative"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_asm.expect_error=true.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_asm.expect_error=true.output
@@ -1,0 +1,4 @@
+Program abort called with error message
+
+    shell_solver: pressure-cell CAV requires pc_type=shell.
+

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_initialized_setter.expect_error=true.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_initialized_setter.expect_error=true.input
@@ -1,0 +1,42 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "initialized_setter"
+ coupling_aware_asm_closure_policy = "RELAXED"
+ shell_pc_type = "multiplicative"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_initialized_setter.expect_error=true.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_initialized_setter.expect_error=true.output
@@ -1,0 +1,4 @@
+Program abort called with error message
+
+    shell_solver::setCouplingAwareASMConstructionMat(): deallocate solver state before changing the matrix.
+

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_missing_matrix.expect_error=true.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_missing_matrix.expect_error=true.input
@@ -1,0 +1,42 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "missing_matrix"
+ coupling_aware_asm_closure_policy = "RELAXED"
+ shell_pc_type = "multiplicative"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_missing_matrix.expect_error=true.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_missing_matrix.expect_error=true.output
@@ -1,0 +1,4 @@
+Program abort called with error message
+
+    shell_solver: pressure-cell CAV requires a live elasticity construction matrix.
+

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_pc_override.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_pc_override.input
@@ -1,0 +1,42 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell_cav_none.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "pc_override"
+ coupling_aware_asm_closure_policy = "RELAXED"
+ shell_pc_type = "multiplicative"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_pc_override.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_pc_override.output
@@ -1,0 +1,5 @@
+effective_pc = none
+pressure_mean = 0
+action_norm = 1.5
+error = 0
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_blas_lapack.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_blas_lapack.input
@@ -1,0 +1,43 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "apply"
+ coupling_aware_asm_closure_policy = "RELAXED"
+ shell_pc_type = "multiplicative-blas-lapack"
+ blas_lapack_subdomain_solver_type = "svd"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_blas_lapack.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_blas_lapack.output
@@ -1,0 +1,13 @@
+pressure_patches = 16
+partition_size = 0
+pressure_mean = 1.73472347598e-18
+action_norm = 0.254534600232
+error = 2.77555756156e-16
+repeated_error = 2.77555756156e-16
+pressure_patches = 16
+partition_size = 0
+pressure_mean = -6.93889390391e-18
+action_norm = 0.493241332266
+error = 5.87203896618e-16
+repeated_error = 5.87203896618e-16
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_eigen.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_eigen.input
@@ -1,0 +1,43 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "apply"
+ coupling_aware_asm_closure_policy = "RELAXED"
+ shell_pc_type = "multiplicative-eigen"
+ eigen_subdomain_solver_type = "FULL_PIV_HOUSEHOLDER_QR"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_eigen.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_eigen.output
@@ -1,0 +1,13 @@
+pressure_patches = 16
+partition_size = 0
+pressure_mean = -1.04083408559e-17
+action_norm = 0.254534600232
+error = 5.93275428784e-16
+repeated_error = 5.93275428784e-16
+pressure_patches = 16
+partition_size = 0
+pressure_mean = 6.07153216592e-18
+action_norm = 0.493241332266
+error = 5.49560397189e-15
+repeated_error = 5.49560397189e-15
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_petsc.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_petsc.input
@@ -1,0 +1,42 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "apply"
+ coupling_aware_asm_closure_policy = "RELAXED"
+ shell_pc_type = "multiplicative"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_petsc.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_relaxed_petsc.output
@@ -1,0 +1,13 @@
+pressure_patches = 16
+partition_size = 0
+pressure_mean = 0
+action_norm = 0.254534600232
+error = 8.32667268469e-17
+repeated_error = 8.32667268469e-17
+pressure_patches = 16
+partition_size = 0
+pressure_mean = -4.33680868994e-18
+action_norm = 0.493241332266
+error = 6.96491475605e-16
+repeated_error = 6.96491475605e-16
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_strict_eigen_schur.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_strict_eigen_schur.input
@@ -1,0 +1,44 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "apply"
+ coupling_aware_asm_closure_policy = "STRICT"
+ shell_pc_type = "multiplicative-eigen-schur-complement"
+ a00_solver_type = "FULL_PIV_LU"
+ schur_solver_type = "JACOBI_SVD"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_strict_eigen_schur.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_strict_eigen_schur.output
@@ -1,0 +1,15 @@
+velocity_dofs = 32 pressure_dofs = 16
+pressure_patches = 16
+partition_size = 0
+pressure_mean = -1.73472347598e-18
+action_norm = 0.233941349699
+error = 1.11022302463e-14
+repeated_error = 1.11022302463e-14
+velocity_dofs = 32 pressure_dofs = 16
+pressure_patches = 16
+partition_size = 0
+pressure_mean = -4.33680868994e-18
+action_norm = 0.238584215378
+error = 1.05193631583e-14
+repeated_error = 1.05193631583e-14
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_strict_petsc.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_strict_petsc.input
@@ -1,0 +1,42 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "apply"
+ coupling_aware_asm_closure_policy = "STRICT"
+ shell_pc_type = "multiplicative"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_strict_petsc.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_2d.CAV.apply_strict_petsc.output
@@ -1,0 +1,13 @@
+pressure_patches = 16
+partition_size = 0
+pressure_mean = 2.60208521397e-18
+action_norm = 0.233941349699
+error = 1.38777878078e-16
+repeated_error = 1.38777878078e-16
+pressure_patches = 16
+partition_size = 0
+pressure_mean = -6.93889390391e-18
+action_norm = 0.238584215378
+error = 8.32667268469e-17
+repeated_error = 8.32667268469e-17
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_relaxed_petsc.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_relaxed_petsc.input
@@ -1,0 +1,42 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "apply"
+ coupling_aware_asm_closure_policy = "RELAXED"
+ shell_pc_type = "multiplicative"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 1, 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_relaxed_petsc.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_relaxed_petsc.output
@@ -1,0 +1,13 @@
+pressure_patches = 64
+partition_size = 0
+pressure_mean = 5.20417042793e-18
+action_norm = 0.354849931227
+error = 1.11022302463e-16
+repeated_error = 1.11022302463e-16
+pressure_patches = 64
+partition_size = 0
+pressure_mean = -4.33680868994e-18
+action_norm = 0.366004609991
+error = 1.66533453694e-16
+repeated_error = 1.66533453694e-16
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_blas_lapack.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_blas_lapack.input
@@ -1,0 +1,43 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "apply"
+ coupling_aware_asm_closure_policy = "STRICT"
+ shell_pc_type = "multiplicative-blas-lapack"
+ blas_lapack_subdomain_solver_type = "svd"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 1, 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_blas_lapack.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_blas_lapack.output
@@ -1,0 +1,13 @@
+pressure_patches = 64
+partition_size = 0
+pressure_mean = 5.20417042793e-18
+action_norm = 0.325767678053
+error = 3.33066907388e-16
+repeated_error = 3.33066907388e-16
+pressure_patches = 64
+partition_size = 0
+pressure_mean = -2.16840434497e-18
+action_norm = 0.323801574248
+error = 3.88578058619e-16
+repeated_error = 3.88578058619e-16
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_eigen_pseudoinverse.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_eigen_pseudoinverse.input
@@ -1,0 +1,43 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "apply"
+ coupling_aware_asm_closure_policy = "STRICT"
+ shell_pc_type = "multiplicative-eigen-pseudoinverse"
+ eigen_subdomain_pseudoinverse_type = "JACOBI_SVD"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 1, 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_eigen_pseudoinverse.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_eigen_pseudoinverse.output
@@ -1,0 +1,13 @@
+pressure_patches = 64
+partition_size = 0
+pressure_mean = 9.54097911787e-18
+action_norm = 0.325767678053
+error = 1.02973185534e-14
+repeated_error = 1.02973185534e-14
+pressure_patches = 64
+partition_size = 0
+pressure_mean = -1.04083408559e-17
+action_norm = 0.323801574248
+error = 9.78384040451e-15
+repeated_error = 9.78384040451e-15
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_petsc.input
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_petsc.input
@@ -1,0 +1,42 @@
+PETSC_OPTIONS_FILE = "stokes_petsc_level_solver_shell.opts"
+test {
+ f_data_type = "CELL"
+ n_components = 1
+ ghost_width = 1
+ cav_application = "apply"
+ coupling_aware_asm_closure_policy = "STRICT"
+ shell_pc_type = "multiplicative"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+}
+N = 4
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 1, 1, 1
+}
+GriddingAlgorithm {
+   max_levels = 1
+   largest_patch_size {
+      level_0 = N/2, N/2, N/2
+   }
+   smallest_patch_size {
+      level_0 = N/2, N/2, N/2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   }
+}
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_petsc.output
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_3d.CAV.apply_strict_petsc.output
@@ -1,0 +1,13 @@
+pressure_patches = 64
+partition_size = 0
+pressure_mean = -1.90819582357e-17
+action_norm = 0.325767678053
+error = 1.66533453694e-16
+repeated_error = 1.66533453694e-16
+pressure_patches = 64
+partition_size = 0
+pressure_mean = -1.25767452008e-17
+action_norm = 0.323801574248
+error = 1.11022302463e-16
+repeated_error = 1.11022302463e-16
+failures = 0

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_cav_asm.opts
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_cav_asm.opts
@@ -1,0 +1,1 @@
+-shell_pc_type asm

--- a/tests/navier_stokes/stokes_petsc_level_solver_shell_cav_none.opts
+++ b/tests/navier_stokes/stokes_petsc_level_solver_shell_cav_none.opts
@@ -1,0 +1,1 @@
+-shell_pc_type none


### PR DESCRIPTION
Apply the pressure-cell-seeded coupling-aware Vanka (CAV) patches as a multiplicative shell smoother in `StaggeredStokesPETScLevelSolver`, using a supplied elasticity construction matrix.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?

