### PR TITLE
[CAV R15] Smooth Stokes-IB FAC levels with coupling-aware Vanka patches

### DIFF
--- a/doc/news/changes/minor/20260910Boyce_R15
+++ b/doc/news/changes/minor/20260910Boyce_R15
@@ -1,0 +1,3 @@
+New: Integrate multiplicative CAV smoothing with the Stokes-IB FAC preconditioner.
+<br>
+(Boyce Griffith, 2026/09/10)

--- a/src/IB/StaggeredStokesIBLevelRelaxationFACOperator.cpp
+++ b/src/IB/StaggeredStokesIBLevelRelaxationFACOperator.cpp
@@ -600,6 +600,7 @@ StaggeredStokesIBLevelRelaxationFACOperator::initializeOperatorStateSpecialized(
             level_solver->setOperatorMat(nullptr);
             level_solver->setAugmentedOperatorMat(d_SAJ_mat[ln]);
         }
+        level_solver->setCouplingAwareASMConstructionMat(d_SAJ_mat[ln]);
         level_solver->initializeSolverState(*getLevelSAMRAIVectorReal(*d_solution, ln),
                                             *getLevelSAMRAIVectorReal(*d_rhs, ln));
         const KSP level_ksp = level_solver->getPETScKSP();
@@ -661,6 +662,7 @@ StaggeredStokesIBLevelRelaxationFACOperator::initializeOperatorStateSpecialized(
             p_coarse_petsc_solver->setOperatorMat(d_galerkin_stokesib_mat[d_coarsest_ln]);
             p_coarse_petsc_solver->setAugmentedOperatorMat(nullptr);
         }
+        p_coarse_petsc_solver->setCouplingAwareASMConstructionMat(d_SAJ_mat[d_coarsest_ln]);
         d_coarse_solver->initializeSolverState(*getLevelSAMRAIVectorReal(*d_solution, d_coarsest_ln),
                                                *getLevelSAMRAIVectorReal(*d_rhs, d_coarsest_ln));
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -212,6 +212,9 @@ SETUP(IB explicit_ex1.cpp IBAMR2d)
 SETUP(IB implicit_stokes_ib_01.cpp IBAMR2d)
 SETUP(IB implicit_stokes_ib_coarse_saj_transfer_parity_01.cpp IBAMR2d)
 SETUP(IB implicit_stokes_ib_solver_components_01.cpp IBAMR2d)
+SETUP_3D(IB implicit_stokes_ib_solver_components_01.cpp)
+TARGET_COMPILE_DEFINITIONS(tests-IB_implicit_stokes_ib_solver_components_01_3d PRIVATE
+  IBTK_MAX_BSPLINE_ORDER=${IBTK_MAX_BSPLINE_ORDER})
 TARGET_COMPILE_DEFINITIONS(tests-IB_implicit_stokes_ib_solver_components_01 PRIVATE
   IBTK_MAX_BSPLINE_ORDER=${IBTK_MAX_BSPLINE_ORDER})
 SETUP(IB ib_body_force.cpp IBAMR2d)

--- a/tests/IB/implicit_stokes_ib_01.cav_regrid.input
+++ b/tests/IB/implicit_stokes_ib_01.cav_regrid.input
@@ -1,0 +1,100 @@
+N = 8
+MAX_LEVELS = 2
+VERIFY_REGRID = TRUE
+IB_RULE = "BACKWARD_EULER"
+JAC_KERNEL = "IB_4"
+custom_kernel = FALSE
+IBHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.0025
+   dt_max = 0.001
+   num_cycles = 1
+   regrid_interval = 1
+   error_on_dt_change = FALSE
+   warn_on_dt_change = FALSE
+   time_stepping_type = IB_RULE
+   jacobian_delta_fcn = JAC_KERNEL
+   rel_residual_tol = 1.0e-10
+   abs_residual_tol = 1.0e-12
+   max_iterations = 20
+   stokes_ib_precond_db {
+      has_pressure_nullspace = TRUE
+      U_prolongation_method = "RT0_REFINE"
+      U_restriction_method = "RT0_COARSEN"
+      num_pre_sweeps = 1
+      num_post_sweeps = 1
+      level_solver_type = "PETSC_LEVEL_SOLVER"
+      level_solver_max_iterations = 1
+      level_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+      }
+      coarse_solver_max_iterations = 1
+      coarse_solver_db {
+         ksp_type = "preonly"
+         pc_type = "svd"
+         initial_guess_nonzero = FALSE
+      }
+   }
+}
+INSStaggeredHierarchyIntegrator {
+   start_time = 0.0
+   end_time = 0.0025
+   mu = 0.01
+   rho = 1.0
+   creeping_flow = TRUE
+   viscous_time_stepping_type = "BACKWARD_EULER"
+   normalize_pressure = TRUE
+   num_cycles = 1
+   dt_max = 0.001
+   enable_logging_solver_iterations = FALSE
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = MAX_LEVELS
+   base_filenames_1 = "ellipse"
+}
+VelocityInitialConditions {
+   function_0 = "0.1*sin(2*pi*X_1)"
+   function_1 = "0.05*cos(2*pi*X_0)"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "100"
+      stokes_ib_pc_level_0_ksp_type = "preonly"
+      stokes_ib_pc_level_0_pc_type = "svd"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser { level_1 = 2,2 }
+   largest_patch_size { level_0 = N,N
+      level_1 = 2*N,2*N }
+   smallest_patch_size { level_0 = N,N
+      level_1 = 2*N,2*N }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes { level_0 = [(0, 0), (N - 1, N - 1)] }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_01.cav_regrid.output
+++ b/tests/IB/implicit_stokes_ib_01.cav_regrid.output
@@ -1,0 +1,8 @@
+IBHierarchyIntegrator::initializePatchHierarchy(): tag_buffer = 3
+INSStaggeredHierarchyIntegrator::initializeCompositeHierarchyData():
+  projecting the interpolated velocity field
+IBRedundantInitializer:  Deallocating initialization data.
+step 1 time 1.00000000e-03 velocity_L2 7.90343261e-02 pressure_L2 5.94053932e-01 radius_L2 8.71318690e-01
+step 2 time 2.00000000e-03 velocity_L2 7.90290925e-02 pressure_L2 5.94051440e-01 radius_L2 8.71314470e-01
+step 3 time 2.50000000e-03 velocity_L2 7.90331011e-02 pressure_L2 5.94050332e-01 radius_L2 8.71311859e-01
+regrids 3 levels 2

--- a/tests/IB/implicit_stokes_ib_01.cpp
+++ b/tests/IB/implicit_stokes_ib_01.cpp
@@ -76,14 +76,32 @@ count_integration_cycles(double /*current_time*/, double /*new_time*/, const int
     ++*callback_count;
 }
 
+struct RegridState
+{
+    int count = 0;
+    int expected_levels = 1;
+};
+
+void
+count_regrids(Pointer<BasePatchHierarchy<NDIM>> hierarchy, double /*data_time*/, bool /*initial_time*/, void* ctx)
+{
+    auto* state = static_cast<RegridState*>(ctx);
+    if (hierarchy->getNumberOfLevels() != state->expected_levels)
+    {
+        TBOX_ERROR("Regrid did not retain the assigned hierarchy levels.\n");
+    }
+    ++state->count;
+}
+
 void
 generate_structure(const unsigned int& structure,
                    const int& level,
                    int& num_vertices,
                    std::vector<IBTK::Point>& positions,
-                   void*)
+                   void* ctx)
 {
-    num_vertices = (structure == 0 && level == 0) ? NUM_POINTS : 0;
+    const int finest_level = *static_cast<const int*>(ctx);
+    num_vertices = (structure == 0 && level == finest_level) ? NUM_POINTS : 0;
     positions.resize(num_vertices);
     for (int k = 0; k < num_vertices; ++k)
     {
@@ -99,9 +117,10 @@ generate_springs(
     const int& level,
     std::multimap<int, IBRedundantInitializer::Edge>& spring_map,
     std::map<IBRedundantInitializer::Edge, IBRedundantInitializer::SpringSpec, IBRedundantInitializer::EdgeComp>& specs,
-    void*)
+    void* ctx)
 {
-    if (structure != 0 || level != 0)
+    const int finest_level = *static_cast<const int*>(ctx);
+    if (structure != 0 || level != finest_level)
     {
         return;
     }
@@ -125,10 +144,8 @@ int
 main(int argc, char* argv[])
 {
     IBTKInit init(argc, argv, MPI_COMM_WORLD);
-#ifndef IBTK_HAVE_SILO
-    // Suppress warnings caused by running without Silo.
+    // Keep optional-library warnings and build paths out of compared output.
     SAMRAI::tbox::Logger::getInstance()->setWarning(false);
-#endif
     {
         Pointer<AppInitializer> app = new AppInitializer(argc, argv, "output");
         Pointer<Database> input = app->getInputDatabase();
@@ -143,6 +160,14 @@ main(int argc, char* argv[])
         Pointer<IBMethod> method = new IBMethod("IBMethod", app->getComponentDatabase("IBMethod"));
         Pointer<IBImplicitStaggeredHierarchyIntegrator> integrator = new IBImplicitStaggeredHierarchyIntegrator(
             "IBHierarchyIntegrator", app->getComponentDatabase("IBHierarchyIntegrator"), method, ins);
+        int finest_level = input->getIntegerWithDefault("MAX_LEVELS", 1) - 1;
+        const bool verify_regrid = input->getBoolWithDefault("VERIFY_REGRID", false);
+        RegridState regrid_state;
+        regrid_state.expected_levels = finest_level + 1;
+        if (verify_regrid)
+        {
+            integrator->registerRegridHierarchyCallback(count_regrids, &regrid_state);
+        }
         int callback_count = 0;
         integrator->registerIntegrateHierarchyCallback(count_integration_cycles, &callback_count);
         Pointer<CartesianGridGeometry<NDIM>> geometry =
@@ -157,9 +182,9 @@ main(int argc, char* argv[])
             "GriddingAlgorithm", app->getComponentDatabase("GriddingAlgorithm"), tagging, boxes, load_balancer);
         Pointer<IBRedundantInitializer> initializer =
             new IBRedundantInitializer("IBRedundantInitializer", app->getComponentDatabase("IBRedundantInitializer"));
-        initializer->setStructureNamesOnLevel(0, { "ellipse" });
-        initializer->registerInitStructureFunction(generate_structure);
-        initializer->registerInitSpringDataFunction(generate_springs);
+        initializer->setStructureNamesOnLevel(finest_level, { "ellipse" });
+        initializer->registerInitStructureFunction(generate_structure, &finest_level);
+        initializer->registerInitSpringDataFunction(generate_springs, &finest_level);
         method->registerLInitStrategy(initializer);
         method->registerIBLagrangianForceFunction(new IBStandardForceGen());
         ins->registerVelocityInitialConditions(new muParserCartGridFunction(
@@ -171,12 +196,9 @@ main(int argc, char* argv[])
         VariableDatabase<NDIM>* variables = VariableDatabase<NDIM>::getDatabase();
         const int u = variables->mapVariableAndContextToIndex(ins->getVelocityVariable(), ins->getCurrentContext());
         const int p = variables->mapVariableAndContextToIndex(ins->getPressureVariable(), ins->getCurrentContext());
-        HierarchySideDataOpsReal<NDIM, double> velocity_ops(hierarchy, 0, 0);
-        HierarchyCellDataOpsReal<NDIM, double> pressure_ops(hierarchy, 0, 0);
+        HierarchySideDataOpsReal<NDIM, double> velocity_ops(hierarchy, 0, finest_level);
+        HierarchyCellDataOpsReal<NDIM, double> pressure_ops(hierarchy, 0, finest_level);
         Pointer<HierarchyMathOps> math_ops = ins->getHierarchyMathOps();
-        Vec centered_positions = nullptr;
-        PetscErrorCode ierr = VecDuplicate(method->getLDataManager()->getLData("X", 0)->getVec(), &centered_positions);
-        IBTK_CHKERRQ(ierr);
         plog << std::scientific << std::setprecision(8);
         for (int step = 0; step < 3; ++step)
         {
@@ -189,24 +211,44 @@ main(int argc, char* argv[])
                 TBOX_ERROR("Integration callback count does not match the number of cycles.\n");
             }
             // Geometric norms are independent of redistribution's Lagrangian vector ordering.
-            ierr = VecCopy(method->getLDataManager()->getLData("X", 0)->getVec(), centered_positions);
+            finest_level = hierarchy->getFinestLevelNumber();
+            velocity_ops.resetLevels(0, finest_level);
+            pressure_ops.resetLevels(0, finest_level);
+            Vec positions = method->getLDataManager()->getLData("X", finest_level)->getVec();
+            Vec centered_positions = nullptr;
+            PetscErrorCode ierr = VecDuplicate(positions, &centered_positions);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecCopy(positions, centered_positions);
             IBTK_CHKERRQ(ierr);
             ierr = VecShift(centered_positions, -0.5);
             IBTK_CHKERRQ(ierr);
             double radius_norm = 0.0;
             ierr = VecNorm(centered_positions, NORM_2, &radius_norm);
             IBTK_CHKERRQ(ierr);
+            const double velocity_norm = velocity_ops.L2Norm(u, math_ops->getSideWeightPatchDescriptorIndex());
+            const double pressure_norm = pressure_ops.L2Norm(p, math_ops->getCellWeightPatchDescriptorIndex());
+            if (!std::isfinite(radius_norm) || radius_norm <= 0.0 || !std::isfinite(velocity_norm) ||
+                !std::isfinite(pressure_norm))
+            {
+                TBOX_ERROR("Non-finite or trivial state after hierarchy advancement.\n");
+            }
+            ierr = VecDestroy(&centered_positions);
+            IBTK_CHKERRQ(ierr);
             plog << "step " << step + 1 << " time " << integrator->getIntegratorTime() << " velocity_L2 "
-                 << velocity_ops.L2Norm(u, math_ops->getSideWeightPatchDescriptorIndex()) << " pressure_L2 "
-                 << pressure_ops.L2Norm(p, math_ops->getCellWeightPatchDescriptorIndex()) << " radius_L2 "
-                 << radius_norm << '\n';
+                 << velocity_norm << " pressure_L2 " << pressure_norm << " radius_L2 " << radius_norm << '\n';
             if (custom_kernel && evaluator_calls == previous_calls)
             {
                 TBOX_ERROR("The selected application evaluator was not used during advancement.\n");
             }
         }
-        ierr = VecDestroy(&centered_positions);
-        IBTK_CHKERRQ(ierr);
+        if (verify_regrid)
+        {
+            if (regrid_state.count != 3)
+            {
+                TBOX_ERROR("Expected the initial automatic regrid and two subsequent regrids.\n");
+            }
+            plog << "regrids " << regrid_state.count << " levels " << hierarchy->getNumberOfLevels() << '\n';
+        }
     }
     return 0;
 }

--- a/tests/IB/implicit_stokes_ib_solver_components_01.cav_structure_w1.input
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.cav_structure_w1.input
@@ -1,0 +1,93 @@
+test_case = "foundation"
+CAV_APPLICATION_ONLY = TRUE
+VERIFY_FGMRES_PHYSICAL_RESIDUALS = FALSE
+N = 64
+MAX_LEVELS = 1
+MU = 0.01
+RHO = 1.0
+DT = 0.005
+DS = 1.0/64.0
+SPRING_STIFFNESS = 640000
+IB_TIME_STEPPING = "BACKWARD_EULER"
+TAG_BUFFER = 2
+USE_FIXED_LE_OPERATORS = TRUE
+stokes_ib_precond_db {
+   num_pre_sweeps = 1
+   num_post_sweeps = 0
+   U_prolongation_method = "RT0_REFINE"
+   U_restriction_method = "RT0_COARSEN"
+   rediscretize_stokes = TRUE
+   res_rediscretized_stokes = TRUE
+   level_solver_type = "PETSC_LEVEL_SOLVER"
+   level_solver_max_iterations = 1
+   level_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative-blas-lapack"
+      blas_lapack_subdomain_solver_type = "lu"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+   }
+   coarse_solver_type = "PETSC_LEVEL_SOLVER"
+   coarse_solver_max_iterations = 1
+   coarse_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative-blas-lapack"
+      blas_lapack_subdomain_solver_type = "lu"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+   }
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = MAX_LEVELS
+   base_filenames_0 = "curve"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "200"
+      ib_ksp_gmres_restart = "100"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+   }
+   largest_patch_size {
+      level_0 = N * 1, N * 1
+   }
+   smallest_patch_size {
+      level_0 = N * 1, N * 1
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N * 1 - 1, N * 1 - 1)]
+   }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_solver_components_01.cav_structure_w1.output
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.cav_structure_w1.output
@@ -1,0 +1,4 @@
+IBRedundantInitializer:  Deallocating initialization data.
+lifetime 1 levels 1 dofs 12288 patches 4096 correction_L2 1.16189 elasticity_L2 540298 reconstruction_error 0 elasticity_error 0
+lifetime 2 levels 1 dofs 12288 patches 4096 correction_L2 1.16189 elasticity_L2 540298 reconstruction_error 0 elasticity_error 0
+test_failures = 0

--- a/tests/IB/implicit_stokes_ib_solver_components_01.cav_structure_w2.input
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.cav_structure_w2.input
@@ -1,0 +1,102 @@
+test_case = "foundation"
+CAV_APPLICATION_ONLY = TRUE
+VERIFY_FGMRES_PHYSICAL_RESIDUALS = FALSE
+N = 16
+MAX_LEVELS = 3
+MU = 0.01
+RHO = 1.0
+DT = 0.005
+DS = 1.0/64.0
+SPRING_STIFFNESS = 640000
+IB_TIME_STEPPING = "BACKWARD_EULER"
+TAG_BUFFER = 2
+USE_FIXED_LE_OPERATORS = TRUE
+stokes_ib_precond_db {
+   num_pre_sweeps = 1
+   num_post_sweeps = 0
+   U_prolongation_method = "RT0_REFINE"
+   U_restriction_method = "RT0_COARSEN"
+   rediscretize_stokes = TRUE
+   res_rediscretized_stokes = TRUE
+   level_solver_type = "PETSC_LEVEL_SOLVER"
+   level_solver_max_iterations = 1
+   level_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative-blas-lapack"
+      blas_lapack_subdomain_solver_type = "lu"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+   }
+   coarse_solver_type = "PETSC_LEVEL_SOLVER"
+   coarse_solver_max_iterations = 1
+   coarse_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative-blas-lapack"
+      blas_lapack_subdomain_solver_type = "lu"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+   }
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = MAX_LEVELS
+   base_filenames_0 = "curve"
+   base_filenames_1 = "curve"
+   base_filenames_2 = "curve"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "200"
+      ib_ksp_gmres_restart = "100"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = 2, 2
+      level_2 = 2, 2
+   }
+   largest_patch_size {
+      level_0 = N * 1, N * 1
+      level_1 = N * 2, N * 2
+      level_2 = N * 4, N * 4
+   }
+   smallest_patch_size {
+      level_0 = N * 1, N * 1
+      level_1 = N * 2, N * 2
+      level_2 = N * 4, N * 4
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N * 1 - 1, N * 1 - 1)]
+      level_1 = [(0, 0), (N * 2 - 1, N * 2 - 1)]
+   }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_solver_components_01.cav_structure_w2.output
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.cav_structure_w2.output
@@ -1,0 +1,4 @@
+IBRedundantInitializer:  Deallocating initialization data.
+lifetime 1 levels 3 dofs 16128 patches 5376 correction_L2 5.72452 elasticity_L2 613507 reconstruction_error 0 elasticity_error 0
+lifetime 2 levels 3 dofs 16128 patches 5376 correction_L2 5.72452 elasticity_L2 613507 reconstruction_error 0 elasticity_error 0
+test_failures = 0

--- a/tests/IB/implicit_stokes_ib_solver_components_01.cpp
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.cpp
@@ -2447,6 +2447,7 @@ generate_structure(const unsigned int& strct_num,
     for (int k = 0; k < num_vertices; ++k)
     {
         const double theta = 2.0 * M_PI * static_cast<double>(k) / static_cast<double>(num_vertices);
+        vertex_posn[k].setConstant(0.5);
         vertex_posn[k](0) = spec->x_center + spec->x_radius * std::cos(theta);
         vertex_posn[k](1) = spec->y_center + spec->y_radius * std::sin(theta);
     }
@@ -2556,6 +2557,8 @@ run_foundation(Pointer<AppInitializer> app_initializer)
         const double rho = input_db->getDoubleWithDefault("RHO", 1.0);
         const double mu = input_db->getDoubleWithDefault("MU", 1.0);
         const double new_time = current_time + dt;
+        const bool application_only = input_db->getBoolWithDefault("CAV_APPLICATION_ONLY", false);
+        const bool verify_physical_residuals = input_db->getBoolWithDefault("VERIFY_FGMRES_PHYSICAL_RESIDUALS", false);
         const bool use_fixed_le_operators = input_db->getBoolWithDefault("USE_FIXED_LE_OPERATORS", true);
         StructureSpec structure_spec;
         structure_spec.ds = input_db->getDoubleWithDefault("DS", 1.0 / 64.0);
@@ -2902,6 +2905,197 @@ run_foundation(Pointer<AppInitializer> app_initializer)
         fac_pc->setIBImplicitStrategy(ib_method_ops);
         fac_pc->initializeSolverState(*eul_sol_vec, *eul_rhs_vec);
 
+        Pointer<SAMRAIVectorReal<NDIM, double>> linear_sol = eul_sol_vec->cloneVector("linear_sol");
+        linear_sol->allocateVectorData();
+        linear_sol->setToScalar(0.0);
+        const auto cleanup = [&]()
+        {
+            jac_op->deallocateOperatorState();
+            nonlinear_op.deallocateOperatorState();
+
+            ib_method_ops->postprocessIntegrateData(current_time, new_time, /*num_cycles*/ 1);
+
+            for (const Pointer<SAMRAIVectorReal<NDIM, double>>& vec :
+                 { nonlinear_probe, f_probe, v, jv, diff, linear_sol })
+            {
+                free_vector_components(*vec);
+            }
+
+            deallocate_vector_data(*eul_sol_vec);
+            deallocate_vector_data(*eul_rhs_vec);
+            free_vector_components(*eul_sol_vec);
+            free_vector_components(*eul_rhs_vec);
+
+            for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+            {
+                Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+                for (const int data_idx : allocated_patch_data_indices)
+                {
+                    if (level->checkAllocated(data_idx))
+                    {
+                        level->deallocatePatchData(data_idx);
+                    }
+                }
+            }
+
+            PetscErrorCode ierr = MatDestroy(&A);
+            IBTK_CHKERRQ(ierr);
+            ierr = MatDestroy(&J);
+            IBTK_CHKERRQ(ierr);
+
+            for (unsigned int d = 0; d < NDIM; ++d)
+            {
+                delete u_bc_coefs[d];
+            }
+
+            pout << "test_failures = " << test_failures << std::endl;
+        };
+        if (application_only)
+        {
+            const int expected_levels = input_db->getInteger("MAX_LEVELS");
+            if (finest_ln + 1 != expected_levels)
+            {
+                TBOX_ERROR("CAV lifecycle did not construct the assigned hierarchy.\n");
+            }
+            std::vector<Vec> first_elasticity_action(finest_ln + 1, nullptr);
+            double initial_force_norm = 0.0, initial_interp_norm = 0.0;
+            PetscErrorCode ierr = MatNorm(A, NORM_FROBENIUS, &initial_force_norm);
+            IBTK_CHKERRQ(ierr);
+            ierr = MatNorm(J, NORM_FROBENIUS, &initial_interp_norm);
+            IBTK_CHKERRQ(ierr);
+            for (int lifetime = 0; lifetime < 2; ++lifetime)
+            {
+                if (lifetime == 1)
+                {
+                    fac_pc->initializeSolverState(*eul_sol_vec, *eul_rhs_vec);
+                }
+                std::vector<Pointer<StaggeredStokesPETScLevelSolver>> level_solvers;
+                std::vector<std::vector<IS>*> overlap_containers;
+                int total_dofs = 0, total_patches = 0;
+                double elasticity_norm = 0.0, elasticity_error = 0.0;
+                for (int ln = 0; ln <= finest_ln; ++ln)
+                {
+                    Pointer<StaggeredStokesPETScLevelSolver> solver = fac_op->getStaggeredStokesPETScLevelSolver(ln);
+                    level_solvers.push_back(solver);
+                    const KSP ksp = solver->getPETScKSP();
+                    TBOX_ASSERT(ksp);
+                    PC pc = nullptr;
+                    PCType pc_type = nullptr;
+                    ierr = KSPGetPC(ksp, &pc);
+                    IBTK_CHKERRQ(ierr);
+                    ierr = PCGetType(pc, &pc_type);
+                    IBTK_CHKERRQ(ierr);
+                    std::vector<IS>* overlap = nullptr;
+                    std::vector<IS>* nonoverlap = nullptr;
+                    solver->getASMSubdomains(&nonoverlap, &overlap);
+                    overlap_containers.push_back(overlap);
+                    const int cells_per_axis = input_db->getInteger("N") * (1 << ln);
+                    const int cells = static_cast<int>(std::pow(cells_per_axis, NDIM));
+                    // Periodic full-domain levels contain one pressure patch per cell.
+                    Mat level_operator = nullptr;
+                    ierr = KSPGetOperators(ksp, &level_operator, nullptr);
+                    IBTK_CHKERRQ(ierr);
+                    PetscInt rows = 0, columns = 0;
+                    ierr = MatGetSize(level_operator, &rows, &columns);
+                    IBTK_CHKERRQ(ierr);
+                    if (std::string(pc_type) != PCSHELL || !overlap || static_cast<int>(overlap->size()) != cells ||
+                        rows != (NDIM + 1) * cells || columns != rows)
+                    {
+                        TBOX_ERROR("CAV lifecycle level solver or patch/DOF cardinality mismatch.\n");
+                    }
+                    total_dofs += rows;
+                    total_patches += overlap->size();
+                    const Mat elasticity = fac_op->getEulerianElasticityLevelOp(ln);
+                    Vec input = nullptr, action = nullptr;
+                    ierr = MatCreateVecs(elasticity, &input, &action);
+                    IBTK_CHKERRQ(ierr);
+                    StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(input,
+                                                                          v->getComponentDescriptorIndex(0),
+                                                                          u_dof_index_idx,
+                                                                          v->getComponentDescriptorIndex(1),
+                                                                          p_dof_index_idx,
+                                                                          patch_hierarchy->getPatchLevel(ln));
+                    ierr = MatMult(elasticity, input, action);
+                    IBTK_CHKERRQ(ierr);
+                    double norm = 0.0;
+                    ierr = VecNorm(action, NORM_2, &norm);
+                    IBTK_CHKERRQ(ierr);
+                    if (!std::isfinite(norm) || norm <= 1.0e-14)
+                    {
+                        TBOX_ERROR("CAV lifecycle requires a finite nonzero elasticity action on every level.\n");
+                    }
+                    elasticity_norm = std::hypot(elasticity_norm, norm);
+                    if (lifetime == 0)
+                    {
+                        ierr = VecDuplicate(action, &first_elasticity_action[ln]);
+                        IBTK_CHKERRQ(ierr);
+                        ierr = VecCopy(action, first_elasticity_action[ln]);
+                        IBTK_CHKERRQ(ierr);
+                    }
+                    else
+                    {
+                        ierr = VecAXPY(action, -1.0, first_elasticity_action[ln]);
+                        IBTK_CHKERRQ(ierr);
+                        ierr = VecNorm(action, NORM_2, &norm);
+                        IBTK_CHKERRQ(ierr);
+                        elasticity_error = std::hypot(elasticity_error, norm);
+                    }
+                    ierr = VecDestroy(&input);
+                    IBTK_CHKERRQ(ierr);
+                    ierr = VecDestroy(&action);
+                    IBTK_CHKERRQ(ierr);
+                }
+                diff->setToScalar(0.0);
+                fac_pc->solveSystem(*diff, *jv);
+                const double correction_norm = diff->L2Norm();
+                if (lifetime == 0)
+                {
+                    linear_sol->copyVector(diff);
+                }
+                diff->subtract(diff, linear_sol);
+                const double reconstruction_error = diff->L2Norm();
+                constexpr double RECONSTRUCTION_TOL = 1.0e-10;
+                if (!std::isfinite(correction_norm) || correction_norm <= 1.0e-14 ||
+                    !std::isfinite(reconstruction_error) ||
+                    reconstruction_error > RECONSTRUCTION_TOL * std::max(1.0, correction_norm) ||
+                    !std::isfinite(elasticity_error) ||
+                    elasticity_error > RECONSTRUCTION_TOL * std::max(1.0, elasticity_norm))
+                {
+                    TBOX_ERROR("CAV lifecycle action did not reconstruct within its relative bound: correction = "
+                               << correction_norm << ", error = " << reconstruction_error
+                               << ", elasticity = " << elasticity_norm << ", error = " << elasticity_error << '\n');
+                }
+                plog << "lifetime " << lifetime + 1 << " levels " << finest_ln + 1 << " dofs " << total_dofs
+                     << " patches " << total_patches << " correction_L2 " << correction_norm << " elasticity_L2 "
+                     << elasticity_norm << " reconstruction_error " << reconstruction_error << " elasticity_error "
+                     << elasticity_error << '\n';
+                fac_pc->deallocateSolverState();
+                for (int ln = 0; ln <= finest_ln; ++ln)
+                {
+                    if (level_solvers[ln]->getPETScKSP() || !overlap_containers[ln]->empty())
+                    {
+                        TBOX_ERROR("CAV level state survived FAC teardown.\n");
+                    }
+                }
+            }
+            for (Vec& action : first_elasticity_action)
+            {
+                ierr = VecDestroy(&action);
+                IBTK_CHKERRQ(ierr);
+            }
+            double force_norm = 0.0, interp_norm = 0.0;
+            ierr = MatNorm(A, NORM_FROBENIUS, &force_norm);
+            IBTK_CHKERRQ(ierr);
+            ierr = MatNorm(J, NORM_FROBENIUS, &interp_norm);
+            IBTK_CHKERRQ(ierr);
+            if (force_norm != initial_force_norm || interp_norm != initial_interp_norm)
+            {
+                TBOX_ERROR("FAC lifecycle changed caller-owned force/interpolation matrices.\n");
+            }
+            cleanup();
+            return test_failures;
+        }
+
         const bool verify_galerkin_operator_borrowing =
             input_db->getBoolWithDefault("VERIFY_GALERKIN_OPERATOR_BORROWING", false);
         const bool rediscretize_stokes = stokes_ib_precond_db->getBoolWithDefault("rediscretize_stokes", true);
@@ -3237,9 +3431,6 @@ run_foundation(Pointer<AppInitializer> app_initializer)
         // uses a right preconditioner and measures the unpreconditioned residual.
         linear_solver->setKSPType("fgmres");
 
-        Pointer<SAMRAIVectorReal<NDIM, double>> linear_sol = eul_sol_vec->cloneVector("linear_sol");
-        linear_sol->allocateVectorData();
-        linear_sol->setToScalar(0.0);
         linear_solver->initializeSolverState(*linear_sol, *jv);
         // Outer initialization clears the Jacobian base and rebuilds FAC state.
         jac_op->formJacobian(*eul_sol_vec);
@@ -3273,7 +3464,10 @@ run_foundation(Pointer<AppInitializer> app_initializer)
             ++test_failures;
             pout << "krylov linear solve failed" << std::endl;
         }
-        pout << "krylov_linear_iterations = " << linear_solver->getNumIterations() << std::endl;
+        if (!verify_physical_residuals)
+        {
+            pout << "krylov_linear_iterations = " << linear_solver->getNumIterations() << std::endl;
+        }
         jac_op->apply(*linear_sol, *diff);
         diff->subtract(diff, jv);
         const double actual_residual = diff->L2Norm();
@@ -3299,9 +3493,12 @@ run_foundation(Pointer<AppInitializer> app_initializer)
                                                   linear_solver->getResidualNorm() >= 0.0 && physical_residual_valid;
         // The integration check requires a bounded physical residual, not a
         // particular over-converged residual from the preconditioned solve.
-        pout << "physical_residual_valid = " << (physical_residual_valid ? "true" : "false")
-             << ", acceptance_bound = " << residual_bound << ", pc_side = " << side << ", norm_type = " << norm_type
-             << ", ksp_type = " << ksp_type << ", reason = " << reason << std::endl;
+        if (!verify_physical_residuals)
+        {
+            pout << "physical_residual_valid = " << (physical_residual_valid ? "true" : "false")
+                 << ", acceptance_bound = " << residual_bound << ", pc_side = " << side << ", norm_type = " << norm_type
+                 << ", ksp_type = " << ksp_type << ", reason = " << reason << std::endl;
+        }
         if (!krylov_linear_residual_valid)
         {
             pout << "Krylov residual check failed: actual_residual = " << std::setprecision(17) << actual_residual
@@ -3326,6 +3523,145 @@ run_foundation(Pointer<AppInitializer> app_initializer)
             pout << "krylov linear solve action is trivial" << std::endl;
         }
 
+        if (verify_physical_residuals)
+        {
+            PetscErrorCode ierr;
+            const Mat SAJ = fac_op->getEulerianElasticityLevelOp(finest_ln);
+            Pointer<SAMRAIVectorReal<NDIM, double>> linear_action = eul_rhs_vec->cloneVector("linear_action");
+            Pointer<SAMRAIVectorReal<NDIM, double>> original_residual = eul_rhs_vec->cloneVector("original_residual");
+            Pointer<SAMRAIVectorReal<NDIM, double>> ib_action_matrix_free =
+                eul_rhs_vec->cloneVector("ib_action_matrix_free");
+            for (const Pointer<SAMRAIVectorReal<NDIM, double>>& diagnostic_vec :
+                 { linear_action, original_residual, ib_action_matrix_free })
+            {
+                diagnostic_vec->allocateVectorData();
+                diagnostic_vec->setToScalar(0.0);
+            }
+
+            // Re-evaluate the original matrix-free Jacobian after the solve;
+            // the KSP-reported residual is not used as a physical substitute.
+            jac_op->apply(*linear_sol, *linear_action);
+            original_residual->subtract(jv, linear_action);
+
+            // Evaluate the matrix-free IB action directly. With zero velocity
+            // coefficients and zero pressure, the auxiliary Jacobian's
+            // momentum component contains only the live IB coupling action;
+            // its divergence component is intentionally discarded.
+            PoissonSpecifications ib_only_coefs("stokes_ib_solver_components::ib_only_coefs");
+            ib_only_coefs.setCConstant(0.0);
+            ib_only_coefs.setDConstant(0.0);
+            Pointer<StaggeredStokesOperator> ib_only_stokes_op =
+                new StaggeredStokesOperator("stokes_ib_solver_components::ib_only_stokes_op", false);
+            ib_only_stokes_op->setVelocityPoissonSpecifications(ib_only_coefs);
+            ib_only_stokes_op->setPhysicalBcCoefs(u_bc_coefs, nullptr);
+            ib_only_stokes_op->setTimeInterval(current_time, new_time);
+            ib_only_stokes_op->setSolutionTime(new_time);
+            StaggeredStokesIBOperator::Context ib_only_ctx = ctx;
+            ib_only_ctx.stokes_op = ib_only_stokes_op;
+            Pointer<StaggeredStokesIBJacobianOperator> ib_only_jac_op =
+                new StaggeredStokesIBJacobianOperator("stokes_ib_solver_components::ib_only_jacobian_op");
+            ib_only_jac_op->setOperatorContext(ib_only_ctx);
+            ib_only_jac_op->setTimeInterval(current_time, new_time);
+            ib_only_jac_op->setSolutionTime(new_time);
+            ib_only_jac_op->initializeOperatorState(*eul_sol_vec, *eul_rhs_vec);
+            ib_only_jac_op->formJacobian(*eul_sol_vec);
+            Pointer<SAMRAIVectorReal<NDIM, double>> ib_input = linear_sol->cloneVector("ib_input");
+            ib_input->allocateVectorData();
+            ib_input->copyVector(linear_sol);
+            hier_pressure_data_ops->setToScalar(ib_input->getComponentDescriptorIndex(1), 0.0, false);
+            ib_only_jac_op->apply(*ib_input, *ib_action_matrix_free);
+            hier_pressure_data_ops->setToScalar(ib_action_matrix_free->getComponentDescriptorIndex(1), 0.0, false);
+
+            const double rhs_momentum_norm =
+                hier_velocity_data_ops->L2Norm(jv->getComponentDescriptorIndex(0), wgt_sc_idx);
+            const double rhs_divergence_norm =
+                hier_pressure_data_ops->L2Norm(jv->getComponentDescriptorIndex(1), wgt_cc_idx);
+            const double momentum_residual_norm =
+                hier_velocity_data_ops->L2Norm(original_residual->getComponentDescriptorIndex(0), wgt_sc_idx);
+            const double divergence_residual_norm =
+                hier_pressure_data_ops->L2Norm(original_residual->getComponentDescriptorIndex(1), wgt_cc_idx);
+            const double rhs_norm = std::hypot(rhs_momentum_norm, rhs_divergence_norm);
+            const double original_residual_norm = std::hypot(momentum_residual_norm, divergence_residual_norm);
+            const double denominator_floor = std::sqrt(std::numeric_limits<double>::epsilon()) * rhs_norm;
+            const double original_relative_residual = original_residual_norm / std::max(rhs_norm, 1.0e-30);
+            const double momentum_relative_residual =
+                momentum_residual_norm / std::max({ rhs_momentum_norm, denominator_floor, 1.0e-30 });
+            const double divergence_relative_residual =
+                divergence_residual_norm / std::max({ rhs_divergence_norm, denominator_floor, 1.0e-30 });
+
+            Vec saj_input = nullptr;
+            Vec saj_output = nullptr;
+            Vec rhs_output = nullptr;
+            Vec ib_matrix_free_output = nullptr;
+            ierr = MatCreateVecs(SAJ, &saj_input, &saj_output);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecDuplicate(saj_output, &rhs_output);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecDuplicate(saj_output, &ib_matrix_free_output);
+            IBTK_CHKERRQ(ierr);
+            StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(saj_input,
+                                                                  linear_sol->getComponentDescriptorIndex(0),
+                                                                  u_dof_index_idx,
+                                                                  linear_sol->getComponentDescriptorIndex(1),
+                                                                  p_dof_index_idx,
+                                                                  patch_hierarchy->getPatchLevel(finest_ln));
+            ierr = MatMult(SAJ, saj_input, saj_output);
+            IBTK_CHKERRQ(ierr);
+            StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(rhs_output,
+                                                                  jv->getComponentDescriptorIndex(0),
+                                                                  u_dof_index_idx,
+                                                                  jv->getComponentDescriptorIndex(1),
+                                                                  p_dof_index_idx,
+                                                                  patch_hierarchy->getPatchLevel(finest_ln));
+            StaggeredStokesPETScVecUtilities::copyToPatchLevelVec(ib_matrix_free_output,
+                                                                  ib_action_matrix_free->getComponentDescriptorIndex(0),
+                                                                  u_dof_index_idx,
+                                                                  ib_action_matrix_free->getComponentDescriptorIndex(1),
+                                                                  p_dof_index_idx,
+                                                                  patch_hierarchy->getPatchLevel(finest_ln));
+            double ib_matrix_free_action_norm = std::numeric_limits<double>::quiet_NaN();
+            double ib_saj_action_norm = std::numeric_limits<double>::quiet_NaN();
+            double rhs_algebraic_norm = std::numeric_limits<double>::quiet_NaN();
+            ierr = VecNorm(rhs_output, NORM_2, &rhs_algebraic_norm);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecNorm(ib_matrix_free_output, NORM_2, &ib_matrix_free_action_norm);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecNorm(saj_output, NORM_2, &ib_saj_action_norm);
+            IBTK_CHKERRQ(ierr);
+            ierr = VecAXPY(ib_matrix_free_output, -1.0, saj_output);
+            IBTK_CHKERRQ(ierr);
+            double ib_coupling_residual_norm = std::numeric_limits<double>::quiet_NaN();
+            ierr = VecNorm(ib_matrix_free_output, NORM_2, &ib_coupling_residual_norm);
+            IBTK_CHKERRQ(ierr);
+            const double ib_coupling_relative_residual =
+                ib_coupling_residual_norm /
+                std::max({ ib_matrix_free_action_norm,
+                           ib_saj_action_norm,
+                           std::sqrt(std::numeric_limits<double>::epsilon()) * rhs_algebraic_norm,
+                           1.0e-30 });
+
+            if (!std::isfinite(momentum_relative_residual) || !std::isfinite(divergence_relative_residual) ||
+                !std::isfinite(original_relative_residual) || original_relative_residual > 1.0e-10 ||
+                !std::isfinite(ib_coupling_relative_residual) || ib_coupling_relative_residual > 1.0e-10)
+            {
+                TBOX_ERROR("FGMRES physical or live IB coupling residual exceeded 1e-10: "
+                           << original_relative_residual << ", " << ib_coupling_relative_residual << '\n');
+            }
+            plog << "physical_K " << structure_spec.spring_stiffness * structure_spec.ds << " momentum_L2 "
+                 << momentum_residual_norm << " divergence_L2 " << divergence_residual_norm << " original_relative "
+                 << original_relative_residual << " IB_relative " << ib_coupling_relative_residual << '\n';
+            for (Vec* vector : { &saj_input, &saj_output, &rhs_output, &ib_matrix_free_output })
+            {
+                ierr = VecDestroy(vector);
+                IBTK_CHKERRQ(ierr);
+            }
+            ib_only_jac_op->deallocateOperatorState();
+            for (const Pointer<SAMRAIVectorReal<NDIM, double>>& vector :
+                 { linear_action, original_residual, ib_action_matrix_free, ib_input })
+            {
+                free_vector_components(*vector);
+            }
+        }
         linear_solver->deallocateSolverState();
         fac_pc->deallocateSolverState();
         for (int ln = 0; ln <= finest_ln; ++ln)
@@ -3352,44 +3688,7 @@ run_foundation(Pointer<AppInitializer> app_initializer)
         pout << "fac_residual_repeat_error = " << fac_residual_work_vector_reuse_error
              << ", reinitialized_repeat_error = " << fac_residual_work_vector_reinitialize_error << std::endl;
 
-        jac_op->deallocateOperatorState();
-        nonlinear_op.deallocateOperatorState();
-
-        ib_method_ops->postprocessIntegrateData(current_time, new_time, /*num_cycles*/ 1);
-
-        for (auto vec : { nonlinear_probe, f_probe, v, jv, diff, linear_sol })
-        {
-            free_vector_components(*vec);
-        }
-
-        deallocate_vector_data(*eul_sol_vec);
-        deallocate_vector_data(*eul_rhs_vec);
-        free_vector_components(*eul_sol_vec);
-        free_vector_components(*eul_rhs_vec);
-
-        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
-        {
-            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
-            for (const int data_idx : allocated_patch_data_indices)
-            {
-                if (level->checkAllocated(data_idx))
-                {
-                    level->deallocatePatchData(data_idx);
-                }
-            }
-        }
-
-        PetscErrorCode ierr = MatDestroy(&A);
-        IBTK_CHKERRQ(ierr);
-        ierr = MatDestroy(&J);
-        IBTK_CHKERRQ(ierr);
-
-        for (unsigned int d = 0; d < NDIM; ++d)
-        {
-            delete u_bc_coefs[d];
-        }
-
-        pout << "test_failures = " << test_failures << std::endl;
+        cleanup();
     }
 
     return test_failures;

--- a/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav.input
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav.input
@@ -1,0 +1,88 @@
+test_case = "foundation"
+CAV_APPLICATION_ONLY = FALSE
+VERIFY_FGMRES_PHYSICAL_RESIDUALS = TRUE
+N = 4
+MAX_LEVELS = 2
+MU = 0.01
+RHO = 1.0
+DT = 0.005
+DS = 1.0/8.0
+SPRING_STIFFNESS = 200
+IB_TIME_STEPPING = "BACKWARD_EULER"
+TAG_BUFFER = 2
+USE_FIXED_LE_OPERATORS = TRUE
+stokes_ib_precond_db {
+   num_pre_sweeps = 1
+   num_post_sweeps = 1
+   U_prolongation_method = "RT0_REFINE"
+   U_restriction_method = "RT0_COARSEN"
+   rediscretize_stokes = TRUE
+   res_rediscretized_stokes = TRUE
+   level_solver_type = "PETSC_LEVEL_SOLVER"
+   level_solver_max_iterations = 1
+   level_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+   }
+   coarse_solver_type = "PETSC_LEVEL_SOLVER"
+   coarse_solver_max_iterations = 1
+   coarse_solver_db {
+      ksp_type = "preonly"
+      pc_type = "svd"
+      initial_guess_nonzero = FALSE
+   }
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = MAX_LEVELS
+   base_filenames_0 = "curve"
+   base_filenames_1 = "curve"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      stokes_ib_pc_level_1__subpc_type = "svd"
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "200"
+      ib_ksp_gmres_restart = "100"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = 2, 2
+   }
+   largest_patch_size {
+      level_0 = N * 1, N * 1
+      level_1 = N * 2, N * 2
+   }
+   smallest_patch_size {
+      level_0 = N * 1, N * 1
+      level_1 = N * 2, N * 2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N * 1 - 1, N * 1 - 1)]
+   }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav.output
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav.output
@@ -1,0 +1,9 @@
+IBRedundantInitializer:  Deallocating initialization data.
+FAC checks use stated accuracy bounds; attained roundoff may vary.
+fac_operator_valid = true, residual_composition_valid = true, absolute_inf_bound = 1e-09, elastic_action_norm = 37.7871
+fac_operator_valid = true, residual_composition_valid = true, absolute_inf_bound = 1e-09, elastic_action_norm = 37.7871
+initialized_jacobian_action_valid = true, L2_bound = 2.03407e-07
+physical_K 25 momentum_L2 3.03024e-14 divergence_L2 3.25392e-15 original_relative 1.49831e-16 IB_relative 3.58921e-16
+FAC Vec allocation measurement: calibrated and enforced with PETSC_USE_LOG; unavailable without it.
+fac_residual_repeat_error = 0, reinitialized_repeat_error = 0
+test_failures = 0

--- a/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1.input
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1.input
@@ -1,0 +1,88 @@
+test_case = "foundation"
+CAV_APPLICATION_ONLY = FALSE
+VERIFY_FGMRES_PHYSICAL_RESIDUALS = TRUE
+N = 4
+MAX_LEVELS = 2
+MU = 0.01
+RHO = 1.0
+DT = 0.005
+DS = 1.0/8.0
+SPRING_STIFFNESS = 8
+IB_TIME_STEPPING = "BACKWARD_EULER"
+TAG_BUFFER = 2
+USE_FIXED_LE_OPERATORS = TRUE
+stokes_ib_precond_db {
+   num_pre_sweeps = 1
+   num_post_sweeps = 1
+   U_prolongation_method = "RT0_REFINE"
+   U_restriction_method = "RT0_COARSEN"
+   rediscretize_stokes = TRUE
+   res_rediscretized_stokes = TRUE
+   level_solver_type = "PETSC_LEVEL_SOLVER"
+   level_solver_max_iterations = 1
+   level_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+   }
+   coarse_solver_type = "PETSC_LEVEL_SOLVER"
+   coarse_solver_max_iterations = 1
+   coarse_solver_db {
+      ksp_type = "preonly"
+      pc_type = "svd"
+      initial_guess_nonzero = FALSE
+   }
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = MAX_LEVELS
+   base_filenames_0 = "curve"
+   base_filenames_1 = "curve"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      stokes_ib_pc_level_1__subpc_type = "svd"
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "200"
+      ib_ksp_gmres_restart = "100"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = 2, 2
+   }
+   largest_patch_size {
+      level_0 = N * 1, N * 1
+      level_1 = N * 2, N * 2
+   }
+   smallest_patch_size {
+      level_0 = N * 1, N * 1
+      level_1 = N * 2, N * 2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N * 1 - 1, N * 1 - 1)]
+   }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1.output
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1.output
@@ -1,0 +1,9 @@
+IBRedundantInitializer:  Deallocating initialization data.
+FAC checks use stated accuracy bounds; attained roundoff may vary.
+fac_operator_valid = true, residual_composition_valid = true, absolute_inf_bound = 1e-09, elastic_action_norm = 1.51148
+fac_operator_valid = true, residual_composition_valid = true, absolute_inf_bound = 1e-09, elastic_action_norm = 1.51148
+initialized_jacobian_action_valid = true, L2_bound = 2.00495e-07
+physical_K 1 momentum_L2 3.49451e-14 divergence_L2 3.22729e-15 original_relative 1.75036e-16 IB_relative 3.0632e-16
+FAC Vec allocation measurement: calibrated and enforced with PETSC_USE_LOG; unavailable without it.
+fac_residual_repeat_error = 0, reinitialized_repeat_error = 0
+test_failures = 0

--- a/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1e2.input
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1e2.input
@@ -1,0 +1,88 @@
+test_case = "foundation"
+CAV_APPLICATION_ONLY = FALSE
+VERIFY_FGMRES_PHYSICAL_RESIDUALS = TRUE
+N = 4
+MAX_LEVELS = 2
+MU = 0.01
+RHO = 1.0
+DT = 0.005
+DS = 1.0/8.0
+SPRING_STIFFNESS = 800
+IB_TIME_STEPPING = "BACKWARD_EULER"
+TAG_BUFFER = 2
+USE_FIXED_LE_OPERATORS = TRUE
+stokes_ib_precond_db {
+   num_pre_sweeps = 1
+   num_post_sweeps = 1
+   U_prolongation_method = "RT0_REFINE"
+   U_restriction_method = "RT0_COARSEN"
+   rediscretize_stokes = TRUE
+   res_rediscretized_stokes = TRUE
+   level_solver_type = "PETSC_LEVEL_SOLVER"
+   level_solver_max_iterations = 1
+   level_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+   }
+   coarse_solver_type = "PETSC_LEVEL_SOLVER"
+   coarse_solver_max_iterations = 1
+   coarse_solver_db {
+      ksp_type = "preonly"
+      pc_type = "svd"
+      initial_guess_nonzero = FALSE
+   }
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = MAX_LEVELS
+   base_filenames_0 = "curve"
+   base_filenames_1 = "curve"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      stokes_ib_pc_level_1__subpc_type = "svd"
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "200"
+      ib_ksp_gmres_restart = "100"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = 2, 2
+   }
+   largest_patch_size {
+      level_0 = N * 1, N * 1
+      level_1 = N * 2, N * 2
+   }
+   smallest_patch_size {
+      level_0 = N * 1, N * 1
+      level_1 = N * 2, N * 2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N * 1 - 1, N * 1 - 1)]
+   }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1e2.output
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1e2.output
@@ -1,0 +1,9 @@
+IBRedundantInitializer:  Deallocating initialization data.
+FAC checks use stated accuracy bounds; attained roundoff may vary.
+fac_operator_valid = true, residual_composition_valid = true, absolute_inf_bound = 1e-09, elastic_action_norm = 151.148
+fac_operator_valid = true, residual_composition_valid = true, absolute_inf_bound = 1e-09, elastic_action_norm = 151.148
+initialized_jacobian_action_valid = true, L2_bound = 2.12873e-07
+physical_K 100 momentum_L2 3.94815e-14 divergence_L2 3.22538e-15 original_relative 1.86088e-16 IB_relative 3.92723e-16
+FAC Vec allocation measurement: calibrated and enforced with PETSC_USE_LOG; unavailable without it.
+fac_residual_repeat_error = 0, reinitialized_repeat_error = 0
+test_failures = 0

--- a/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1e4.input
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1e4.input
@@ -1,0 +1,88 @@
+test_case = "foundation"
+CAV_APPLICATION_ONLY = FALSE
+VERIFY_FGMRES_PHYSICAL_RESIDUALS = TRUE
+N = 4
+MAX_LEVELS = 2
+MU = 0.01
+RHO = 1.0
+DT = 0.005
+DS = 1.0/8.0
+SPRING_STIFFNESS = 80000
+IB_TIME_STEPPING = "BACKWARD_EULER"
+TAG_BUFFER = 2
+USE_FIXED_LE_OPERATORS = TRUE
+stokes_ib_precond_db {
+   num_pre_sweeps = 1
+   num_post_sweeps = 1
+   U_prolongation_method = "RT0_REFINE"
+   U_restriction_method = "RT0_COARSEN"
+   rediscretize_stokes = TRUE
+   res_rediscretized_stokes = TRUE
+   level_solver_type = "PETSC_LEVEL_SOLVER"
+   level_solver_max_iterations = 1
+   level_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+   }
+   coarse_solver_type = "PETSC_LEVEL_SOLVER"
+   coarse_solver_max_iterations = 1
+   coarse_solver_db {
+      ksp_type = "preonly"
+      pc_type = "svd"
+      initial_guess_nonzero = FALSE
+   }
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = MAX_LEVELS
+   base_filenames_0 = "curve"
+   base_filenames_1 = "curve"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      stokes_ib_pc_level_1__subpc_type = "svd"
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "200"
+      ib_ksp_gmres_restart = "100"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0), (N - 1, N - 1)]
+   x_lo = 0.0, 0.0
+   x_up = 1.0, 1.0
+   periodic_dimension = 1, 1
+}
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = 2, 2
+   }
+   largest_patch_size {
+      level_0 = N * 1, N * 1
+      level_1 = N * 2, N * 2
+   }
+   smallest_patch_size {
+      level_0 = N * 1, N * 1
+      level_1 = N * 2, N * 2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0), (N * 1 - 1, N * 1 - 1)]
+   }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1e4.output
+++ b/tests/IB/implicit_stokes_ib_solver_components_01.max_levels=2.pressure_cav_K=1e4.output
@@ -1,0 +1,9 @@
+IBRedundantInitializer:  Deallocating initialization data.
+FAC checks use stated accuracy bounds; attained roundoff may vary.
+fac_operator_valid = true, residual_composition_valid = true, absolute_inf_bound = 1e-09, elastic_action_norm = 15114.8
+fac_operator_valid = true, residual_composition_valid = true, absolute_inf_bound = 1e-09, elastic_action_norm = 15114.8
+initialized_jacobian_action_valid = true, L2_bound = 2.02252e-06
+physical_K 10000 momentum_L2 1.02937e-12 divergence_L2 6.2113e-15 original_relative 5.08964e-16 IB_relative 4.43898e-16
+FAC Vec allocation measurement: calibrated and enforced with PETSC_USE_LOG; unavailable without it.
+fac_residual_repeat_error = 0, reinitialized_repeat_error = 0
+test_failures = 0

--- a/tests/IB/implicit_stokes_ib_solver_components_01_3d.cav_lifecycle.input
+++ b/tests/IB/implicit_stokes_ib_solver_components_01_3d.cav_lifecycle.input
@@ -1,0 +1,101 @@
+test_case = "foundation"
+CAV_APPLICATION_ONLY = TRUE
+VERIFY_FGMRES_PHYSICAL_RESIDUALS = FALSE
+N = 4
+MAX_LEVELS = 2
+MU = 0.01
+RHO = 1.0
+DT = 0.005
+DS = 1.0/8.0
+SPRING_STIFFNESS = 8
+IB_TIME_STEPPING = "BACKWARD_EULER"
+TAG_BUFFER = 2
+USE_FIXED_LE_OPERATORS = TRUE
+stokes_ib_precond_db {
+   num_pre_sweeps = 1
+   num_post_sweeps = 0
+   U_prolongation_method = "RT0_REFINE"
+   U_restriction_method = "RT0_COARSEN"
+   rediscretize_stokes = TRUE
+   res_rediscretized_stokes = TRUE
+   level_solver_type = "PETSC_LEVEL_SOLVER"
+   level_solver_max_iterations = 1
+   level_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+   }
+   coarse_solver_type = "PETSC_LEVEL_SOLVER"
+   coarse_solver_max_iterations = 1
+   coarse_solver_db {
+      use_ksp_as_smoother = TRUE
+      initial_guess_nonzero = FALSE
+      ksp_type = "preonly"
+      pc_type = "shell"
+      shell_pc_type = "multiplicative"
+      shell_pc_subdomain_traversal = "FORWARD"
+      shell_pc_relaxation_factor = 1.0
+      asm_subdomain_construction_mode = "COUPLING_AWARE"
+      coupling_aware_asm_patch_seed_type = "PRESSURE_CELL"
+      coupling_aware_asm_closure_policy = "RELAXED"
+      coupling_aware_asm_seed_stride = 1
+   }
+}
+IBMethod { delta_fcn = "IB_4" }
+IBRedundantInitializer {
+   max_levels = MAX_LEVELS
+   base_filenames_0 = "curve"
+   base_filenames_1 = "curve"
+}
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+   petsc_settings {
+      stokes_ib_pc_level_0__subpc_type = "lu"
+      stokes_ib_pc_level_0__subpc_factor_shift_type = "nonzero"
+      stokes_ib_pc_level_0__subpc_factor_shift_amount = "1e-12"
+      stokes_ib_pc_level_1__subpc_type = "lu"
+      stokes_ib_pc_level_1__subpc_factor_shift_type = "nonzero"
+      stokes_ib_pc_level_1__subpc_factor_shift_amount = "1e-12"
+      ib_ksp_type = "fgmres"
+      ib_ksp_rtol = "1e-11"
+      ib_ksp_atol = "1e-13"
+      ib_ksp_max_it = "200"
+      ib_ksp_gmres_restart = "100"
+   }
+}
+CartesianGeometry {
+   domain_boxes = [(0, 0, 0), (N - 1, N - 1, N - 1)]
+   x_lo = 0.0, 0.0, 0.0
+   x_up = 1.0, 1.0, 1.0
+   periodic_dimension = 1, 1, 1
+}
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = 2, 2, 2
+   }
+   largest_patch_size {
+      level_0 = N * 1, N * 1, N * 1
+      level_1 = N * 2, N * 2, N * 2
+   }
+   smallest_patch_size {
+      level_0 = N * 1, N * 1, N * 1
+      level_1 = N * 2, N * 2, N * 2
+   }
+}
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [(0, 0, 0), (N * 1 - 1, N * 1 - 1, N * 1 - 1)]
+   }
+}
+LoadBalancer { bin_pack_method = "SPATIAL" }

--- a/tests/IB/implicit_stokes_ib_solver_components_01_3d.cav_lifecycle.output
+++ b/tests/IB/implicit_stokes_ib_solver_components_01_3d.cav_lifecycle.output
@@ -1,0 +1,4 @@
+IBRedundantInitializer:  Deallocating initialization data.
+lifetime 1 levels 2 dofs 2304 patches 576 correction_L2 1.22465 elasticity_L2 9.34735 reconstruction_error 0 elasticity_error 0
+lifetime 2 levels 2 dofs 2304 patches 576 correction_L2 1.22465 elasticity_L2 9.34735 reconstruction_error 0 elasticity_error 0
+test_failures = 0


### PR DESCRIPTION
Smooth the Stokes-IB FAC levels with multiplicative coupling-aware Vanka (CAV) patches built from each level's Stokes-IB coupling matrix, with native tests for pressure-coupled solves, FAC lifecycle reconstruction, and regridding.

<!--
This template should be included in all pull requests. Items in the list should
either be completed by the original author or explicitly dismissed by one of the
IBAMR principal developers.

IBAMR is a community effort and it wouldn't exist without people contributing
code. Thanks in advance for helping to make IBAMR better!
-->

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [ ] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [ ] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [ ] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?

