### PR TITLE
Enforce hierarchy ghost-width limits before filling

### DIFF
--- a/doc/news/changes/incompatibilities/20260910Griffith
+++ b/doc/news/changes/incompatibilities/20260910Griffith
@@ -1,0 +1,11 @@
+Changed: HierarchyGhostCellInterpolation now completes deferred physical
+boundary-box construction during initialization and enforces SAMRAI's
+registered ghost-width limit before constructing schedules, resetting
+transactions, or filling data. Register the required maximum before boundary
+construction and keep a registration maintaining that maximum if later reuse
+is needed: a smaller registered maximum observed by a check or level
+construction can lower the shared limit. Operations on an empty hierarchy do
+not establish a new limit. Existing boundary boxes and filling formulas are
+unchanged.
+<br>
+(Boyce Griffith, 2026/09/10)

--- a/ibtk/include/ibtk/HierarchyGhostCellInterpolation.h
+++ b/ibtk/include/ibtk/HierarchyGhostCellInterpolation.h
@@ -78,6 +78,20 @@ namespace IBTK
  * \note In cases where physical boundary conditions are set via extrapolation
  * from interior values, setting ghost cell values may require both coarsening
  * and refining.
+ *
+ * Initialization completes deferred physical boundary-box construction on
+ * levels zero through the requested finest level, including coarse levels
+ * below the requested fill range. Register the required maximum ghost width
+ * before boundary construction. Initialization, transaction reset, and filling
+ * enforce SAMRAI's componentwise limit on the entire patch descriptor, including
+ * unused registrations and periodic configurations.
+ *
+ * SAMRAI's shared grid-geometry limit can decrease when a width check or level
+ * construction observes a smaller registered maximum. Restoring a wider
+ * registration can then fail even if older boundary boxes had sufficient
+ * width. Keep a registration maintaining the required maximum to preserve its
+ * later use. Deallocating or reinitializing this operator does not reset that
+ * limit. Operations on an empty hierarchy do not establish a new limit.
  */
 class HierarchyGhostCellInterpolation : public SAMRAI::tbox::DescribedClass
 {
@@ -339,6 +353,12 @@ public:
 
 protected:
 private:
+    /*!
+     * \brief Enforce SAMRAI's ghost-width limit without establishing a limit
+     * for an empty hierarchy.
+     */
+    void validateGhostWidth();
+
     /*!
      * \brief Copy constructor.
      *

--- a/ibtk/src/boundary/HierarchyGhostCellInterpolation.cpp
+++ b/ibtk/src/boundary/HierarchyGhostCellInterpolation.cpp
@@ -164,6 +164,15 @@ HierarchyGhostCellInterpolation::initializeOperatorState(
     d_coarsest_ln = coarsest_ln == invalid_level_number ? 0 : coarsest_ln;
     d_finest_ln = finest_ln == invalid_level_number ? d_hierarchy->getFinestLevelNumber() : finest_ln;
 
+    // Complete deferred construction before checking the width. The level
+    // operation preserves existing boxes and includes coarse dependencies.
+    for (int ln = 0; ln <= d_finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
+        level->setBoundaryBoxes();
+    }
+    validateGhostWidth();
+
     // Register the cubic coarsen operators with the grid geometry object.
     IBTK_DO_ONCE(d_grid_geom->addSpatialCoarsenOperator(new CartCellDoubleCubicCoarsen());
                  d_grid_geom->addSpatialCoarsenOperator(new CartSideDoubleCubicCoarsen()););
@@ -263,6 +272,9 @@ HierarchyGhostCellInterpolation::initializeOperatorState(
             if (d_transaction_comps[comp_idx].d_use_cf_bdry_interpolation)
             {
                 d_cf_bdry_ops[comp_idx] = new CartSideDoubleQuadraticCFInterpolation();
+                // The constructor registers scratch data that setPatchHierarchy()
+                // allocates and fills, so validate before that setup begins.
+                validateGhostWidth();
                 d_cf_bdry_ops[comp_idx]->setConsistentInterpolationScheme(
                     d_transaction_comps[comp_idx].d_consistent_type_2_bdry);
                 d_cf_bdry_ops[comp_idx]->setPatchDataIndex(dst_data_idx);
@@ -333,6 +345,8 @@ HierarchyGhostCellInterpolation::initializeOperatorState(
     d_refine_strategy =
         std::make_unique<RefinePatchStrategySet>(refine_patch_strategies.begin(), refine_patch_strategies.end(), false);
 
+    // Coarse-fine operator setup can register additional scratch variables.
+    validateGhostWidth();
     d_refine_scheds.resize(d_finest_ln + 1);
     for (int dst_ln = d_coarsest_ln; dst_ln <= d_finest_ln; ++dst_ln)
     {
@@ -385,6 +399,8 @@ HierarchyGhostCellInterpolation::resetTransactionComponents(
                    << "  invalid reset operation.  attempting to change the number of registered "
                       "interpolation transaction components.\n");
     }
+
+    validateGhostWidth();
 
     // Reset the transaction components.
     d_transaction_comps = transaction_comps;
@@ -578,6 +594,8 @@ HierarchyGhostCellInterpolation::fillData(double fill_time)
 #if !defined(NDEBUG)
     TBOX_ASSERT(d_is_initialized);
 #endif
+    validateGhostWidth();
+
     // Ensure the boundary condition objects are in the correct state.
     for (unsigned int comp_idx = 0; comp_idx < d_transaction_comps.size(); ++comp_idx)
     {
@@ -659,6 +677,16 @@ HierarchyGhostCellInterpolation::fillData(double fill_time)
 /////////////////////////////// PROTECTED ////////////////////////////////////
 
 /////////////////////////////// PRIVATE //////////////////////////////////////
+
+void
+HierarchyGhostCellInterpolation::validateGhostWidth()
+{
+    if (d_finest_ln >= 0)
+    {
+        d_grid_geom->computeMaxGhostWidth(d_hierarchy->getPatchDescriptor());
+    }
+    return;
+} // validateGhostWidth
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,6 +160,8 @@ SETUP_3D(navier_stokes stokes_operator.cpp)
 
 # physical_boundary:
 SETUP(physical_boundary extrapolation_01.cpp IBAMR2d)
+SETUP_2D(physical_boundary ghost_width_policy.cpp)
+SETUP_3D(physical_boundary ghost_width_policy.cpp)
 SETUP_2D(physical_boundary 01.cpp)
 SETUP_3D(physical_boundary 01.cpp)
 SETUP_2D(physical_boundary staggered_helper.cpp)

--- a/tests/physical_boundary/ghost_width_policy.cpp
+++ b/tests/physical_boundary/ghost_width_policy.cpp
@@ -1,0 +1,500 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2026 - 2026 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/CartExtrapPhysBdryOp.h>
+#include <ibtk/HierarchyGhostCellInterpolation.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
+
+#include <tbox/Logger.h>
+
+#include <CartesianGridGeometry.h>
+#include <PatchHierarchy.h>
+#include <SideGeometry.h>
+#include <SideVariable.h>
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <sstream>
+#include <utility>
+
+#include "../tests.h"
+
+#include <ibtk/app_namespaces.h>
+
+class ObservedGeometry : public CartesianGridGeometry<NDIM>
+{
+public:
+    using CartesianGridGeometry<NDIM>::CartesianGridGeometry;
+
+    void setGeometryDataOnPatch(Patch<NDIM>& patch,
+                                const IntVector<NDIM>& ratio,
+                                const tbox::Array<tbox::Array<bool>>& regular,
+                                const tbox::Array<tbox::Array<bool>>& periodic) const override
+    {
+        ++d_created;
+        CartesianGridGeometry<NDIM>::setGeometryDataOnPatch(patch, ratio, regular, periodic);
+    }
+
+    int getCreatedCount() const
+    {
+        return d_created;
+    }
+
+private:
+    mutable int d_created = 0;
+};
+
+class PolicyTestAppender : public TestAppender
+{
+public:
+    explicit PolicyTestAppender(std::function<bool()> unchanged) : d_unchanged(std::move(unchanged))
+    {
+    }
+    void logMessage(const std::string& message, const std::string& file, const int line) override
+    {
+        plog << "Patch data unchanged before rejection: " << (d_unchanged() ? "true" : "false") << std::endl;
+        TestAppender::logMessage(message, file, line);
+    }
+
+private:
+    std::function<bool()> d_unchanged;
+};
+
+std::string
+capture_boundary_boxes(Pointer<PatchHierarchy<NDIM>> hierarchy, const bool require_wall_boxes)
+{
+    std::ostringstream boxes;
+    for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<PatchGeometry<NDIM>> geometry = level->getPatch(p())->getPatchGeometry();
+            // Every patch in this nonperiodic fixture meets a physical wall.
+            if (require_wall_boxes && geometry->getCodimensionBoundaries(1).size() == 0)
+            {
+                TBOX_ERROR("Deferred boundary boxes were not constructed on every required level.\n");
+            }
+            for (int codim = 1; codim <= NDIM; ++codim)
+            {
+                const auto& boundaries = geometry->getCodimensionBoundaries(codim);
+                for (int k = 0; k < boundaries.size(); ++k)
+                {
+                    boxes << ln << ' ' << p() << ' ' << codim << ' ' << boundaries[k].getLocationIndex() << ' '
+                          << boundaries[k].getBox() << '\n';
+                }
+            }
+        }
+    }
+    return boxes.str();
+}
+
+double
+exact_value(Pointer<Patch<NDIM>> patch,
+            const SideIndex<NDIM>& index,
+            const int axis,
+            const bool constant,
+            const bool quadratic)
+{
+    if (constant)
+    {
+        return 3.0 + axis;
+    }
+    Pointer<CartesianPatchGeometry<NDIM>> geometry = patch->getPatchGeometry();
+    double value = 3.0 + axis;
+    for (int d = 0; d < NDIM; ++d)
+    {
+        const double x = geometry->getXLower()[d] +
+                         geometry->getDx()[d] * (index(d) - patch->getBox().lower()(d) + (d == axis ? 0.0 : 0.5));
+        value += (d + 1) * (quadratic ? x * x : x);
+    }
+    return value;
+}
+
+void
+seed(Pointer<PatchHierarchy<NDIM>> hierarchy, const int data_idx, const bool constant, const bool quadratic)
+{
+    for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+        if (!level->checkAllocated(data_idx))
+        {
+            level->allocatePatchData(data_idx);
+        }
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            Pointer<SideData<NDIM, double>> data = patch->getPatchData(data_idx);
+            data->fillAll(std::numeric_limits<double>::quiet_NaN());
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                for (SideIterator<NDIM> i(patch->getBox(), axis); i; i++)
+                {
+                    (*data)(i()) = exact_value(patch, i(), axis, constant, quadratic);
+                }
+            }
+        }
+    }
+}
+
+bool
+unchanged(Pointer<PatchHierarchy<NDIM>> hierarchy, const int data_idx, const bool constant, const bool quadratic)
+{
+    for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+        // Only the transaction data were allocated before initialization.
+        // In particular, a rejected internal registration must not allocate
+        // the coarse-fine helper's scratch data before the width check.
+        const int n_components = hierarchy->getPatchDescriptor()->getMaxNumberRegisteredComponents();
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            for (int idx = 0; idx < n_components; ++idx)
+            {
+                if (idx != data_idx && patch->checkAllocated(idx))
+                {
+                    return false;
+                }
+            }
+            Pointer<SideData<NDIM, double>> data = patch->getPatchData(data_idx);
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                const Box<NDIM> interior = SideGeometry<NDIM>::toSideBox(patch->getBox(), axis);
+                for (SideIterator<NDIM> i(data->getGhostBox(), axis); i; i++)
+                {
+                    const double value = (*data)(i());
+                    if (interior.contains(i()))
+                    {
+                        if (value != exact_value(patch, i(), axis, constant, quadratic))
+                        {
+                            return false;
+                        }
+                    }
+                    else if (!std::isnan(value))
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+    return true;
+}
+
+void
+check(Pointer<PatchHierarchy<NDIM>> hierarchy,
+      const int data_idx,
+      const bool constant,
+      const bool quadratic,
+      const int coarsest)
+{
+    int bad = 0;
+    double error = 0.0;
+    for (int ln = coarsest; ln <= hierarchy->getFinestLevelNumber(); ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            Pointer<SideData<NDIM, double>> data = patch->getPatchData(data_idx);
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                for (SideIterator<NDIM> i(data->getGhostBox(), axis); i; i++)
+                {
+                    const double value = (*data)(i());
+                    if (!std::isfinite(value))
+                    {
+                        ++bad;
+                    }
+                    else
+                    {
+                        // Check quadratic data only on faces with domain cells on
+                        // both sides. Linear physical boundary extrapolation need
+                        // not reproduce quadratic data on boundary faces.
+                        hier::Index<NDIM> lower_cell = i(), upper_cell = i();
+                        --lower_cell(axis);
+                        bool lower_inside = false, upper_inside = false;
+                        const BoxArray<NDIM>& domain = level->getPhysicalDomain();
+                        for (int k = 0; k < domain.size(); ++k)
+                        {
+                            lower_inside = lower_inside || domain[k].contains(lower_cell);
+                            upper_inside = upper_inside || domain[k].contains(upper_cell);
+                        }
+                        if (quadratic && !(lower_inside && upper_inside))
+                        {
+                            continue;
+                        }
+                        const double expected = exact_value(patch, i(), axis, constant, quadratic);
+                        const double local_error = std::abs(value - expected);
+                        error = std::max(error, local_error);
+                    }
+                }
+            }
+        }
+    }
+    bad = IBTK_MPI::sumReduction(bad);
+    error = IBTK_MPI::maxReduction(error);
+    plog << "Nonfinite entries: " << bad << "; maximum error: " << error << std::endl;
+    if (bad || error > 1.0e-10)
+    {
+        TBOX_ERROR("Ghost-width policy test failed field verification.\n");
+    }
+}
+
+int
+register_side_variable(const std::string& name, const IntVector<NDIM>& width)
+{
+    auto* db = VariableDatabase<NDIM>::getDatabase();
+    Pointer<SideVariable<NDIM, double>> variable = new SideVariable<NDIM, double>(name);
+    return db->registerVariableAndContext(variable, db->getContext("ghost_width_policy"), width);
+}
+
+int
+report_missing_rejection()
+{
+    plog << "Expected width-policy rejection was not raised." << std::endl;
+    Logger::getInstance()->setAbortAppender(new TestAppender());
+    return 0;
+}
+
+int
+main(int argc, char* argv[])
+{
+    IBTKInit init(argc, argv, MPI_COMM_WORLD);
+    {
+        TimerManager::createManager(nullptr);
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "output");
+        Pointer<Database> input = app_initializer->getInputDatabase();
+        const std::string mode = input->getString("test");
+        plog << "Case: " << mode << std::endl;
+
+        const bool deferred = mode == "deferred-before" || mode == "deferred-after" || mode == "deferred-range";
+        const bool partial_range = mode == "range" || mode == "deferred-range";
+        const bool periodic = mode == "periodic" || mode == "periodic-late";
+        const bool use_cf = mode == "cf-constant" || mode == "cf-late-scratch";
+        const bool constant = periodic || use_cf;
+        const bool quadratic = mode == "l-shape";
+        const bool multilevel = mode != "single" && mode != "late-init" && mode != "deferred-after" &&
+                                mode != "cf-late-scratch" && !quadratic;
+        const bool anisotropic = mode == "anisotropic-valid" || mode == "anisotropic-reject";
+        const bool reserved = mode == "shrink-restore" || mode == "shrink-fill-restore" || mode == "temporary-shrink" ||
+                              mode == "restore-unobserved" || mode == "retained-reservation" || anisotropic;
+        const int initial_width = mode == "cf-late-scratch" ? 0 :
+                                  mode == "early" || mode == "single" || partial_range || mode == "coarsen" ||
+                                          mode == "fresh-geometry" || periodic || use_cf || quadratic ?
+                                                              2 :
+                                                              1;
+        auto* db = VariableDatabase<NDIM>::getDatabase();
+        int data_idx = register_side_variable("field", IntVector<NDIM>(initial_width));
+        int reserve_idx = -1;
+        if (reserved)
+        {
+            IntVector<NDIM> width(anisotropic ? 1 : 2);
+            width(0) = 2;
+            reserve_idx = register_side_variable("unused_reservation", width);
+        }
+
+        BoxArray<NDIM> domain(quadratic ? 2 : 1), coarse(2), fine(2);
+        domain[0] = Box<NDIM>(hier::Index<NDIM>(0), hier::Index<NDIM>(15));
+        coarse[0] = coarse[1] = domain[0];
+        coarse[0].upper()(0) = 7;
+        coarse[1].lower()(0) = 8;
+        if (quadratic)
+        {
+            coarse[1].upper()(1) = 7;
+            domain = coarse;
+        }
+        fine[0] = fine[1] = Box<NDIM>(hier::Index<NDIM>(0), hier::Index<NDIM>(31));
+        fine[0].lower()(0) = 8;
+        fine[0].upper()(0) = 15;
+        fine[1].lower()(0) = 16;
+        fine[1].upper()(0) = 23;
+        fine[0].upper()(1) = fine[1].upper()(1) = 15;
+        double lo[NDIM], hi[NDIM];
+        for (int d = 0; d < NDIM; ++d)
+        {
+            lo[d] = 0.0;
+            hi[d] = 16.0;
+        }
+        Pointer<ObservedGeometry> geometry = new ObservedGeometry("geometry", lo, hi, domain, false);
+        if (periodic)
+        {
+            geometry->initializePeriodicShift(IntVector<NDIM>(1));
+        }
+        Pointer<PatchHierarchy<NDIM>> hierarchy = new PatchHierarchy<NDIM>("hierarchy", geometry, false);
+        using Transaction = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
+        if (mode == "empty")
+        {
+            HierarchyGhostCellInterpolation empty_op;
+            Transaction empty_transaction(data_idx, "CONSERVATIVE_LINEAR_REFINE", false, "NONE", "LINEAR");
+            empty_op.initializeOperatorState(empty_transaction, hierarchy);
+            empty_op.resetTransactionComponent(empty_transaction);
+            empty_op.fillData(0.0);
+            register_side_variable("before_first_level", IntVector<NDIM>(2));
+        }
+        ProcessorMapping mapping(2);
+        mapping.setProcessorAssignment(0, 0);
+        mapping.setProcessorAssignment(1, IBTK_MPI::getNodes() > 1 ? 1 : 0);
+        hierarchy->makeNewPatchLevel(0, IntVector<NDIM>(1), coarse, mapping, deferred);
+        if (multilevel)
+        {
+            hierarchy->makeNewPatchLevel(1, IntVector<NDIM>(2), fine, mapping, deferred);
+        }
+        if (mode == "deferred-before" || mode == "late-init")
+        {
+            data_idx = register_side_variable("before_init", IntVector<NDIM>(2));
+        }
+        const std::string original_boundary_boxes = capture_boundary_boxes(hierarchy, !deferred && !periodic);
+        if (mode == "shrink-restore" || mode == "temporary-shrink")
+        {
+            db->removePatchDataIndex(reserve_idx);
+        }
+        if (mode == "temporary-shrink")
+        {
+            // Native construction can lower the shared limit even before HGC
+            // observes the narrower descriptor. Destroying that level cannot
+            // restore the limit used by the older, surviving boundary boxes.
+            {
+                Pointer<PatchLevel<NDIM>> temporary = new PatchLevel<NDIM>(
+                    coarse, mapping, IntVector<NDIM>(1), geometry, hierarchy->getPatchDescriptor());
+            }
+            register_side_variable("replacement", IntVector<NDIM>(2));
+        }
+        seed(hierarchy, data_idx, constant, quadratic);
+        Pointer<Logger::Appender> appender =
+            new PolicyTestAppender([&]() { return unchanged(hierarchy, data_idx, constant, quadratic); });
+        Logger::getInstance()->setAbortAppender(appender);
+
+        Transaction transaction(data_idx,
+                                mode == "cf-late-scratch" ? "NONE" : "CONSERVATIVE_LINEAR_REFINE",
+                                use_cf,
+                                mode == "coarsen" ? "CONSERVATIVE_COARSEN" : "NONE",
+                                "LINEAR");
+        const int coarsest = partial_range ? 1 : 0;
+        const int finest = hierarchy->getFinestLevelNumber();
+        const int before = geometry->getCreatedCount();
+        HierarchyGhostCellInterpolation op;
+        plog << "Checking initialization." << std::endl;
+        op.initializeOperatorState(transaction, hierarchy, coarsest, finest);
+        if (mode == "late-init" || mode == "temporary-shrink" || mode == "cf-late-scratch")
+        {
+            return report_missing_rejection();
+        }
+        const std::string initialized_boundary_boxes = capture_boundary_boxes(hierarchy, !periodic);
+        if (!deferred && original_boundary_boxes != initialized_boundary_boxes)
+        {
+            TBOX_ERROR("Initialization changed existing boundary boxes.\n");
+        }
+        const int created = IBTK_MPI::sumReduction(geometry->getCreatedCount() - before);
+        if (multilevel && created == 0)
+        {
+            TBOX_ERROR("Expected temporary coarse-level geometry.\n");
+        }
+
+        if (mode == "shrink-restore")
+        {
+            op.deallocateOperatorState();
+            register_side_variable("replacement", IntVector<NDIM>(2));
+            plog << "Checking reinitialization after temporary levels were destroyed." << std::endl;
+            op.initializeOperatorState(transaction, hierarchy, coarsest, finest);
+            return report_missing_rejection();
+        }
+        if (mode == "shrink-fill-restore" || mode == "restore-unobserved")
+        {
+            db->removePatchDataIndex(reserve_idx);
+        }
+        if (mode == "late-fill" || mode == "late-reset" || mode == "deferred-after" || mode == "periodic-late" ||
+            mode == "restore-unobserved" || mode == "retained-reservation")
+        {
+            register_side_variable("later", IntVector<NDIM>(periodic ? 3 : 2));
+        }
+        if (mode == "retained-reservation")
+        {
+            register_side_variable("later_smaller", IntVector<NDIM>(1));
+        }
+        if (anisotropic)
+        {
+            IntVector<NDIM> width(1);
+            width(mode == "anisotropic-valid" ? 0 : NDIM - 1) = 2;
+            register_side_variable("later_anisotropic", width);
+        }
+        if (mode == "late-reset")
+        {
+            plog << "Checking reset." << std::endl;
+            op.resetTransactionComponent(transaction);
+            return report_missing_rejection();
+        }
+        plog << "Checking fill." << std::endl;
+        op.fillData(0.0);
+        if (mode == "late-fill" || mode == "deferred-after" || mode == "periodic-late" || mode == "anisotropic-reject")
+        {
+            return report_missing_rejection();
+        }
+        check(hierarchy, data_idx, constant, quadratic, coarsest);
+        if (quadratic)
+        {
+            // A subsequent exchange can mask overwrites inside the domain.
+            // Also check the physical boundary operator on already filled data.
+            CartExtrapPhysBdryOp extrapolation(data_idx, "LINEAR");
+            Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(0);
+            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+            {
+                extrapolation.setPhysicalBoundaryConditions(*level->getPatch(p()), 0.0, IntVector<NDIM>(2));
+            }
+            check(hierarchy, data_idx, constant, quadratic, coarsest);
+        }
+        if (mode == "shrink-fill-restore")
+        {
+            seed(hierarchy, data_idx, constant, quadratic);
+            register_side_variable("replacement", IntVector<NDIM>(2));
+            plog << "Checking fill after the limit decreased." << std::endl;
+            op.fillData(0.0);
+            return report_missing_rejection();
+        }
+
+        op.resetTransactionComponent(transaction);
+        seed(hierarchy, data_idx, constant, quadratic);
+        op.fillData(0.0);
+        check(hierarchy, data_idx, constant, quadratic, coarsest);
+        op.reinitializeOperatorState(hierarchy);
+        seed(hierarchy, data_idx, constant, quadratic);
+        op.fillData(0.0);
+        check(hierarchy, data_idx, constant, quadratic, 0);
+        HierarchyGhostCellInterpolation other;
+        other.initializeOperatorState(transaction, hierarchy);
+        op.deallocateOperatorState();
+        seed(hierarchy, data_idx, constant, quadratic);
+        other.fillData(0.0);
+        check(hierarchy, data_idx, constant, quadratic, 0);
+
+        if (mode == "fresh-geometry")
+        {
+            register_side_variable("wider_on_new_geometry", IntVector<NDIM>(3));
+            geometry = new ObservedGeometry("new_geometry", lo, hi, domain, false);
+            hierarchy = new PatchHierarchy<NDIM>("new_hierarchy", geometry, false);
+            hierarchy->makeNewPatchLevel(0, IntVector<NDIM>(1), coarse, mapping);
+            hierarchy->makeNewPatchLevel(1, IntVector<NDIM>(2), fine, mapping);
+            seed(hierarchy, data_idx, constant, quadratic);
+            op.initializeOperatorState(transaction, hierarchy);
+            op.fillData(0.0);
+            check(hierarchy, data_idx, constant, quadratic, 0);
+        }
+        plog << "Completed." << std::endl;
+        Logger::getInstance()->setAbortAppender(new TestAppender());
+    }
+}

--- a/tests/physical_boundary/ghost_width_policy_2d.anisotropic-reject.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.anisotropic-reject.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "anisotropic-reject"

--- a/tests/physical_boundary/ghost_width_policy_2d.anisotropic-reject.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.anisotropic-reject.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: anisotropic-reject
+Checking initialization.
+Checking fill.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_2d.anisotropic-valid.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.anisotropic-valid.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "anisotropic-valid"

--- a/tests/physical_boundary/ghost_width_policy_2d.anisotropic-valid.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.anisotropic-valid.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: anisotropic-valid
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.cf-constant.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.cf-constant.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "cf-constant"

--- a/tests/physical_boundary/ghost_width_policy_2d.cf-constant.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.cf-constant.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: cf-constant
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.cf-late-scratch.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.cf-late-scratch.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "cf-late-scratch"

--- a/tests/physical_boundary/ghost_width_policy_2d.cf-late-scratch.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.cf-late-scratch.expect_error=true.output
@@ -1,0 +1,6 @@
+Case: cf-late-scratch
+Checking initialization.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_2d.coarsen.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.coarsen.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "coarsen"

--- a/tests/physical_boundary/ghost_width_policy_2d.coarsen.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.coarsen.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: coarsen
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.deferred-after.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.deferred-after.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "deferred-after"

--- a/tests/physical_boundary/ghost_width_policy_2d.deferred-after.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.deferred-after.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: deferred-after
+Checking initialization.
+Checking fill.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_2d.deferred-before.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.deferred-before.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "deferred-before"

--- a/tests/physical_boundary/ghost_width_policy_2d.deferred-before.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.deferred-before.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: deferred-before
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.deferred-range.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.deferred-range.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "deferred-range"

--- a/tests/physical_boundary/ghost_width_policy_2d.deferred-range.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.deferred-range.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: deferred-range
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.early.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.early.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "early"

--- a/tests/physical_boundary/ghost_width_policy_2d.early.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.early.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: early
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.empty.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.empty.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "empty"

--- a/tests/physical_boundary/ghost_width_policy_2d.empty.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.empty.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: empty
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.fresh-geometry.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.fresh-geometry.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "fresh-geometry"

--- a/tests/physical_boundary/ghost_width_policy_2d.fresh-geometry.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.fresh-geometry.mpirun=2.output
@@ -1,0 +1,9 @@
+Case: fresh-geometry
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.l-shape.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.l-shape.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "l-shape"

--- a/tests/physical_boundary/ghost_width_policy_2d.l-shape.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.l-shape.mpirun=2.output
@@ -1,0 +1,9 @@
+Case: l-shape
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.late-fill.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.late-fill.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "late-fill"

--- a/tests/physical_boundary/ghost_width_policy_2d.late-fill.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.late-fill.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: late-fill
+Checking initialization.
+Checking fill.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_2d.late-init.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.late-init.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "late-init"

--- a/tests/physical_boundary/ghost_width_policy_2d.late-init.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.late-init.expect_error=true.output
@@ -1,0 +1,6 @@
+Case: late-init
+Checking initialization.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_2d.late-reset.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.late-reset.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "late-reset"

--- a/tests/physical_boundary/ghost_width_policy_2d.late-reset.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.late-reset.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: late-reset
+Checking initialization.
+Checking reset.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_2d.periodic-late.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.periodic-late.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "periodic-late"

--- a/tests/physical_boundary/ghost_width_policy_2d.periodic-late.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.periodic-late.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: periodic-late
+Checking initialization.
+Checking fill.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_2d.periodic.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.periodic.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "periodic"

--- a/tests/physical_boundary/ghost_width_policy_2d.periodic.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.periodic.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: periodic
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.range.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.range.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "range"

--- a/tests/physical_boundary/ghost_width_policy_2d.range.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.range.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: range
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.restore-unobserved.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.restore-unobserved.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "restore-unobserved"

--- a/tests/physical_boundary/ghost_width_policy_2d.restore-unobserved.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.restore-unobserved.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: restore-unobserved
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.retained-reservation.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.retained-reservation.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "retained-reservation"

--- a/tests/physical_boundary/ghost_width_policy_2d.retained-reservation.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.retained-reservation.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: retained-reservation
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.shrink-fill-restore.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.shrink-fill-restore.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "shrink-fill-restore"

--- a/tests/physical_boundary/ghost_width_policy_2d.shrink-fill-restore.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.shrink-fill-restore.expect_error=true.output
@@ -1,0 +1,9 @@
+Case: shrink-fill-restore
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Checking fill after the limit decreased.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_2d.shrink-restore.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.shrink-restore.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "shrink-restore"

--- a/tests/physical_boundary/ghost_width_policy_2d.shrink-restore.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.shrink-restore.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: shrink-restore
+Checking initialization.
+Checking reinitialization after temporary levels were destroyed.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_2d.single.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.single.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "single"

--- a/tests/physical_boundary/ghost_width_policy_2d.single.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.single.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: single
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_2d.temporary-shrink.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_2d.temporary-shrink.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "temporary-shrink"

--- a/tests/physical_boundary/ghost_width_policy_2d.temporary-shrink.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_2d.temporary-shrink.expect_error=true.output
@@ -1,0 +1,6 @@
+Case: temporary-shrink
+Checking initialization.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_3d.anisotropic-reject.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.anisotropic-reject.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "anisotropic-reject"

--- a/tests/physical_boundary/ghost_width_policy_3d.anisotropic-reject.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.anisotropic-reject.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: anisotropic-reject
+Checking initialization.
+Checking fill.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_3d.anisotropic-valid.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.anisotropic-valid.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "anisotropic-valid"

--- a/tests/physical_boundary/ghost_width_policy_3d.anisotropic-valid.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.anisotropic-valid.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: anisotropic-valid
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.cf-constant.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.cf-constant.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "cf-constant"

--- a/tests/physical_boundary/ghost_width_policy_3d.cf-constant.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.cf-constant.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: cf-constant
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.cf-late-scratch.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.cf-late-scratch.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "cf-late-scratch"

--- a/tests/physical_boundary/ghost_width_policy_3d.cf-late-scratch.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.cf-late-scratch.expect_error=true.output
@@ -1,0 +1,6 @@
+Case: cf-late-scratch
+Checking initialization.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_3d.coarsen.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.coarsen.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "coarsen"

--- a/tests/physical_boundary/ghost_width_policy_3d.coarsen.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.coarsen.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: coarsen
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.deferred-after.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.deferred-after.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "deferred-after"

--- a/tests/physical_boundary/ghost_width_policy_3d.deferred-after.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.deferred-after.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: deferred-after
+Checking initialization.
+Checking fill.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_3d.deferred-before.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.deferred-before.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "deferred-before"

--- a/tests/physical_boundary/ghost_width_policy_3d.deferred-before.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.deferred-before.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: deferred-before
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.deferred-range.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.deferred-range.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "deferred-range"

--- a/tests/physical_boundary/ghost_width_policy_3d.deferred-range.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.deferred-range.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: deferred-range
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.early.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.early.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "early"

--- a/tests/physical_boundary/ghost_width_policy_3d.early.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.early.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: early
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.empty.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.empty.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "empty"

--- a/tests/physical_boundary/ghost_width_policy_3d.empty.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.empty.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: empty
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.fresh-geometry.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.fresh-geometry.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "fresh-geometry"

--- a/tests/physical_boundary/ghost_width_policy_3d.fresh-geometry.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.fresh-geometry.mpirun=2.output
@@ -1,0 +1,9 @@
+Case: fresh-geometry
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.l-shape.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.l-shape.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "l-shape"

--- a/tests/physical_boundary/ghost_width_policy_3d.l-shape.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.l-shape.mpirun=2.output
@@ -1,0 +1,9 @@
+Case: l-shape
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.late-fill.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.late-fill.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "late-fill"

--- a/tests/physical_boundary/ghost_width_policy_3d.late-fill.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.late-fill.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: late-fill
+Checking initialization.
+Checking fill.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_3d.late-init.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.late-init.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "late-init"

--- a/tests/physical_boundary/ghost_width_policy_3d.late-init.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.late-init.expect_error=true.output
@@ -1,0 +1,6 @@
+Case: late-init
+Checking initialization.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_3d.late-reset.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.late-reset.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "late-reset"

--- a/tests/physical_boundary/ghost_width_policy_3d.late-reset.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.late-reset.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: late-reset
+Checking initialization.
+Checking reset.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_3d.periodic-late.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.periodic-late.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "periodic-late"

--- a/tests/physical_boundary/ghost_width_policy_3d.periodic-late.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.periodic-late.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: periodic-late
+Checking initialization.
+Checking fill.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_3d.periodic.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.periodic.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "periodic"

--- a/tests/physical_boundary/ghost_width_policy_3d.periodic.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.periodic.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: periodic
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.range.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.range.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "range"

--- a/tests/physical_boundary/ghost_width_policy_3d.range.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.range.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: range
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.restore-unobserved.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.restore-unobserved.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "restore-unobserved"

--- a/tests/physical_boundary/ghost_width_policy_3d.restore-unobserved.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.restore-unobserved.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: restore-unobserved
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.retained-reservation.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.retained-reservation.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "retained-reservation"

--- a/tests/physical_boundary/ghost_width_policy_3d.retained-reservation.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.retained-reservation.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: retained-reservation
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.shrink-fill-restore.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.shrink-fill-restore.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "shrink-fill-restore"

--- a/tests/physical_boundary/ghost_width_policy_3d.shrink-fill-restore.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.shrink-fill-restore.expect_error=true.output
@@ -1,0 +1,9 @@
+Case: shrink-fill-restore
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Checking fill after the limit decreased.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_3d.shrink-restore.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.shrink-restore.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "shrink-restore"

--- a/tests/physical_boundary/ghost_width_policy_3d.shrink-restore.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.shrink-restore.expect_error=true.output
@@ -1,0 +1,7 @@
+Case: shrink-restore
+Checking initialization.
+Checking reinitialization after temporary levels were destroyed.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!

--- a/tests/physical_boundary/ghost_width_policy_3d.single.mpirun=2.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.single.mpirun=2.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "single"

--- a/tests/physical_boundary/ghost_width_policy_3d.single.mpirun=2.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.single.mpirun=2.output
@@ -1,0 +1,8 @@
+Case: single
+Checking initialization.
+Checking fill.
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Nonfinite entries: 0; maximum error: 0
+Completed.

--- a/tests/physical_boundary/ghost_width_policy_3d.temporary-shrink.expect_error=true.input
+++ b/tests/physical_boundary/ghost_width_policy_3d.temporary-shrink.expect_error=true.input
@@ -1,0 +1,4 @@
+Main {
+   log_file_name = "output"
+}
+test = "temporary-shrink"

--- a/tests/physical_boundary/ghost_width_policy_3d.temporary-shrink.expect_error=true.output
+++ b/tests/physical_boundary/ghost_width_policy_3d.temporary-shrink.expect_error=true.output
@@ -1,0 +1,6 @@
+Case: temporary-shrink
+Checking initialization.
+Patch data unchanged before rejection: true
+Program abort called with error message
+
+    Error in hier::GridGeometry<DIM> object with name = geometry: in computeMaxGhostWidth():  Cannot add variables and increase maximum ghost width after creating the GridGeometry!


### PR DESCRIPTION
As an alternative to #1767, enforce SAMRAI's registered ghost-width limit in `HierarchyGhostCellInterpolation` before schedule setup, transaction reset, and filling. Initialization completes deferred boundary construction while preserving existing boundary boxes and extrapolation formulas.

### IBAMR Pull Request Checklist
- [ ] Does the test suite pass?
- [x] Was clang-format (i.e., `make indent`) run? For more information see
      `scripts/formatting/README.md`.
- [x] Were relevant issues cited? Please remember to add `Fixes #12345` to close
      the issue automatically if we are fixing the problem.
- [x] Is this a change others will want to know about? If so, then has a
      changelog entry been added?
- [x] If new data structures have been added to a class then have they been set
      up appropriately for restarts? If so, ensure that the restart version
      number is incremented.
- [x] Does this change include a bug fix or new functionality? If so, a new test
      or tests should be added. New tests should run quickly (less than a minute
      in release mode). If possible, an older test should gain a new option so
      that we do not need to compile more test executables.
- [x] Did you (if your account has permission to do so) set relevant labels on
      GitHub for the pull request?
