### PR TITLE
Fix Poiseuille test registration

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,7 +154,7 @@ SETUP(multiphase_flow water_entry_circular_cylinder.cpp IBAMR2d)
 # navier_stokes:
 SETUP_2D(navier_stokes navier_stokes_01.cpp)
 SETUP_3D(navier_stokes navier_stokes_01.cpp)
-SETUP_2D(navier_stokes poiseuille_flow_2d.cpp)
+SETUP(navier_stokes poiseuille_flow_2d.cpp IBAMR2d)
 SETUP_2D(navier_stokes stokes_operator.cpp)
 SETUP_3D(navier_stokes stokes_operator.cpp)
 


### PR DESCRIPTION
Register the existing Poiseuille regression under the executable name expected by `attest`, so it runs without an alias. This restores coverage associated with #1610 and #1687.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [ ] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
